### PR TITLE
Publish intents

### DIFF
--- a/Gomfile
+++ b/Gomfile
@@ -1,4 +1,6 @@
 gom 'github.com/codegangsta/negroni', :commit => 'c64702ca03d0f858ab7866638b69e85f0d4c6ee7'
+gom 'github.com/gorilla/mux', :commit => 'e444e69cbd2e2e3e0749a2f3c717cec491552bbf'
+gom 'github.com/gorilla/context', :commit => '215affda49addc4c8ef7e2534915df2c8c35c6cd'
 gom 'gopkg.in/unrolled/render.v1', :commit => '40ac5716c7e0bffcc440aac649ea4b880a5d7735'
 gom 'github.com/alext/tablecloth', :commit => '7f49e40'
 

--- a/content_store_handler.go
+++ b/content_store_handler.go
@@ -6,12 +6,13 @@ import (
 	"io/ioutil"
 	"net/http"
 
+	"github.com/gorilla/mux"
+
 	"github.com/alphagov/publishing-api/contentstore"
 	"github.com/alphagov/publishing-api/urlarbiter"
 )
 
 type ContentStoreRequest struct {
-	BasePath      string `json:"base_path"`
 	PublishingApp string `json:"publishing_app"`
 }
 
@@ -28,6 +29,8 @@ func NewContentStoreHandler(arbiterURL, contentStoreURL string) *ContentStoreHan
 }
 
 func (cs *ContentStoreHandler) PutContentStoreRequest(w http.ResponseWriter, r *http.Request) {
+	urlParameters := mux.Vars(r)
+
 	requestBody, err := ioutil.ReadAll(r.Body)
 	if err != nil {
 		renderer.JSON(w, http.StatusInternalServerError, err)
@@ -45,7 +48,7 @@ func (cs *ContentStoreHandler) PutContentStoreRequest(w http.ResponseWriter, r *
 		return
 	}
 
-	if !cs.registerWithURLArbiter(contentStoreRequest.BasePath, contentStoreRequest.PublishingApp, w) {
+	if !cs.registerWithURLArbiter(urlParameters["base_path"], contentStoreRequest.PublishingApp, w) {
 		// errors already written to ResponseWriter
 		return
 	}

--- a/content_store_handler.go
+++ b/content_store_handler.go
@@ -11,6 +11,7 @@ import (
 )
 
 type ContentStoreRequest struct {
+	BasePath      string `json:"base_path"`
 	PublishingApp string `json:"publishing_app"`
 }
 
@@ -26,9 +27,7 @@ func NewContentStoreHandler(arbiterURL, contentStoreURL string) *ContentStoreHan
 	}
 }
 
-func (cs *ContentStoreHandler) PutContentItem(w http.ResponseWriter, r *http.Request) {
-	path := r.URL.Path[len("/content"):]
-
+func (cs *ContentStoreHandler) PutContentStoreRequest(w http.ResponseWriter, r *http.Request) {
 	requestBody, err := ioutil.ReadAll(r.Body)
 	if err != nil {
 		renderer.JSON(w, http.StatusInternalServerError, err)
@@ -46,12 +45,12 @@ func (cs *ContentStoreHandler) PutContentItem(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	if !cs.registerWithURLArbiter(path, contentStoreRequest.PublishingApp, w) {
+	if !cs.registerWithURLArbiter(contentStoreRequest.BasePath, contentStoreRequest.PublishingApp, w) {
 		// errors already written to ResponseWriter
 		return
 	}
 
-	resp, err := cs.contentStore.PutContentItem(path, requestBody)
+	resp, err := cs.contentStore.PutRequest(r.URL.Path, requestBody)
 	if err != nil {
 		renderer.JSON(w, http.StatusInternalServerError, err)
 	}

--- a/content_store_handler.go
+++ b/content_store_handler.go
@@ -27,12 +27,6 @@ func NewContentStoreHandler(arbiterURL, contentStoreURL string) *ContentStoreHan
 }
 
 func (cs *ContentStoreHandler) PutContentItem(w http.ResponseWriter, r *http.Request) {
-	if r.Method != "PUT" {
-		responseBody := `{"errors":{"method": "only PUT HTTP methods are allowed"}}`
-		renderer.JSON(w, http.StatusMethodNotAllowed, responseBody)
-		return
-	}
-
 	path := r.URL.Path[len("/content"):]
 
 	requestBody, err := ioutil.ReadAll(r.Body)

--- a/content_store_handler.go
+++ b/content_store_handler.go
@@ -79,3 +79,15 @@ func (cs *ContentStoreHandler) registerWithURLArbiter(path, publishingApp string
 	}
 	return true
 }
+
+func (cs *ContentStoreHandler) GetContentStoreRequest(w http.ResponseWriter, r *http.Request) {
+	resp, err := cs.contentStore.GetRequest(r.URL.Path)
+	if err != nil {
+		renderer.JSON(w, http.StatusInternalServerError, err)
+	}
+	defer resp.Body.Close()
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(resp.StatusCode)
+	io.Copy(w, resp.Body)
+}

--- a/content_store_handler.go
+++ b/content_store_handler.go
@@ -91,3 +91,15 @@ func (cs *ContentStoreHandler) GetContentStoreRequest(w http.ResponseWriter, r *
 	w.WriteHeader(resp.StatusCode)
 	io.Copy(w, resp.Body)
 }
+
+func (cs *ContentStoreHandler) DeleteContentStoreRequest(w http.ResponseWriter, r *http.Request) {
+	resp, err := cs.contentStore.DeleteRequest(r.URL.Path)
+	if err != nil {
+		renderer.JSON(w, http.StatusInternalServerError, err)
+	}
+	defer resp.Body.Close()
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(resp.StatusCode)
+	io.Copy(w, resp.Body)
+}

--- a/content_store_handler.go
+++ b/content_store_handler.go
@@ -50,15 +50,7 @@ func (cs *ContentStoreHandler) PutContentStoreRequest(w http.ResponseWriter, r *
 		return
 	}
 
-	resp, err := cs.contentStore.PutRequest(r.URL.Path, requestBody)
-	if err != nil {
-		renderer.JSON(w, http.StatusInternalServerError, err)
-	}
-	defer resp.Body.Close()
-
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(resp.StatusCode)
-	io.Copy(w, resp.Body)
+	cs.doContentStoreRequest("PUT", r.URL.Path, requestBody, w)
 }
 
 // Register the given path and publishing app with the URL arbiter.  Returns
@@ -81,19 +73,16 @@ func (cs *ContentStoreHandler) registerWithURLArbiter(path, publishingApp string
 }
 
 func (cs *ContentStoreHandler) GetContentStoreRequest(w http.ResponseWriter, r *http.Request) {
-	resp, err := cs.contentStore.GetRequest(r.URL.Path)
-	if err != nil {
-		renderer.JSON(w, http.StatusInternalServerError, err)
-	}
-	defer resp.Body.Close()
-
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(resp.StatusCode)
-	io.Copy(w, resp.Body)
+	cs.doContentStoreRequest("GET", r.URL.Path, nil, w)
 }
 
 func (cs *ContentStoreHandler) DeleteContentStoreRequest(w http.ResponseWriter, r *http.Request) {
-	resp, err := cs.contentStore.DeleteRequest(r.URL.Path)
+	cs.doContentStoreRequest("DELETE", r.URL.Path, nil, w)
+}
+
+// data will be nil for requests without bodies
+func (cs *ContentStoreHandler) doContentStoreRequest(httpMethod string, path string, data []byte, w http.ResponseWriter) {
+	resp, err := cs.contentStore.DoRequest(httpMethod, path, data)
 	if err != nil {
 		renderer.JSON(w, http.StatusInternalServerError, err)
 	}

--- a/contentstore/client.go
+++ b/contentstore/client.go
@@ -3,6 +3,7 @@ package contentstore
 import (
 	"bytes"
 	"errors"
+	"io"
 	"io/ioutil"
 	"net/http"
 )
@@ -23,36 +24,23 @@ func NewClient(rootURL string) *ContentStoreClient {
 	}
 }
 
-func (p *ContentStoreClient) PutRequest(path string, data []byte) (*http.Response, error) {
+// data will be nil for requests without bodies
+func (p *ContentStoreClient) DoRequest(httpMethod string, path string, data []byte) (*http.Response, error) {
 	url := p.rootURL + path
+	var reqBody io.Reader
 
-	reqBody := ioutil.NopCloser(bytes.NewBuffer(data))
-	req, err := http.NewRequest("PUT", url, reqBody)
-	if err != nil {
-		return nil, err
+	if data != nil {
+		reqBody = ioutil.NopCloser(bytes.NewBuffer(data))
 	}
-	req.Header.Set("Content-Type", "application/json")
 
-	return p.client.Do(req)
-}
+	req, err := http.NewRequest(httpMethod, url, reqBody)
 
-func (p *ContentStoreClient) GetRequest(path string) (*http.Response, error) {
-	url := p.rootURL + path
-
-	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	return p.client.Do(req)
-}
-
-func (p *ContentStoreClient) DeleteRequest(path string) (*http.Response, error) {
-	url := p.rootURL + path
-
-	req, err := http.NewRequest("DELETE", url, nil)
-	if err != nil {
-		return nil, err
+	if data != nil {
+		req.Header.Set("Content-Type", "application/json")
 	}
 
 	return p.client.Do(req)

--- a/contentstore/client.go
+++ b/contentstore/client.go
@@ -35,3 +35,14 @@ func (p *ContentStoreClient) PutRequest(path string, data []byte) (*http.Respons
 
 	return p.client.Do(req)
 }
+
+func (p *ContentStoreClient) GetRequest(path string) (*http.Response, error) {
+	url := p.rootURL + path
+
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return p.client.Do(req)
+}

--- a/contentstore/client.go
+++ b/contentstore/client.go
@@ -46,3 +46,14 @@ func (p *ContentStoreClient) GetRequest(path string) (*http.Response, error) {
 
 	return p.client.Do(req)
 }
+
+func (p *ContentStoreClient) DeleteRequest(path string) (*http.Response, error) {
+	url := p.rootURL + path
+
+	req, err := http.NewRequest("DELETE", url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return p.client.Do(req)
+}

--- a/contentstore/client.go
+++ b/contentstore/client.go
@@ -23,8 +23,8 @@ func NewClient(rootURL string) *ContentStoreClient {
 	}
 }
 
-func (p *ContentStoreClient) PutContentItem(basePath string, data []byte) (*http.Response, error) {
-	url := p.rootURL + "/content" + basePath
+func (p *ContentStoreClient) PutRequest(path string, data []byte) (*http.Response, error) {
+	url := p.rootURL + path
 
 	reqBody := ioutil.NopCloser(bytes.NewBuffer(data))
 	req, err := http.NewRequest("PUT", url, reqBody)

--- a/contentstore/client_test.go
+++ b/contentstore/client_test.go
@@ -52,6 +52,27 @@ var _ = Describe("URLArbiter", func() {
 			Expect(response.StatusCode).To(Equal(http.StatusOK))
 		})
 	})
+
+	Describe("GetRequest", func() {
+		It("should perform a GET request to content-store", func() {
+			responseBody := `{"base_path":"/foo/bar","remaining_fields":"omitted"}`
+			testServer.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest("GET", "/foo/bar"),
+					ghttp.RespondWith(http.StatusOK, responseBody, http.Header{"Content-Type": []string{"application/json"}}),
+				),
+			)
+
+			client := contentstore.NewClient(testServer.URL())
+
+			response, err := client.GetRequest("/foo/bar")
+
+			Expect(testServer.ReceivedRequests()).To(HaveLen(1))
+
+			Expect(err).To(BeNil())
+			Expect(response.StatusCode).To(Equal(http.StatusOK))
+		})
+	})
 })
 
 func verifyRequestBody(expectedBody string) http.HandlerFunc {

--- a/contentstore/client_test.go
+++ b/contentstore/client_test.go
@@ -73,6 +73,27 @@ var _ = Describe("URLArbiter", func() {
 			Expect(response.StatusCode).To(Equal(http.StatusOK))
 		})
 	})
+
+	Describe("DeleteRequest", func() {
+		It("should perform a DELETE request to content-store", func() {
+			responseBody := `{"base_path":"/foo/bar","remaining_fields":"omitted"}`
+			testServer.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest("DELETE", "/foo/bar"),
+					ghttp.RespondWith(http.StatusOK, responseBody, http.Header{"Content-Type": []string{"application/json"}}),
+				),
+			)
+
+			client := contentstore.NewClient(testServer.URL())
+
+			response, err := client.DeleteRequest("/foo/bar")
+
+			Expect(testServer.ReceivedRequests()).To(HaveLen(1))
+
+			Expect(err).To(BeNil())
+			Expect(response.StatusCode).To(Equal(http.StatusOK))
+		})
+	})
 })
 
 func verifyRequestBody(expectedBody string) http.HandlerFunc {

--- a/contentstore/client_test.go
+++ b/contentstore/client_test.go
@@ -30,25 +30,27 @@ var _ = Describe("URLArbiter", func() {
 		testServer.Close()
 	})
 
-	It("should PUT some JSON to the content-store", func() {
-		responseBody := `{"base_path":"/foo/bar","remaining_fields":"omitted"}`
-		testServer.AppendHandlers(
-			ghttp.CombineHandlers(
-				ghttp.VerifyRequest("PUT", "/foo/bar"),
-				ghttp.VerifyContentType("application/json"),
-				verifyRequestBody("Something"),
-				ghttp.RespondWith(http.StatusOK, responseBody, http.Header{"Content-Type": []string{"application/json"}}),
-			),
-		)
+	Describe("PutRequest", func() {
+		It("should PUT some JSON to the content-store", func() {
+			responseBody := `{"base_path":"/foo/bar","remaining_fields":"omitted"}`
+			testServer.AppendHandlers(
+				ghttp.CombineHandlers(
+					ghttp.VerifyRequest("PUT", "/foo/bar"),
+					ghttp.VerifyContentType("application/json"),
+					verifyRequestBody("Something"),
+					ghttp.RespondWith(http.StatusOK, responseBody, http.Header{"Content-Type": []string{"application/json"}}),
+				),
+			)
 
-		client := contentstore.NewClient(testServer.URL())
+			client := contentstore.NewClient(testServer.URL())
 
-		response, err := client.PutRequest("/foo/bar", []byte("Something"))
+			response, err := client.PutRequest("/foo/bar", []byte("Something"))
 
-		Expect(testServer.ReceivedRequests()).To(HaveLen(1))
+			Expect(testServer.ReceivedRequests()).To(HaveLen(1))
 
-		Expect(err).To(BeNil())
-		Expect(response.StatusCode).To(Equal(http.StatusOK))
+			Expect(err).To(BeNil())
+			Expect(response.StatusCode).To(Equal(http.StatusOK))
+		})
 	})
 })
 

--- a/contentstore/client_test.go
+++ b/contentstore/client_test.go
@@ -30,11 +30,11 @@ var _ = Describe("URLArbiter", func() {
 		testServer.Close()
 	})
 
-	It("should submit a content item to the content-store", func() {
+	It("should PUT some JSON to the content-store", func() {
 		responseBody := `{"base_path":"/foo/bar","remaining_fields":"omitted"}`
 		testServer.AppendHandlers(
 			ghttp.CombineHandlers(
-				ghttp.VerifyRequest("PUT", "/content/foo/bar"),
+				ghttp.VerifyRequest("PUT", "/foo/bar"),
 				ghttp.VerifyContentType("application/json"),
 				verifyRequestBody("Something"),
 				ghttp.RespondWith(http.StatusOK, responseBody, http.Header{"Content-Type": []string{"application/json"}}),
@@ -43,7 +43,7 @@ var _ = Describe("URLArbiter", func() {
 
 		client := contentstore.NewClient(testServer.URL())
 
-		response, err := client.PutContentItem("/foo/bar", []byte("Something"))
+		response, err := client.PutRequest("/foo/bar", []byte("Something"))
 
 		Expect(testServer.ReceivedRequests()).To(HaveLen(1))
 

--- a/contentstore/client_test.go
+++ b/contentstore/client_test.go
@@ -30,8 +30,8 @@ var _ = Describe("URLArbiter", func() {
 		testServer.Close()
 	})
 
-	Describe("PutRequest", func() {
-		It("should PUT some JSON to the content-store", func() {
+	Describe("DoRequest with a body", func() {
+		It("should send the body on the path with the HTTP method to content-store", func() {
 			responseBody := `{"base_path":"/foo/bar","remaining_fields":"omitted"}`
 			testServer.AppendHandlers(
 				ghttp.CombineHandlers(
@@ -44,7 +44,7 @@ var _ = Describe("URLArbiter", func() {
 
 			client := contentstore.NewClient(testServer.URL())
 
-			response, err := client.PutRequest("/foo/bar", []byte("Something"))
+			response, err := client.DoRequest("PUT", "/foo/bar", []byte("Something"))
 
 			Expect(testServer.ReceivedRequests()).To(HaveLen(1))
 
@@ -53,8 +53,8 @@ var _ = Describe("URLArbiter", func() {
 		})
 	})
 
-	Describe("GetRequest", func() {
-		It("should perform a GET request to content-store", func() {
+	Describe("DoRequest without a body", func() {
+		It("should send a request to the path with the HTTP method to content-store", func() {
 			responseBody := `{"base_path":"/foo/bar","remaining_fields":"omitted"}`
 			testServer.AppendHandlers(
 				ghttp.CombineHandlers(
@@ -65,28 +65,7 @@ var _ = Describe("URLArbiter", func() {
 
 			client := contentstore.NewClient(testServer.URL())
 
-			response, err := client.GetRequest("/foo/bar")
-
-			Expect(testServer.ReceivedRequests()).To(HaveLen(1))
-
-			Expect(err).To(BeNil())
-			Expect(response.StatusCode).To(Equal(http.StatusOK))
-		})
-	})
-
-	Describe("DeleteRequest", func() {
-		It("should perform a DELETE request to content-store", func() {
-			responseBody := `{"base_path":"/foo/bar","remaining_fields":"omitted"}`
-			testServer.AppendHandlers(
-				ghttp.CombineHandlers(
-					ghttp.VerifyRequest("DELETE", "/foo/bar"),
-					ghttp.RespondWith(http.StatusOK, responseBody, http.Header{"Content-Type": []string{"application/json"}}),
-				),
-			)
-
-			client := contentstore.NewClient(testServer.URL())
-
-			response, err := client.DeleteRequest("/foo/bar")
+			response, err := client.DoRequest("GET", "/foo/bar", nil)
 
 			Expect(testServer.ReceivedRequests()).To(HaveLen(1))
 

--- a/integration_test.go
+++ b/integration_test.go
@@ -47,159 +47,161 @@ var _ = Describe("Integration Testing", func() {
 		})
 	})
 
-	Describe("PUT /content", func() {
-		var (
-			requestOrder     chan TestRequestLabel
-			testContentStore *httptest.Server
-			testURLArbiter   *httptest.Server
-		)
-
-		BeforeEach(func() {
-			requestOrder = make(chan TestRequestLabel, 2)
-
-			testContentStore = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				requestOrder <- ContentStoreRequestLabel
-
-				Expect(r.URL.Path).To(Equal("/content/foo/bar"))
-				Expect(r.Method).To(Equal("PUT"))
-
-				w.WriteHeader(http.StatusOK)
-				fmt.Fprintln(w, `{
-	              "base_path": "/foo/bar",
-	              "title": "Content Title",
-	              "description": "Short description of content",
-	              "format": "the format of this content",
-	              "locale": "en",
-	              "details": {
-	                "app": "or format",
-	                "specific": "data..."
-	              }
-	           }`)
-			}))
-			testURLArbiter = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				requestOrder <- URLArbiterRequestLabel
-
-				defer GinkgoRecover()
-
-				Expect(r.URL.Path).To(Equal("/paths/foo/bar"))
-				Expect(r.Method).To(Equal("PUT"))
-
-				body, err := ReadHTTPBody(r.Body)
-				Expect(err).To(BeNil())
-				Expect(body).To(MatchJSON(`{"publishing_app":"foo_publisher"}`))
-
-				w.WriteHeader(http.StatusOK)
-				fmt.Fprintln(w, `{"path":"/foo/bar","publishing_app":"foo_publisher"}`)
-			}))
-			testPublishingAPI = httptest.NewServer(BuildHTTPMux(testURLArbiter.URL, testContentStore.URL))
-		})
-
-		AfterEach(func() {
-			testContentStore.Close()
-			testURLArbiter.Close()
-			testPublishingAPI.Close()
-			close(requestOrder)
-		})
-
-		Describe("URL arbiter error responses", func() {
+	for _, resource := range [...]string{"/content", "/publish-intent"} {
+		Describe("PUT "+resource, func() {
 			var (
-				URLArbiterReturnStatus   int
-				URLArbiterReturnResponse string
+				requestOrder     chan TestRequestLabel
+				testContentStore *httptest.Server
+				testURLArbiter   *httptest.Server
 			)
 
 			BeforeEach(func() {
-				testURLArbiter = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-					w.WriteHeader(URLArbiterReturnStatus)
-					fmt.Fprintln(w, URLArbiterReturnResponse)
-				}))
+				requestOrder = make(chan TestRequestLabel, 2)
 
+				testContentStore = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					requestOrder <- ContentStoreRequestLabel
+
+					Expect(r.URL.Path).To(Equal(resource + "/foo/bar"))
+					Expect(r.Method).To(Equal("PUT"))
+
+					w.WriteHeader(http.StatusOK)
+					fmt.Fprintln(w, `{
+						"base_path": "/foo/bar",
+						"title": "Content Title",
+						"description": "Short description of content",
+						"format": "the format of this content",
+						"locale": "en",
+						"details": {
+						"app": "or format",
+						"specific": "data..."
+						}
+					 }`)
+				}))
+				testURLArbiter = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					requestOrder <- URLArbiterRequestLabel
+
+					defer GinkgoRecover()
+
+					Expect(r.URL.Path).To(Equal("/paths/foo/bar"))
+					Expect(r.Method).To(Equal("PUT"))
+
+					body, err := ReadHTTPBody(r.Body)
+					Expect(err).To(BeNil())
+					Expect(body).To(MatchJSON(`{"publishing_app":"foo_publisher"}`))
+
+					w.WriteHeader(http.StatusOK)
+					fmt.Fprintln(w, `{"path":"/foo/bar","publishing_app":"foo_publisher"}`)
+				}))
 				testPublishingAPI = httptest.NewServer(BuildHTTPMux(testURLArbiter.URL, testContentStore.URL))
 			})
 
 			AfterEach(func() {
+				testContentStore.Close()
 				testURLArbiter.Close()
 				testPublishingAPI.Close()
+				close(requestOrder)
 			})
 
-			It("should return a 422 status with the original response", func() {
-				URLArbiterReturnStatus = 422
-				URLArbiterReturnResponse = `{"publishing_app":"foo_publisher","path":"/foo","errors":{"a":["b","c"]}}`
+			Describe("URL arbiter error responses", func() {
+				var (
+					URLArbiterReturnStatus   int
+					URLArbiterReturnResponse string
+				)
 
+				BeforeEach(func() {
+					testURLArbiter = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+						w.WriteHeader(URLArbiterReturnStatus)
+						fmt.Fprintln(w, URLArbiterReturnResponse)
+					}))
+
+					testPublishingAPI = httptest.NewServer(BuildHTTPMux(testURLArbiter.URL, testContentStore.URL))
+				})
+
+				AfterEach(func() {
+					testURLArbiter.Close()
+					testPublishingAPI.Close()
+				})
+
+				It("should return a 422 status with the original response", func() {
+					URLArbiterReturnStatus = 422
+					URLArbiterReturnResponse = `{"publishing_app":"foo_publisher","path":"/foo","errors":{"a":["b","c"]}}`
+
+					jsonRequestBody, err := json.Marshal(&ContentStoreRequest{
+						BasePath:      "/foo/bar",
+						PublishingApp: "foo_publisher",
+					})
+					Expect(err).To(BeNil())
+
+					url := testPublishingAPI.URL + resource + "/foo/bar"
+
+					response := DoRequest("PUT", url, jsonRequestBody)
+					Expect(response.StatusCode).To(Equal(422))
+
+					body, err := ReadHTTPBody(response.Body)
+					Expect(err).To(BeNil())
+					Expect(body).To(Equal([]uint8(URLArbiterReturnResponse)))
+				})
+
+				It("should return a 409 status with the original response", func() {
+					URLArbiterReturnStatus = 409
+					URLArbiterReturnResponse = `{"publishing_app":"foo_publisher","path":"/foo","errors":{"a":["b"]}}`
+
+					jsonRequestBody, err := json.Marshal(&ContentStoreRequest{
+						BasePath:      "/foo/bar",
+						PublishingApp: "foo_publisher",
+					})
+					Expect(err).To(BeNil())
+
+					url := testPublishingAPI.URL + resource + "/foo/bar"
+
+					response := DoRequest("PUT", url, jsonRequestBody)
+					Expect(response.StatusCode).To(Equal(409))
+
+					body, err := ReadHTTPBody(response.Body)
+					Expect(err).To(BeNil())
+					Expect(body).To(Equal([]uint8(URLArbiterReturnResponse)))
+				})
+			})
+
+			It("registers a path with URL arbiter and then publishes the content to the content store", func() {
 				jsonRequestBody, err := json.Marshal(&ContentStoreRequest{
 					BasePath:      "/foo/bar",
 					PublishingApp: "foo_publisher",
 				})
 				Expect(err).To(BeNil())
 
-				url := testPublishingAPI.URL + "/content" + "/foo/bar"
+				url := testPublishingAPI.URL + resource + "/foo/bar"
 
 				response := DoRequest("PUT", url, jsonRequestBody)
-				Expect(response.StatusCode).To(Equal(422))
+
+				Expect(response.StatusCode).To(Equal(http.StatusOK))
+
+				// Testing for order.
+				Expect(<-requestOrder).To(Equal(URLArbiterRequestLabel))
+				Expect(<-requestOrder).To(Equal(ContentStoreRequestLabel))
 
 				body, err := ReadHTTPBody(response.Body)
+				Expect(body).To(MatchJSON(`{
+					"base_path": "/foo/bar",
+					"title": "Content Title",
+					"description": "Short description of content",
+					"format": "the format of this content",
+					"locale": "en",
+					"details": {
+					"app": "or format",
+					"specific": "data..."
+					}
+				}`))
 				Expect(err).To(BeNil())
-				Expect(body).To(Equal([]uint8(URLArbiterReturnResponse)))
 			})
 
-			It("should return a 409 status with the original response", func() {
-				URLArbiterReturnStatus = 409
-				URLArbiterReturnResponse = `{"publishing_app":"foo_publisher","path":"/foo","errors":{"a":["b"]}}`
-
-				jsonRequestBody, err := json.Marshal(&ContentStoreRequest{
-					BasePath:      "/foo/bar",
-					PublishingApp: "foo_publisher",
-				})
-				Expect(err).To(BeNil())
-
-				url := testPublishingAPI.URL + "/content" + "/foo/bar"
-
-				response := DoRequest("PUT", url, jsonRequestBody)
-				Expect(response.StatusCode).To(Equal(409))
-
-				body, err := ReadHTTPBody(response.Body)
-				Expect(err).To(BeNil())
-				Expect(body).To(Equal([]uint8(URLArbiterReturnResponse)))
+			It("returns a 400 error if given invalid JSON", func() {
+				url := testPublishingAPI.URL + resource + "/foo/bar"
+				response := DoRequest("PUT", url, []byte("i'm not json"))
+				Expect(response.StatusCode).To(Equal(http.StatusBadRequest))
 			})
 		})
-
-		It("registers a path with URL arbiter and then publishes the content to the content store", func() {
-			jsonRequestBody, err := json.Marshal(&ContentStoreRequest{
-				BasePath:      "/foo/bar",
-				PublishingApp: "foo_publisher",
-			})
-			Expect(err).To(BeNil())
-
-			url := testPublishingAPI.URL + "/content" + "/foo/bar"
-
-			response := DoRequest("PUT", url, jsonRequestBody)
-
-			Expect(response.StatusCode).To(Equal(http.StatusOK))
-
-			// Testing for order.
-			Expect(<-requestOrder).To(Equal(URLArbiterRequestLabel))
-			Expect(<-requestOrder).To(Equal(ContentStoreRequestLabel))
-
-			body, err := ReadHTTPBody(response.Body)
-			Expect(body).To(MatchJSON(`{
-	          "base_path": "/foo/bar",
-	          "title": "Content Title",
-	          "description": "Short description of content",
-	          "format": "the format of this content",
-	          "locale": "en",
-	          "details": {
-	            "app": "or format",
-	            "specific": "data..."
-	          }
-	        }`))
-			Expect(err).To(BeNil())
-		})
-
-		It("returns a 400 error if given invalid JSON", func() {
-			url := testPublishingAPI.URL + "/content" + "/foo/bar"
-			response := DoRequest("PUT", url, []byte("i'm not json"))
-			Expect(response.StatusCode).To(Equal(http.StatusBadRequest))
-		})
-	})
+	}
 })
 
 func DoRequest(verb string, url string, body []byte) *http.Response {

--- a/integration_test.go
+++ b/integration_test.go
@@ -127,7 +127,6 @@ var _ = Describe("Integration Testing", func() {
 					URLArbiterReturnResponse = `{"publishing_app":"foo_publisher","path":"/foo","errors":{"a":["b","c"]}}`
 
 					jsonRequestBody, err := json.Marshal(&ContentStoreRequest{
-						BasePath:      "/foo/bar",
 						PublishingApp: "foo_publisher",
 					})
 					Expect(err).To(BeNil())
@@ -147,7 +146,6 @@ var _ = Describe("Integration Testing", func() {
 					URLArbiterReturnResponse = `{"publishing_app":"foo_publisher","path":"/foo","errors":{"a":["b"]}}`
 
 					jsonRequestBody, err := json.Marshal(&ContentStoreRequest{
-						BasePath:      "/foo/bar",
 						PublishingApp: "foo_publisher",
 					})
 					Expect(err).To(BeNil())
@@ -165,7 +163,6 @@ var _ = Describe("Integration Testing", func() {
 
 			It("registers a path with URL arbiter and then publishes the content to the content store", func() {
 				jsonRequestBody, err := json.Marshal(&ContentStoreRequest{
-					BasePath:      "/foo/bar",
 					PublishingApp: "foo_publisher",
 				})
 				Expect(err).To(BeNil())

--- a/integration_test.go
+++ b/integration_test.go
@@ -60,6 +60,9 @@ var _ = Describe("Integration Testing", func() {
 			testContentStore = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				requestOrder <- ContentStoreRequestLabel
 
+				Expect(r.URL.Path).To(Equal("/content/foo/bar"))
+				Expect(r.Method).To(Equal("PUT"))
+
 				w.WriteHeader(http.StatusOK)
 				fmt.Fprintln(w, `{
 	              "base_path": "/foo/bar",

--- a/integration_test.go
+++ b/integration_test.go
@@ -123,6 +123,7 @@ var _ = Describe("Integration Testing", func() {
 				URLArbiterReturnResponse = `{"publishing_app":"foo_publisher","path":"/foo","errors":{"a":["b","c"]}}`
 
 				jsonRequestBody, err := json.Marshal(&ContentStoreRequest{
+					BasePath:      "/foo/bar",
 					PublishingApp: "foo_publisher",
 				})
 				Expect(err).To(BeNil())
@@ -142,6 +143,7 @@ var _ = Describe("Integration Testing", func() {
 				URLArbiterReturnResponse = `{"publishing_app":"foo_publisher","path":"/foo","errors":{"a":["b"]}}`
 
 				jsonRequestBody, err := json.Marshal(&ContentStoreRequest{
+					BasePath:      "/foo/bar",
 					PublishingApp: "foo_publisher",
 				})
 				Expect(err).To(BeNil())
@@ -159,6 +161,7 @@ var _ = Describe("Integration Testing", func() {
 
 		It("registers a path with URL arbiter and then publishes the content to the content store", func() {
 			jsonRequestBody, err := json.Marshal(&ContentStoreRequest{
+				BasePath:      "/foo/bar",
 				PublishingApp: "foo_publisher",
 			})
 			Expect(err).To(BeNil())

--- a/integration_test.go
+++ b/integration_test.go
@@ -188,42 +188,6 @@ var _ = Describe("Integration Testing", func() {
 			Expect(err).To(BeNil())
 		})
 
-		Describe("disabled HTTP methods", func() {
-			var client = &http.Client{}
-			var url string
-
-			BeforeEach(func() {
-				url = testPublishingAPI.URL + "/content/disabled/http/methods"
-			})
-
-			It("should not allow GET requets", func() {
-				response, err := client.Get(url)
-				Expect(err).To(BeNil())
-				Expect(response.StatusCode).To(Equal(http.StatusMethodNotAllowed))
-			})
-
-			It("should not allow POST requets", func() {
-				response, err := client.Post(url, "application/json", bytes.NewBufferString(`{"foo": "bar"}`))
-				Expect(err).To(BeNil())
-				Expect(response.StatusCode).To(Equal(http.StatusMethodNotAllowed))
-			})
-
-			It("should not allow HEAD requets", func() {
-				response, err := client.Head(url)
-				Expect(err).To(BeNil())
-				Expect(response.StatusCode).To(Equal(http.StatusMethodNotAllowed))
-			})
-
-			It("should not allow DELETE requets", func() {
-				request, err := http.NewRequest("DELETE", url, nil)
-				Expect(err).To(BeNil())
-
-				response, err := client.Do(request)
-				Expect(err).To(BeNil())
-				Expect(response.StatusCode).To(Equal(http.StatusMethodNotAllowed))
-			})
-		})
-
 		It("returns a 400 error if given invalid JSON", func() {
 			url := testPublishingAPI.URL + "/content" + "/foo/bar"
 			response := DoRequest("PUT", url, []byte("i'm not json"))

--- a/main.go
+++ b/main.go
@@ -30,10 +30,10 @@ func BuildHTTPMux(arbiterURL, contentStoreURL string) http.Handler {
 	httpMux := mux.NewRouter()
 	httpMux.Methods("GET").Path("/healthcheck").HandlerFunc(HealthCheckHandler)
 	contentStoreHandler := NewContentStoreHandler(arbiterURL, contentStoreURL)
-	httpMux.Methods("PUT").PathPrefix("/content/").HandlerFunc(contentStoreHandler.PutContentStoreRequest)
-	httpMux.Methods("PUT").PathPrefix("/publish-intent/").HandlerFunc(contentStoreHandler.PutContentStoreRequest)
-	httpMux.Methods("GET").PathPrefix("/publish-intent/").HandlerFunc(contentStoreHandler.GetContentStoreRequest)
-	httpMux.Methods("DELETE").PathPrefix("/publish-intent/").HandlerFunc(contentStoreHandler.DeleteContentStoreRequest)
+	httpMux.Methods("PUT").Path("/content{base_path:.*}").HandlerFunc(contentStoreHandler.PutContentStoreRequest)
+	httpMux.Methods("PUT").Path("/publish-intent{base_path:.*}").HandlerFunc(contentStoreHandler.PutContentStoreRequest)
+	httpMux.Methods("GET").Path("/publish-intent{base_path:.*}").HandlerFunc(contentStoreHandler.GetContentStoreRequest)
+	httpMux.Methods("DELETE").Path("/publish-intent{base_path:.*}").HandlerFunc(contentStoreHandler.DeleteContentStoreRequest)
 	return httpMux
 }
 

--- a/main.go
+++ b/main.go
@@ -33,6 +33,7 @@ func BuildHTTPMux(arbiterURL, contentStoreURL string) http.Handler {
 	httpMux.Methods("PUT").PathPrefix("/content/").HandlerFunc(contentStoreHandler.PutContentStoreRequest)
 	httpMux.Methods("PUT").PathPrefix("/publish-intent/").HandlerFunc(contentStoreHandler.PutContentStoreRequest)
 	httpMux.Methods("GET").PathPrefix("/publish-intent/").HandlerFunc(contentStoreHandler.GetContentStoreRequest)
+	httpMux.Methods("DELETE").PathPrefix("/publish-intent/").HandlerFunc(contentStoreHandler.DeleteContentStoreRequest)
 	return httpMux
 }
 

--- a/main.go
+++ b/main.go
@@ -30,7 +30,7 @@ func BuildHTTPMux(arbiterURL, contentStoreURL string) http.Handler {
 	httpMux := mux.NewRouter()
 	httpMux.Methods("GET").Path("/healthcheck").HandlerFunc(HealthCheckHandler)
 	contentStoreHandler := NewContentStoreHandler(arbiterURL, contentStoreURL)
-	httpMux.Methods("PUT").PathPrefix("/content/").HandlerFunc(contentStoreHandler.PutContentItem)
+	httpMux.Methods("PUT").PathPrefix("/content/").HandlerFunc(contentStoreHandler.PutContentStoreRequest)
 	return httpMux
 }
 

--- a/main.go
+++ b/main.go
@@ -31,6 +31,7 @@ func BuildHTTPMux(arbiterURL, contentStoreURL string) http.Handler {
 	httpMux.Methods("GET").Path("/healthcheck").HandlerFunc(HealthCheckHandler)
 	contentStoreHandler := NewContentStoreHandler(arbiterURL, contentStoreURL)
 	httpMux.Methods("PUT").PathPrefix("/content/").HandlerFunc(contentStoreHandler.PutContentStoreRequest)
+	httpMux.Methods("PUT").PathPrefix("/publish-intent/").HandlerFunc(contentStoreHandler.PutContentStoreRequest)
 	return httpMux
 }
 

--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/alext/tablecloth"
 	"github.com/codegangsta/negroni"
+	"github.com/gorilla/mux"
 	"gopkg.in/unrolled/render.v1"
 
 	"github.com/alphagov/publishing-api/request_logger"
@@ -25,11 +26,11 @@ func HealthCheckHandler(w http.ResponseWriter, r *http.Request) {
 	renderer.JSON(w, http.StatusOK, map[string]string{"status": "OK"})
 }
 
-func BuildHTTPMux(arbiterURL, contentStoreURL string) *http.ServeMux {
-	httpMux := http.NewServeMux()
-	httpMux.HandleFunc("/healthcheck", HealthCheckHandler)
+func BuildHTTPMux(arbiterURL, contentStoreURL string) http.Handler {
+	httpMux := mux.NewRouter()
+	httpMux.Methods("GET").Path("/healthcheck").HandlerFunc(HealthCheckHandler)
 	contentStoreHandler := NewContentStoreHandler(arbiterURL, contentStoreURL)
-	httpMux.HandleFunc("/content/", contentStoreHandler.PutContentItem)
+	httpMux.Methods("PUT").PathPrefix("/content/").HandlerFunc(contentStoreHandler.PutContentItem)
 	return httpMux
 }
 

--- a/main.go
+++ b/main.go
@@ -32,6 +32,7 @@ func BuildHTTPMux(arbiterURL, contentStoreURL string) http.Handler {
 	contentStoreHandler := NewContentStoreHandler(arbiterURL, contentStoreURL)
 	httpMux.Methods("PUT").PathPrefix("/content/").HandlerFunc(contentStoreHandler.PutContentStoreRequest)
 	httpMux.Methods("PUT").PathPrefix("/publish-intent/").HandlerFunc(contentStoreHandler.PutContentStoreRequest)
+	httpMux.Methods("GET").PathPrefix("/publish-intent/").HandlerFunc(contentStoreHandler.GetContentStoreRequest)
 	return httpMux
 }
 

--- a/main.go
+++ b/main.go
@@ -30,10 +30,10 @@ func BuildHTTPMux(arbiterURL, contentStoreURL string) http.Handler {
 	httpMux := mux.NewRouter()
 	httpMux.Methods("GET").Path("/healthcheck").HandlerFunc(HealthCheckHandler)
 	contentStoreHandler := NewContentStoreHandler(arbiterURL, contentStoreURL)
-	httpMux.Methods("PUT").Path("/content{base_path:.*}").HandlerFunc(contentStoreHandler.PutContentStoreRequest)
-	httpMux.Methods("PUT").Path("/publish-intent{base_path:.*}").HandlerFunc(contentStoreHandler.PutContentStoreRequest)
-	httpMux.Methods("GET").Path("/publish-intent{base_path:.*}").HandlerFunc(contentStoreHandler.GetContentStoreRequest)
-	httpMux.Methods("DELETE").Path("/publish-intent{base_path:.*}").HandlerFunc(contentStoreHandler.DeleteContentStoreRequest)
+	httpMux.Methods("PUT").Path("/content{base_path:/.*}").HandlerFunc(contentStoreHandler.PutContentStoreRequest)
+	httpMux.Methods("PUT").Path("/publish-intent{base_path:/.*}").HandlerFunc(contentStoreHandler.PutContentStoreRequest)
+	httpMux.Methods("GET").Path("/publish-intent{base_path:/.*}").HandlerFunc(contentStoreHandler.GetContentStoreRequest)
+	httpMux.Methods("DELETE").Path("/publish-intent{base_path:/.*}").HandlerFunc(contentStoreHandler.DeleteContentStoreRequest)
 	return httpMux
 }
 


### PR DESCRIPTION
publishing-api needs to support the existing API of content-store, which this PR would complete. The publishing-api vhost currently is an alias for content-store. Once this is merged, publishing-api should be capable of proxying content-store and taking over the publishing-api vhost.

Currently, content-store registers content with url-arbiter, but not publish-intents. This PR registers both content and publish-intents with url-arbiter. We will remove the url-arbiter integration from content-store to avoid them duplicating the functionality for content.

Further context:
Our intent is to have publishing-api handle url-arbiter registration to avoid two content-stores (one for `draft` and one for `live`) racing against each other. 