### PR TITLE
Add contract testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@
 !/log/.keep
 /tmp
 /coverage
+/spec/reports

--- a/Gemfile
+++ b/Gemfile
@@ -27,10 +27,11 @@ end
 group :development, :test do
   # Call "byebug" anywhere in the code to stop execution and get a debugger console
   gem "byebug"
+  gem "pact"
+  gem "database_cleaner"
 end
 
 group :test do
-  gem "database_cleaner"
   gem "webmock"
   gem "timecop"
   gem "rspec"

--- a/Gemfile
+++ b/Gemfile
@@ -32,7 +32,7 @@ group :development, :test do
 end
 
 group :test do
-  gem "webmock"
+  gem "webmock", require: false
   gem "timecop"
   gem "rspec"
   gem "rspec-rails", "~> 3.3"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -43,6 +43,7 @@ GEM
       multi_json
     amq-protocol (1.9.2)
     arel (6.0.2)
+    awesome_print (1.6.1)
     binding_of_caller (0.7.2)
       debug_inspector (>= 0.0.1)
     builder (3.2.2)
@@ -62,6 +63,7 @@ GEM
       unf (>= 0.0.5, < 1.0.0)
     erubis (2.7.0)
     execjs (2.5.2)
+    find_a_port (1.0.1)
     gds-api-adapters (22.0.0)
       link_header
       lrucache (~> 0.1.1)
@@ -99,6 +101,37 @@ GEM
     nokogiri (1.6.6.2)
       mini_portile (~> 0.6.0)
     null_logger (0.0.1)
+    pact (1.9.0)
+      awesome_print (~> 1.1)
+      find_a_port (~> 1.0.1)
+      json
+      pact-mock_service (~> 0.7)
+      pact-support (~> 0.5)
+      rack-test (~> 0.6.2)
+      randexp (~> 0.1.7)
+      rspec (>= 2.14)
+      term-ansicolor (~> 1.0)
+      thor
+      webrick
+    pact-mock_service (0.7.1)
+      find_a_port (~> 1.0.1)
+      json
+      pact-support (~> 0.5)
+      rack
+      rack-test (~> 0.6.2)
+      rspec (>= 2.14)
+      term-ansicolor (~> 1.0)
+      thor
+      webrick
+    pact-support (0.5.3)
+      awesome_print (~> 1.1)
+      find_a_port (~> 1.0.1)
+      json
+      rack-test (~> 0.6.2)
+      randexp (~> 0.1.7)
+      rspec (>= 2.14)
+      term-ansicolor (~> 1.0)
+      thor
     pg (0.18.3)
     plek (1.11.0)
     rack (1.6.4)
@@ -132,6 +165,7 @@ GEM
       thor (>= 0.18.1, < 2.0)
     raindrops (0.15.0)
     rake (10.4.2)
+    randexp (0.1.7)
     request_store (1.2.0)
     rest-client (1.8.0)
       http-cookie (>= 1.0.2, < 2.0)
@@ -179,10 +213,13 @@ GEM
       actionpack (>= 3.0)
       activesupport (>= 3.0)
       sprockets (>= 2.8, < 4.0)
+    term-ansicolor (1.3.2)
+      tins (~> 1.0)
     thor (0.19.1)
     thread_safe (0.3.5)
     tilt (1.4.1)
     timecop (0.8.0)
+    tins (1.6.0)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
     uglifier (2.7.1)
@@ -203,6 +240,7 @@ GEM
     webmock (1.21.0)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
+    webrick (1.3.1)
     whenever (0.9.4)
       chronic (>= 0.6.3)
 
@@ -217,6 +255,7 @@ DEPENDENCIES
   gds-api-adapters (= 22.0.0)
   govuk-client-url_arbiter (= 0.0.2)
   logstasher (= 0.6.2)
+  pact
   pg
   plek (~> 1.10)
   rails (= 4.2.3)

--- a/README.md
+++ b/README.md
@@ -55,6 +55,38 @@ port 3093. Currently on GOV.UK machines it also be available at
 
 You can run the tests locally with: `rake`.
 
+## Running the contract tests
+
+The publishing API also has contract tests which verify that the service
+behaves in the way expected by its clients. We use a library called
+[`pact`](https://github.com/realestate-com-au/pact) which follows the *consumer driven contract testing* pattern. What this means is:
+
+* the expected interactions are defined in the [publishing_api_test.rb in gds-api-adapters](https://github.com/alphagov/gds-api-adapters/blob/master/test/publishing_api_test.rb#L19)
+* when these tests are run they output a pactfile which is stashed as an [archived artefact in CI](https://ci-new.alphagov.co.uk/job/govuk_gds_api_adapters/lastSuccessfulBuild/artifact/spec/pacts/gds_api_adapters-publishing_api.json)
+* the build of publishing api will use this archived artefact to test the publishing-api service
+
+When running in development, you can run the pact verification tests using:
+
+```
+$ bundle exec pact:verify
+```
+
+This will read the local file defined at:
+
+```
+../gds-api-adapters/spec/pacts/gds_api_adapters-publishing_api.json
+```
+
+You can also run the tests using the pact file from the master build in ci using
+
+```
+$ PACT_CI_API_KEY=****** bundle exec pact:verify:master
+```
+
+This will fetch the pact file from the ci server over http.
+
+The pacts are not currently run as part of the default rake task.
+
 ### Example API requests
 
 ``` sh

--- a/Rakefile
+++ b/Rakefile
@@ -6,3 +6,15 @@ require File.expand_path('../config/application', __FILE__)
 require 'pact/tasks'
 
 Rails.application.load_tasks
+
+Pact::VerificationTask.new("master") do | pact |
+  pact.uri "https://pactcontract:#{ENV['PACT_CI_API_KEY']}@ci-new.alphagov.co.uk/job/govuk_gds_api_adapters/lastSuccessfulBuild/artifact/spec/pacts/gds_api_adapters-publishing_api.json"
+end
+
+task :require_pact_ci_api_key do
+  unless ENV['PACT_CI_API_KEY']
+    raise "Environment variable 'PACT_CI_API_KEY' required. See https://ci-new.alphagov.co.uk/user/pactcontract/configure"
+  end
+end
+
+task "pact:verify:master" => :require_pact_ci_api_key

--- a/Rakefile
+++ b/Rakefile
@@ -3,18 +3,4 @@
 
 require File.expand_path('../config/application', __FILE__)
 
-require 'pact/tasks'
-
 Rails.application.load_tasks
-
-Pact::VerificationTask.new("master") do | pact |
-  pact.uri "https://pactcontract:#{ENV['PACT_CI_API_KEY']}@ci-new.alphagov.co.uk/job/govuk_gds_api_adapters/lastSuccessfulBuild/artifact/spec/pacts/gds_api_adapters-publishing_api.json"
-end
-
-task :require_pact_ci_api_key do
-  unless ENV['PACT_CI_API_KEY']
-    raise "Environment variable 'PACT_CI_API_KEY' required. See https://ci-new.alphagov.co.uk/user/pactcontract/configure"
-  end
-end
-
-task "pact:verify:master" => :require_pact_ci_api_key

--- a/Rakefile
+++ b/Rakefile
@@ -3,4 +3,6 @@
 
 require File.expand_path('../config/application', __FILE__)
 
+require 'pact/tasks'
+
 Rails.application.load_tasks

--- a/app/command/delete_publish_intent.rb
+++ b/app/command/delete_publish_intent.rb
@@ -3,5 +3,11 @@ class Command::DeletePublishIntent < Command::BaseCommand
     services.service(:live_content_store).delete_publish_intent(base_path)
 
     Command::Success.new({})
+  rescue GdsApi::HTTPServerError => e
+    raise Command::Error.new(code: e.code, message: e.message)
+  rescue GdsApi::HTTPClientError => e
+    raise Command::Error.new(code: e.code, error_details: e.error_details)
+  rescue GdsApi::BaseError => e
+    raise Command::Error.new(code: 500, message: "Unexpected error from content store: #{e.message}")
   end
 end

--- a/app/command/error.rb
+++ b/app/command/error.rb
@@ -16,7 +16,7 @@ class Command::Error < StandardError
   end
 
   def valid_code?(code)
-    [400, 409, 422, 500].include?(code)
+    [400, 404, 409, 422, 500].include?(code)
   end
 
   def as_json

--- a/lib/tasks/pact.rake
+++ b/lib/tasks/pact.rake
@@ -1,0 +1,15 @@
+require 'pact/tasks'
+
+# defines the task "pact:verify:master"
+Pact::VerificationTask.new("master") do | pact |
+  pact.uri "https://pactcontract:#{ENV['PACT_CI_API_KEY']}@ci-new.alphagov.co.uk/job/govuk_gds_api_adapters/lastSuccessfulBuild/artifact/spec/pacts/gds_api_adapters-publishing_api.json"
+end
+
+# This is just to generate a friendly warning message if the PACT_CI_API_KEY env var is not set
+task :require_pact_ci_api_key do
+  unless ENV['PACT_CI_API_KEY']
+    raise "Environment variable 'PACT_CI_API_KEY' required. See https://ci-new.alphagov.co.uk/user/pactcontract/configure"
+  end
+end
+
+task "pact:verify:master" => :require_pact_ci_api_key

--- a/spec/service_consumers/pact_helper.rb
+++ b/spec/service_consumers/pact_helper.rb
@@ -1,0 +1,46 @@
+ENV['RAILS_ENV']='test'
+require 'webmock'
+require 'pact/provider/rspec'
+require "govuk/client/test_helpers/url_arbiter"
+
+Pact.configure do | config |
+  config.reports_dir = "spec/reports/pacts"
+  config.include GOVUK::Client::TestHelpers::URLArbiter
+  config.include WebMock::API
+  config.include WebMock::Matchers
+end
+
+Pact.service_provider "Publishing API" do
+  honours_pact_with 'GDS API Adapters' do
+    pact_uri '../gds-api-adapters/spec/pacts/gds_api_adapters-publishing_api.json'
+  end
+end
+
+Pact.provider_states_for "GDS API Adapters" do
+  provider_state "a publish intent exists at /test-intent in the live content store" do
+    set_up do
+      DatabaseCleaner.clean_with :truncation
+
+      stub_request(:put, Regexp.new('\A' + Regexp.escape(Plek.find('content-store')) + "/content"))
+      stub_request(:put, Regexp.new('\A' + Regexp.escape(Plek.find('draft-content-store')) + "/content"))
+      stub_request(:delete, Plek.find('content-store') + "/publish-intent/test-intent")
+        .to_return(status: 200, body: "{}", headers: {"Content-Type" => "application/json"} )
+
+      # TBD: in theory we should create an event as well
+    end
+  end
+
+  provider_state "both content stores and url-arbiter empty" do
+    set_up do
+      DatabaseCleaner.clean_with :truncation
+
+      stub_default_url_arbiter_responses
+      stub_request(:put, Regexp.new('\A' + Regexp.escape(Plek.find('content-store')) + "/content"))
+      stub_request(:put, Regexp.new('\A' + Regexp.escape(Plek.find('draft-content-store')) + "/content"))
+      stub_request(:delete, Regexp.new('\A' + Regexp.escape(Plek.find('content-store')) + "/publish-intent"))
+        .to_return(status: 404, body: "{}", headers: {"Content-Type" => "application/json"} )
+      stub_request(:put, Regexp.new('\A' + Regexp.escape(Plek.find('content-store')) + "/publish-intent"))
+        .to_return(status: 200, body: "{}", headers: {"Content-Type" => "application/json"} )
+    end
+  end
+end

--- a/spec/service_consumers/pact_helper.rb
+++ b/spec/service_consumers/pact_helper.rb
@@ -3,6 +3,8 @@ require 'webmock'
 require 'pact/provider/rspec'
 require "govuk/client/test_helpers/url_arbiter"
 
+WebMock.disable!
+
 Pact.configure do | config |
   config.reports_dir = "spec/reports/pacts"
   config.include GOVUK::Client::TestHelpers::URLArbiter
@@ -17,6 +19,14 @@ Pact.service_provider "Publishing API" do
 end
 
 Pact.provider_states_for "GDS API Adapters" do
+  set_up do
+    WebMock.enable!
+  end
+
+  tear_down do
+    WebMock.disable!
+  end
+
   provider_state "a publish intent exists at /test-intent in the live content store" do
     set_up do
       DatabaseCleaner.clean_with :truncation


### PR DESCRIPTION
This configures pact contract testing in publishing-api.

When running pact tests locally using `rake pact:verify` the pact file will be read from the local filesystem at `../gds-api-adapters/spec/pacts/gds_api_adapters-publishing_api.json`.

A rake task `pact:verify:master` is added which will fetch the pact file from CI and use that instead. This requires a password to be specified in the `PACT_CI_API_KEY` environment variable.

To run on jenkins, as well as specifying the API key we must also configure the `TEST_TASK` variable to specify that we want to run the contract tests as well (we may make this the default in the future).

Here's a sample output:

```
~/alphagov/publishing-api(add-contract-testing)$ bundle exec rake pact:verify:master
Reading pact at https://pactcontract:*****@ci-new.alphagov.co.uk/job/govuk_gds_api_adapters/lastSuccessfulBuild/artifact/spec/pacts/gds_api_adapters-publishing_api.json

Verifying a pact between GDS API Adapters and Publishing API
  Given a publish intent exists at /test-intent in the live content store
    a request to delete a publish intent
      with DELETE /publish-intent/test-intent
        returns a response which
          has status code 200
          has a matching body
          includes headers
            "Content-Type" with value "application/json; charset=utf-8"
  Given both content stores and url-arbiter empty
    a request to delete a publish intent
      with DELETE /publish-intent/test-intent
        returns a response which
          has status code 404
          has a matching body
          includes headers
            "Content-Type" with value "application/json; charset=utf-8"
  Given both content stores and url-arbiter empty
    a request to create a draft content item
      with PUT /draft-content/test-draft-content-item
        returns a response which
          has status code 200
          has a matching body
          includes headers
            "Content-Type" with value "application/json; charset=utf-8"
  Given both content stores and url-arbiter empty
    a request to create a publish intent
      with PUT /publish-intent/test-intent
        returns a response which
          has status code 200
          has a matching body
          includes headers
            "Content-Type" with value "application/json; charset=utf-8"
  Given both content stores and url-arbiter empty
    a request to create a content item
      with PUT /content/test-content-item
        returns a response which
          has status code 200
          has a matching body
          includes headers
            "Content-Type" with value "application/json; charset=utf-8"

5 interactions, 0 failures

```

You can see a build on ci here:

https://ci-new.alphagov.co.uk/job/govuk_publishing-api_branches/303/console