### PR TITLE
Close all response body file handlers

### DIFF
--- a/controllers/helpers.go
+++ b/controllers/helpers.go
@@ -89,6 +89,7 @@ func doContentStoreRequest(contentStoreClient *contentstore.ContentStoreClient,
 
 func readRequest(w http.ResponseWriter, r *http.Request) ([]byte, *ContentStoreRequest) {
 	requestBody, err := ioutil.ReadAll(r.Body)
+	defer r.Body.Close()
 	if err != nil {
 		renderer.JSON(w, http.StatusInternalServerError, NewErrorResponse("Unexpected error in reading your request body", err))
 		return nil, nil


### PR DESCRIPTION
When reading the HTTP response body, we read from the `io.ReadCloser`
provided. After reading the body we need to make sure that all file
handlers are closed.