### PR TITLE
Create or replace

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,4 +35,5 @@ group :development, :test do
   gem "rspec-rails", "~> 3.3"
   gem "simplecov", "0.10.0", require: false
   gem "simplecov-rcov", "0.2.3", require: false
+  gem "factory_girl_rails", "4.5.0"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -63,6 +63,11 @@ GEM
       unf (>= 0.0.5, < 1.0.0)
     erubis (2.7.0)
     execjs (2.5.2)
+    factory_girl (4.5.0)
+      activesupport (>= 3.0.0)
+    factory_girl_rails (4.5.0)
+      factory_girl (~> 4.5.0)
+      railties (>= 3.0.0)
     find_a_port (1.0.1)
     gds-api-adapters (22.0.0)
       link_header
@@ -252,6 +257,7 @@ DEPENDENCIES
   bunny (= 2.0.0)
   byebug
   database_cleaner
+  factory_girl_rails (= 4.5.0)
   gds-api-adapters (= 22.0.0)
   govuk-client-url_arbiter (= 0.0.2)
   logstasher (= 0.6.2)

--- a/app/command/put_content_with_links.rb
+++ b/app/command/put_content_with_links.rb
@@ -37,32 +37,19 @@ private
   end
 
   def create_or_update_live_content_item!
-    existing = LiveContentItem.find_by(content_id: content_id, locale: content_item[:locale])
-    if existing
-      if existing.base_path != base_path
+    LiveContentItem.create_or_replace(content_item_attributes) do |existing|
+      if existing.persisted? && existing.base_path != base_path
         raise Command::Error.new(
           code: 400,
           message: "Cannot change base path",
           error_details: { errors: { base_path: "cannot change once item is live" } }
         )
       end
-      existing.update_attributes(content_item_attributes)
-      existing.version += 1
-      existing.save!
-    else
-      LiveContentItem.create!(content_item_attributes.merge(version: 1))
     end
   end
 
   def create_or_update_draft_content_item!
-    existing = DraftContentItem.find_by(content_id: content_id, locale: content_item[:locale])
-    if existing
-      existing.update_attributes(content_item_attributes)
-      existing.version += 1
-      existing.save!
-    else
-      DraftContentItem.create!(content_item_attributes.merge(version: 1))
-    end
+    DraftContentItem.create_or_replace(content_item_attributes)
   end
 
   def content_item_attributes

--- a/app/command/put_draft_content_with_links.rb
+++ b/app/command/put_draft_content_with_links.rb
@@ -29,14 +29,7 @@ private
   end
 
   def create_or_update_draft_content_item!
-    existing = DraftContentItem.find_by(content_id: content_id, locale: content_item[:locale])
-    if existing
-      existing.update_attributes(content_item_attributes)
-      existing.version += 1
-      existing.save!
-    else
-      DraftContentItem.create!(content_item_attributes.merge(version: 1))
-    end
+    DraftContentItem.create_or_replace(content_item_attributes)
   end
 
   def content_item_attributes

--- a/app/command/retry.rb
+++ b/app/command/retry.rb
@@ -1,0 +1,2 @@
+class Command::Retry < StandardError
+end

--- a/app/lib/event_logger.rb
+++ b/app/lib/event_logger.rb
@@ -1,9 +1,18 @@
 class EventLogger
   def log(action, user_id, payload, &block)
-    Event.connection.transaction do
-      event = Event.create(action: action, user_uid: user_id, payload: payload)
-      if block_given?
-        yield(event)
+    tries = 3
+    begin
+      Event.connection.transaction do
+        event = Event.create(action: action, user_uid: user_id, payload: payload)
+        if block_given?
+          yield(event)
+        end
+      end
+    rescue Command::Retry => e
+      if (tries -= 1) > 0
+        retry
+      else
+        raise Command::Error.new(code: 500, message: "Too many retries - #{e.message}")
       end
     end
   end

--- a/app/models/draft_content_item.rb
+++ b/app/models/draft_content_item.rb
@@ -1,2 +1,3 @@
 class DraftContentItem < ActiveRecord::Base
+  include Replaceable
 end

--- a/app/models/live_content_item.rb
+++ b/app/models/live_content_item.rb
@@ -1,2 +1,3 @@
 class LiveContentItem < ActiveRecord::Base
+  include Replaceable
 end

--- a/app/models/replaceable.rb
+++ b/app/models/replaceable.rb
@@ -14,6 +14,12 @@ module Replaceable
         )
       )
       item.save!
+    rescue ActiveRecord::StatementInvalid => e
+      if !item.persisted? && e.original_exception.is_a?(PG::UniqueViolation)
+        raise Command::Retry.new("Race condition in create_or_replace, retrying (original error: '#{e.message}')")
+      else
+        raise
+      end
     end
 
     private

--- a/app/models/replaceable.rb
+++ b/app/models/replaceable.rb
@@ -1,0 +1,25 @@
+module Replaceable
+  extend ActiveSupport::Concern
+
+  class_methods do
+    def create_or_replace(payload)
+      item = self.lock.find_or_initialize_by(content_id: payload[:content_id], locale: payload[:locale])
+      if block_given?
+        yield(item)
+      end
+      item.assign_attributes(
+        self.column_defaults.merge(payload).merge(
+          version: increment_version(item.version),
+          id: item.id
+        )
+      )
+      item.save!
+    end
+
+    private
+
+    def increment_version(version)
+      (version.presence || 0) + 1
+    end
+  end
+end

--- a/app/models/replaceable.rb
+++ b/app/models/replaceable.rb
@@ -1,18 +1,35 @@
 module Replaceable
   extend ActiveSupport::Concern
 
+  included do
+    def assign_attributes_with_defaults(attributes)
+      new_attributes = self.class.column_defaults
+        .merge(attributes.stringify_keys)
+        .merge(attribute_overrides)
+      assign_attributes(new_attributes)
+    end
+
+  private
+    def attribute_overrides
+      {
+        "version" => increment_version,
+        "id" => self.id
+      }
+    end
+
+    def increment_version
+      (self.version || 0) + 1
+    end
+  end
+
   class_methods do
     def create_or_replace(payload)
-      item = self.lock.find_or_initialize_by(content_id: payload[:content_id], locale: payload[:locale])
+      payload = payload.stringify_keys
+      item = self.lock.find_or_initialize_by(content_id: payload["content_id"], locale: payload["locale"])
       if block_given?
         yield(item)
       end
-      item.assign_attributes(
-        self.column_defaults.merge(payload).merge(
-          version: increment_version(item.version),
-          id: item.id
-        )
-      )
+      item.assign_attributes_with_defaults(payload)
       item.save!
     rescue ActiveRecord::StatementInvalid => e
       if !item.persisted? && e.original_exception.is_a?(PG::UniqueViolation)
@@ -20,12 +37,6 @@ module Replaceable
       else
         raise
       end
-    end
-
-    private
-
-    def increment_version(version)
-      (version.presence || 0) + 1
     end
   end
 end

--- a/spec/factories/draft_content_item.rb
+++ b/spec/factories/draft_content_item.rb
@@ -1,0 +1,45 @@
+FactoryGirl.define do
+  factory :draft_content_item do
+    content_id { SecureRandom.uuid }
+    base_path "/vat-rates"
+    title "VAT rates"
+    description "VAT rates for goods and services"
+    format "guide"
+    public_updated_at "2014-05-14T13:00:06Z"
+    publishing_app "mainstream_publisher"
+    rendering_app "mainstream_frontend"
+    locale "en"
+    version 1
+    details {
+      { body: "<p>Something about VAT</p>\n", }
+    }
+    access_limited {
+      {
+        users: [ SecureRandom.uuid ]
+      }
+    }
+    metadata {
+      {
+        need_ids: ["100123", "100124"],
+        phase: "beta",
+      }
+    }
+    routes {
+      [
+        {
+          path: "/vat-rates",
+          type: "exact",
+        }
+      ]
+    }
+    redirects {
+      [
+        {
+          path: "/old-vat-rates",
+          type: "exact",
+          destination: "/vat-rates",
+        }
+      ]
+    }
+  end
+end

--- a/spec/factories/link_set.rb
+++ b/spec/factories/link_set.rb
@@ -1,0 +1,11 @@
+FactoryGirl.define do
+  factory :link_set do
+    content_id { SecureRandom.uuid }
+    version 1
+    links {
+      {
+        organisations: [ SecureRandom.uuid ]
+      }
+    }
+  end
+end

--- a/spec/factories/live_content_item.rb
+++ b/spec/factories/live_content_item.rb
@@ -1,0 +1,40 @@
+FactoryGirl.define do
+  factory :live_content_item do
+    content_id { SecureRandom.uuid }
+    base_path "/vat-rates"
+    title "VAT rates"
+    description "VAT rates for goods and services"
+    format "guide"
+    public_updated_at "2014-05-14T13:00:06Z"
+    publishing_app "mainstream_publisher"
+    rendering_app "mainstream_frontend"
+    locale "en"
+    version 1
+    details {
+      { body: "<p>Something about VAT</p>\n", }
+    }
+    metadata {
+      {
+        need_ids: ["100123", "100124"],
+        phase: "beta",
+      }
+    }
+    routes {
+      [
+        {
+          path: "/vat-rates",
+          type: "exact",
+        }
+      ]
+    }
+    redirects {
+      [
+        {
+          path: "/old-vat-rates",
+          type: "exact",
+          destination: "/vat-rates",
+        }
+      ]
+    }
+  end
+end

--- a/spec/lib/event_logger_spec.rb
+++ b/spec/lib/event_logger_spec.rb
@@ -44,4 +44,37 @@ RSpec.describe EventLogger do
     expect(Event.count).to eq(0)
   end
 
+  it "rolls back the transaction and retries if a Command::Retry is thrown" do
+    call_counter = 0
+    EventLogger.new.log(action, user_uid, payload) do
+      if call_counter == 0
+        LiveContentItem.create(content_id: "1234", locale: "en", version: 1)
+        call_counter += 1
+        raise Command::Retry
+      else
+        # The original transaction should have been rolled back, so there should be no
+        # corresponding LiveContentItem in the database
+        expect(LiveContentItem.where(content_id: "1234", locale: "en").count).to eq(0)
+        LiveContentItem.create(content_id: "1234", locale: "en", version: 1)
+      end
+    end
+
+    # The second time it was called, it should have succeeded and created an
+    # event and a content item
+    expect(Event.count).to eq(1)
+    expect(LiveContentItem.count).to eq(1)
+  end
+
+  it "retries three times in case if a Command::Retry is thrown, then raises Command::Error" do
+    command = double()
+    error = Command::Retry.new("something went wrong")
+    expect(command).to receive(:do_something).exactly(3).times.and_raise(error)
+    expect {
+      EventLogger.new.log(action, user_uid, payload) do
+        command.do_something
+      end
+    }.to raise_error(Command::Error)
+    expect(Event.count).to eq(0)
+  end
+
 end

--- a/spec/models/draft_content_item_spec.rb
+++ b/spec/models/draft_content_item_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe DraftContentItem do
+  it_behaves_like Replaceable
+end

--- a/spec/models/live_content_item_spec.rb
+++ b/spec/models/live_content_item_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe LiveContentItem do
+  it_behaves_like Replaceable
+end

--- a/spec/support/factory_girl.rb
+++ b/spec/support/factory_girl.rb
@@ -1,0 +1,3 @@
+RSpec.configure do |config|
+  config.include FactoryGirl::Syntax::Methods
+end

--- a/spec/support/replaceable.rb
+++ b/spec/support/replaceable.rb
@@ -1,0 +1,47 @@
+RSpec.shared_examples Replaceable do
+  let(:payload) {
+    build(described_class).as_json.symbolize_keys.except(:format, :routes).merge(content_id: content_id, title: "New title")
+  }
+
+  context "an item exists with that content_id" do
+
+    let(:existing) { create(described_class) }
+    let(:content_id) { existing.content_id }
+
+    it "replaces an existing instance by content id" do
+      described_class.create_or_replace(payload)
+      expect(described_class.count).to eq(1)
+      item = described_class.first
+      expect(item.content_id).to eq(content_id)
+      expect(item.id).to eq(existing.id)
+      expect(item.title).to eq("New title")
+    end
+
+    it "does not preserve any information from the existing item" do
+      described_class.create_or_replace(payload)
+      expect(described_class.first.format).to be_nil
+      expect(described_class.first.routes).to be_nil
+    end
+
+    it "increases the version number" do
+      described_class.create_or_replace(payload)
+      expect(described_class.first.version).to eq(2)
+    end
+  end
+
+  context "no item exists with that content_id" do
+    let(:content_id) { SecureRandom.uuid }
+
+    it "creates a new instance" do
+      described_class.create_or_replace(payload)
+      expect(described_class.count).to eq(1)
+      expect(described_class.first.content_id).to eq(content_id)
+      expect(described_class.first.title).to eq("New title")
+    end
+
+    it "sets the version number to 1" do
+      described_class.create_or_replace(payload)
+      expect(described_class.first.version).to eq(1)
+    end
+  end
+end


### PR DESCRIPTION
When updating an existing live or draft content item, the entity should be completely replaced by the new data, including blanking any fields which are not supplied.

Adds a create_or_replace method, intended to be called within a transaction, that queries for an existing item by content id and locale, locks it, and completely replaces it by merging the supplied data with
the column defaults for that class, updating the version number. This method is used in the put_draft_content_with_links and put_content_with_links commands.

In addition, this attempts to retry a command if it resulted in a unique constraint violation. These are being caused by a request being retried before the original insert has been committed, retrying the transaction should ensure that the second request sees the original insert.