### PR TITLE
Make request logging JSON format match other apps.

### DIFF
--- a/Gomfile
+++ b/Gomfile
@@ -1,6 +1,4 @@
-gom 'github.com/Sirupsen/logrus', :commit => '965349de21e7b1e9e80b6ae02e093f1522516ef3'
 gom 'github.com/codegangsta/negroni', :commit => 'c64702ca03d0f858ab7866638b69e85f0d4c6ee7'
-gom 'github.com/meatballhat/negroni-logrus', :commit => 'd5e114d7a445f7a3652cf807d3f83d5dceb8de26'
 gom 'github.com/onsi/ginkgo', :commit => '75d0cd9c7ee52e99b13e6ccfd9e58b4f92b7795e'
 gom 'github.com/onsi/gomega', :commit => '835b5e4242c715976b98ed6bc6ece1d9c7879f66'
 gom 'gopkg.in/unrolled/render.v1', :commit => '40ac5716c7e0bffcc440aac649ea4b880a5d7735'

--- a/main.go
+++ b/main.go
@@ -4,16 +4,16 @@ import (
 	"bytes"
 	"encoding/json"
 	"io/ioutil"
+	"log"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
 	"os"
 
-	"github.com/Sirupsen/logrus"
 	"github.com/codegangsta/negroni"
-	"github.com/meatballhat/negroni-logrus"
 	"gopkg.in/unrolled/render.v1"
 
+	"github.com/alphagov/publishing-api/request_logger"
 	"github.com/alphagov/publishing-api/urlarbiter"
 )
 
@@ -22,8 +22,6 @@ var (
 	contentStoreHost = getEnvDefault("CONTENT_STORE", "http://content-store.dev.gov.uk")
 	port             = getEnvDefault("PORT", "3000")
 
-	loggingMiddleware = negronilogrus.NewCustomMiddleware(
-		logrus.InfoLevel, &logrus.JSONFormatter{}, "publishing-api")
 	renderer = render.New(render.Options{})
 )
 
@@ -105,8 +103,13 @@ func BuildHTTPMux(arbiterURL, contentStoreURL string) *http.ServeMux {
 func main() {
 	httpMux := BuildHTTPMux(arbiterHost, contentStoreHost)
 
+	requestLogger, err := request_logger.New("STDOUT")
+	if err != nil {
+		log.Fatal(err)
+	}
+
 	middleware := negroni.New()
-	middleware.Use(loggingMiddleware)
+	middleware.Use(requestLogger)
 	middleware.UseHandler(httpMux)
 	middleware.Run(":" + port)
 }

--- a/main.go
+++ b/main.go
@@ -21,6 +21,7 @@ var (
 	arbiterHost      = getEnvDefault("URL_ARBITER", "http://url-arbiter.dev.gov.uk")
 	contentStoreHost = getEnvDefault("CONTENT_STORE", "http://content-store.dev.gov.uk")
 	port             = getEnvDefault("PORT", "3000")
+	requestLogDest   = getEnvDefault("REQUEST_LOG", "STDOUT")
 
 	renderer = render.New(render.Options{})
 )
@@ -103,7 +104,7 @@ func BuildHTTPMux(arbiterURL, contentStoreURL string) *http.ServeMux {
 func main() {
 	httpMux := BuildHTTPMux(arbiterHost, contentStoreHost)
 
-	requestLogger, err := request_logger.New("STDOUT")
+	requestLogger, err := request_logger.New(requestLogDest)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/request_logger/logger.go
+++ b/request_logger/logger.go
@@ -1,0 +1,103 @@
+package request_logger
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/codegangsta/negroni"
+)
+
+type logEntry struct {
+	Timestamp time.Time              `json:"@timestamp"`
+	Fields    map[string]interface{} `json:"@fields"`
+	Tags      []string               `json:"@tags"`
+}
+
+type logger struct {
+	writer io.Writer
+	lines  chan *[]byte
+}
+
+// New creates a new request logging middleware.   The output variable sets the
+// destination to which log data will be written.  This can be either an
+// io.Writer, or a string.  With the latter, this is either one of "STDOUT" or
+// "STDERR", or the path to the file to log to.
+func New(output interface{}) (negroni.Handler, error) {
+	var err error
+	l := &logger{}
+	l.writer, err = openWriter(output)
+	if err != nil {
+		return nil, err
+	}
+	l.lines = make(chan *[]byte, 100)
+	go l.writeLoop()
+	return l, nil
+}
+
+func openWriter(output interface{}) (io.Writer, error) {
+	switch out := output.(type) {
+	case io.Writer:
+		return out, nil
+	case string:
+		if out == "STDERR" {
+			return os.Stderr, nil
+		} else if out == "STDOUT" {
+			return os.Stdout, nil
+		} else {
+			w, err := os.OpenFile(out, os.O_WRONLY|os.O_APPEND|os.O_CREATE, 0600)
+			if err != nil {
+				return nil, err
+			}
+			return w, nil
+		}
+	default:
+		return nil, fmt.Errorf("Invalid output type %T(%v)", output, output)
+	}
+}
+
+func (l *logger) writeLoop() {
+	for {
+		line := <-l.lines
+		_, err := l.writer.Write(*line)
+		if err != nil {
+			log.Printf("Error writing to log: %v", err)
+		}
+	}
+}
+
+func (l *logger) ServeHTTP(rw http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
+	start := time.Now()
+
+	next(rw, r)
+
+	duration := time.Since(start)
+	res := rw.(negroni.ResponseWriter)
+
+	entry := &logEntry{
+		Timestamp: time.Now(),
+		Fields: map[string]interface{}{
+			"method":       r.Method,
+			"path":         r.URL.Path,
+			"query_string": r.URL.RawQuery,
+			"request":      fmt.Sprintf("%s %s %s", r.Method, r.RequestURI, r.Proto),
+			"remote_addr":  r.RemoteAddr,
+			"status":       res.Status(),
+			"duration":     float64(duration.Nanoseconds()/1000) / 1000, // Milliseconds to 3dp
+			"length":       res.Size(),
+		},
+		Tags: []string{"request"},
+	}
+
+	line, err := json.Marshal(entry)
+	if err != nil {
+		log.Printf("request_logger: Error encoding JSON: %v", err)
+	}
+
+	line = append(line, 10) // Append a newline
+	l.lines <- &line
+}


### PR DESCRIPTION
To keep things consistent in Kibana.

In order to achieve this we've had to move away from using Logrus which
was somewhat opinionated about some of the details.  This implementation
is based on the [error logger in the router](https://github.com/alphagov/router/blob/master/logger/logger.go).

Also allow the request log destination to be configured from the environment.