### PR TITLE
Separate out content store client

### DIFF
--- a/content_store_handler.go
+++ b/content_store_handler.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+
+	"github.com/alphagov/publishing-api/urlarbiter"
+)
+
+type ContentStoreRequest struct {
+	BasePath      string `json:"base_path"`
+	PublishingApp string `json:"publishing_app"`
+	UpdateType    string `json:"update_type"`
+}
+
+func ContentStoreHandler(arbiterURL, contentStoreURL string) http.HandlerFunc {
+	parsedContentStoreURL, err := url.Parse(contentStoreURL)
+	if err != nil {
+		panic(err)
+	}
+
+	arbiter := urlarbiter.NewURLArbiter(arbiterURL)
+	contentStoreProxy := httputil.NewSingleHostReverseProxy(parsedContentStoreURL)
+	contentStoreHostRewriter := requestHostToDestinationHost(contentStoreProxy)
+
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "PUT" {
+			responseBody := `{"errors":{"method": "only PUT HTTP methods are allowed"}}`
+			renderer.JSON(w, http.StatusMethodNotAllowed, responseBody)
+			return
+		}
+
+		path := r.URL.Path[len("/content"):]
+
+		requestBody, err := ioutil.ReadAll(r.Body)
+		if err != nil {
+			renderer.JSON(w, http.StatusInternalServerError, err)
+			return
+		}
+
+		var contentStoreRequest *ContentStoreRequest
+		if err := json.Unmarshal(requestBody, &contentStoreRequest); err != nil {
+			switch err.(type) {
+			case *json.SyntaxError:
+				renderer.JSON(w, http.StatusBadRequest, err)
+			default:
+				renderer.JSON(w, http.StatusInternalServerError, err)
+			}
+			return
+		}
+
+		// Due to the way that Go works, we can't read from the
+		// http.Request body twice. This is because http.Request.Body
+		// implements io.ReadCloser which closes itself once read. To
+		// get around this it's possible to copy the raw bytes from
+		// the body into a buffer and overlay two separate
+		// bytes.NewBuffer instances. Here we're implementing the same
+		// io.ReadCloser interface on top of our bytes.NewBuffer and
+		// replacing the original body with itself.
+		r.Body = ioutil.NopCloser(bytes.NewBuffer(requestBody))
+
+		urlArbiterResponse, err := arbiter.Register(path, contentStoreRequest.PublishingApp)
+		if err != nil {
+			switch err {
+			case urlarbiter.ConflictPathAlreadyReserved:
+				renderer.JSON(w, http.StatusConflict, urlArbiterResponse)
+			case urlarbiter.UnprocessableEntity:
+				renderer.JSON(w, 422, urlArbiterResponse) // Unprocessable Entity.
+			default:
+				renderer.JSON(w, http.StatusInternalServerError, err)
+			}
+
+			return
+		}
+
+		contentStoreHostRewriter.ServeHTTP(w, r)
+	}
+}
+
+// Use this function to wrap httputil.NewSingleHostReverseProxy
+// proxies. It sets the host of the request to the host of the
+// destination server.
+func requestHostToDestinationHost(handler http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		r.Host = r.URL.Host
+		handler.ServeHTTP(w, r)
+	})
+}

--- a/content_store_handler.go
+++ b/content_store_handler.go
@@ -16,58 +16,65 @@ type ContentStoreRequest struct {
 	UpdateType    string `json:"update_type"`
 }
 
-func ContentStoreHandler(arbiterURL, contentStoreURL string) http.HandlerFunc {
-	arbiter := urlarbiter.NewURLArbiter(arbiterURL)
-	contentStore := contentstore.NewClient(contentStoreURL)
+type ContentStoreHandler struct {
+	arbiter      *urlarbiter.URLArbiter
+	contentStore *contentstore.ContentStoreClient
+}
 
-	return func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != "PUT" {
-			responseBody := `{"errors":{"method": "only PUT HTTP methods are allowed"}}`
-			renderer.JSON(w, http.StatusMethodNotAllowed, responseBody)
-			return
-		}
-
-		path := r.URL.Path[len("/content"):]
-
-		requestBody, err := ioutil.ReadAll(r.Body)
-		if err != nil {
-			renderer.JSON(w, http.StatusInternalServerError, err)
-			return
-		}
-
-		var contentStoreRequest *ContentStoreRequest
-		if err := json.Unmarshal(requestBody, &contentStoreRequest); err != nil {
-			switch err.(type) {
-			case *json.SyntaxError:
-				renderer.JSON(w, http.StatusBadRequest, err)
-			default:
-				renderer.JSON(w, http.StatusInternalServerError, err)
-			}
-			return
-		}
-
-		urlArbiterResponse, err := arbiter.Register(path, contentStoreRequest.PublishingApp)
-		if err != nil {
-			switch err {
-			case urlarbiter.ConflictPathAlreadyReserved:
-				renderer.JSON(w, http.StatusConflict, urlArbiterResponse)
-			case urlarbiter.UnprocessableEntity:
-				renderer.JSON(w, 422, urlArbiterResponse) // Unprocessable Entity.
-			default:
-				renderer.JSON(w, http.StatusInternalServerError, err)
-			}
-
-			return
-		}
-
-		resp, err := contentStore.PutContentItem(path, requestBody)
-		if err != nil {
-			renderer.JSON(w, http.StatusInternalServerError, err)
-		}
-		defer resp.Body.Close()
-
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(resp.StatusCode)
-		io.Copy(w, resp.Body)
+func NewContentStoreHandler(arbiterURL, contentStoreURL string) *ContentStoreHandler {
+	return &ContentStoreHandler{
+		arbiter:      urlarbiter.NewURLArbiter(arbiterURL),
+		contentStore: contentstore.NewClient(contentStoreURL),
 	}
+}
+
+func (cs *ContentStoreHandler) PutContentItem(w http.ResponseWriter, r *http.Request) {
+	if r.Method != "PUT" {
+		responseBody := `{"errors":{"method": "only PUT HTTP methods are allowed"}}`
+		renderer.JSON(w, http.StatusMethodNotAllowed, responseBody)
+		return
+	}
+
+	path := r.URL.Path[len("/content"):]
+
+	requestBody, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		renderer.JSON(w, http.StatusInternalServerError, err)
+		return
+	}
+
+	var contentStoreRequest *ContentStoreRequest
+	if err := json.Unmarshal(requestBody, &contentStoreRequest); err != nil {
+		switch err.(type) {
+		case *json.SyntaxError:
+			renderer.JSON(w, http.StatusBadRequest, err)
+		default:
+			renderer.JSON(w, http.StatusInternalServerError, err)
+		}
+		return
+	}
+
+	urlArbiterResponse, err := cs.arbiter.Register(path, contentStoreRequest.PublishingApp)
+	if err != nil {
+		switch err {
+		case urlarbiter.ConflictPathAlreadyReserved:
+			renderer.JSON(w, http.StatusConflict, urlArbiterResponse)
+		case urlarbiter.UnprocessableEntity:
+			renderer.JSON(w, 422, urlArbiterResponse) // Unprocessable Entity.
+		default:
+			renderer.JSON(w, http.StatusInternalServerError, err)
+		}
+
+		return
+	}
+
+	resp, err := cs.contentStore.PutContentItem(path, requestBody)
+	if err != nil {
+		renderer.JSON(w, http.StatusInternalServerError, err)
+	}
+	defer resp.Body.Close()
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(resp.StatusCode)
+	io.Copy(w, resp.Body)
 }

--- a/content_store_request.go
+++ b/content_store_request.go
@@ -1,7 +1,0 @@
-package main
-
-type ContentStoreRequest struct {
-	BasePath      string `json:"base_path"`
-	PublishingApp string `json:"publishing_app"`
-	UpdateType    string `json:"update_type"`
-}

--- a/contentstore/client.go
+++ b/contentstore/client.go
@@ -1,0 +1,37 @@
+package contentstore
+
+import (
+	"bytes"
+	"errors"
+	"io/ioutil"
+	"net/http"
+)
+
+var (
+	UnprocessableEntity = errors.New("request was well-formed but was unable to be followed due to semantic errors")
+)
+
+type ContentStoreClient struct {
+	client  *http.Client
+	rootURL string
+}
+
+func NewClient(rootURL string) *ContentStoreClient {
+	return &ContentStoreClient{
+		client:  &http.Client{},
+		rootURL: rootURL,
+	}
+}
+
+func (p *ContentStoreClient) PutContentItem(basePath string, data []byte) (*http.Response, error) {
+	url := p.rootURL + "/content" + basePath
+
+	reqBody := ioutil.NopCloser(bytes.NewBuffer(data))
+	req, err := http.NewRequest("PUT", url, reqBody)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	return p.client.Do(req)
+}

--- a/contentstore/client_test.go
+++ b/contentstore/client_test.go
@@ -1,0 +1,62 @@
+package contentstore_test
+
+import (
+	"io/ioutil"
+	"net/http"
+	"testing"
+
+	"github.com/alphagov/publishing-api/contentstore"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/ghttp"
+)
+
+func TestURLArbiter(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "URL arbiter client")
+}
+
+var _ = Describe("URLArbiter", func() {
+	var (
+		testServer *ghttp.Server
+	)
+
+	BeforeEach(func() {
+		testServer = ghttp.NewServer()
+	})
+
+	AfterEach(func() {
+		testServer.Close()
+	})
+
+	It("should submit a content item to the content-store", func() {
+		responseBody := `{"base_path":"/foo/bar","remaining_fields":"omitted"}`
+		testServer.AppendHandlers(
+			ghttp.CombineHandlers(
+				ghttp.VerifyRequest("PUT", "/content/foo/bar"),
+				ghttp.VerifyContentType("application/json"),
+				verifyRequestBody("Something"),
+				ghttp.RespondWith(http.StatusOK, responseBody, http.Header{"Content-Type": []string{"application/json"}}),
+			),
+		)
+
+		client := contentstore.NewClient(testServer.URL())
+
+		response, err := client.PutContentItem("/foo/bar", []byte("Something"))
+
+		Expect(testServer.ReceivedRequests()).To(HaveLen(1))
+
+		Expect(err).To(BeNil())
+		Expect(response.StatusCode).To(Equal(http.StatusOK))
+	})
+})
+
+func verifyRequestBody(expectedBody string) http.HandlerFunc {
+	return func(w http.ResponseWriter, req *http.Request) {
+		body, err := ioutil.ReadAll(req.Body)
+		req.Body.Close()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(body)).To(Equal(expectedBody))
+	}
+}

--- a/main.go
+++ b/main.go
@@ -28,7 +28,8 @@ func HealthCheckHandler(w http.ResponseWriter, r *http.Request) {
 func BuildHTTPMux(arbiterURL, contentStoreURL string) *http.ServeMux {
 	httpMux := http.NewServeMux()
 	httpMux.HandleFunc("/healthcheck", HealthCheckHandler)
-	httpMux.HandleFunc("/content/", ContentStoreHandler(arbiterURL, contentStoreURL))
+	contentStoreHandler := NewContentStoreHandler(arbiterURL, contentStoreURL)
+	httpMux.HandleFunc("/content/", contentStoreHandler.PutContentItem)
 	return httpMux
 }
 

--- a/main.go
+++ b/main.go
@@ -1,13 +1,8 @@
 package main
 
 import (
-	"bytes"
-	"encoding/json"
-	"io/ioutil"
 	"log"
 	"net/http"
-	"net/http/httputil"
-	"net/url"
 	"os"
 
 	"github.com/alext/tablecloth"
@@ -15,7 +10,6 @@ import (
 	"gopkg.in/unrolled/render.v1"
 
 	"github.com/alphagov/publishing-api/request_logger"
-	"github.com/alphagov/publishing-api/urlarbiter"
 )
 
 var (
@@ -29,70 +23,6 @@ var (
 
 func HealthCheckHandler(w http.ResponseWriter, r *http.Request) {
 	renderer.JSON(w, http.StatusOK, map[string]string{"status": "OK"})
-}
-
-func ContentStoreHandler(arbiterURL, contentStoreURL string) http.HandlerFunc {
-	parsedContentStoreURL, err := url.Parse(contentStoreURL)
-	if err != nil {
-		panic(err)
-	}
-
-	arbiter := urlarbiter.NewURLArbiter(arbiterURL)
-	contentStoreProxy := httputil.NewSingleHostReverseProxy(parsedContentStoreURL)
-	contentStoreHostRewriter := requestHostToDestinationHost(contentStoreProxy)
-
-	return func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != "PUT" {
-			responseBody := `{"errors":{"method": "only PUT HTTP methods are allowed"}}`
-			renderer.JSON(w, http.StatusMethodNotAllowed, responseBody)
-			return
-		}
-
-		path := r.URL.Path[len("/content"):]
-
-		requestBody, err := ioutil.ReadAll(r.Body)
-		if err != nil {
-			renderer.JSON(w, http.StatusInternalServerError, err)
-			return
-		}
-
-		var contentStoreRequest *ContentStoreRequest
-		if err := json.Unmarshal(requestBody, &contentStoreRequest); err != nil {
-			switch err.(type) {
-			case *json.SyntaxError:
-				renderer.JSON(w, http.StatusBadRequest, err)
-			default:
-				renderer.JSON(w, http.StatusInternalServerError, err)
-			}
-			return
-		}
-
-		// Due to the way that Go works, we can't read from the
-		// http.Request body twice. This is because http.Request.Body
-		// implements io.ReadCloser which closes itself once read. To
-		// get around this it's possible to copy the raw bytes from
-		// the body into a buffer and overlay two separate
-		// bytes.NewBuffer instances. Here we're implementing the same
-		// io.ReadCloser interface on top of our bytes.NewBuffer and
-		// replacing the original body with itself.
-		r.Body = ioutil.NopCloser(bytes.NewBuffer(requestBody))
-
-		urlArbiterResponse, err := arbiter.Register(path, contentStoreRequest.PublishingApp)
-		if err != nil {
-			switch err {
-			case urlarbiter.ConflictPathAlreadyReserved:
-				renderer.JSON(w, http.StatusConflict, urlArbiterResponse)
-			case urlarbiter.UnprocessableEntity:
-				renderer.JSON(w, 422, urlArbiterResponse) // Unprocessable Entity.
-			default:
-				renderer.JSON(w, http.StatusInternalServerError, err)
-			}
-
-			return
-		}
-
-		contentStoreHostRewriter.ServeHTTP(w, r)
-	}
 }
 
 func BuildHTTPMux(arbiterURL, contentStoreURL string) *http.ServeMux {
@@ -134,14 +64,4 @@ func getEnvDefault(key string, defaultVal string) string {
 	}
 
 	return val
-}
-
-// Use this function to wrap httputil.NewSingleHostReverseProxy
-// proxies. It sets the host of the request to the host of the
-// destination server.
-func requestHostToDestinationHost(handler http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		r.Host = r.URL.Host
-		handler.ServeHTTP(w, r)
-	})
 }


### PR DESCRIPTION
This makes the handler code cleaner, and will make it easier to add additional endpoints in future (eg registering publish intents).

This also includes some refactoring of the main content store handler to make things clearer.