### PR TITLE
Port RabbitMQ push from Content Store

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,9 @@ gem "airbrake", "~> 4.2.1"
 gem "govuk-client-url_arbiter", "0.0.2"
 gem "gds-api-adapters", "22.0.0"
 
+gem 'bunny', '2.0.0'
+gem 'whenever', '0.9.4', :require => false
+
 group :development, :test do
   # Call "byebug" anywhere in the code to stop execution and get a debugger console
   gem "byebug"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,12 +41,16 @@ GEM
     airbrake (4.2.1)
       builder
       multi_json
+    amq-protocol (1.9.2)
     arel (6.0.2)
     binding_of_caller (0.7.2)
       debug_inspector (>= 0.0.1)
     builder (3.2.2)
+    bunny (2.0.0)
+      amq-protocol (>= 1.9.2)
     byebug (5.0.0)
       columnize (= 0.9.0)
+    chronic (0.10.2)
     columnize (0.9.0)
     crack (0.4.2)
       safe_yaml (~> 1.0.0)
@@ -193,12 +197,15 @@ GEM
     webmock (1.21.0)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
+    whenever (0.9.4)
+      chronic (>= 0.6.3)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   airbrake (~> 4.2.1)
+  bunny (= 2.0.0)
   byebug
   gds-api-adapters (= 22.0.0)
   govuk-client-url_arbiter (= 0.0.2)
@@ -214,6 +221,7 @@ DEPENDENCIES
   unicorn (~> 4.9.0)
   web-console (~> 2.0)
   webmock
+  whenever (= 0.9.4)
 
 BUNDLED WITH
    1.10.6

--- a/README.md
+++ b/README.md
@@ -15,6 +15,33 @@ content-store.
 - [alphagov/url-arbiter](https://github.com/alphagov/url-arbiter) - publishing-api will take over content-store's job of updating url-arbiter. This is to prevent race conditions as two content-stores try to register with the same url-arbiter.
 - [alphagov/content-store](https://github.com/alphagov/content-store) - publishing-api's function is to proxy requests to multiple content-stores (eg a draft and a live content-store)
 
+Publishing API relies on RabbitMQ as its messaging bus. If you are using the
+development VM, it will be installed for you and the required users and topic
+exchanges will be set up. If not, you need to install RabbitMQ and add them
+yourself. Once RabbitMQ is installed, visit http://localhost:15672 and:
+
+1. add a `publishing_api` user (under "Admin") with the password `publishing_api`
+2. add a `published_documents` and a `published_documents_test` topic exchange
+   (under "Exchanges")
+3. give the `publishing_api` user permissions for the new exchanges.
+
+A more detailed specification of how to configure RabbitMQ can be found in the
+[puppet manifest](https://github.gds/gds/puppet/blob/master/modules/govuk/manifests/apps/publishing_api/rabbitmq.pp)
+for the publishing API.
+
+Publishing to the message queue can be disabled by setting the
+`DISABLE_QUEUE_PUBLISHER` environment variable.
+
+## Post-publishing notifications
+
+After a content item is added or updated, a message is published to RabbitMQ.
+It will be published to the `published_documents` topic exchange with the
+routing_key `"#{content_item.format}.#{content_item.update_type}"`. Interested parties can
+subscribe to this exchange to perform post-publishing actions. For example, a
+search indexing service would be able to add/update the search index based on
+these messages. Or an email notification service would be able to send email
+updates (see https://github.com/alphagov/email-alert-service).
+
 ### Running the application
 
 `./startup.sh`

--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -17,6 +17,8 @@ class ContentItemsController < ApplicationController
         content_item: content_item_without_access_limiting,
       )
 
+      queue_publisher.send_message(content_item_without_access_limiting)
+
       render json: content_item_without_access_limiting,
              content_type: live_response.headers[:content_type]
     end
@@ -55,6 +57,10 @@ private
 
   def live_content_store
     PublishingAPI.services(:live_content_store)
+  end
+
+  def queue_publisher
+    PublishingAPI.services(:queue_publisher)
   end
 
   def content_item_without_access_limiting

--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -2,6 +2,7 @@ class ContentItemsController < ApplicationController
   include URLArbitration
 
   before_filter :parse_content_item
+  before_filter :validate_routing_key_fields, only: [:put_live_content_item]
 
   def put_live_content_item
     with_url_arbitration do
@@ -65,5 +66,11 @@ private
 
   def content_item_without_access_limiting
     @content_item_without_access_limiting ||= content_item.except(:access_limited)
+  end
+
+  def validate_routing_key_fields
+    unless [:format, :update_type].all? {|field| content_item[field] =~ /\A[a-z0-9_]+\z/i}
+      head :unprocessable_entity
+    end
   end
 end

--- a/config/initializers/services.rb
+++ b/config/initializers/services.rb
@@ -28,3 +28,14 @@ PublishingAPI.register_service(
   name: :live_content_store,
   client: ContentStoreWriter.new(Plek.find('content-store'))
 )
+
+if ENV['DISABLE_QUEUE_PUBLISHER'] || (Rails.env.test? && ENV['ENABLE_QUEUE_IN_TEST_MODE'].blank?)
+  rabbitmq_config = {noop: true}
+else
+  rabbitmq_config = YAML.load_file(Rails.root.join("config", "rabbitmq.yml"))[Rails.env].symbolize_keys
+end
+
+PublishingAPI.register_service(
+  name: :queue_publisher,
+  client: QueuePublisher.new(rabbitmq_config)
+)

--- a/config/rabbitmq.yml
+++ b/config/rabbitmq.yml
@@ -1,0 +1,15 @@
+defaults: &defaults
+  host: localhost
+  port: 5672
+  vhost: /
+  user: publishing_api
+  pass: publishing_api
+  recover_from_connection_close: true
+
+development:
+  <<: *defaults
+  exchange: published_documents
+
+test:
+  <<: *defaults
+  exchange: published_documents_test

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,0 +1,11 @@
+require 'whenever'
+
+# default cron env is "/usr/bin:/bin" which is not sufficient as govuk_setenv is in /usr/local/bin
+env :PATH, '/usr/local/bin:/usr/bin:/bin'
+
+set :output, {:error => 'log/cron.error.log', :standard => 'log/cron.log'}
+job_type :rake, "cd :path && govuk_setenv content-store bundle exec rake :task :output"
+
+every 1.minute do
+  rake "heartbeat_messages:send"
+end

--- a/lib/queue_publisher.rb
+++ b/lib/queue_publisher.rb
@@ -1,0 +1,80 @@
+class QueuePublisher
+  def initialize(options = {})
+    @noop = options[:noop]
+    return if @noop
+
+    @exchange_name = options.fetch(:exchange)
+    @options = options.except(:exchange)
+  end
+
+  def connection
+    establish_connection if @connection.nil?
+    @connection
+  end
+
+  def exchange
+    @exchange ||= connect_to_exchange
+  end
+
+  class PublishFailedError < StandardError
+  end
+
+  def send_message(content_item)
+    return if @noop
+    routing_key = "#{content_item[:format]}.#{content_item[:update_type]}"
+    publish_message(routing_key, content_item, content_type: 'application/json', persistent: true)
+  end
+
+  def send_heartbeat
+    return if @noop
+    body = {
+      timestamp: Time.now.utc.iso8601,
+      hostname: Socket.gethostname,
+    }
+
+    publish_message("heartbeat.major", body, content_type: "application/x-heartbeat", persistent: false)
+  end
+
+  private
+
+  def publish_message(routing_key, message_data, options = {})
+    publish_options = options.merge(routing_key: routing_key)
+
+    exchange.publish(message_data.to_json, publish_options)
+    success = exchange.wait_for_confirms
+    if !success
+      Airbrake.notify_or_ignore(
+        PublishFailedError.new("Publishing message failed"),
+        parameters: {
+          routing_key: routing_key,
+          message_body: message_data,
+          options: options,
+        }
+      )
+    end
+  rescue Timeout::Error, Bunny::Exception
+    reset_channel
+    raise
+  end
+
+  def establish_connection
+    @connection = Bunny.new(@options)
+    @connection.start
+  end
+
+  def connect_to_exchange
+    @channel = connection.create_channel
+
+    # Enable publisher confirms, so we get acks back after publishes.
+    @channel.confirm_select
+
+    # passive parameter ensures we don't create the exchange.
+    @channel.topic(@exchange_name, passive: true)
+  end
+
+  def reset_channel
+    @exchange = nil
+    @channel.close if @channel and @channel.open?
+    @channel = nil
+  end
+end

--- a/lib/tasks/heartbeat_messages.rake
+++ b/lib/tasks/heartbeat_messages.rake
@@ -1,0 +1,10 @@
+namespace :heartbeat_messages do
+  desc "Send heartmessages to queue"
+  task :send => :environment do
+    publisher = PublishingAPI.services(:queue_publisher)
+
+    puts "Sending heartbeat message..."
+    publisher.send_heartbeat
+    puts "Heartbeat sent."
+  end
+end

--- a/lib/tasks/queue.rake
+++ b/lib/tasks/queue.rake
@@ -1,0 +1,30 @@
+namespace :queue do
+  desc "Watch the queue, and print messages on the console"
+  task :watcher => :environment do
+    config = YAML.load_file(Rails.root.join("config", "rabbitmq.yml"))[Rails.env].symbolize_keys
+
+    conn = Bunny.new(config)
+    conn.start
+
+    ch = conn.create_channel
+    ex = ch.topic(config[:exchange], passive: true)
+    q = ch.queue("", :exclusive => true)
+    q.bind(ex, :routing_key => '#')
+
+    at_exit do
+      puts "Closing channel"
+      ch.close
+      conn.close
+    end
+
+    puts "Listening for messages"
+    q.subscribe(:block => true) do |delivery_info, properties, payload|
+      puts <<-EOT
+----- New Message -----
+Routing_key: #{delivery_info.routing_key}
+Properties: #{properties.inspect}
+Payload: #{payload}
+      EOT
+    end
+  end
+end

--- a/spec/controllers/content_items_controller_spec.rb
+++ b/spec/controllers/content_items_controller_spec.rb
@@ -1,0 +1,88 @@
+require 'rails_helper'
+require "govuk/client/test_helpers/url_arbiter"
+
+RSpec.describe ContentItemsController do
+  include GOVUK::Client::TestHelpers::URLArbiter
+
+  let(:base_path) {
+    "/vat-rates"
+  }
+
+  let(:base_content_item) {
+    {
+      base_path: base_path,
+      title: "VAT rates",
+      description: "VAT rates for goods and services",
+      format: "guide",
+      need_ids: ["100123", "100124"],
+      public_updated_at: "2014-05-14T13:00:06Z",
+      publishing_app: "mainstream_publisher",
+      rendering_app: "mainstream_frontend",
+      locale: "en",
+      details: {
+        body: "<p>Soemthing about VAT</p>\n",
+      },
+      routes: [
+        {
+          path: "/vat-rates",
+          type: "exact",
+        }
+      ],
+      update_type: "major",
+    }
+  }
+
+  describe 'put_live_content_item' do
+    before do
+      stub_default_url_arbiter_responses
+      stub_request(:put, %r{.*content-store.*/content/.*})
+    end
+
+    describe "validating the fields used for the message routing key" do
+      [
+        "format",
+        "update_type",
+      ].each do |field|
+        it "requires #{field} to be suitable as a routing_key" do
+          %w(
+            word
+            alpha12numeric
+            under_score
+            mixedCASE
+          ).each do |value|
+            content_item = base_content_item.merge(field => value)
+
+            raw_json_put(
+              action: :put_live_content_item,
+              base_path: base_path,
+              json: content_item.to_json,
+            )
+
+            expect(response.status).to eq(200)
+          end
+
+          [
+            'no spaces',
+            'dashed-item',
+            'puncutation!',
+          ].each do |value|
+            content_item = base_content_item.merge(field => value)
+
+            raw_json_put(
+              action: :put_live_content_item,
+              base_path: base_path,
+              json: content_item.to_json,
+            )
+
+            expect(response.status).to eq(422)
+          end
+        end
+      end
+    end
+  end
+
+  def raw_json_put(action:, base_path:, json:)
+    request.env["RAW_POST_DATA"] = json
+    put action, base_path: base_path
+  end
+end

--- a/spec/integration/heartbeat_message_publishing_spec.rb
+++ b/spec/integration/heartbeat_message_publishing_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+require 'open3'
+
+RSpec.describe "sending a heartbeat message on the queue", :type => :request do
+  include MessageQueueHelpers
+
+  around :each do |example|
+    @config = YAML.load_file(Rails.root.join("config", "rabbitmq.yml"))[Rails.env].symbolize_keys
+    conn = Bunny.new(@config)
+    conn.start
+    read_channel = conn.create_channel
+    ex = read_channel.topic(@config.fetch(:exchange), passive: true)
+    @queue = read_channel.queue("", :exclusive => true)
+    @queue.bind(ex, routing_key: 'heartbeat.major')
+    example.run
+
+    read_channel.close
+  end
+
+  it "should place a heartbeat message on the queue" do
+    output, status = Open3.capture2e({"ENABLE_QUEUE_IN_TEST_MODE" => "1"}, "bundle exec rake heartbeat_messages:send")
+    expect(status.exitstatus).to eq(0), "rake task errored. output: #{output}"
+
+    delivery_info, properties, payload = wait_for_message_on(@queue)
+    message = JSON.parse(payload)
+
+    expect(properties.content_type).to eq("application/x-heartbeat")
+    expect(delivery_info.routing_key).to eq("heartbeat.major")
+    expect(message.fetch("hostname")).to eq(Socket.gethostname)
+  end
+end

--- a/spec/lib/queue_publisher_spec.rb
+++ b/spec/lib/queue_publisher_spec.rb
@@ -1,0 +1,217 @@
+require 'rails_helper'
+
+RSpec.describe QueuePublisher do
+  context "real mode" do
+    let(:options) {{
+      :host => "rabbitmq.example.com",
+      :port => 5672,
+      :user => "test_user",
+      :pass => "super_secret",
+      :recover_from_connection_close => true,
+      :exchange => "test_exchange",
+    }}
+    let(:queue_publisher) { QueuePublisher.new(options) }
+
+    let(:mock_session) { instance_double("Bunny::Session", :start => nil, :create_channel => mock_channel) }
+    let(:mock_channel) { instance_double("Bunny::Channel", :confirm_select => nil, :topic => mock_exchange) }
+    let(:mock_exchange) { instance_double("Bunny::Exchange", :publish => nil, :wait_for_confirms => true) }
+    before :each do
+      allow(Bunny).to receive(:new) { mock_session }
+    end
+
+    describe "setting up the connection etc" do
+      it "connects to rabbitmq using the given parameters" do
+        expect(Bunny).to receive(:new).with(options.except(:exchange)).and_return(mock_session)
+        expect(mock_session).to receive(:start)
+
+        queue_publisher.connection
+      end
+
+      it "does not raise an exception from the constructor if connecting to rabbitmq fails" do
+        # This is to ensure the application can still boot when rabbitmq is unavailable.
+        allow(Bunny).to receive(:new).and_raise(Bunny::TCPConnectionFailedForAllHosts)
+
+        expect {
+          queue_publisher
+        }.not_to raise_error
+      end
+
+      it "creates the channel and exchange" do
+        expect(mock_session).to receive(:create_channel).and_return(mock_channel).ordered
+        expect(mock_channel).to receive(:confirm_select).ordered
+        expect(mock_channel).to receive(:topic).with(options[:exchange], :passive => true).and_return(mock_exchange).ordered
+
+        expect(queue_publisher.exchange).to eq(mock_exchange)
+      end
+
+      it "memoizes the created channel and exchange" do
+        first_result = queue_publisher.exchange
+
+        expect(mock_session).not_to receive(:create_channel)
+        expect(mock_channel).not_to receive(:confirm_select)
+        expect(mock_channel).not_to receive(:topic)
+
+        expect(queue_publisher.exchange).to eq(first_result)
+      end
+    end
+
+    describe "sending a message" do
+      let(:content_item) {
+        {
+          base_path: "/vat-rates",
+          title: "VAT Rates",
+          description: "VAT rates for goods and services",
+          format: "guide",
+          publishing_app: "mainstream_publisher",
+          locale: "en",
+          details: {
+            app: "or format",
+            specific: "data...",
+          },
+          update_type: "major",
+        }
+      }
+
+      it "sends the json representation of the item on the message queue" do
+        expect(mock_exchange).to receive(:publish).with(content_item.to_json, hash_including(:content_type => "application/json"))
+
+        queue_publisher.send_message(content_item)
+      end
+
+      it "uses a routing key of format.update_type" do
+        expect(mock_exchange).to receive(:publish).with(anything, hash_including(:routing_key => "#{content_item[:format]}.#{content_item[:update_type]}"))
+
+        queue_publisher.send_message(content_item)
+      end
+
+      it "sends the message as persistent" do
+        expect(mock_exchange).to receive(:publish).with(anything, hash_including(:persistent => true))
+
+        queue_publisher.send_message(content_item)
+      end
+
+      describe "error handling" do
+        context "when message delivery is not acknowledged positively" do
+          before :each do
+            allow(mock_exchange).to receive(:wait_for_confirms).and_return(false)
+          end
+
+          it "notifies errbit of the error" do
+            expect(Airbrake).to receive(:notify_or_ignore).with(an_instance_of(QueuePublisher::PublishFailedError), anything())
+
+            queue_publisher.send_message(content_item)
+          end
+
+          it "includes the message details in the notification" do
+            expect(Airbrake).to receive(:notify_or_ignore).with(
+              anything(),
+              :parameters => {
+                :message_body => content_item,
+                :routing_key => "#{content_item[:format]}.#{content_item[:update_type]}",
+                :options => {:content_type => "application/json", :persistent => true},
+              }
+            )
+
+            queue_publisher.send_message(content_item)
+          end
+        end
+
+        shared_examples "closes channel and raises exception" do |expected_exception_class|
+          before :each do
+            allow(mock_channel).to receive_messages(:close => nil, :open? => true)
+          end
+
+          it "closes the channel" do
+            expect(mock_channel).to receive(:close)
+
+            begin
+              queue_publisher.send_message(content_item)
+            rescue # Swallow exception
+            end
+          end
+
+          it "raises the exception" do
+            expect {
+              queue_publisher.send_message(content_item)
+            }.to raise_error(expected_exception_class)
+          end
+
+          it "creates a new channel for subsequent messages" do
+            begin
+              queue_publisher.send_message(content_item)
+            rescue # Swallow exception
+            end
+
+            expect(mock_session).to receive(:create_channel).and_return(mock_channel).ordered
+            expect(mock_channel).to receive(:confirm_select).ordered
+            expect(mock_channel).to receive(:topic).with(options[:exchange], :passive => true).and_return(mock_exchange).ordered
+
+            queue_publisher.exchange
+          end
+        end
+
+        context "when sending the message fails" do
+          before :each do
+            allow(mock_exchange).to receive(:publish).and_raise(Bunny::Exception)
+          end
+
+          it_behaves_like "closes channel and raises exception", Bunny::Exception
+        end
+
+        context "when sending the message times out" do
+          before :each do
+            allow(mock_exchange).to receive(:publish).and_raise(Timeout::Error)
+          end
+
+          it_behaves_like "closes channel and raises exception", Timeout::Error
+        end
+      end
+    end
+
+    describe "sending a heartbeat message" do
+      before :each do
+        allow(Socket).to receive(:gethostname) { "example-hostname" }
+      end
+
+      it "sends a heartbeat message" do
+        Timecop.freeze do
+          expected_data = {
+            timestamp: Time.now.utc.iso8601,
+            hostname: "example-hostname",
+          }
+          expect(mock_exchange).to receive(:publish).with(expected_data.to_json, hash_including(:content_type => "application/x-heartbeat"))
+
+          queue_publisher.send_heartbeat
+        end
+      end
+
+      it "uses a routing key of 'heartbeat.major'" do
+        expect(mock_exchange).to receive(:publish).with(anything, hash_including(:routing_key => "heartbeat.major"))
+
+        queue_publisher.send_heartbeat
+      end
+
+      it "sends the message as non-persistent" do
+        expect(mock_exchange).to receive(:publish).with(anything, hash_including(:persistent => false))
+
+        queue_publisher.send_heartbeat
+      end
+    end
+  end
+
+  context "noop mode" do
+    subject { QueuePublisher.new(noop: true) }
+
+    it 'does not send messages' do
+      expect_any_instance_of(Bunny::Exchange).not_to receive(:publish)
+
+      subject.send_message(:something)
+    end
+
+    it 'does not sent heartbeats' do
+      expect_any_instance_of(Bunny::Exchange).not_to receive(:publish)
+
+      subject.send_heartbeat
+    end
+  end
+end

--- a/spec/support/json_request_helpers.rb
+++ b/spec/support/json_request_helpers.rb
@@ -1,0 +1,7 @@
+module JSONRequestHelper
+  def put_json(path, attrs, headers = {})
+    put path, attrs.to_json, {"CONTENT_TYPE" => "application/json"}.merge(headers)
+  end
+end
+
+RSpec.configuration.include JSONRequestHelper, :type => :request

--- a/spec/support/message_queue_helpers.rb
+++ b/spec/support/message_queue_helpers.rb
@@ -1,0 +1,17 @@
+module MessageQueueHelpers
+
+  # Messages don't necessarily appear on the queue immediately, and
+  # queue.pop is non-blocking.  It will return [nil, nil, nil] if
+  # there are no messages on the queue.
+  #
+  # retry a few times to help with reliably picking up a message.
+  def wait_for_message_on(queue, tries = 3)
+    tries.times do |n|
+      delivery_info, properties, payload = queue.pop
+      return delivery_info, properties, payload unless delivery_info.nil?
+      sleep 0.1
+    end
+    fail "No message found on queue"
+  end
+
+end


### PR DESCRIPTION
This allows us to better prevent messages from being pushed onto the queue for draft content items.

https://trello.com/c/ldrFj0UN/282-move-queue-publishing-from-content-store-to-publishing-api

This may require some careful deploying in concert with the content store change.