### PR TITLE
Improve url arbiter response handling

### DIFF
--- a/contentstore/client.go
+++ b/contentstore/client.go
@@ -46,6 +46,7 @@ func (p *ContentStoreClient) DoRequest(httpMethod, path string, data []byte) (*h
 		return nil, err
 	}
 
+	req.Header.Set("Accept", "application/json")
 	if data != nil {
 		req.Header.Set("Content-Type", "application/json")
 	}

--- a/contentstore/client_test.go
+++ b/contentstore/client_test.go
@@ -37,6 +37,7 @@ var _ = Describe("URLArbiter", func() {
 				ghttp.CombineHandlers(
 					ghttp.VerifyRequest("PUT", "/foo/bar"),
 					ghttp.VerifyContentType("application/json"),
+					ghttp.VerifyHeaderKV("Accept", "application/json"),
 					verifyRequestBody("Something"),
 					ghttp.RespondWith(http.StatusOK, responseBody, http.Header{"Content-Type": []string{"application/json"}}),
 				),

--- a/controllers/helpers.go
+++ b/controllers/helpers.go
@@ -75,7 +75,7 @@ func doContentStoreRequest(contentStoreClient *contentstore.ContentStoreClient,
 			renderer.JSON(w, http.StatusInternalServerError, NewErrorResponse("Unexpected error in request to content-store", err))
 			return
 		}
-		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Content-Type", resp.Header.Get("Content-Type"))
 		w.WriteHeader(resp.StatusCode)
 		io.Copy(w, resp.Body)
 	}

--- a/integration_tests/content_item_requests_test.go
+++ b/integration_tests/content_item_requests_test.go
@@ -45,7 +45,7 @@ var _ = Describe("Content Item Requests", func() {
 			trackRequest(URLArbiterRequestLabel),
 			ghttp.VerifyRequest("PUT", "/paths/vat-rates"),
 			ghttp.VerifyJSON(`{"publishing_app": "mainstream_publisher"}`),
-			ghttp.RespondWithPtr(&urlArbiterResponseCode, &urlArbiterResponseBody),
+			ghttp.RespondWithPtr(&urlArbiterResponseCode, &urlArbiterResponseBody, http.Header{"Content-Type": []string{"application/json"}}),
 		))
 
 		testDraftContentStore = ghttp.NewServer()

--- a/integration_tests/content_item_requests_test.go
+++ b/integration_tests/content_item_requests_test.go
@@ -139,5 +139,15 @@ var _ = Describe("Content Item Requests", func() {
 			expectedResponse = HTTPTestResponse{Code: http.StatusBadRequest, Body: expectedResponseBody}
 			assertSameResponse(actualResponse, &expectedResponse)
 		})
+
+		It("returns Content-Type header as received from content-store", func() {
+			testLiveContentStore.SetHandler(0,
+				ghttp.RespondWithPtr(&liveContentStoreResponseCode, &liveContentStoreResponseBody, http.Header{"Content-Type": []string{"text/html"}}))
+
+			actualResponse := doRequest("PUT", endpoint, contentItemPayload)
+
+			Expect(testLiveContentStore.ReceivedRequests()).To(HaveLen(1))
+			Expect(actualResponse.Header.Get("Content-Type")).To(Equal("text/html"))
+		})
 	})
 })

--- a/integration_tests/draft_content_item_requests_test.go
+++ b/integration_tests/draft_content_item_requests_test.go
@@ -45,7 +45,7 @@ var _ = Describe("Draft Content Item Requests", func() {
 			trackRequest(URLArbiterRequestLabel),
 			ghttp.VerifyRequest("PUT", "/paths/vat-rates"),
 			ghttp.VerifyJSON(`{"publishing_app": "mainstream_publisher"}`),
-			ghttp.RespondWithPtr(&urlArbiterResponseCode, &urlArbiterResponseBody),
+			ghttp.RespondWithPtr(&urlArbiterResponseCode, &urlArbiterResponseBody, http.Header{"Content-Type": []string{"application/json"}}),
 		))
 
 		testDraftContentStore = ghttp.NewServer()

--- a/integration_tests/publish_intent_requests_test.go
+++ b/integration_tests/publish_intent_requests_test.go
@@ -61,7 +61,7 @@ var _ = Describe("Publish Intent Requests", func() {
 					trackRequest(URLArbiterRequestLabel),
 					ghttp.VerifyRequest("PUT", "/paths/vat-rates"),
 					ghttp.VerifyJSON(`{"publishing_app": "mainstream_publisher"}`),
-					ghttp.RespondWithPtr(&urlArbiterResponseCode, &urlArbiterResponseBody),
+					ghttp.RespondWithPtr(&urlArbiterResponseCode, &urlArbiterResponseBody, http.Header{"Content-Type": []string{"application/json"}}),
 				))
 
 				testDraftContentStore = ghttp.NewServer()

--- a/urlarbiter/url_arbiter.go
+++ b/urlarbiter/url_arbiter.go
@@ -42,11 +42,11 @@ func (u *URLArbiter) Register(path, publishingAppName string) (URLArbiterRespons
 	jsonRequestBody, _ := json.Marshal(requestBody)
 
 	request, err := http.NewRequest("PUT", url, bytes.NewBuffer(jsonRequestBody))
-	request.Header.Set("Content-Type", "application/json")
-
 	if err != nil {
 		return URLArbiterResponse{}, err
 	}
+	request.Header.Set("Content-Type", "application/json")
+	request.Header.Set("Accept", "application/json")
 
 	response, err := u.client.Do(request)
 	if err != nil {

--- a/urlarbiter/url_arbiter.go
+++ b/urlarbiter/url_arbiter.go
@@ -53,9 +53,11 @@ func (u *URLArbiter) Register(path, publishingAppName string) (URLArbiterRespons
 		return URLArbiterResponse{}, err
 	}
 
-	var arbiterResponse URLArbiterResponse
-	if err := json.NewDecoder(response.Body).Decode(&arbiterResponse); err != nil {
-		return URLArbiterResponse{}, err
+	arbiterResponse := URLArbiterResponse{}
+	if response.Header.Get("Content-Type") == "application/json" {
+		if err := json.NewDecoder(response.Body).Decode(&arbiterResponse); err != nil {
+			return URLArbiterResponse{}, err
+		}
 	}
 
 	if response.StatusCode >= 200 && response.StatusCode < 300 {

--- a/urlarbiter/url_arbiter_test.go
+++ b/urlarbiter/url_arbiter_test.go
@@ -10,6 +10,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/ghttp"
 )
 
 func TestURLArbiter(t *testing.T) {
@@ -18,6 +19,17 @@ func TestURLArbiter(t *testing.T) {
 }
 
 var _ = Describe("URLArbiter", func() {
+	It("sets appropriate headers in request to url-arbiter", func() {
+		testURLArbiter := ghttp.NewServer()
+		testURLArbiter.AppendHandlers(ghttp.CombineHandlers(
+			ghttp.VerifyHeaderKV("Content-Type", "application/json"),
+			ghttp.VerifyHeaderKV("Accept", "application/json"),
+		))
+		arbiterClient := urlarbiter.NewURLArbiter(testURLArbiter.URL())
+
+		arbiterClient.Register("/foo/bar", "foo_publishing")
+	})
+
 	It("should register a path successfully when the path is available", func() {
 		testServer := buildTestServer(http.StatusOK, `{"path":"/foo/bar","publishing_app":"foo_publisher"}`)
 		arbiter := urlarbiter.NewURLArbiter(testServer.URL)

--- a/urlarbiter/url_arbiter_test.go
+++ b/urlarbiter/url_arbiter_test.go
@@ -40,6 +40,16 @@ var _ = Describe("URLArbiter", func() {
 		Expect(response.PublishingApp).To(Equal("foo_publisher"))
 	})
 
+	It("doesn't error trying to parse response as JSON if the response Content-Type is not application/json", func() {
+		testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-type", "text/html")
+		}))
+		arbiter := urlarbiter.NewURLArbiter(testServer.URL)
+
+		_, err := arbiter.Register("/foo/bar", "foo_publishing")
+		Expect(err).To(BeNil())
+	})
+
 	It("responds with a conflict error if the path is already reserved", func() {
 		testServer := buildTestServer(http.StatusConflict, `{
 "path":"/foo/bar",


### PR DESCRIPTION
https://trello.com/c/8zCaPXNh

publishing-api fails to handle HTML error responses from Rails causing [errors](https://errbit.preview.alphagov.co.uk/apps/53020c2d0da11590e70000a0/problems/550fbf860da1152033002ba7). it fails because it tries to [parse HTML response as JSON](https://github.com/alphagov/publishing-api/blob/master/urlarbiter/url_arbiter.go#L57-L59).

this causes publishing-api to return JSON decoding errors to clients who're expecting to know what exactly went wrong with their requests. by setting an appropriate 'Accept' header we're ensuring Rails returns errors as a JSON document instead of HTML.

also, updating content-store client with the same change and passing the response content-type back to clients as-is.

hat-tip: @alext 