### PR TITLE
Fix controller race condition.

### DIFF
--- a/controllers/content_items_controller.go
+++ b/controllers/content_items_controller.go
@@ -64,7 +64,7 @@ func (c *ContentItemsController) PutLiveContentItem(w http.ResponseWriter, r *ht
 			defer wg.Done()
 			resp, err := c.draftContentStore.DoRequest("PUT", r.URL.Path, requestBodyWithoutAccessLimiting)
 			if err == nil && resp.StatusCode == http.StatusBadGateway && os.Getenv("SUPPRESS_DRAFT_STORE_502_ERROR") == "1" {
-				w.WriteHeader(http.StatusOK)
+				// Ignore response.  The response from the live content-store will be passed through.
 			} else {
 				// for now, we ignore the response from draft content store for storing live content, hence `w` is nil
 				handleContentStoreResponse(resp, err, nil, r, c.errorNotifier)


### PR DESCRIPTION
When ignoring errors from the draft content-store, there's a race in the
controller because both the live and draft request goroutines will
attempt to call WriteHeader on the response.  The first one wins.

This updates the code to completely ignore the draft content-store
response in this scenario.