### PR TITLE
Renames for better understanding

### DIFF
--- a/content_store_controller.go
+++ b/content_store_controller.go
@@ -12,23 +12,23 @@ import (
 	"github.com/alphagov/publishing-api/urlarbiter"
 )
 
-type ContentStoreRequest struct {
-	PublishingApp string `json:"publishing_app"`
-}
-
-type ContentStoreHandler struct {
+type ContentStoreController struct {
 	arbiter      *urlarbiter.URLArbiter
 	contentStore *contentstore.ContentStoreClient
 }
 
-func NewContentStoreHandler(arbiterURL, contentStoreURL string) *ContentStoreHandler {
-	return &ContentStoreHandler{
+type ContentStoreRequest struct {
+	PublishingApp string `json:"publishing_app"`
+}
+
+func NewContentStoreController(arbiterURL, contentStoreURL string) *ContentStoreController {
+	return &ContentStoreController{
 		arbiter:      urlarbiter.NewURLArbiter(arbiterURL),
 		contentStore: contentstore.NewClient(contentStoreURL),
 	}
 }
 
-func (cs *ContentStoreHandler) PutContentStoreRequest(w http.ResponseWriter, r *http.Request) {
+func (cs *ContentStoreController) PutContentStoreRequest(w http.ResponseWriter, r *http.Request) {
 	urlParameters := mux.Vars(r)
 
 	requestBody, err := ioutil.ReadAll(r.Body)
@@ -59,7 +59,7 @@ func (cs *ContentStoreHandler) PutContentStoreRequest(w http.ResponseWriter, r *
 // Register the given path and publishing app with the URL arbiter.  Returns
 // true on success.  On failure, writes an error to the ResponseWriter, and
 // returns false
-func (cs *ContentStoreHandler) registerWithURLArbiter(path, publishingApp string, w http.ResponseWriter) bool {
+func (cs *ContentStoreController) registerWithURLArbiter(path, publishingApp string, w http.ResponseWriter) bool {
 	urlArbiterResponse, err := cs.arbiter.Register(path, publishingApp)
 	if err != nil {
 		switch err {
@@ -75,16 +75,16 @@ func (cs *ContentStoreHandler) registerWithURLArbiter(path, publishingApp string
 	return true
 }
 
-func (cs *ContentStoreHandler) GetContentStoreRequest(w http.ResponseWriter, r *http.Request) {
+func (cs *ContentStoreController) GetContentStoreRequest(w http.ResponseWriter, r *http.Request) {
 	cs.doContentStoreRequest("GET", r.URL.Path, nil, w)
 }
 
-func (cs *ContentStoreHandler) DeleteContentStoreRequest(w http.ResponseWriter, r *http.Request) {
+func (cs *ContentStoreController) DeleteContentStoreRequest(w http.ResponseWriter, r *http.Request) {
 	cs.doContentStoreRequest("DELETE", r.URL.Path, nil, w)
 }
 
 // data will be nil for requests without bodies
-func (cs *ContentStoreHandler) doContentStoreRequest(httpMethod string, path string, data []byte, w http.ResponseWriter) {
+func (cs *ContentStoreController) doContentStoreRequest(httpMethod string, path string, data []byte, w http.ResponseWriter) {
 	resp, err := cs.contentStore.DoRequest(httpMethod, path, data)
 	if err != nil {
 		renderer.JSON(w, http.StatusInternalServerError, err)

--- a/main.go
+++ b/main.go
@@ -22,18 +22,19 @@ var (
 	renderer = render.New(render.Options{})
 )
 
-func HealthCheckHandler(w http.ResponseWriter, r *http.Request) {
-	renderer.JSON(w, http.StatusOK, map[string]string{"status": "OK"})
-}
-
 func BuildHTTPMux(arbiterURL, contentStoreURL string) http.Handler {
 	httpMux := mux.NewRouter()
-	httpMux.Methods("GET").Path("/healthcheck").HandlerFunc(HealthCheckHandler)
+
+	httpMux.Methods("GET").Path("/healthcheck").HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		renderer.JSON(w, http.StatusOK, map[string]string{"status": "OK"})
+	})
+
 	contentStoreController := NewContentStoreController(arbiterURL, contentStoreURL)
 	httpMux.Methods("PUT").Path("/content{base_path:/.*}").HandlerFunc(contentStoreController.PutContentStoreRequest)
 	httpMux.Methods("PUT").Path("/publish-intent{base_path:/.*}").HandlerFunc(contentStoreController.PutContentStoreRequest)
 	httpMux.Methods("GET").Path("/publish-intent{base_path:/.*}").HandlerFunc(contentStoreController.GetContentStoreRequest)
 	httpMux.Methods("DELETE").Path("/publish-intent{base_path:/.*}").HandlerFunc(contentStoreController.DeleteContentStoreRequest)
+
 	return httpMux
 }
 

--- a/main.go
+++ b/main.go
@@ -29,11 +29,11 @@ func HealthCheckHandler(w http.ResponseWriter, r *http.Request) {
 func BuildHTTPMux(arbiterURL, contentStoreURL string) http.Handler {
 	httpMux := mux.NewRouter()
 	httpMux.Methods("GET").Path("/healthcheck").HandlerFunc(HealthCheckHandler)
-	contentStoreHandler := NewContentStoreHandler(arbiterURL, contentStoreURL)
-	httpMux.Methods("PUT").Path("/content{base_path:/.*}").HandlerFunc(contentStoreHandler.PutContentStoreRequest)
-	httpMux.Methods("PUT").Path("/publish-intent{base_path:/.*}").HandlerFunc(contentStoreHandler.PutContentStoreRequest)
-	httpMux.Methods("GET").Path("/publish-intent{base_path:/.*}").HandlerFunc(contentStoreHandler.GetContentStoreRequest)
-	httpMux.Methods("DELETE").Path("/publish-intent{base_path:/.*}").HandlerFunc(contentStoreHandler.DeleteContentStoreRequest)
+	contentStoreController := NewContentStoreController(arbiterURL, contentStoreURL)
+	httpMux.Methods("PUT").Path("/content{base_path:/.*}").HandlerFunc(contentStoreController.PutContentStoreRequest)
+	httpMux.Methods("PUT").Path("/publish-intent{base_path:/.*}").HandlerFunc(contentStoreController.PutContentStoreRequest)
+	httpMux.Methods("GET").Path("/publish-intent{base_path:/.*}").HandlerFunc(contentStoreController.GetContentStoreRequest)
+	httpMux.Methods("DELETE").Path("/publish-intent{base_path:/.*}").HandlerFunc(contentStoreController.DeleteContentStoreRequest)
 	return httpMux
 }
 


### PR DESCRIPTION
renaming to convey intent better and not to confuse with: http://golang.org/pkg/net/http/#Handler

a Handler in Go implements the Handler interface and defines a `ServeHTTP` method. you should be able to pass a Handler to `http.Handle("/", ContentStoreHandler)` and allow it to handle requests at that path.

in our case, `ContentStoreHandler` is not a `Handler`, but a struct that has `func`s which are later typed to `HandlerFunc`s in main.go: http://git.io/AeDs

since we're using it as a controller with functions that are more or less actions, `ContentStoreController` is a suitable name.