### PR TITLE
Use relative path in _vendor symlink

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,6 @@ check_fmt:
 $(VENDOR_STAMP): Gomfile
 	rm -rf _vendor/src/$(IMPORT_PATH)
 	mkdir -p _vendor/src/$(ORG_PATH)
-	ln -s $(CURDIR) _vendor/src/$(IMPORT_PATH)
+	ln -s ../../../.. _vendor/src/$(IMPORT_PATH)
 	gom install
 	touch $(VENDOR_STAMP)


### PR DESCRIPTION
This symlink needs to point back at the base of the repo.  Making this a
relative symlink means that when using the dev VM, it will work
consistently between the host and the guest (editor plugins like
goimports will run on the host, and they have issues if the GOPATH isn't
populated correctly).