### PR TITLE
Run on port 3093 rather than 3000 by default

### DIFF
--- a/main.go
+++ b/main.go
@@ -16,7 +16,7 @@ import (
 var (
 	arbiterHost      = getEnvDefault("URL_ARBITER", "http://url-arbiter.dev.gov.uk")
 	contentStoreHost = getEnvDefault("CONTENT_STORE", "http://content-store.dev.gov.uk")
-	port             = getEnvDefault("PORT", "3000")
+	port             = getEnvDefault("PORT", "3093")
 	requestLogDest   = getEnvDefault("REQUEST_LOG", "STDOUT")
 
 	renderer = render.New(render.Options{})


### PR DESCRIPTION
If you run the app on a GOV.UK dev machine with:

  govuk_setenv publishing-api make run

Then it does get the correct port, otherwise it doesn't. This means that the
README is incorrect when it says that `make run` starts the app on 3093. Rather
than have two modes, let's have one.