### PR TITLE
Correct the owner of the copyright

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2014 GOV.UK
+Copyright (c) 2014 Crown Copyright (Government Digital Service)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Works by civil servants come under Crown copyright: there's a bit more context
on The National Archives: http://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/copyright/crown-copyright/