### PR TITLE
Close url-arbiter client file handlers.

### DIFF
--- a/urlarbiter/url_arbiter.go
+++ b/urlarbiter/url_arbiter.go
@@ -49,6 +49,9 @@ func (u *URLArbiter) Register(path, publishingAppName string) (URLArbiterRespons
 	request.Header.Set("Accept", "application/json")
 
 	response, err := u.client.Do(request)
+	if response != nil {
+		defer response.Body.Close()
+	}
 	if err != nil {
 		return URLArbiterResponse{}, err
 	}


### PR DESCRIPTION
This fixes a problem with running out of file handlers in connecting to url-arbiter when a large number of updates are pushed through.