### PR TITLE
Accept root path

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,14 +1,12 @@
 Rails.application.routes.draw do
   with_options format: false do |r|
-    r.get '/healthcheck', :to => proc { [200, {}, ['OK']] }
+    r.put "/draft-content/*base_path", to: "content_items#put_draft_content_item"
+    r.put "/content/*base_path", to: "content_items#put_live_content_item"
 
-    r.constraints base_path: %r[/.*] do
-      put "/draft-content/*base_path", to: "content_items#put_draft_content_item"
-      put "/content/*base_path", to: "content_items#put_live_content_item"
-
-      put "/publish-intent/*base_path", to: "publish_intents#create_or_update"
-      get "/publish-intent/*base_path", to: "publish_intents#show"
-      delete "/publish-intent/*base_path", to: "publish_intents#destroy"
-    end
+    r.put "/publish-intent/*base_path", to: "publish_intents#create_or_update"
+    r.get "/publish-intent/*base_path", to: "publish_intents#show"
+    r.delete "/publish-intent/*base_path", to: "publish_intents#destroy"
   end
+
+  get '/healthcheck', :to => proc { [200, {}, ['OK']] }
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,11 +1,11 @@
 Rails.application.routes.draw do
-  with_options format: false do |r|
-    r.put "/draft-content/*base_path", to: "content_items#put_draft_content_item"
-    r.put "/content/*base_path", to: "content_items#put_live_content_item"
+  scope format: false do |r|
+    put "/draft-content(/*base_path)", to: "content_items#put_draft_content_item"
+    put "/content(/*base_path)", to: "content_items#put_live_content_item"
 
-    r.put "/publish-intent/*base_path", to: "publish_intents#create_or_update"
-    r.get "/publish-intent/*base_path", to: "publish_intents#show"
-    r.delete "/publish-intent/*base_path", to: "publish_intents#destroy"
+    put "/publish-intent(/*base_path)", to: "publish_intents#create_or_update"
+    get "/publish-intent(/*base_path)", to: "publish_intents#show"
+    delete "/publish-intent(/*base_path)", to: "publish_intents#destroy"
   end
 
   get '/healthcheck', :to => proc { [200, {}, ['OK']] }

--- a/spec/requests/content_item_requests_spec.rb
+++ b/spec/requests/content_item_requests_spec.rb
@@ -66,6 +66,7 @@ RSpec.describe "Content item requests", :type => :request do
     check_content_type_header
     check_draft_content_store_502_suppression
     check_forwards_locale_extension
+    check_accepts_root_path
 
     before :all do
       @config = YAML.load_file(Rails.root.join("config", "rabbitmq.yml"))[Rails.env].symbolize_keys
@@ -195,6 +196,7 @@ RSpec.describe "Content item requests", :type => :request do
     check_content_type_header
     check_draft_content_store_502_suppression
     check_forwards_locale_extension
+    check_accepts_root_path
 
     def put_content_item(body: content_item.to_json)
       put "/draft-content#{base_path}", body

--- a/spec/requests/publish_intent_requests_spec.rb
+++ b/spec/requests/publish_intent_requests_spec.rb
@@ -8,6 +8,10 @@ end
 RSpec.describe "Publish intent requests", :type => :request do
   include GOVUK::Client::TestHelpers::URLArbiter
 
+  let(:base_path) {
+    "/vat-rates"
+  }
+
   let(:content_item) {
     {
       publish_time: (Time.zone.now + 3.hours).iso8601,
@@ -15,7 +19,7 @@ RSpec.describe "Publish intent requests", :type => :request do
       rendering_app: "frontend",
       routers: [
         {
-          path: "/vat-rates",
+          path: base_path,
           type: "exact",
         }
       ],
@@ -33,9 +37,10 @@ RSpec.describe "Publish intent requests", :type => :request do
     check_200_response
     check_400_on_invalid_json
     check_draft_content_store_502_suppression
+    check_accepts_root_path
 
     def put_content_item(body: content_item.to_json)
-      put "/publish-intent/vat-rates", body
+      put "/publish-intent#{base_path}", body
     end
 
     it "sends to live content store after registering the URL" do

--- a/spec/support/request_helpers.rb
+++ b/spec/support/request_helpers.rb
@@ -135,4 +135,17 @@ module RequestHelpers
       end
     end
   end
+
+  def check_accepts_root_path
+    context "with the root path as a base_path" do
+      let(:base_path) { "/" }
+
+      it "creates the content item" do
+        put_content_item
+
+        expect(response.status).to eq(200)
+        expect(a_request(:put, %r{.*/(content|publish-intent)/$})).to have_been_made.at_least_once
+      end
+    end
+  end
 end


### PR DESCRIPTION
Because Rails, we have to duplicate the routes to
accept a base path of `/`.  The write endpoints
will be at some point changed to use content IDs
removing this duplication, though the read endpoints
will need to stay.

Required for https://trello.com/c/blLdEZN5/292-make-apps-register-special-routes-on-deploy