### PR TITLE
Stub draft content store response

### DIFF
--- a/contentstore/client.go
+++ b/contentstore/client.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
+	"strings"
 )
 
 var (
@@ -25,7 +26,13 @@ func NewClient(rootURL string) *ContentStoreClient {
 }
 
 // data will be nil for requests without bodies
-func (p *ContentStoreClient) DoRequest(httpMethod string, path string, data []byte) (*http.Response, error) {
+func (p *ContentStoreClient) DoRequest(httpMethod, path string, data []byte) (*http.Response, error) {
+	if len(p.rootURL) == 0 {
+		// FIXME: remove once we have a draft content store wherever publishing-api is present.
+		// return a dummy OK response if the client doesn't know which server to call
+		return dummyOKResponse(), nil
+	}
+
 	url := p.rootURL + path
 	var reqBody io.Reader
 
@@ -44,4 +51,13 @@ func (p *ContentStoreClient) DoRequest(httpMethod string, path string, data []by
 	}
 
 	return p.client.Do(req)
+}
+
+// FIXME: remove once we have a draft content store wherever publishing-api is present.
+func dummyOKResponse() *http.Response {
+	return &http.Response{
+		Status:     "200 OK",
+		StatusCode: 200,
+		Body:       ioutil.NopCloser(strings.NewReader("Draft content-store not configured. This is a dummy response")),
+	}
 }

--- a/main.go
+++ b/main.go
@@ -15,11 +15,12 @@ import (
 )
 
 var (
-	arbiterHost           = getEnvDefault("URL_ARBITER", "http://url-arbiter.dev.gov.uk")
-	liveContentStoreHost  = getEnvDefault("CONTENT_STORE", "http://content-store.dev.gov.uk")
-	draftContentStoreHost = getEnvDefault("DRAFT_CONTENT_STORE", "http://draft-content-store.dev.gov.uk")
-	port                  = getEnvDefault("PORT", "3093")
-	requestLogDest        = getEnvDefault("REQUEST_LOG", "STDOUT")
+	arbiterHost          = getEnvDefault("URL_ARBITER", "http://url-arbiter.dev.gov.uk")
+	liveContentStoreHost = getEnvDefault("CONTENT_STORE", "http://content-store.dev.gov.uk")
+	port                 = getEnvDefault("PORT", "3093")
+	requestLogDest       = getEnvDefault("REQUEST_LOG", "STDOUT")
+
+	draftContentStoreHost = os.Getenv("DRAFT_CONTENT_STORE")
 
 	renderer = render.New(render.Options{})
 )


### PR DESCRIPTION
https://trello.com/c/PbCzGBIB

this changes the client.go to return a `200 OK` response when its rootURL is not configured. by default it would generate an internal server error.

until we have a draft-content store running on all environments where publishing-api is installed, we return a `200 OK` response with body indicating it is a dummy response. this will ensure that live content items get stored to live content store, and there are no errors trying to save the same to a non-existent draft content store.