### PR TITLE
Remove .rspec config file

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,0 @@
---color
---require spec_helper


### PR DESCRIPTION
This was overlooked (as is easy to do) when the app was coverted from Rails to Go.