### PR TITLE
Remove fields that weren't used

### DIFF
--- a/content_store_handler.go
+++ b/content_store_handler.go
@@ -11,9 +11,7 @@ import (
 )
 
 type ContentStoreRequest struct {
-	BasePath      string `json:"base_path"`
 	PublishingApp string `json:"publishing_app"`
-	UpdateType    string `json:"update_type"`
 }
 
 type ContentStoreHandler struct {

--- a/integration_test.go
+++ b/integration_test.go
@@ -112,9 +112,7 @@ var _ = Describe("Integration Testing", func() {
 			URLArbiterReturnResponse = `{"publishing_app":"foo_publisher","path":"/foo","errors":{"a":["b","c"]}}`
 
 			jsonRequestBody, err := json.Marshal(&ContentStoreRequest{
-				BasePath:      "/foo/bar",
 				PublishingApp: "foo_publisher",
-				UpdateType:    "publish",
 			})
 			Expect(err).To(BeNil())
 
@@ -137,9 +135,7 @@ var _ = Describe("Integration Testing", func() {
 			URLArbiterReturnResponse = `{"publishing_app":"foo_publisher","path":"/foo","errors":{"a":["b"]}}`
 
 			jsonRequestBody, err := json.Marshal(&ContentStoreRequest{
-				BasePath:      "/foo/bar",
 				PublishingApp: "foo_publisher",
-				UpdateType:    "publish",
 			})
 			Expect(err).To(BeNil())
 
@@ -160,9 +156,7 @@ var _ = Describe("Integration Testing", func() {
 
 	It("registers a path with URL arbiter and then publishes the content to the content store", func() {
 		jsonRequestBody, err := json.Marshal(&ContentStoreRequest{
-			BasePath:      "/foo/bar",
 			PublishingApp: "foo_publisher",
-			UpdateType:    "publish",
 		})
 		Expect(err).To(BeNil())
 


### PR DESCRIPTION
publishing-api doesn't need any knowledge of these fields.