### PR TITLE
Suppress 502 for draft store

### DIFF
--- a/contentstore/client.go
+++ b/contentstore/client.go
@@ -14,14 +14,16 @@ var (
 )
 
 type ContentStoreClient struct {
-	client  *http.Client
-	rootURL string
+	client           *http.Client
+	rootURL          string
+	DraftStoreClient bool
 }
 
-func NewClient(rootURL string) *ContentStoreClient {
+func NewClient(rootURL string, draftStoreClient bool) *ContentStoreClient {
 	return &ContentStoreClient{
-		client:  &http.Client{},
-		rootURL: rootURL,
+		client:           &http.Client{},
+		rootURL:          rootURL,
+		DraftStoreClient: draftStoreClient,
 	}
 }
 

--- a/contentstore/client_test.go
+++ b/contentstore/client_test.go
@@ -43,7 +43,7 @@ var _ = Describe("URLArbiter", func() {
 				),
 			)
 
-			client := contentstore.NewClient(testServer.URL())
+			client := contentstore.NewClient(testServer.URL(), false)
 
 			response, err := client.DoRequest("PUT", "/foo/bar", []byte("Something"))
 
@@ -64,7 +64,7 @@ var _ = Describe("URLArbiter", func() {
 				),
 			)
 
-			client := contentstore.NewClient(testServer.URL())
+			client := contentstore.NewClient(testServer.URL(), false)
 
 			response, err := client.DoRequest("GET", "/foo/bar", nil)
 

--- a/controllers/content_items_controller.go
+++ b/controllers/content_items_controller.go
@@ -18,8 +18,8 @@ type ContentItemsController struct {
 func NewContentItemsController(arbiterURL, liveContentStoreURL, draftContentStoreURL string) *ContentItemsController {
 	return &ContentItemsController{
 		arbiter:           urlarbiter.NewURLArbiter(arbiterURL),
-		liveContentStore:  contentstore.NewClient(liveContentStoreURL),
-		draftContentStore: contentstore.NewClient(draftContentStoreURL),
+		liveContentStore:  contentstore.NewClient(liveContentStoreURL, false),
+		draftContentStore: contentstore.NewClient(draftContentStoreURL, true),
 	}
 }
 

--- a/controllers/publish_intents_controller.go
+++ b/controllers/publish_intents_controller.go
@@ -15,7 +15,7 @@ type PublishIntentsController struct {
 func NewPublishIntentsController(arbiterURL, liveContentStoreURL string) *PublishIntentsController {
 	return &PublishIntentsController{
 		arbiter:          urlarbiter.NewURLArbiter(arbiterURL),
-		liveContentStore: contentstore.NewClient(liveContentStoreURL),
+		liveContentStore: contentstore.NewClient(liveContentStoreURL, false),
 	}
 }
 


### PR DESCRIPTION
https://trello.com/c/YUO21nch

an environment variable `SUPPRESS_DRAFT_STORE_502_ERROR`, intended
to be set in development environment, controls whether we pass-on
or suppress 502 returned while communicating with draft content store.

this will not cause failures communicating with publishing-api if
draft content store is not running during development.

there will be a related puppet change to set this variable to true
only in development.