### PR TITLE
Improve error responses

### DIFF
--- a/controllers/helpers.go
+++ b/controllers/helpers.go
@@ -66,7 +66,7 @@ func doContentStoreRequest(contentStoreClient *contentstore.ContentStoreClient,
 
 	if w != nil {
 		if err != nil {
-			renderer.JSON(w, http.StatusInternalServerError, err)
+			renderer.JSON(w, http.StatusInternalServerError, ErrorResponse{Message: "Unexpected error in request to content-store"})
 			return
 		}
 		w.Header().Set("Content-Type", "application/json")
@@ -78,7 +78,7 @@ func doContentStoreRequest(contentStoreClient *contentstore.ContentStoreClient,
 func readRequest(w http.ResponseWriter, r *http.Request) ([]byte, *ContentStoreRequest) {
 	requestBody, err := ioutil.ReadAll(r.Body)
 	if err != nil {
-		renderer.JSON(w, http.StatusInternalServerError, err)
+		renderer.JSON(w, http.StatusInternalServerError, ErrorResponse{Message: "Unexpected error in reading your request body"})
 		return nil, nil
 	}
 
@@ -88,7 +88,7 @@ func readRequest(w http.ResponseWriter, r *http.Request) ([]byte, *ContentStoreR
 		case *json.SyntaxError:
 			renderer.JSON(w, http.StatusBadRequest, ErrorResponse{Message: "Invalid JSON in request body"})
 		default:
-			renderer.JSON(w, http.StatusInternalServerError, err)
+			renderer.JSON(w, http.StatusInternalServerError, ErrorResponse{Message: "Unexpected error unmarshalling your request body to JSON"})
 		}
 		return nil, nil
 	}

--- a/controllers/helpers.go
+++ b/controllers/helpers.go
@@ -46,7 +46,8 @@ func registerWithURLArbiter(urlArbiter *urlarbiter.URLArbiter, path, publishingA
 		case urlarbiter.UnprocessableEntity:
 			renderer.JSON(w, 422, urlArbiterResponse)
 		default:
-			renderer.JSON(w, http.StatusInternalServerError, err)
+			message := "Unexpected error whilst registering with url-arbiter"
+			renderer.JSON(w, http.StatusInternalServerError, ErrorResponse{Message: message})
 		}
 		return false
 	}

--- a/controllers/helpers.go
+++ b/controllers/helpers.go
@@ -26,7 +26,8 @@ func registerWithURLArbiterAndForward(urlArbiter *urlarbiter.URLArbiter, w http.
 	afterRegister func(basePath string, requestBody []byte)) {
 
 	urlParameters := mux.Vars(r)
-	if requestBody, contentStoreRequest := readRequest(w, r); contentStoreRequest != nil {
+	requestBody, contentStoreRequest := readRequest(w, r)
+	if contentStoreRequest != nil {
 		if !registerWithURLArbiter(urlArbiter, urlParameters["base_path"], contentStoreRequest.PublishingApp, w) {
 			return
 		}

--- a/controllers/helpers.go
+++ b/controllers/helpers.go
@@ -44,7 +44,7 @@ func registerWithURLArbiter(urlArbiter *urlarbiter.URLArbiter, path, publishingA
 		case urlarbiter.ConflictPathAlreadyReserved:
 			renderer.JSON(w, http.StatusConflict, urlArbiterResponse)
 		case urlarbiter.UnprocessableEntity:
-			renderer.JSON(w, 422, urlArbiterResponse) // Unprocessable Entity.
+			renderer.JSON(w, 422, urlArbiterResponse)
 		default:
 			renderer.JSON(w, http.StatusInternalServerError, err)
 		}

--- a/controllers/helpers.go
+++ b/controllers/helpers.go
@@ -18,6 +18,10 @@ type ContentStoreRequest struct {
 	PublishingApp string `json:"publishing_app"`
 }
 
+type ErrorResponse struct {
+	Message string `json:"message"`
+}
+
 func registerWithURLArbiterAndForward(urlArbiter *urlarbiter.URLArbiter, w http.ResponseWriter, r *http.Request,
 	afterRegister func(basePath string, requestBody []byte)) {
 
@@ -80,7 +84,7 @@ func readRequest(w http.ResponseWriter, r *http.Request) ([]byte, *ContentStoreR
 	if err := json.Unmarshal(requestBody, &contentStoreRequest); err != nil {
 		switch err.(type) {
 		case *json.SyntaxError:
-			renderer.JSON(w, http.StatusBadRequest, err)
+			renderer.JSON(w, http.StatusBadRequest, ErrorResponse{Message: "Invalid JSON in request body"})
 		default:
 			renderer.JSON(w, http.StatusInternalServerError, err)
 		}

--- a/integration_tests/content_item_requests_test.go
+++ b/integration_tests/content_item_requests_test.go
@@ -135,7 +135,8 @@ var _ = Describe("Content Item Requests", func() {
 			Expect(testDraftContentStore.ReceivedRequests()).To(BeZero())
 			Expect(testLiveContentStore.ReceivedRequests()).To(BeZero())
 
-			expectedResponse = HTTPTestResponse{Code: http.StatusBadRequest}
+			expectedResponseBody := `{"message": "Invalid JSON in request body"}`
+			expectedResponse = HTTPTestResponse{Code: http.StatusBadRequest, Body: expectedResponseBody}
 			assertSameResponse(actualResponse, &expectedResponse)
 		})
 	})

--- a/integration_tests/content_item_requests_test.go
+++ b/integration_tests/content_item_requests_test.go
@@ -135,7 +135,7 @@ var _ = Describe("Content Item Requests", func() {
 			Expect(testDraftContentStore.ReceivedRequests()).To(BeZero())
 			Expect(testLiveContentStore.ReceivedRequests()).To(BeZero())
 
-			expectedResponseBody := `{"message": "Invalid JSON in request body"}`
+			expectedResponseBody := `{"message": "Invalid JSON in request body: invalid character 'i' looking for beginning of value"}`
 			expectedResponse = HTTPTestResponse{Code: http.StatusBadRequest, Body: expectedResponseBody}
 			assertSameResponse(actualResponse, &expectedResponse)
 		})

--- a/integration_tests/draft_content_item_requests_test.go
+++ b/integration_tests/draft_content_item_requests_test.go
@@ -129,7 +129,8 @@ var _ = Describe("Draft Content Item Requests", func() {
 			Expect(testDraftContentStore.ReceivedRequests()).To(BeZero())
 			Expect(testLiveContentStore.ReceivedRequests()).To(BeZero())
 
-			expectedResponse = HTTPTestResponse{Code: http.StatusBadRequest}
+			expectedResponseBody := `{"message": "Invalid JSON in request body"}`
+			expectedResponse = HTTPTestResponse{Code: http.StatusBadRequest, Body: expectedResponseBody}
 			assertSameResponse(actualResponse, &expectedResponse)
 		})
 	})

--- a/integration_tests/draft_content_item_requests_test.go
+++ b/integration_tests/draft_content_item_requests_test.go
@@ -129,7 +129,7 @@ var _ = Describe("Draft Content Item Requests", func() {
 			Expect(testDraftContentStore.ReceivedRequests()).To(BeZero())
 			Expect(testLiveContentStore.ReceivedRequests()).To(BeZero())
 
-			expectedResponseBody := `{"message": "Invalid JSON in request body"}`
+			expectedResponseBody := `{"message": "Invalid JSON in request body: invalid character 'i' looking for beginning of value"}`
 			expectedResponse = HTTPTestResponse{Code: http.StatusBadRequest, Body: expectedResponseBody}
 			assertSameResponse(actualResponse, &expectedResponse)
 		})

--- a/integration_tests/publish_intent_requests_test.go
+++ b/integration_tests/publish_intent_requests_test.go
@@ -121,7 +121,7 @@ var _ = Describe("Publish Intent Requests", func() {
 					Expect(testDraftContentStore.ReceivedRequests()).To(BeEmpty())
 					Expect(testLiveContentStore.ReceivedRequests()).To(BeEmpty())
 
-					expectedResponseBody := `{"message": "Unexpected error whilst registering with url-arbiter"}`
+					expectedResponseBody := `{"message": "Unexpected error whilst registering with url-arbiter: Unexpected response status: 418"}`
 					expectedResponse = HTTPTestResponse{Code: 500, Body: expectedResponseBody}
 					assertSameResponse(actualResponse, &expectedResponse)
 				})
@@ -149,7 +149,7 @@ var _ = Describe("Publish Intent Requests", func() {
 				Expect(testDraftContentStore.ReceivedRequests()).To(BeEmpty())
 				Expect(testLiveContentStore.ReceivedRequests()).To(BeEmpty())
 
-				expectedResponseBody := `{"message": "Invalid JSON in request body"}`
+				expectedResponseBody := `{"message": "Invalid JSON in request body: invalid character 'i' looking for beginning of value"}`
 				expectedResponse = HTTPTestResponse{Code: http.StatusBadRequest, Body: expectedResponseBody}
 				assertSameResponse(actualResponse, &expectedResponse)
 			})

--- a/integration_tests/publish_intent_requests_test.go
+++ b/integration_tests/publish_intent_requests_test.go
@@ -134,7 +134,8 @@ var _ = Describe("Publish Intent Requests", func() {
 				Expect(testDraftContentStore.ReceivedRequests()).To(BeEmpty())
 				Expect(testLiveContentStore.ReceivedRequests()).To(BeEmpty())
 
-				expectedResponse = HTTPTestResponse{Code: http.StatusBadRequest}
+				expectedResponseBody := `{"message": "Invalid JSON in request body"}`
+				expectedResponse = HTTPTestResponse{Code: http.StatusBadRequest, Body: expectedResponseBody}
 				assertSameResponse(actualResponse, &expectedResponse)
 			})
 		})

--- a/integration_tests/publish_intent_requests_test.go
+++ b/integration_tests/publish_intent_requests_test.go
@@ -110,6 +110,21 @@ var _ = Describe("Publish Intent Requests", func() {
 					expectedResponse = HTTPTestResponse{Code: 409, Body: urlArbiterResponseBody}
 					assertSameResponse(actualResponse, &expectedResponse)
 				})
+
+				It("returns a 500 error with a custom response", func() {
+					urlArbiterResponseCode = 418
+					urlArbiterResponseBody = `{ "message": "I'm a teapot"}`
+
+					actualResponse := doRequest("PUT", endpoint, publishIntentPayload)
+
+					Expect(testURLArbiter.ReceivedRequests()).To(HaveLen(1))
+					Expect(testDraftContentStore.ReceivedRequests()).To(BeEmpty())
+					Expect(testLiveContentStore.ReceivedRequests()).To(BeEmpty())
+
+					expectedResponseBody := `{"message": "Unexpected error whilst registering with url-arbiter"}`
+					expectedResponse = HTTPTestResponse{Code: 500, Body: expectedResponseBody}
+					assertSameResponse(actualResponse, &expectedResponse)
+				})
 			})
 
 			It("registers a path with URL arbiter and then forwards the publish intent to the content store", func() {

--- a/urlarbiter/url_arbiter.go
+++ b/urlarbiter/url_arbiter.go
@@ -5,12 +5,12 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
+	"strconv"
 )
 
 var (
-	UnexpectedResponse          = errors.New("unexpected response")
-	ConflictPathAlreadyReserved = errors.New("path is already reserved")
-	UnprocessableEntity         = errors.New("request was well-formed but was unable to be followed due to semantic errors")
+	ConflictPathAlreadyReserved = errors.New("Path is already reserved")
+	UnprocessableEntity         = errors.New("Request was well-formed but was unable to be followed due to semantic errors")
 )
 
 type URLArbiter struct {
@@ -67,7 +67,7 @@ func (u *URLArbiter) Register(path, publishingAppName string) (URLArbiterRespons
 		case http.StatusConflict:
 			return arbiterResponse, ConflictPathAlreadyReserved
 		default:
-			return arbiterResponse, UnexpectedResponse
+			return arbiterResponse, errors.New("Unexpected response status: " + strconv.Itoa(response.StatusCode))
 		}
 	}
 }


### PR DESCRIPTION
Currently, aside from errors relayed back from content-store, the errors returned from publishing-api are inscrutable. This is because the app is simply serialising the error object, which might contains an `Offset` key (in the case of a `json.SyntaxError`) or nothing serialisable.

~~I would like to include more detail by taking information out of the error objects but I am not sure how - are error objects in Go required to consistently implement anything?~~

This also fixes a potential source of bugs where we were assuming that any response from url-arbiter that wasn't 409 or 422 meant that it was OK to proceed.

This applies a pattern of including a top-level "message" key with a string containing a human-friendly summary of the response. This is based upon an RFC here: https://gov-uk.atlassian.net/wiki/display/PUB/RFC%3A+API+guidelines

Fixes https://github.com/alphagov/publishing-api/issues/24