### PR TITLE
Remove global timecop freeze.

### DIFF
--- a/spec/support/timecop.rb
+++ b/spec/support/timecop.rb
@@ -1,1 +1,4 @@
-Timecop.freeze(Time.zone.now)
+
+RSpec.configuration.after :each do
+  Timecop.return
+end


### PR DESCRIPTION
Replace it with a teardown to ensure any timecop traveling is reset
after each test.

Having time frozen globally is not obvious when reading/writing tests.
Instead of freezing it globally, we should freeze as necessary for the
specific tests that require it. Doing so will make it more obvious that
the tests are time-sensitive.