### PR TITLE
Make builds fail when files are not gofmt'd

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ BINARY := publishing-api
 ORG_PATH := github.com/alphagov
 REPO_PATH := $(ORG_PATH)/$(BINARY)
 
-all: test build
+all: check_fmt test build
 
 deps:
 	gom install
@@ -25,3 +25,6 @@ run: build
 
 clean:
 	rm -rf bin $(BINARY) _vendor
+
+check_fmt:
+	./check_fmt.sh

--- a/check_fmt.sh
+++ b/check_fmt.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+UNFMTD_FILES_DIFF=`find . -name "*.go" -not -path './_vendor*' | xargs -L1 gofmt -d`
+if [ -n "$UNFMTD_FILES_DIFF" ]; then
+  echo -e "ERROR: You need to gofmt the following files: \n$UNFMTD_FILES_DIFF"
+  exit 1
+else
+  echo "INFO: All files are gofmt'd!"
+  exit 0
+fi


### PR DESCRIPTION
based on @jamiecobbett's [suggestion](https://github.com/alphagov/publishing-api/pull/17#issuecomment-73937716) to have CI tell us if files are not gofmt'd.

we're looking through all files with extension .go in the project directory, excluding the _vendor directory, and running `gofmt` against them. if there are files pending formatting, we return a non-zero exit status, which causes the make target to fail, and in turn the build to go red.

this branch build is failing because it is based on master which has am unfmt'd file, which will be fixed by https://github.com/alphagov/publishing-api/pull/17.