### PR TITLE
Add base_path to content item published on queue.

### DIFF
--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -18,7 +18,7 @@ class ContentItemsController < ApplicationController
         content_item: content_item_without_access_limiting,
       )
 
-      queue_publisher.send_message(content_item_without_access_limiting)
+      queue_publisher.send_message(content_item_with_base_path)
 
       render json: content_item_without_access_limiting,
              content_type: live_response.headers[:content_type]
@@ -66,6 +66,10 @@ private
 
   def content_item_without_access_limiting
     @content_item_without_access_limiting ||= content_item.except(:access_limited)
+  end
+
+  def content_item_with_base_path
+    content_item_without_access_limiting.merge(base_path: base_path)
   end
 
   def validate_routing_key_fields

--- a/spec/requests/content_item_requests_spec.rb
+++ b/spec/requests/content_item_requests_spec.rb
@@ -15,7 +15,6 @@ RSpec.describe "Content item requests", :type => :request do
 
   let(:content_item) {
     {
-      base_path: base_path,
       title: "VAT rates",
       description: "VAT rates for goods and services",
       format: "guide",
@@ -143,6 +142,7 @@ RSpec.describe "Content item requests", :type => :request do
       expect(properties[:content_type]).to eq('application/json')
       message = JSON.parse(payload)
       expect(message['title']).to eq('VAT rates')
+      expect(message['base_path']).to eq(base_path)
 
       # Check for a private field
       expect(message).to have_key('publishing_app')


### PR DESCRIPTION
Services listening to the queue expect the content item to contain a
`base_path` key, however since the queue publishing functionality was
moved from content-store to publishing-api this has not been provided.