### PR TITLE
Return a 400 when given bad JSON.

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 
 	. "github.com/alphagov/publishing-api"
 
@@ -226,6 +227,16 @@ var _ = Describe("Integration Testing", func() {
 			Expect(err).To(BeNil())
 			Expect(response.StatusCode).To(Equal(http.StatusMethodNotAllowed))
 		})
+	})
+
+	It("returns a 400 error if given invalid JSON", func() {
+		url := testPublishingAPI.URL + "/content" + "/foo/bar"
+		request, err := http.NewRequest("PUT", url, strings.NewReader("i'm not json"))
+		Expect(err).To(BeNil())
+
+		response, err := client.Do(request)
+		Expect(err).To(BeNil())
+		Expect(response.StatusCode).To(Equal(http.StatusBadRequest))
 	})
 })
 

--- a/main.go
+++ b/main.go
@@ -56,7 +56,12 @@ func ContentStoreHandler(arbiterURL, contentStoreURL string) http.HandlerFunc {
 
 		var contentStoreRequest *ContentStoreRequest
 		if err := json.Unmarshal(requestBody, &contentStoreRequest); err != nil {
-			renderer.JSON(w, http.StatusInternalServerError, err)
+			switch err.(type) {
+			case *json.SyntaxError:
+				renderer.JSON(w, http.StatusBadRequest, err)
+			default:
+				renderer.JSON(w, http.StatusInternalServerError, err)
+			}
 			return
 		}
 


### PR DESCRIPTION
This is more correct that throwing a 500 error.