### PR TITLE
Update makefile to avoid unnecessary gom installs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 BINARY := publishing-api
 ORG_PATH := github.com/alphagov
-REPO_PATH := $(ORG_PATH)/$(BINARY)
+IMPORT_PATH := $(ORG_PATH)/publishing-api
 VENDOR_STAMP := _vendor/stamp
 
 all: check_fmt test build
@@ -24,11 +24,9 @@ clean:
 check_fmt:
 	./check_fmt.sh
 
-$(VENDOR_STAMP): Gomfile _vendor/src/$(REPO_PATH)
+$(VENDOR_STAMP): Gomfile
+	rm -rf _vendor/src/$(IMPORT_PATH)
+	mkdir -p _vendor/src/$(ORG_PATH)
+	ln -s $(CURDIR) _vendor/src/$(IMPORT_PATH)
 	gom install
 	touch $(VENDOR_STAMP)
-
-_vendor/src/$(REPO_PATH):
-	rm -rf _vendor/src/$(ORG_PATH)
-	mkdir -p _vendor/src/$(ORG_PATH)
-	ln -s $(CURDIR) _vendor/src/$(REPO_PATH)


### PR DESCRIPTION
Previously the `VENDOR_STAMP` task depended on the
`_vendor/src/$(IMPORT_PATH)` task.  Because this was a symlink to the root
dir of the repo, its timestamp would be updated avery time the project
was changed, causing make to rebuild both that and the `gom install` task.

Combining these into one task means that it'll only get run when the
Gomfile is updated.

This also makes it more consistent with the router's `Makefile`.