### PR TITLE
Update Makefile to avoid unnecessary compiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 .PHONY: all test build run clean check_fmt
 
 BINARY := publishing-api
+SOURCE_FILES := $(shell find . -type f -name '*.go')
 ORG_PATH := github.com/alphagov
 IMPORT_PATH := $(ORG_PATH)/publishing-api
 VENDOR_STAMP := _vendor/stamp
@@ -12,17 +13,19 @@ deps: $(VENDOR_STAMP)
 test: $(VENDOR_STAMP)
 	gom test -v ./...
 
-build: $(VENDOR_STAMP)
-	gom build -o $(BINARY)
+build: $(BINARY)
 
-run: build
+run: $(BINARY)
 	./$(BINARY)
 
 clean:
-	rm -rf bin $(BINARY) _vendor
+	rm -rf $(BINARY) _vendor
 
 check_fmt:
 	./check_fmt.sh
+
+$(BINARY): $(VENDOR_STAMP) $(SOURCE_FILES)
+	gom build -o $(BINARY)
 
 $(VENDOR_STAMP): Gomfile
 	rm -rf _vendor/src/$(IMPORT_PATH)


### PR DESCRIPTION
The existing make rules cause the app to be recompiles every time the
app is started via `make run`.  This is unnecessary, and slows things
down for people who just want to run the app via bowler etc.

Update the make rules so that the generated binary depends on all .go
source files so that it will be recompiles when one of them changes, but
not otherwise.