### PR TITLE
Rework the Makefile and fix ordering issues.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,23 +1,18 @@
-.PHONY: deps test build
+.PHONY: all test build run clean check_fmt
 
 BINARY := publishing-api
 ORG_PATH := github.com/alphagov
 REPO_PATH := $(ORG_PATH)/$(BINARY)
+VENDOR_STAMP := _vendor/stamp
 
 all: check_fmt test build
 
-deps:
-	gom install
+deps: $(VENDOR_STAMP)
 
-vendor: deps
-	rm -rf _vendor/src/$(ORG_PATH)
-	mkdir -p _vendor/src/$(ORG_PATH)
-	ln -s $(CURDIR) _vendor/src/$(REPO_PATH)
-
-test: vendor
+test: $(VENDOR_STAMP)
 	gom test -v ./...
 
-build: vendor
+build: $(VENDOR_STAMP)
 	gom build -o $(BINARY)
 
 run: build
@@ -28,3 +23,12 @@ clean:
 
 check_fmt:
 	./check_fmt.sh
+
+$(VENDOR_STAMP): Gomfile _vendor/src/$(REPO_PATH)
+	gom install
+	touch $(VENDOR_STAMP)
+
+_vendor/src/$(REPO_PATH):
+	rm -rf _vendor/src/$(ORG_PATH)
+	mkdir -p _vendor/src/$(ORG_PATH)
+	ln -s $(CURDIR) _vendor/src/$(REPO_PATH)


### PR DESCRIPTION
Previously, the _vendor task was triggering a `gom install`, then doing a
`rm -rf _vendor/src/github.com/alphagov` before symlinking the app repo.
This was effectively preventing us from using any packages hosted under
alphagov.

This reworks the Makefile to do the symlink dance before `gom install`. It
also changes things to have proper dependencies where appropriate, which
means that make won't need to call `gom install` every time.