### PR TITLE
Fix processing of url-arbiter responses.

### DIFF
--- a/urlarbiter/url_arbiter.go
+++ b/urlarbiter/url_arbiter.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"mime"
 	"net/http"
 	"strconv"
 )
@@ -57,7 +58,8 @@ func (u *URLArbiter) Register(path, publishingAppName string) (URLArbiterRespons
 	}
 
 	arbiterResponse := URLArbiterResponse{}
-	if response.Header.Get("Content-Type") == "application/json" {
+	mediaType, _, err := mime.ParseMediaType(response.Header.Get("Content-Type"))
+	if err == nil && mediaType == "application/json" {
 		if err := json.NewDecoder(response.Body).Decode(&arbiterResponse); err != nil {
 			return URLArbiterResponse{}, err
 		}

--- a/urlarbiter/url_arbiter_test.go
+++ b/urlarbiter/url_arbiter_test.go
@@ -80,7 +80,7 @@ var _ = Describe("URLArbiter", func() {
 
 func buildTestServer(status int, body string) *httptest.Server {
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-type", "application/json")
+		w.Header().Set("Content-type", "application/json; charset=utf-8")
 		w.WriteHeader(status)
 		fmt.Fprintln(w, body)
 	}))


### PR DESCRIPTION
We were only JSON decoding the url-arbiter responses if the Content-Type
header was set to "application/json".  url-arbiter actually sets the
header to "application/json; charset=utf-8", meaning that we ignored the
response body, and returned blank responses on url-arbiter conflicts etc.

this updates the code in question to use [mime.ParseMediaType](https://golang.org/pkg/mime/#ParseMediaType) to
ensure that the header is processed in a robust manner.