### PR TITLE
Strip access limiting

### DIFF
--- a/controllers/content_items_controller.go
+++ b/controllers/content_items_controller.go
@@ -51,16 +51,18 @@ func (c *ContentItemsController) PutLiveContentItem(w http.ResponseWriter, r *ht
 			return
 		}
 
+		requestBodyWithoutAccessLimiting := stripAccessLimitingMetadata(requestBody)
+
 		var wg sync.WaitGroup
 		wg.Add(2)
 		go func() {
 			defer wg.Done()
-			resp, err := c.liveContentStore.DoRequest("PUT", r.URL.Path, requestBody)
+			resp, err := c.liveContentStore.DoRequest("PUT", r.URL.Path, requestBodyWithoutAccessLimiting)
 			handleContentStoreResponse(resp, err, w, r, c.errorNotifier)
 		}()
 		go func() {
 			defer wg.Done()
-			resp, err := c.draftContentStore.DoRequest("PUT", r.URL.Path, requestBody)
+			resp, err := c.draftContentStore.DoRequest("PUT", r.URL.Path, requestBodyWithoutAccessLimiting)
 			if err == nil && resp.StatusCode == http.StatusBadGateway && os.Getenv("SUPPRESS_DRAFT_STORE_502_ERROR") == "1" {
 				w.WriteHeader(http.StatusOK)
 			} else {

--- a/controllers/helpers.go
+++ b/controllers/helpers.go
@@ -101,3 +101,17 @@ func readRequest(w http.ResponseWriter, r *http.Request, errorNotifier errornoti
 
 	return requestBody, contentStoreRequest
 }
+
+func stripAccessLimitingMetadata(body []byte) []byte {
+	// This helper doesn't do any error handling as
+	// the request has already been passed through
+	// helpers#readRequest which does appropriate
+	// error handling.
+	var unmarshalled map[string]interface{}
+	json.Unmarshal(body, &unmarshalled)
+
+	delete(unmarshalled, "access_limited")
+
+	withoutAccessLimitedField, _ := json.Marshal(unmarshalled)
+	return withoutAccessLimitedField
+}

--- a/integration_tests/content_item_requests_test.go
+++ b/integration_tests/content_item_requests_test.go
@@ -1,6 +1,7 @@
 package integration
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 
@@ -12,56 +13,60 @@ import (
 )
 
 var _ = Describe("Content Item Requests", func() {
-	var (
-		contentItemJSON = `{
-      "base_path": "/vat-rates",
-      "title": "VAT Rates",
-      "description": "VAT rates for goods and services",
-      "format": "guide",
-      "publishing_app": "mainstream_publisher",
-      "locale": "en",
-      "details": {
-        "app": "or format",
-        "specific": "data..."
-      }
-    }`
-		contentItemPayload = []byte(contentItemJSON)
-		urlArbiterResponse = `{"path":"/vat-rates","publishing_app":"mainstream_publisher"}`
+	contentItemWithAccessLimiting := map[string]interface{}{
+		"base_path":      "/vat-rates",
+		"title":          "VAT Rates",
+		"description":    "VAT rates for goods and services",
+		"format":         "guide",
+		"publishing_app": "mainstream_publisher",
+		"locale":         "en",
+		"details": map[string]interface{}{
+			"app":      "or format",
+			"specific": "data...",
+		},
+		"access_limited": map[string]interface{}{
+			"users": []string{
+				"f17250b0-7540-0131-f036-005056030202",
+				"74c7d700-5b4a-0131-7a8e-005056030037",
+			},
+		},
+	}
 
-		testPublishingAPI                                           *httptest.Server
-		testURLArbiter, testDraftContentStore, testLiveContentStore *ghttp.Server
+	contentItem := make(map[string]interface{})
 
-		urlArbiterResponseCode, draftContentStoreResponseCode, liveContentStoreResponseCode           int
-		urlArbiterResponseBody, draftContentStoreResponseBody, liveContentStoreResponseBody, endpoint string
+	for k, v := range contentItemWithAccessLimiting {
+		if k != "access_limited" {
+			contentItem[k] = v
+		}
+	}
 
-		expectedResponse HTTPTestResponse
-	)
+	var testPublishingAPI *httptest.Server
+	var testURLArbiter, testDraftContentStore, testLiveContentStore *ghttp.Server
+	var endpoint string
+
+	var expectedResponse HTTPTestResponse
+
+	// Mock server configurations. A default is set in the BeforeEach, but can be
+	// overridden if needed in your test.
+	var urlArbiterResponseCode int
+	var urlArbiterResponseBody string
 
 	BeforeEach(func() {
+		// URL arbiter mock server - default response (override in your test if needed)
+		urlArbiterResponseCode = http.StatusOK
+		urlArbiterResponseBody = `{"path":"/vat-rates","publishing_app":"mainstream_publisher"}`
+
 		TestRequestOrderTracker = make(chan TestRequestLabel, 3)
 
 		testURLArbiter = ghttp.NewServer()
+		testDraftContentStore = ghttp.NewServer()
+		testLiveContentStore = ghttp.NewServer()
+
 		testURLArbiter.AppendHandlers(ghttp.CombineHandlers(
 			trackRequest(URLArbiterRequestLabel),
 			ghttp.VerifyRequest("PUT", "/paths/vat-rates"),
 			ghttp.VerifyJSON(`{"publishing_app": "mainstream_publisher"}`),
 			ghttp.RespondWithPtr(&urlArbiterResponseCode, &urlArbiterResponseBody, http.Header{"Content-Type": []string{"application/json"}}),
-		))
-
-		testDraftContentStore = ghttp.NewServer()
-		testDraftContentStore.AppendHandlers(ghttp.CombineHandlers(
-			trackRequest(DraftContentStoreRequestLabel),
-			ghttp.VerifyRequest("PUT", "/content/vat-rates"),
-			ghttp.VerifyJSON(contentItemJSON),
-			ghttp.RespondWithPtr(&draftContentStoreResponseCode, &draftContentStoreResponseBody),
-		))
-
-		testLiveContentStore = ghttp.NewServer()
-		testLiveContentStore.AppendHandlers(ghttp.CombineHandlers(
-			trackRequest(LiveContentStoreRequestLabel),
-			ghttp.VerifyRequest("PUT", "/content/vat-rates"),
-			ghttp.VerifyJSON(contentItemJSON),
-			ghttp.RespondWithPtr(&liveContentStoreResponseCode, &liveContentStoreResponseBody),
 		))
 
 		testPublishingAPI = httptest.NewServer(main.BuildHTTPMux(testURLArbiter.URL(), testLiveContentStore.URL(), testDraftContentStore.URL(), nil))
@@ -82,7 +87,7 @@ var _ = Describe("Content Item Requests", func() {
 				urlArbiterResponseCode = 422
 				urlArbiterResponseBody = `{"path":"/vat-rates","publishing_app":"mainstream_publisher","errors":{"base_path":["is not valid"]}}`
 
-				actualResponse := doRequest("PUT", endpoint, contentItemPayload)
+				actualResponse := doJSONRequest("PUT", endpoint, contentItem)
 
 				Expect(testURLArbiter.ReceivedRequests()).To(HaveLen(1))
 				Expect(testDraftContentStore.ReceivedRequests()).To(BeEmpty())
@@ -96,7 +101,7 @@ var _ = Describe("Content Item Requests", func() {
 				urlArbiterResponseCode = 409
 				urlArbiterResponseBody = `{"path":"/vat-rates","publishing_app":"mainstream_publisher","errors":{"base_path":["is already taken"]}}`
 
-				actualResponse := doRequest("PUT", endpoint, contentItemPayload)
+				actualResponse := doJSONRequest("PUT", endpoint, contentItem)
 
 				Expect(testURLArbiter.ReceivedRequests()).To(HaveLen(1))
 				Expect(testDraftContentStore.ReceivedRequests()).To(BeEmpty())
@@ -108,17 +113,28 @@ var _ = Describe("Content Item Requests", func() {
 		})
 
 		It("registers a path with URL arbiter and then publishes the content to the live and draft content store", func() {
-			urlArbiterResponseCode, urlArbiterResponseBody = http.StatusOK, urlArbiterResponse
-			draftContentStoreResponseCode, draftContentStoreResponseBody = http.StatusOK, contentItemJSON
-			liveContentStoreResponseCode, liveContentStoreResponseBody = http.StatusOK, contentItemJSON
+			testDraftContentStore.AppendHandlers(ghttp.CombineHandlers(
+				trackRequest(DraftContentStoreRequestLabel),
+				ghttp.VerifyRequest("PUT", "/content/vat-rates"),
+				ghttp.VerifyJSONRepresenting(contentItem),
+				ghttp.RespondWithJSONEncoded(http.StatusOK, contentItem),
+			))
 
-			actualResponse := doRequest("PUT", endpoint, contentItemPayload)
+			testLiveContentStore.AppendHandlers(ghttp.CombineHandlers(
+				trackRequest(LiveContentStoreRequestLabel),
+				ghttp.VerifyRequest("PUT", "/content/vat-rates"),
+				ghttp.VerifyJSONRepresenting(contentItem),
+				ghttp.RespondWithJSONEncoded(http.StatusOK, contentItem),
+			))
+
+			actualResponse := doJSONRequest("PUT", endpoint, contentItem)
 
 			Expect(testURLArbiter.ReceivedRequests()).To(HaveLen(1))
 			Expect(testDraftContentStore.ReceivedRequests()).To(HaveLen(1))
 			Expect(testLiveContentStore.ReceivedRequests()).To(HaveLen(1))
 
-			expectedResponse = HTTPTestResponse{Code: http.StatusOK, Body: contentItemJSON}
+			expectedBody, _ := json.Marshal(contentItem)
+			expectedResponse = HTTPTestResponse{Code: http.StatusOK, Body: string(expectedBody[:])}
 			assertSameResponse(actualResponse, &expectedResponse)
 
 			// assert that url-arbiter is called before making requests to content stores. communication
@@ -141,10 +157,14 @@ var _ = Describe("Content Item Requests", func() {
 		})
 
 		It("returns Content-Type header as received from content-store", func() {
-			testLiveContentStore.SetHandler(0,
-				ghttp.RespondWithPtr(&liveContentStoreResponseCode, &liveContentStoreResponseBody, http.Header{"Content-Type": []string{"text/html"}}))
+			testDraftContentStore.AppendHandlers(
+				ghttp.RespondWithJSONEncoded(http.StatusOK, contentItem),
+			)
+			testLiveContentStore.AppendHandlers(
+				ghttp.RespondWithJSONEncoded(http.StatusOK, contentItem, http.Header{"Content-Type": []string{"text/html"}}),
+			)
 
-			actualResponse := doRequest("PUT", endpoint, contentItemPayload)
+			actualResponse := doJSONRequest("PUT", endpoint, contentItem)
 
 			Expect(testLiveContentStore.ReceivedRequests()).To(HaveLen(1))
 			Expect(actualResponse.Header.Get("Content-Type")).To(Equal("text/html"))

--- a/integration_tests/draft_content_item_requests_test.go
+++ b/integration_tests/draft_content_item_requests_test.go
@@ -25,6 +25,12 @@ var _ = Describe("Draft Content Item Requests", func() {
 			"app":      "or format",
 			"specific": "data...",
 		},
+		"access_limited": map[string]interface{}{
+			"users": []string{
+				"f17250b0-7540-0131-f036-005056030202",
+				"74c7d700-5b4a-0131-7a8e-005056030037",
+			},
+		},
 	}
 
 	var testPublishingAPI *httptest.Server
@@ -99,7 +105,7 @@ var _ = Describe("Draft Content Item Requests", func() {
 			})
 		})
 
-		It("registers a path with URL arbiter and then publishes the content only to the draft content store", func() {
+		It("registers a path with URL arbiter and then publishes the content only to the draft content store including access limiting information", func() {
 			testDraftContentStore.AppendHandlers(ghttp.CombineHandlers(
 				trackRequest(DraftContentStoreRequestLabel),
 				ghttp.VerifyRequest("PUT", "/content/vat-rates"),

--- a/integration_tests/draft_content_item_requests_test.go
+++ b/integration_tests/draft_content_item_requests_test.go
@@ -1,11 +1,12 @@
 package integration
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"os"
 
-	"github.com/alphagov/publishing-api"
+	main "github.com/alphagov/publishing-api"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -13,60 +14,50 @@ import (
 )
 
 var _ = Describe("Draft Content Item Requests", func() {
-	var (
-		contentItemJSON = `{
-      "base_path": "/vat-rates",
-      "title": "Draft VAT Rates",
-      "description": "VAT rates for goods and services",
-      "format": "guide",
-      "publishing_app": "mainstream_publisher",
-      "locale": "en",
-      "details": {
-        "app": "or format",
-        "specific": "data..."
-      }
-    }`
-		contentItemPayload = []byte(contentItemJSON)
-		urlArbiterResponse = `{"path":"/vat-rates","publishing_app":"mainstream_publisher"}`
+	contentItem := map[string]interface{}{
+		"base_path":      "/vat-rates",
+		"title":          "VAT Rates",
+		"description":    "VAT rates for goods and services",
+		"format":         "guide",
+		"publishing_app": "mainstream_publisher",
+		"locale":         "en",
+		"details": map[string]interface{}{
+			"app":      "or format",
+			"specific": "data...",
+		},
+	}
 
-		testPublishingAPI                                           *httptest.Server
-		testURLArbiter, testLiveContentStore, testDraftContentStore *ghttp.Server
+	var testPublishingAPI *httptest.Server
+	var testURLArbiter, testDraftContentStore, testLiveContentStore *ghttp.Server
+	var endpoint string
 
-		urlArbiterResponseCode, liveContentStoreResponseCode, draftContentStoreResponseCode           int
-		urlArbiterResponseBody, liveContentStoreResponseBody, draftContentStoreResponseBody, endpoint string
+	var expectedResponse HTTPTestResponse
 
-		expectedResponse HTTPTestResponse
-	)
+	// Mock server configurations. A default is set in the BeforeEach, but can be
+	// overridden if needed in your test.
+	var urlArbiterResponseCode int
+	var urlArbiterResponseBody string
 
 	BeforeEach(func() {
+		// URL arbiter mock server - default response (override in your test if needed)
+		urlArbiterResponseCode = http.StatusOK
+		urlArbiterResponseBody = `{"path":"/vat-rates","publishing_app":"mainstream_publisher"}`
+
 		TestRequestOrderTracker = make(chan TestRequestLabel, 3)
 
 		testURLArbiter = ghttp.NewServer()
+		testDraftContentStore = ghttp.NewServer()
+		testLiveContentStore = ghttp.NewServer()
+		testPublishingAPI = httptest.NewServer(main.BuildHTTPMux(testURLArbiter.URL(), testLiveContentStore.URL(), testDraftContentStore.URL(), nil))
+		endpoint = testPublishingAPI.URL + "/draft-content/vat-rates"
+
+		// Set expectation and canned response for URL arbiter dummy server
 		testURLArbiter.AppendHandlers(ghttp.CombineHandlers(
 			trackRequest(URLArbiterRequestLabel),
 			ghttp.VerifyRequest("PUT", "/paths/vat-rates"),
 			ghttp.VerifyJSON(`{"publishing_app": "mainstream_publisher"}`),
 			ghttp.RespondWithPtr(&urlArbiterResponseCode, &urlArbiterResponseBody, http.Header{"Content-Type": []string{"application/json"}}),
 		))
-
-		testDraftContentStore = ghttp.NewServer()
-		testDraftContentStore.AppendHandlers(ghttp.CombineHandlers(
-			trackRequest(DraftContentStoreRequestLabel),
-			ghttp.VerifyRequest("PUT", "/content/vat-rates"),
-			ghttp.VerifyJSON(contentItemJSON),
-			ghttp.RespondWithPtr(&draftContentStoreResponseCode, &draftContentStoreResponseBody),
-		))
-
-		testLiveContentStore = ghttp.NewServer()
-		testLiveContentStore.AppendHandlers(ghttp.CombineHandlers(
-			trackRequest(LiveContentStoreRequestLabel),
-			ghttp.VerifyRequest("PUT", "/content/vat-rates"),
-			ghttp.VerifyJSON(contentItemJSON),
-			ghttp.RespondWithPtr(&liveContentStoreResponseCode, &liveContentStoreResponseBody),
-		))
-
-		testPublishingAPI = httptest.NewServer(main.BuildHTTPMux(testURLArbiter.URL(), testLiveContentStore.URL(), testDraftContentStore.URL(), nil))
-		endpoint = testPublishingAPI.URL + "/draft-content/vat-rates"
 	})
 
 	AfterEach(func() {
@@ -83,7 +74,7 @@ var _ = Describe("Draft Content Item Requests", func() {
 				urlArbiterResponseCode = 422
 				urlArbiterResponseBody = `{"path":"/vat-rates","publishing_app":"mainstream_publisher","errors":{"base_path":["is not valid"]}}`
 
-				actualResponse := doRequest("PUT", endpoint, contentItemPayload)
+				actualResponse := doJSONRequest("PUT", endpoint, contentItem)
 
 				Expect(testURLArbiter.ReceivedRequests()).To(HaveLen(1))
 				Expect(testDraftContentStore.ReceivedRequests()).To(BeEmpty())
@@ -97,7 +88,7 @@ var _ = Describe("Draft Content Item Requests", func() {
 				urlArbiterResponseCode = 409
 				urlArbiterResponseBody = `{"path":"/vat-rates","publishing_app":"mainstream_publisher","errors":{"base_path":["is already taken"]}}`
 
-				actualResponse := doRequest("PUT", endpoint, contentItemPayload)
+				actualResponse := doJSONRequest("PUT", endpoint, contentItem)
 
 				Expect(testURLArbiter.ReceivedRequests()).To(HaveLen(1))
 				Expect(testDraftContentStore.ReceivedRequests()).To(BeEmpty())
@@ -109,16 +100,21 @@ var _ = Describe("Draft Content Item Requests", func() {
 		})
 
 		It("registers a path with URL arbiter and then publishes the content only to the draft content store", func() {
-			urlArbiterResponseCode, urlArbiterResponseBody = http.StatusOK, urlArbiterResponse
-			draftContentStoreResponseCode, draftContentStoreResponseBody = http.StatusOK, contentItemJSON
+			testDraftContentStore.AppendHandlers(ghttp.CombineHandlers(
+				trackRequest(DraftContentStoreRequestLabel),
+				ghttp.VerifyRequest("PUT", "/content/vat-rates"),
+				ghttp.VerifyJSONRepresenting(contentItem),
+				ghttp.RespondWithJSONEncoded(http.StatusOK, contentItem),
+			))
 
-			actualResponse := doRequest("PUT", endpoint, contentItemPayload)
+			actualResponse := doJSONRequest("PUT", endpoint, contentItem)
 
 			Expect(testURLArbiter.ReceivedRequests()).To(HaveLen(1))
 			Expect(testDraftContentStore.ReceivedRequests()).To(HaveLen(1))
 			Expect(testLiveContentStore.ReceivedRequests()).To(BeEmpty())
 
-			expectedResponse = HTTPTestResponse{Code: http.StatusOK, Body: contentItemJSON}
+			expectedBody, _ := json.Marshal(contentItem)
+			expectedResponse = HTTPTestResponse{Code: http.StatusOK, Body: string(expectedBody[:])}
 			assertSameResponse(actualResponse, &expectedResponse)
 			assertRequestOrder(URLArbiterRequestLabel, DraftContentStoreRequestLabel)
 		})
@@ -140,10 +136,9 @@ var _ = Describe("Draft Content Item Requests", func() {
 				os.Setenv("SUPPRESS_DRAFT_STORE_502_ERROR", "1")
 				defer os.Unsetenv("SUPPRESS_DRAFT_STORE_502_ERROR")
 
-				urlArbiterResponseCode, urlArbiterResponseBody = http.StatusOK, urlArbiterResponse
-				draftContentStoreResponseCode, draftContentStoreResponseBody = http.StatusBadGateway, ``
+				testDraftContentStore.AppendHandlers(ghttp.RespondWith(http.StatusBadGateway, ``))
 
-				actualResponse := doRequest("PUT", endpoint, contentItemPayload)
+				actualResponse := doJSONRequest("PUT", endpoint, contentItem)
 
 				expectedResponse = HTTPTestResponse{Code: http.StatusOK, Body: ""}
 				assertSameResponse(actualResponse, &expectedResponse)

--- a/integration_tests/request_response_helpers.go
+++ b/integration_tests/request_response_helpers.go
@@ -2,6 +2,7 @@ package integration
 
 import (
 	"bytes"
+	"encoding/json"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -15,6 +16,13 @@ func readResponseBody(response *http.Response) (string, error) {
 	defer response.Body.Close()
 
 	return strings.TrimSpace(string(body)), err
+}
+
+func doJSONRequest(verb string, url string, object interface{}) *http.Response {
+	jsonPayload, err := json.Marshal(object)
+	Expect(err).To(BeNil())
+
+	return doRequest(verb, url, jsonPayload)
 }
 
 func doRequest(verb string, url string, body []byte) *http.Response {


### PR DESCRIPTION
In order to prevent the live content store protecting content which was sent with an access limited flag (which should only be going to the draft content store) the publishing API strips this information away if it is sent to the live endpoint.

There has been some debate about whether this should be a rejection of the request instead, but this approach was chosen in the short-medium term to avoid duplicating the logic around access limiting in clients which use the API.

This code was written by:
- Elliot Crosby-McCullough <elliot.cm@gmail.com>
- David Heath <david.heath@digital.cabinet-office.gov.uk>

https://trello.com/c/w1ltlWUm/232-prevent-access-limiting-from-being-enforced-for-published-content