### PR TITLE
Notify errbit about internal server errors

### DIFF
--- a/Gomfile
+++ b/Gomfile
@@ -4,6 +4,7 @@ gom 'github.com/gorilla/context', :commit => '215affda49addc4c8ef7e2534915df2c8c
 gom 'gopkg.in/unrolled/render.v1', :commit => '40ac5716c7e0bffcc440aac649ea4b880a5d7735'
 gom 'github.com/alext/tablecloth', :commit => '7f49e40'
 gom 'github.com/alphagov/plek/go', :commit => 'f5da97e'
+gom 'github.com/dwilkie/gobrake', :commit => '716d910'
 
 # Testing
 gom 'github.com/onsi/ginkgo', :commit => '75d0cd9c7ee52e99b13e6ccfd9e58b4f92b7795e'

--- a/Gomfile
+++ b/Gomfile
@@ -3,7 +3,7 @@ gom 'github.com/gorilla/mux', :commit => 'e444e69cbd2e2e3e0749a2f3c717cec491552b
 gom 'github.com/gorilla/context', :commit => '215affda49addc4c8ef7e2534915df2c8c35c6cd'
 gom 'gopkg.in/unrolled/render.v1', :commit => '40ac5716c7e0bffcc440aac649ea4b880a5d7735'
 gom 'github.com/alext/tablecloth', :commit => '7f49e40'
-gom 'github.com/alphagov/plek/go', :commit => 'f5da97e'
+gom 'github.com/alphagov/plek/go', :commit => 'c0c56fb'
 gom 'github.com/dwilkie/gobrake', :commit => '716d910'
 
 # Testing

--- a/contentstore/client.go
+++ b/contentstore/client.go
@@ -14,16 +14,14 @@ var (
 )
 
 type ContentStoreClient struct {
-	client           *http.Client
-	rootURL          string
-	DraftStoreClient bool
+	client  *http.Client
+	rootURL string
 }
 
-func NewClient(rootURL string, draftStoreClient bool) *ContentStoreClient {
+func NewClient(rootURL string) *ContentStoreClient {
 	return &ContentStoreClient{
-		client:           &http.Client{},
-		rootURL:          rootURL,
-		DraftStoreClient: draftStoreClient,
+		client:  &http.Client{},
+		rootURL: rootURL,
 	}
 }
 

--- a/contentstore/client_test.go
+++ b/contentstore/client_test.go
@@ -43,7 +43,7 @@ var _ = Describe("URLArbiter", func() {
 				),
 			)
 
-			client := contentstore.NewClient(testServer.URL(), false)
+			client := contentstore.NewClient(testServer.URL())
 
 			response, err := client.DoRequest("PUT", "/foo/bar", []byte("Something"))
 
@@ -64,7 +64,7 @@ var _ = Describe("URLArbiter", func() {
 				),
 			)
 
-			client := contentstore.NewClient(testServer.URL(), false)
+			client := contentstore.NewClient(testServer.URL())
 
 			response, err := client.DoRequest("GET", "/foo/bar", nil)
 

--- a/controllers/content_items_controller.go
+++ b/controllers/content_items_controller.go
@@ -2,6 +2,7 @@ package controllers
 
 import (
 	"net/http"
+	"os"
 	"strings"
 	"sync"
 
@@ -18,8 +19,8 @@ type ContentItemsController struct {
 func NewContentItemsController(arbiterURL, liveContentStoreURL, draftContentStoreURL string) *ContentItemsController {
 	return &ContentItemsController{
 		arbiter:           urlarbiter.NewURLArbiter(arbiterURL),
-		liveContentStore:  contentstore.NewClient(liveContentStoreURL, false),
-		draftContentStore: contentstore.NewClient(draftContentStoreURL, true),
+		liveContentStore:  contentstore.NewClient(liveContentStoreURL),
+		draftContentStore: contentstore.NewClient(draftContentStoreURL),
 	}
 }
 

--- a/controllers/content_items_controller.go
+++ b/controllers/content_items_controller.go
@@ -26,7 +26,8 @@ func NewContentItemsController(arbiterURL, liveContentStoreURL, draftContentStor
 func (c *ContentItemsController) PutDraftContentItem(w http.ResponseWriter, r *http.Request) {
 	requestBody, contentStoreRequest := readRequest(w, r)
 	if contentStoreRequest != nil {
-		if !registerWithURLArbiter(c.arbiter, extractBasePath(r), contentStoreRequest.PublishingApp, w) {
+		if urlArbiterResponse, err := c.arbiter.Register(extractBasePath(r), contentStoreRequest.PublishingApp); err != nil {
+			handleURLArbiterResponse(urlArbiterResponse, err, w)
 			return
 		}
 		doContentStoreRequest(c.draftContentStore, "PUT", strings.Replace(r.URL.Path, "/draft-content/", "/content/", 1), requestBody, w)
@@ -36,7 +37,8 @@ func (c *ContentItemsController) PutDraftContentItem(w http.ResponseWriter, r *h
 func (c *ContentItemsController) PutLiveContentItem(w http.ResponseWriter, r *http.Request) {
 	requestBody, contentStoreRequest := readRequest(w, r)
 	if contentStoreRequest != nil {
-		if !registerWithURLArbiter(c.arbiter, extractBasePath(r), contentStoreRequest.PublishingApp, w) {
+		if urlArbiterResponse, err := c.arbiter.Register(extractBasePath(r), contentStoreRequest.PublishingApp); err != nil {
+			handleURLArbiterResponse(urlArbiterResponse, err, w)
 			return
 		}
 

--- a/controllers/content_items_controller.go
+++ b/controllers/content_items_controller.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 
 	"github.com/alphagov/publishing-api/contentstore"
+	"github.com/alphagov/publishing-api/errornotifier"
 	"github.com/alphagov/publishing-api/urlarbiter"
 )
 
@@ -14,37 +15,39 @@ type ContentItemsController struct {
 	arbiter           *urlarbiter.URLArbiter
 	liveContentStore  *contentstore.ContentStoreClient
 	draftContentStore *contentstore.ContentStoreClient
+	errbitNotifier    errornotifier.Notifier
 }
 
-func NewContentItemsController(arbiterURL, liveContentStoreURL, draftContentStoreURL string) *ContentItemsController {
+func NewContentItemsController(arbiterURL, liveContentStoreURL, draftContentStoreURL string, errbitNotifier errornotifier.Notifier) *ContentItemsController {
 	return &ContentItemsController{
 		arbiter:           urlarbiter.NewURLArbiter(arbiterURL),
 		liveContentStore:  contentstore.NewClient(liveContentStoreURL),
 		draftContentStore: contentstore.NewClient(draftContentStoreURL),
+		errbitNotifier:    errbitNotifier,
 	}
 }
 
 func (c *ContentItemsController) PutDraftContentItem(w http.ResponseWriter, r *http.Request) {
-	requestBody, contentStoreRequest := readRequest(w, r)
+	requestBody, contentStoreRequest := readRequest(w, r, c.errbitNotifier)
 	if contentStoreRequest != nil {
 		if urlArbiterResponse, err := c.arbiter.Register(extractBasePath(r), contentStoreRequest.PublishingApp); err != nil {
-			handleURLArbiterResponse(urlArbiterResponse, err, w)
+			handleURLArbiterResponse(urlArbiterResponse, err, w, r, c.errbitNotifier)
 			return
 		}
 		resp, err := c.draftContentStore.DoRequest("PUT", strings.Replace(r.URL.Path, "/draft-content/", "/content/", 1), requestBody)
 		if resp.StatusCode == http.StatusBadGateway && os.Getenv("SUPPRESS_DRAFT_STORE_502_ERROR") == "1" {
 			w.WriteHeader(http.StatusOK)
 		} else {
-			handleContentStoreResponse(resp, err, w)
+			handleContentStoreResponse(resp, err, w, r, c.errbitNotifier)
 		}
 	}
 }
 
 func (c *ContentItemsController) PutLiveContentItem(w http.ResponseWriter, r *http.Request) {
-	requestBody, contentStoreRequest := readRequest(w, r)
+	requestBody, contentStoreRequest := readRequest(w, r, c.errbitNotifier)
 	if contentStoreRequest != nil {
 		if urlArbiterResponse, err := c.arbiter.Register(extractBasePath(r), contentStoreRequest.PublishingApp); err != nil {
-			handleURLArbiterResponse(urlArbiterResponse, err, w)
+			handleURLArbiterResponse(urlArbiterResponse, err, w, r, c.errbitNotifier)
 			return
 		}
 
@@ -53,7 +56,7 @@ func (c *ContentItemsController) PutLiveContentItem(w http.ResponseWriter, r *ht
 		go func() {
 			defer wg.Done()
 			resp, err := c.liveContentStore.DoRequest("PUT", r.URL.Path, requestBody)
-			handleContentStoreResponse(resp, err, w)
+			handleContentStoreResponse(resp, err, w, r, c.errbitNotifier)
 		}()
 		go func() {
 			defer wg.Done()
@@ -62,7 +65,7 @@ func (c *ContentItemsController) PutLiveContentItem(w http.ResponseWriter, r *ht
 				w.WriteHeader(http.StatusOK)
 			} else {
 				// for now, we ignore the response from draft content store for storing live content, hence `w` is nil
-				handleContentStoreResponse(resp, err, nil)
+				handleContentStoreResponse(resp, err, nil, r, c.errbitNotifier)
 			}
 		}()
 		wg.Wait()

--- a/controllers/content_items_controller.go
+++ b/controllers/content_items_controller.go
@@ -15,39 +15,39 @@ type ContentItemsController struct {
 	arbiter           *urlarbiter.URLArbiter
 	liveContentStore  *contentstore.ContentStoreClient
 	draftContentStore *contentstore.ContentStoreClient
-	errbitNotifier    errornotifier.Notifier
+	errorNotifier     errornotifier.Notifier
 }
 
-func NewContentItemsController(arbiterURL, liveContentStoreURL, draftContentStoreURL string, errbitNotifier errornotifier.Notifier) *ContentItemsController {
+func NewContentItemsController(arbiterURL, liveContentStoreURL, draftContentStoreURL string, errorNotifier errornotifier.Notifier) *ContentItemsController {
 	return &ContentItemsController{
 		arbiter:           urlarbiter.NewURLArbiter(arbiterURL),
 		liveContentStore:  contentstore.NewClient(liveContentStoreURL),
 		draftContentStore: contentstore.NewClient(draftContentStoreURL),
-		errbitNotifier:    errbitNotifier,
+		errorNotifier:     errorNotifier,
 	}
 }
 
 func (c *ContentItemsController) PutDraftContentItem(w http.ResponseWriter, r *http.Request) {
-	requestBody, contentStoreRequest := readRequest(w, r, c.errbitNotifier)
+	requestBody, contentStoreRequest := readRequest(w, r, c.errorNotifier)
 	if contentStoreRequest != nil {
 		if urlArbiterResponse, err := c.arbiter.Register(extractBasePath(r), contentStoreRequest.PublishingApp); err != nil {
-			handleURLArbiterResponse(urlArbiterResponse, err, w, r, c.errbitNotifier)
+			handleURLArbiterResponse(urlArbiterResponse, err, w, r, c.errorNotifier)
 			return
 		}
 		resp, err := c.draftContentStore.DoRequest("PUT", strings.Replace(r.URL.Path, "/draft-content/", "/content/", 1), requestBody)
 		if resp.StatusCode == http.StatusBadGateway && os.Getenv("SUPPRESS_DRAFT_STORE_502_ERROR") == "1" {
 			w.WriteHeader(http.StatusOK)
 		} else {
-			handleContentStoreResponse(resp, err, w, r, c.errbitNotifier)
+			handleContentStoreResponse(resp, err, w, r, c.errorNotifier)
 		}
 	}
 }
 
 func (c *ContentItemsController) PutLiveContentItem(w http.ResponseWriter, r *http.Request) {
-	requestBody, contentStoreRequest := readRequest(w, r, c.errbitNotifier)
+	requestBody, contentStoreRequest := readRequest(w, r, c.errorNotifier)
 	if contentStoreRequest != nil {
 		if urlArbiterResponse, err := c.arbiter.Register(extractBasePath(r), contentStoreRequest.PublishingApp); err != nil {
-			handleURLArbiterResponse(urlArbiterResponse, err, w, r, c.errbitNotifier)
+			handleURLArbiterResponse(urlArbiterResponse, err, w, r, c.errorNotifier)
 			return
 		}
 
@@ -56,7 +56,7 @@ func (c *ContentItemsController) PutLiveContentItem(w http.ResponseWriter, r *ht
 		go func() {
 			defer wg.Done()
 			resp, err := c.liveContentStore.DoRequest("PUT", r.URL.Path, requestBody)
-			handleContentStoreResponse(resp, err, w, r, c.errbitNotifier)
+			handleContentStoreResponse(resp, err, w, r, c.errorNotifier)
 		}()
 		go func() {
 			defer wg.Done()
@@ -65,7 +65,7 @@ func (c *ContentItemsController) PutLiveContentItem(w http.ResponseWriter, r *ht
 				w.WriteHeader(http.StatusOK)
 			} else {
 				// for now, we ignore the response from draft content store for storing live content, hence `w` is nil
-				handleContentStoreResponse(resp, err, nil, r, c.errbitNotifier)
+				handleContentStoreResponse(resp, err, nil, r, c.errorNotifier)
 			}
 		}()
 		wg.Wait()

--- a/controllers/helpers.go
+++ b/controllers/helpers.go
@@ -29,11 +29,7 @@ func NewErrorResponse(message string, err error) *ErrorResponse {
 	}
 }
 
-// Register the given path and publishing app with the URL arbiter.  Returns
-// true on success.  On failure, writes an error to the ResponseWriter, and
-// returns false
-func registerWithURLArbiter(urlArbiter *urlarbiter.URLArbiter, path, publishingApp string, w http.ResponseWriter) bool {
-	urlArbiterResponse, err := urlArbiter.Register(path, publishingApp)
+func handleURLArbiterResponse(urlArbiterResponse urlarbiter.URLArbiterResponse, err error, w http.ResponseWriter) {
 	if err != nil {
 		switch err {
 		case urlarbiter.ConflictPathAlreadyReserved:
@@ -44,9 +40,7 @@ func registerWithURLArbiter(urlArbiter *urlarbiter.URLArbiter, path, publishingA
 			message := "Unexpected error whilst registering with url-arbiter"
 			renderer.JSON(w, http.StatusInternalServerError, NewErrorResponse(message, err))
 		}
-		return false
 	}
-	return true
 }
 
 // data will be nil for requests without bodies

--- a/controllers/helpers.go
+++ b/controllers/helpers.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"net/http"
 
+	"github.com/alphagov/publishing-api/errornotifier"
 	"github.com/alphagov/publishing-api/urlarbiter"
 	"github.com/gorilla/mux"
 	"gopkg.in/unrolled/render.v1"
@@ -27,7 +28,9 @@ func NewErrorResponse(message string, err error) *ErrorResponse {
 	}
 }
 
-func handleURLArbiterResponse(urlArbiterResponse urlarbiter.URLArbiterResponse, err error, w http.ResponseWriter) {
+func handleURLArbiterResponse(urlArbiterResponse urlarbiter.URLArbiterResponse, err error,
+	w http.ResponseWriter, r *http.Request, errbitNotifier errornotifier.Notifier) {
+
 	if err != nil {
 		switch err {
 		case urlarbiter.ConflictPathAlreadyReserved:
@@ -41,7 +44,9 @@ func handleURLArbiterResponse(urlArbiterResponse urlarbiter.URLArbiterResponse, 
 	}
 }
 
-func handleContentStoreResponse(resp *http.Response, err error, w http.ResponseWriter) {
+func handleContentStoreResponse(resp *http.Response, err error, w http.ResponseWriter,
+	r *http.Request, errbitNotifier errornotifier.Notifier) {
+
 	if resp != nil {
 		defer resp.Body.Close()
 	}
@@ -63,7 +68,7 @@ func extractBasePath(r *http.Request) string {
 	return urlParameters["base_path"]
 }
 
-func readRequest(w http.ResponseWriter, r *http.Request) ([]byte, *ContentStoreRequest) {
+func readRequest(w http.ResponseWriter, r *http.Request, errbitNotifier errornotifier.Notifier) ([]byte, *ContentStoreRequest) {
 	requestBody, err := ioutil.ReadAll(r.Body)
 	if err != nil {
 		renderer.JSON(w, http.StatusInternalServerError, NewErrorResponse("Unexpected error in reading your request body", err))

--- a/controllers/helpers.go
+++ b/controllers/helpers.go
@@ -29,7 +29,7 @@ func NewErrorResponse(message string, err error) *ErrorResponse {
 }
 
 func handleURLArbiterResponse(urlArbiterResponse urlarbiter.URLArbiterResponse, err error,
-	w http.ResponseWriter, r *http.Request, errbitNotifier errornotifier.Notifier) {
+	w http.ResponseWriter, r *http.Request, errorNotifier errornotifier.Notifier) {
 
 	if err != nil {
 		switch err {
@@ -40,15 +40,15 @@ func handleURLArbiterResponse(urlArbiterResponse urlarbiter.URLArbiterResponse, 
 		default:
 			message := "Unexpected error whilst registering with url-arbiter"
 			renderer.JSON(w, http.StatusInternalServerError, NewErrorResponse(message, err))
-			if errbitNotifier != nil {
-				errbitNotifier.Notify(err, r)
+			if errorNotifier != nil {
+				errorNotifier.Notify(err, r)
 			}
 		}
 	}
 }
 
 func handleContentStoreResponse(resp *http.Response, err error, w http.ResponseWriter,
-	r *http.Request, errbitNotifier errornotifier.Notifier) {
+	r *http.Request, errorNotifier errornotifier.Notifier) {
 
 	if resp != nil {
 		defer resp.Body.Close()
@@ -57,8 +57,8 @@ func handleContentStoreResponse(resp *http.Response, err error, w http.ResponseW
 	if w != nil {
 		if err != nil {
 			renderer.JSON(w, http.StatusInternalServerError, NewErrorResponse("Unexpected error in request to content-store", err))
-			if errbitNotifier != nil {
-				errbitNotifier.Notify(err, r)
+			if errorNotifier != nil {
+				errorNotifier.Notify(err, r)
 			}
 			return
 		}
@@ -74,12 +74,12 @@ func extractBasePath(r *http.Request) string {
 	return urlParameters["base_path"]
 }
 
-func readRequest(w http.ResponseWriter, r *http.Request, errbitNotifier errornotifier.Notifier) ([]byte, *ContentStoreRequest) {
+func readRequest(w http.ResponseWriter, r *http.Request, errorNotifier errornotifier.Notifier) ([]byte, *ContentStoreRequest) {
 	requestBody, err := ioutil.ReadAll(r.Body)
 	if err != nil {
 		renderer.JSON(w, http.StatusInternalServerError, NewErrorResponse("Unexpected error in reading your request body", err))
-		if errbitNotifier != nil {
-			errbitNotifier.Notify(err, r)
+		if errorNotifier != nil {
+			errorNotifier.Notify(err, r)
 		}
 		return nil, nil
 	}
@@ -91,8 +91,8 @@ func readRequest(w http.ResponseWriter, r *http.Request, errbitNotifier errornot
 			renderer.JSON(w, http.StatusBadRequest, NewErrorResponse("Invalid JSON in request body", err))
 		default:
 			renderer.JSON(w, http.StatusInternalServerError, NewErrorResponse("Unexpected error unmarshalling your request body to JSON", err))
-			if errbitNotifier != nil {
-				errbitNotifier.Notify(err, r)
+			if errorNotifier != nil {
+				errorNotifier.Notify(err, r)
 			}
 		}
 		return nil, nil

--- a/controllers/helpers.go
+++ b/controllers/helpers.go
@@ -5,7 +5,6 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
-	"os"
 
 	"github.com/alphagov/publishing-api/urlarbiter"
 	"github.com/gorilla/mux"

--- a/controllers/helpers.go
+++ b/controllers/helpers.go
@@ -29,19 +29,6 @@ func NewErrorResponse(message string, err error) *ErrorResponse {
 	}
 }
 
-func registerWithURLArbiterAndForward(urlArbiter *urlarbiter.URLArbiter, w http.ResponseWriter, r *http.Request,
-	afterRegister func(basePath string, requestBody []byte)) {
-
-	urlParameters := mux.Vars(r)
-	requestBody, contentStoreRequest := readRequest(w, r)
-	if contentStoreRequest != nil {
-		if !registerWithURLArbiter(urlArbiter, urlParameters["base_path"], contentStoreRequest.PublishingApp, w) {
-			return
-		}
-		afterRegister(r.URL.Path, requestBody)
-	}
-}
-
 // Register the given path and publishing app with the URL arbiter.  Returns
 // true on success.  On failure, writes an error to the ResponseWriter, and
 // returns false
@@ -85,6 +72,11 @@ func doContentStoreRequest(contentStoreClient *contentstore.ContentStoreClient,
 			io.Copy(w, resp.Body)
 		}
 	}
+}
+
+func extractBasePath(r *http.Request) string {
+	urlParameters := mux.Vars(r)
+	return urlParameters["base_path"]
 }
 
 func readRequest(w http.ResponseWriter, r *http.Request) ([]byte, *ContentStoreRequest) {

--- a/controllers/helpers.go
+++ b/controllers/helpers.go
@@ -40,6 +40,9 @@ func handleURLArbiterResponse(urlArbiterResponse urlarbiter.URLArbiterResponse, 
 		default:
 			message := "Unexpected error whilst registering with url-arbiter"
 			renderer.JSON(w, http.StatusInternalServerError, NewErrorResponse(message, err))
+			if errbitNotifier != nil {
+				errbitNotifier.Notify(err, r)
+			}
 		}
 	}
 }
@@ -54,6 +57,9 @@ func handleContentStoreResponse(resp *http.Response, err error, w http.ResponseW
 	if w != nil {
 		if err != nil {
 			renderer.JSON(w, http.StatusInternalServerError, NewErrorResponse("Unexpected error in request to content-store", err))
+			if errbitNotifier != nil {
+				errbitNotifier.Notify(err, r)
+			}
 			return
 		}
 
@@ -72,6 +78,9 @@ func readRequest(w http.ResponseWriter, r *http.Request, errbitNotifier errornot
 	requestBody, err := ioutil.ReadAll(r.Body)
 	if err != nil {
 		renderer.JSON(w, http.StatusInternalServerError, NewErrorResponse("Unexpected error in reading your request body", err))
+		if errbitNotifier != nil {
+			errbitNotifier.Notify(err, r)
+		}
 		return nil, nil
 	}
 
@@ -82,6 +91,9 @@ func readRequest(w http.ResponseWriter, r *http.Request, errbitNotifier errornot
 			renderer.JSON(w, http.StatusBadRequest, NewErrorResponse("Invalid JSON in request body", err))
 		default:
 			renderer.JSON(w, http.StatusInternalServerError, NewErrorResponse("Unexpected error unmarshalling your request body to JSON", err))
+			if errbitNotifier != nil {
+				errbitNotifier.Notify(err, r)
+			}
 		}
 		return nil, nil
 	}

--- a/controllers/publish_intents_controller.go
+++ b/controllers/publish_intents_controller.go
@@ -20,9 +20,13 @@ func NewPublishIntentsController(arbiterURL, liveContentStoreURL string) *Publis
 }
 
 func (c *PublishIntentsController) PutPublishIntent(w http.ResponseWriter, r *http.Request) {
-	registerWithURLArbiterAndForward(c.arbiter, w, r, func(basePath string, requestBody []byte) {
-		doContentStoreRequest(c.liveContentStore, "PUT", basePath, requestBody, w)
-	})
+	requestBody, contentStoreRequest := readRequest(w, r)
+	if contentStoreRequest != nil {
+		if !registerWithURLArbiter(c.arbiter, extractBasePath(r), contentStoreRequest.PublishingApp, w) {
+			return
+		}
+		doContentStoreRequest(c.liveContentStore, "PUT", r.URL.Path, requestBody, w)
+	}
 }
 
 func (c *PublishIntentsController) GetPublishIntent(w http.ResponseWriter, r *http.Request) {

--- a/controllers/publish_intents_controller.go
+++ b/controllers/publish_intents_controller.go
@@ -26,14 +26,17 @@ func (c *PublishIntentsController) PutPublishIntent(w http.ResponseWriter, r *ht
 			handleURLArbiterResponse(urlArbiterResponse, err, w)
 			return
 		}
-		doContentStoreRequest(c.liveContentStore, "PUT", r.URL.Path, requestBody, w)
+		resp, err := c.liveContentStore.DoRequest("PUT", r.URL.Path, requestBody)
+		handleContentStoreResponse(resp, err, w)
 	}
 }
 
 func (c *PublishIntentsController) GetPublishIntent(w http.ResponseWriter, r *http.Request) {
-	doContentStoreRequest(c.liveContentStore, "GET", r.URL.Path, nil, w)
+	resp, err := c.liveContentStore.DoRequest("GET", r.URL.Path, nil)
+	handleContentStoreResponse(resp, err, w)
 }
 
 func (c *PublishIntentsController) DeletePublishIntent(w http.ResponseWriter, r *http.Request) {
-	doContentStoreRequest(c.liveContentStore, "DELETE", r.URL.Path, nil, w)
+	resp, err := c.liveContentStore.DoRequest("DELETE", r.URL.Path, nil)
+	handleContentStoreResponse(resp, err, w)
 }

--- a/controllers/publish_intents_controller.go
+++ b/controllers/publish_intents_controller.go
@@ -11,35 +11,35 @@ import (
 type PublishIntentsController struct {
 	arbiter          *urlarbiter.URLArbiter
 	liveContentStore *contentstore.ContentStoreClient
-	errbitNotifier   errornotifier.Notifier
+	errorNotifier    errornotifier.Notifier
 }
 
-func NewPublishIntentsController(arbiterURL, liveContentStoreURL string, errbitNotifier errornotifier.Notifier) *PublishIntentsController {
+func NewPublishIntentsController(arbiterURL, liveContentStoreURL string, errorNotifier errornotifier.Notifier) *PublishIntentsController {
 	return &PublishIntentsController{
 		arbiter:          urlarbiter.NewURLArbiter(arbiterURL),
 		liveContentStore: contentstore.NewClient(liveContentStoreURL),
-		errbitNotifier:   errbitNotifier,
+		errorNotifier:    errorNotifier,
 	}
 }
 
 func (c *PublishIntentsController) PutPublishIntent(w http.ResponseWriter, r *http.Request) {
-	requestBody, contentStoreRequest := readRequest(w, r, c.errbitNotifier)
+	requestBody, contentStoreRequest := readRequest(w, r, c.errorNotifier)
 	if contentStoreRequest != nil {
 		if urlArbiterResponse, err := c.arbiter.Register(extractBasePath(r), contentStoreRequest.PublishingApp); err != nil {
-			handleURLArbiterResponse(urlArbiterResponse, err, w, r, c.errbitNotifier)
+			handleURLArbiterResponse(urlArbiterResponse, err, w, r, c.errorNotifier)
 			return
 		}
 		resp, err := c.liveContentStore.DoRequest("PUT", r.URL.Path, requestBody)
-		handleContentStoreResponse(resp, err, w, r, c.errbitNotifier)
+		handleContentStoreResponse(resp, err, w, r, c.errorNotifier)
 	}
 }
 
 func (c *PublishIntentsController) GetPublishIntent(w http.ResponseWriter, r *http.Request) {
 	resp, err := c.liveContentStore.DoRequest("GET", r.URL.Path, nil)
-	handleContentStoreResponse(resp, err, w, r, c.errbitNotifier)
+	handleContentStoreResponse(resp, err, w, r, c.errorNotifier)
 }
 
 func (c *PublishIntentsController) DeletePublishIntent(w http.ResponseWriter, r *http.Request) {
 	resp, err := c.liveContentStore.DoRequest("DELETE", r.URL.Path, nil)
-	handleContentStoreResponse(resp, err, w, r, c.errbitNotifier)
+	handleContentStoreResponse(resp, err, w, r, c.errorNotifier)
 }

--- a/controllers/publish_intents_controller.go
+++ b/controllers/publish_intents_controller.go
@@ -22,7 +22,8 @@ func NewPublishIntentsController(arbiterURL, liveContentStoreURL string) *Publis
 func (c *PublishIntentsController) PutPublishIntent(w http.ResponseWriter, r *http.Request) {
 	requestBody, contentStoreRequest := readRequest(w, r)
 	if contentStoreRequest != nil {
-		if !registerWithURLArbiter(c.arbiter, extractBasePath(r), contentStoreRequest.PublishingApp, w) {
+		if urlArbiterResponse, err := c.arbiter.Register(extractBasePath(r), contentStoreRequest.PublishingApp); err != nil {
+			handleURLArbiterResponse(urlArbiterResponse, err, w)
 			return
 		}
 		doContentStoreRequest(c.liveContentStore, "PUT", r.URL.Path, requestBody, w)

--- a/controllers/publish_intents_controller.go
+++ b/controllers/publish_intents_controller.go
@@ -15,7 +15,7 @@ type PublishIntentsController struct {
 func NewPublishIntentsController(arbiterURL, liveContentStoreURL string) *PublishIntentsController {
 	return &PublishIntentsController{
 		arbiter:          urlarbiter.NewURLArbiter(arbiterURL),
-		liveContentStore: contentstore.NewClient(liveContentStoreURL, false),
+		liveContentStore: contentstore.NewClient(liveContentStoreURL),
 	}
 }
 

--- a/controllers/publish_intents_controller.go
+++ b/controllers/publish_intents_controller.go
@@ -4,39 +4,42 @@ import (
 	"net/http"
 
 	"github.com/alphagov/publishing-api/contentstore"
+	"github.com/alphagov/publishing-api/errornotifier"
 	"github.com/alphagov/publishing-api/urlarbiter"
 )
 
 type PublishIntentsController struct {
 	arbiter          *urlarbiter.URLArbiter
 	liveContentStore *contentstore.ContentStoreClient
+	errbitNotifier   errornotifier.Notifier
 }
 
-func NewPublishIntentsController(arbiterURL, liveContentStoreURL string) *PublishIntentsController {
+func NewPublishIntentsController(arbiterURL, liveContentStoreURL string, errbitNotifier errornotifier.Notifier) *PublishIntentsController {
 	return &PublishIntentsController{
 		arbiter:          urlarbiter.NewURLArbiter(arbiterURL),
 		liveContentStore: contentstore.NewClient(liveContentStoreURL),
+		errbitNotifier:   errbitNotifier,
 	}
 }
 
 func (c *PublishIntentsController) PutPublishIntent(w http.ResponseWriter, r *http.Request) {
-	requestBody, contentStoreRequest := readRequest(w, r)
+	requestBody, contentStoreRequest := readRequest(w, r, c.errbitNotifier)
 	if contentStoreRequest != nil {
 		if urlArbiterResponse, err := c.arbiter.Register(extractBasePath(r), contentStoreRequest.PublishingApp); err != nil {
-			handleURLArbiterResponse(urlArbiterResponse, err, w)
+			handleURLArbiterResponse(urlArbiterResponse, err, w, r, c.errbitNotifier)
 			return
 		}
 		resp, err := c.liveContentStore.DoRequest("PUT", r.URL.Path, requestBody)
-		handleContentStoreResponse(resp, err, w)
+		handleContentStoreResponse(resp, err, w, r, c.errbitNotifier)
 	}
 }
 
 func (c *PublishIntentsController) GetPublishIntent(w http.ResponseWriter, r *http.Request) {
 	resp, err := c.liveContentStore.DoRequest("GET", r.URL.Path, nil)
-	handleContentStoreResponse(resp, err, w)
+	handleContentStoreResponse(resp, err, w, r, c.errbitNotifier)
 }
 
 func (c *PublishIntentsController) DeletePublishIntent(w http.ResponseWriter, r *http.Request) {
 	resp, err := c.liveContentStore.DoRequest("DELETE", r.URL.Path, nil)
-	handleContentStoreResponse(resp, err, w)
+	handleContentStoreResponse(resp, err, w, r, c.errbitNotifier)
 }

--- a/errornotifier/notifier.go
+++ b/errornotifier/notifier.go
@@ -1,0 +1,28 @@
+package errornotifier
+
+import (
+	"net/http"
+
+	"github.com/dwilkie/gobrake"
+)
+
+type Notifier interface {
+	Notify(err error, request *http.Request) error
+}
+
+type ErrbitNotifier struct {
+	errbitClient *gobrake.Notifier
+}
+
+func NewErrbitNotifier(host, apiKey, envName string) ErrbitNotifier {
+	errbitClient := gobrake.NewNotifier(0, apiKey, host)
+	errbitClient.SetContext("environment", envName)
+
+	return ErrbitNotifier{
+		errbitClient: errbitClient,
+	}
+}
+
+func (en ErrbitNotifier) Notify(err error, request *http.Request) error {
+	return en.errbitClient.Notify(err, request)
+}

--- a/integration_tests/content_item_requests_test.go
+++ b/integration_tests/content_item_requests_test.go
@@ -64,7 +64,7 @@ var _ = Describe("Content Item Requests", func() {
 			ghttp.RespondWithPtr(&liveContentStoreResponseCode, &liveContentStoreResponseBody),
 		))
 
-		testPublishingAPI = httptest.NewServer(main.BuildHTTPMux(testURLArbiter.URL(), testLiveContentStore.URL(), testDraftContentStore.URL()))
+		testPublishingAPI = httptest.NewServer(main.BuildHTTPMux(testURLArbiter.URL(), testLiveContentStore.URL(), testDraftContentStore.URL(), nil))
 		endpoint = testPublishingAPI.URL + "/content/vat-rates"
 	})
 

--- a/integration_tests/draft_content_item_requests_test.go
+++ b/integration_tests/draft_content_item_requests_test.go
@@ -65,7 +65,7 @@ var _ = Describe("Draft Content Item Requests", func() {
 			ghttp.RespondWithPtr(&liveContentStoreResponseCode, &liveContentStoreResponseBody),
 		))
 
-		testPublishingAPI = httptest.NewServer(main.BuildHTTPMux(testURLArbiter.URL(), testLiveContentStore.URL(), testDraftContentStore.URL()))
+		testPublishingAPI = httptest.NewServer(main.BuildHTTPMux(testURLArbiter.URL(), testLiveContentStore.URL(), testDraftContentStore.URL(), nil))
 		endpoint = testPublishingAPI.URL + "/draft-content/vat-rates"
 	})
 

--- a/integration_tests/healthcheck_requests_test.go
+++ b/integration_tests/healthcheck_requests_test.go
@@ -11,7 +11,7 @@ import (
 
 var _ = Describe("GET /healthcheck", func() {
 	It("has a healthcheck endpoint which responds with a status of OK", func() {
-		var testPublishingAPI = httptest.NewServer(main.BuildHTTPMux("", "", ""))
+		var testPublishingAPI = httptest.NewServer(main.BuildHTTPMux("", "", "", nil))
 
 		actualResponse := doRequest("GET", testPublishingAPI.URL+"/healthcheck", nil)
 

--- a/integration_tests/publish_intent_requests_test.go
+++ b/integration_tests/publish_intent_requests_test.go
@@ -42,7 +42,7 @@ var _ = Describe("Publish Intent Requests", func() {
 		testLiveContentStore = ghttp.NewServer()
 		testDraftContentStore = ghttp.NewServer()
 
-		testPublishingAPI = httptest.NewServer(main.BuildHTTPMux(testURLArbiter.URL(), testLiveContentStore.URL(), testDraftContentStore.URL()))
+		testPublishingAPI = httptest.NewServer(main.BuildHTTPMux(testURLArbiter.URL(), testLiveContentStore.URL(), testDraftContentStore.URL(), nil))
 		endpoint = testPublishingAPI.URL + "/publish-intent/vat-rates"
 	})
 

--- a/main.go
+++ b/main.go
@@ -26,7 +26,7 @@ var (
 
 	renderer = render.New(render.Options{})
 
-	errbitHost    = os.Getenv("ERRBIT_HOST")
+	errbitHost    = plek.FindURL("errbit").Host
 	errbitApiKey  = os.Getenv("ERRBIT_API_KEY")
 	errbitEnvName = os.Getenv("ERRBIT_ENVIRONMENT_NAME")
 	errorNotifier errornotifier.Notifier

--- a/main.go
+++ b/main.go
@@ -60,6 +60,9 @@ func main() {
 
 	requestLogger, err := request_logger.New(requestLogDest)
 	if err != nil {
+		if errbitNotifier != nil {
+			errbitNotifier.Notify(err, &http.Request{})
+		}
 		log.Fatal(err)
 	}
 
@@ -76,6 +79,9 @@ func main() {
 
 	err = tablecloth.ListenAndServe(":"+port, middleware)
 	if err != nil {
+		if errbitNotifier != nil {
+			errbitNotifier.Notify(err, &http.Request{})
+		}
 		log.Fatal(err)
 	}
 }

--- a/main.go
+++ b/main.go
@@ -12,32 +12,38 @@ import (
 
 	"github.com/alphagov/plek/go"
 	"github.com/alphagov/publishing-api/controllers"
+	"github.com/alphagov/publishing-api/errornotifier"
 	"github.com/alphagov/publishing-api/request_logger"
 )
 
 var (
-	arbiterHost          = plek.Find("url-arbiter")
-	liveContentStoreHost = getEnvDefault("CONTENT_STORE", "http://content-store.dev.gov.uk")
-	port                 = getEnvDefault("PORT", "3093")
-	requestLogDest       = getEnvDefault("REQUEST_LOG", "STDOUT")
+	arbiterHost         = plek.Find("url-arbiter")
+	liveContentStoreURL = getEnvDefault("CONTENT_STORE", "http://content-store.dev.gov.uk")
+	port                = getEnvDefault("PORT", "3093")
+	requestLogDest      = getEnvDefault("REQUEST_LOG", "STDOUT")
 
-	draftContentStoreHost = os.Getenv("DRAFT_CONTENT_STORE")
+	draftContentStoreURL = os.Getenv("DRAFT_CONTENT_STORE")
 
 	renderer = render.New(render.Options{})
+
+	errbitHost     = os.Getenv("ERRBIT_HOST")
+	errbitApiKey   = os.Getenv("ERRBIT_API_KEY")
+	errbitEnvName  = os.Getenv("ERRBIT_ENVIRONMENT_NAME")
+	errbitNotifier errornotifier.Notifier
 )
 
-func BuildHTTPMux(arbiterURL, liveContentStoreURL, draftContentStoreURL string) http.Handler {
+func BuildHTTPMux(arbiterURL, liveContentStoreURL, draftContentStoreURL string, errbitNotifier errornotifier.Notifier) http.Handler {
 	httpMux := mux.NewRouter()
 
 	httpMux.Methods("GET").Path("/healthcheck").HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		renderer.JSON(w, http.StatusOK, map[string]string{"status": "OK"})
 	})
 
-	contentItemsController := controllers.NewContentItemsController(arbiterURL, liveContentStoreURL, draftContentStoreURL)
+	contentItemsController := controllers.NewContentItemsController(arbiterURL, liveContentStoreURL, draftContentStoreURL, errbitNotifier)
 	httpMux.Methods("PUT").Path("/draft-content{base_path:/.*}").HandlerFunc(contentItemsController.PutDraftContentItem)
 	httpMux.Methods("PUT").Path("/content{base_path:/.*}").HandlerFunc(contentItemsController.PutLiveContentItem)
 
-	publishIntentsController := controllers.NewPublishIntentsController(arbiterURL, liveContentStoreURL)
+	publishIntentsController := controllers.NewPublishIntentsController(arbiterURL, liveContentStoreURL, errbitNotifier)
 	httpMux.Methods("PUT").Path("/publish-intent{base_path:/.*}").HandlerFunc(publishIntentsController.PutPublishIntent)
 	httpMux.Methods("GET").Path("/publish-intent{base_path:/.*}").HandlerFunc(publishIntentsController.GetPublishIntent)
 	httpMux.Methods("DELETE").Path("/publish-intent{base_path:/.*}").HandlerFunc(publishIntentsController.DeletePublishIntent)
@@ -46,7 +52,11 @@ func BuildHTTPMux(arbiterURL, liveContentStoreURL, draftContentStoreURL string) 
 }
 
 func main() {
-	httpMux := BuildHTTPMux(arbiterHost, liveContentStoreHost, draftContentStoreHost)
+	if errbitHost != "" && errbitApiKey != "" && errbitEnvName != "" {
+		errbitNotifier = errornotifier.NewErrbitNotifier(errbitHost, errbitApiKey, errbitEnvName)
+	}
+
+	httpMux := BuildHTTPMux(arbiterHost, liveContentStoreURL, draftContentStoreURL, errbitNotifier)
 
 	requestLogger, err := request_logger.New(requestLogDest)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -17,7 +17,7 @@ import (
 )
 
 var (
-	arbiterHost         = plek.Find("url-arbiter")
+	arbiterURL          = plek.Find("url-arbiter")
 	liveContentStoreURL = getEnvDefault("CONTENT_STORE", "http://content-store.dev.gov.uk")
 	port                = getEnvDefault("PORT", "3093")
 	requestLogDest      = getEnvDefault("REQUEST_LOG", "STDOUT")
@@ -56,7 +56,7 @@ func main() {
 		errbitNotifier = errornotifier.NewErrbitNotifier(errbitHost, errbitApiKey, errbitEnvName)
 	}
 
-	httpMux := BuildHTTPMux(arbiterHost, liveContentStoreURL, draftContentStoreURL, errbitNotifier)
+	httpMux := BuildHTTPMux(arbiterURL, liveContentStoreURL, draftContentStoreURL, errbitNotifier)
 
 	requestLogger, err := request_logger.New(requestLogDest)
 	if err != nil {


### PR DESCRIPTION
## Prerequisites:

- [x] [puppet changes](https://github.gds/gds/puppet/pull/2725)
- [ ] make deployment repo changes mentioned on the Trello card
- [x] [upgrade errbit](https://github.com/alphagov/errbit/pull/29)

## Description

https://trello.com/c/HfNnOLFJ

this brings publishing-api in line with other applications
with respect to error reporting by integrating it with errbit.

to begin with, we notify errbit whenever a 500 is returned
to clients. we don't adequately handle internal server errors,
and send clients back an unhelpful message saying that an
unexpected error occurred. notifying errbit will inform us about
such occurrences, enabling us to figure-out what we should
be doing.

### gobrake

- we're using gobrake, which is airbrake's official Go client
- we've used a fork of that client [dwilkie/gobrake](https://github.com/dwilkie/gobrake), which allows the host to be configured, so that we can point it towards errbit ;)

### puppet

there is a related [puppet PR](https://github.gds/gds/puppet/pull/2725) which configures the host, api key
and environment name to be used by the gobrake client.

### refactoring

this required that some code in helper.go is moved back into
the controller, from where it was extracted. this enables us to
pass fewer parameters to those helper methods. especially,
prevents us from passing the `errorNotifier` endlessly.

this also allowed us to clean-up the `DraftStoreClient` value
on the content store client structs, which was needed only
by the helper to decide whether to suppress 502 errors
from draft content store.