### PR TITLE
Apply route constraints to retain locale extension.

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,10 +1,14 @@
 Rails.application.routes.draw do
-  get '/healthcheck', :to => proc { [200, {}, ['OK']] }
+  with_options format: false do |r|
+    r.get '/healthcheck', :to => proc { [200, {}, ['OK']] }
 
-  put "/draft-content/*base_path", to: "content_items#put_draft_content_item"
-  put "/content/*base_path", to: "content_items#put_live_content_item"
+    r.constraints base_path: %r[/.*] do
+      put "/draft-content/*base_path", to: "content_items#put_draft_content_item"
+      put "/content/*base_path", to: "content_items#put_live_content_item"
 
-  put "/publish-intent/*base_path", to: "publish_intents#create_or_update"
-  get "/publish-intent/*base_path", to: "publish_intents#show"
-  delete "/publish-intent/*base_path", to: "publish_intents#destroy"
+      put "/publish-intent/*base_path", to: "publish_intents#create_or_update"
+      get "/publish-intent/*base_path", to: "publish_intents#show"
+      delete "/publish-intent/*base_path", to: "publish_intents#destroy"
+    end
+  end
 end

--- a/spec/requests/content_item_requests_spec.rb
+++ b/spec/requests/content_item_requests_spec.rb
@@ -56,9 +56,10 @@ RSpec.describe "Content item requests", :type => :request do
     check_400_on_invalid_json
     check_content_type_header
     check_draft_content_store_502_suppression
+    check_forwards_locale_extension
 
     def put_content_item(body: content_item.to_json)
-      put "/content/vat-rates", body
+      put "/content#{base_path}", body
     end
 
     it "sends to draft content store after registering the URL" do
@@ -111,9 +112,10 @@ RSpec.describe "Content item requests", :type => :request do
     check_400_on_invalid_json
     check_content_type_header
     check_draft_content_store_502_suppression
+    check_forwards_locale_extension
 
     def put_content_item(body: content_item.to_json)
-      put "/draft-content/vat-rates", body
+      put "/draft-content#{base_path}", body
     end
 
     it "sends to draft content store after registering the URL" do

--- a/spec/support/request_helpers.rb
+++ b/spec/support/request_helpers.rb
@@ -122,4 +122,17 @@ module RequestHelpers
       end
     end
   end
+
+  def check_forwards_locale_extension
+    context "with a translation URL" do
+      let(:base_path) { "/vat-rates.pl" }
+
+      it "passes through the locale extension" do
+        expect(PublishingAPI.services(:draft_content_store)).to receive(:put_content_item)
+          .with(hash_including(base_path: base_path))
+
+        put_content_item
+      end
+    end
+  end
 end


### PR DESCRIPTION
This is otherwise stripped off by Rails and
treated as a format.

This now matches the routing in the content store:
https://github.com/alphagov/content-store/blob/master/config/routes.rb