### PR TITLE
Make tests more generic

### DIFF
--- a/spec/requests/content_item_requests/derived_representations_spec.rb
+++ b/spec/requests/content_item_requests/derived_representations_spec.rb
@@ -2,18 +2,18 @@ require "rails_helper"
 
 RSpec.describe "Derived representations", type: :request do
   context "/content" do
-    let(:content_item) { content_item_without_access_limiting }
+    let(:request_body) { content_item_without_access_limiting.to_json }
     let(:request_path) { "/content#{base_path}" }
 
-    creates_a_link_representation
-    creates_a_content_item_representation(LiveContentItem, immutable_base_path: true)
+    creates_a_link_representation(expected_attributes: RequestHelpers::Mocks.links_attributes)
+    creates_a_content_item_representation(LiveContentItem, expected_attributes: RequestHelpers::Mocks.content_item_without_access_limiting, immutable_base_path: true)
   end
 
   context "/draft-content" do
-    let(:content_item) { content_item_with_access_limiting }
+    let(:request_body) { content_item_with_access_limiting.to_json }
     let(:request_path) { "/draft-content#{base_path}" }
 
-    creates_a_link_representation
-    creates_a_content_item_representation(DraftContentItem, access_limited: true)
+    creates_a_link_representation(expected_attributes: RequestHelpers::Mocks.links_attributes)
+    creates_a_content_item_representation(DraftContentItem, expected_attributes: RequestHelpers::Mocks.content_item_with_access_limiting, access_limited: true)
   end
 end

--- a/spec/requests/content_item_requests/downstream_requests_spec.rb
+++ b/spec/requests/content_item_requests/downstream_requests_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe "Downstream requests", type: :request do
         .and_return(json_response)
         .ordered
 
-      put_content_item
+      do_request
     end
 
     it "strips access limiting metadata from the document" do
@@ -42,7 +42,7 @@ RSpec.describe "Downstream requests", type: :request do
         )
         .and_return(json_response)
 
-      put_content_item(body: content_item_with_access_limiting.to_json)
+      do_request(body: content_item_with_access_limiting.to_json)
     end
   end
 
@@ -58,7 +58,7 @@ RSpec.describe "Downstream requests", type: :request do
       expect(PublishingAPI.service(:live_content_store)).to receive(:put_content_item).never
       expect(WebMock).not_to have_requested(:any, /draft-content-store.*/)
 
-      put_content_item
+      do_request
     end
 
     it "leaves access limiting metadata in the document" do
@@ -69,7 +69,7 @@ RSpec.describe "Downstream requests", type: :request do
         )
         .and_return(json_response)
 
-      put_content_item(body: content_item.to_json)
+      do_request(body: content_item.to_json)
     end
   end
 end

--- a/spec/requests/content_item_requests/downstream_requests_spec.rb
+++ b/spec/requests/content_item_requests/downstream_requests_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe "Downstream requests", type: :request do
 
   context "/content" do
     let(:content_item) { content_item_without_access_limiting }
+    let(:request_body) { content_item.to_json }
     let(:request_path) { "/content#{base_path}" }
 
     url_registration_happens
@@ -48,6 +49,7 @@ RSpec.describe "Downstream requests", type: :request do
 
   context "/draft-content" do
     let(:content_item) { content_item_with_access_limiting }
+    let(:request_body) { content_item.to_json }
     let(:request_path) { "/draft-content#{base_path}" }
 
     url_registration_happens

--- a/spec/requests/content_item_requests/downstream_timeouts_spec.rb
+++ b/spec/requests/content_item_requests/downstream_timeouts_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe "Downstream timeouts", type: :request do
   context "/content" do
-    let(:content_item) { content_item_without_access_limiting }
+    let(:request_body) { content_item_without_access_limiting.to_json }
     let(:request_path) { "/content#{base_path}" }
 
     behaves_well_when_draft_content_store_times_out
@@ -10,7 +10,7 @@ RSpec.describe "Downstream timeouts", type: :request do
   end
 
   context "/draft-content" do
-    let(:content_item) { content_item_with_access_limiting }
+    let(:request_body) { content_item_with_access_limiting.to_json }
     let(:request_path) { "/draft-content#{base_path}" }
 
     behaves_well_when_draft_content_store_times_out

--- a/spec/requests/content_item_requests/endpoint_behaviour_spec.rb
+++ b/spec/requests/content_item_requests/endpoint_behaviour_spec.rb
@@ -3,6 +3,7 @@ require "rails_helper"
 RSpec.describe "Endpoint behaviour", type: :request do
   context "/content" do
     let(:content_item) { content_item_without_access_limiting }
+    let(:request_body) { content_item.to_json }
     let(:request_path) { "/content#{base_path}" }
 
     returns_200_response
@@ -12,8 +13,8 @@ RSpec.describe "Endpoint behaviour", type: :request do
     accepts_root_path
 
     context "without a content id" do
-      let(:content_item) {
-        super().except(:content_id)
+      let(:request_body) {
+        content_item.except(:content_id)
       }
 
       creates_no_derived_representations
@@ -22,6 +23,7 @@ RSpec.describe "Endpoint behaviour", type: :request do
 
   context "/draft-content" do
     let(:content_item) { content_item_with_access_limiting }
+    let(:request_body) { content_item.to_json }
     let(:request_path) { "/draft-content#{base_path}" }
 
     returns_200_response
@@ -31,8 +33,8 @@ RSpec.describe "Endpoint behaviour", type: :request do
     accepts_root_path
 
     context "without a content id" do
-      let(:content_item) {
-        super().except(:content_id)
+      let(:request_body) {
+        content_item.except(:content_id)
       }
 
       creates_no_derived_representations

--- a/spec/requests/content_item_requests/event_logging_spec.rb
+++ b/spec/requests/content_item_requests/event_logging_spec.rb
@@ -2,16 +2,16 @@ require "rails_helper"
 
 RSpec.describe "Event logging", type: :request do
   context "/content" do
-    let(:content_item) { content_item_without_access_limiting }
+    let(:request_body) { content_item_without_access_limiting.to_json }
     let(:request_path) { "/content#{base_path}" }
 
-    logs_event('PutContentWithLinks')
+    logs_event('PutContentWithLinks', expected_payload: RequestHelpers::Mocks.content_item_without_access_limiting)
   end
 
   context "/draft-content" do
-    let(:content_item) { content_item_with_access_limiting }
+    let(:request_body) { content_item_with_access_limiting.to_json }
     let(:request_path) { "/draft-content#{base_path}" }
 
-    logs_event('PutDraftContentWithLinks')
+    logs_event('PutDraftContentWithLinks', expected_payload: RequestHelpers::Mocks.content_item_with_access_limiting)
   end
 end

--- a/spec/requests/content_item_requests/invalid_requests_spec.rb
+++ b/spec/requests/content_item_requests/invalid_requests_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe "Invalid content requests", type: :request do
     let(:request_path) { "/content#{base_path}" }
 
     it "does not log an event in the event log" do
-      put_content_item
+      do_request
 
       expect(Event.count).to eq(0)
       expect(response.status).to eq(422)
@@ -32,7 +32,7 @@ RSpec.describe "Invalid content requests", type: :request do
     let(:request_path) { "/draft-content#{base_path}" }
 
     it "does not log an event in the event log" do
-      put_content_item
+      do_request
 
       expect(Event.count).to eq(0)
       expect(response.status).to eq(422)

--- a/spec/requests/content_item_requests/invalid_requests_spec.rb
+++ b/spec/requests/content_item_requests/invalid_requests_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "Invalid content requests", type: :request do
   end
 
   context "/content" do
-    let(:content_item) { content_item_without_access_limiting }
+    let(:request_body) { content_item_without_access_limiting.to_json }
     let(:request_path) { "/content#{base_path}" }
 
     it "does not log an event in the event log" do
@@ -28,7 +28,7 @@ RSpec.describe "Invalid content requests", type: :request do
   end
 
   context "/draft-content" do
-    let(:content_item) { content_item_with_access_limiting }
+    let(:request_body) { content_item_with_access_limiting.to_json }
     let(:request_path) { "/draft-content#{base_path}" }
 
     it "does not log an event in the event log" do

--- a/spec/requests/content_item_requests/message_bus_spec.rb
+++ b/spec/requests/content_item_requests/message_bus_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe "Message bus", type: :request do
   end
 
   context "/content" do
-    let(:content_item) { content_item_without_access_limiting }
+    let(:request_body) { content_item_without_access_limiting.to_json }
     let(:request_path) { "/content#{base_path}" }
 
     it 'should place a message on the queue using the private representation of the content item' do
@@ -52,14 +52,24 @@ RSpec.describe "Message bus", type: :request do
       expect(message).to have_key('update_type')
     end
 
-    it 'routing key depends on format and update type' do
-      do_request(body: content_item.merge(update_type: "minor").to_json)
-      delivery_info, _, payload = wait_for_message_on(@queue)
-      expect(delivery_info.routing_key).to eq('guide.minor')
+    context "minor update type" do
+      let(:request_body) { content_item_without_access_limiting.merge(update_type: "minor").to_json }
 
-      do_request(body: content_item.merge(format: "detailed_guide").to_json)
-      delivery_info, _, payload = wait_for_message_on(@queue)
-      expect(delivery_info.routing_key).to eq('detailed_guide.major')
+      it 'uses the update type for the routing key' do
+        do_request
+        delivery_info, _, payload = wait_for_message_on(@queue)
+        expect(delivery_info.routing_key).to eq('guide.minor')
+      end
+    end
+
+    context "detailed_guide format" do
+      let(:request_body) { content_item_without_access_limiting.merge(format: "detailed_guide").to_json }
+
+      it "uses the format for the routing key" do
+        do_request
+        delivery_info, _, payload = wait_for_message_on(@queue)
+        expect(delivery_info.routing_key).to eq('detailed_guide.major')
+      end
     end
 
     it 'publishes a message for a redirect update' do
@@ -71,7 +81,7 @@ RSpec.describe "Message bus", type: :request do
   end
 
   context "/draft-content" do
-    let(:content_item) { content_item_with_access_limiting }
+    let(:request_body) { content_item_with_access_limiting }
     let(:request_path) { "/draft-content#{base_path}" }
 
     it "doesn't send any messages" do

--- a/spec/requests/content_item_requests/message_bus_spec.rb
+++ b/spec/requests/content_item_requests/message_bus_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe "Message bus", type: :request do
     let(:request_path) { "/content#{base_path}" }
 
     it 'should place a message on the queue using the private representation of the content item' do
-      put_content_item
+      do_request
 
       _, properties, payload = wait_for_message_on(@queue)
       expect(properties[:content_type]).to eq('application/json')
@@ -45,7 +45,7 @@ RSpec.describe "Message bus", type: :request do
     end
 
     it 'should include the update_type in the output json' do
-      put_content_item
+      do_request
 
       _, _, payload = wait_for_message_on(@queue)
       message = JSON.parse(payload)
@@ -53,17 +53,17 @@ RSpec.describe "Message bus", type: :request do
     end
 
     it 'routing key depends on format and update type' do
-      put_content_item(body: content_item.merge(update_type: "minor").to_json)
+      do_request(body: content_item.merge(update_type: "minor").to_json)
       delivery_info, _, payload = wait_for_message_on(@queue)
       expect(delivery_info.routing_key).to eq('guide.minor')
 
-      put_content_item(body: content_item.merge(format: "detailed_guide").to_json)
+      do_request(body: content_item.merge(format: "detailed_guide").to_json)
       delivery_info, _, payload = wait_for_message_on(@queue)
       expect(delivery_info.routing_key).to eq('detailed_guide.major')
     end
 
     it 'publishes a message for a redirect update' do
-      put_content_item(body: redirect_content_item.to_json)
+      do_request(body: redirect_content_item.to_json)
 
       delivery_info, _, _ = wait_for_message_on(@queue)
       expect(delivery_info.routing_key).to eq('redirect.major')
@@ -77,7 +77,7 @@ RSpec.describe "Message bus", type: :request do
     it "doesn't send any messages" do
       expect(PublishingAPI.service(:queue_publisher)).not_to receive(:send_message)
 
-      put_content_item
+      do_request
     end
   end
 end

--- a/spec/requests/publish_intent_requests_spec.rb
+++ b/spec/requests/publish_intent_requests_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe "Publish intent requests", type: :request do
     suppresses_draft_content_store_502s
     accepts_root_path
 
-    def put_content_item(body: content_item.to_json)
+    def do_request(body: content_item.to_json)
       put "/publish-intent#{base_path}", body
     end
 
@@ -45,19 +45,19 @@ RSpec.describe "Publish intent requests", type: :request do
         .with(base_path: "/vat-rates", publish_intent: content_item)
         .ordered
 
-      put_content_item
+      do_request
     end
 
     it "does not send anything to the draft content store" do
       expect(PublishingAPI.service(:draft_content_store)).to receive(:put_publish_intent).never
 
-      put_content_item
+      do_request
 
       expect(WebMock).not_to have_requested(:any, /draft-content-store.*/)
     end
 
     it "logs a 'PutPublishIntent' event in the event log" do
-      put_content_item
+      do_request
       expect(Event.count).to eq(1)
       expect(Event.first.action).to eq('PutPublishIntent')
       expect(Event.first.user_uid).to eq(nil)

--- a/spec/requests/publish_intent_requests_spec.rb
+++ b/spec/requests/publish_intent_requests_spec.rb
@@ -14,6 +14,9 @@ RSpec.describe "Publish intent requests", type: :request do
       ],
     }
   }
+  let(:request_body) {
+    content_item.to_json
+  }
 
   before do
     stub_request(:put, %r{^content-store.*/publish-intent/.*})
@@ -27,7 +30,7 @@ RSpec.describe "Publish intent requests", type: :request do
     suppresses_draft_content_store_502s
     accepts_root_path
 
-    def do_request(body: content_item.to_json)
+    def do_request(body: request_body)
       put "/publish-intent#{base_path}", body
     end
 

--- a/spec/requests/publish_intent_requests_spec.rb
+++ b/spec/requests/publish_intent_requests_spec.rb
@@ -17,6 +17,9 @@ RSpec.describe "Publish intent requests", type: :request do
   let(:request_body) {
     content_item.to_json
   }
+  let(:request_path) {
+    "/publish-intent#{base_path}"
+  }
 
   before do
     stub_request(:put, %r{^content-store.*/publish-intent/.*})
@@ -29,10 +32,6 @@ RSpec.describe "Publish intent requests", type: :request do
     returns_400_on_invalid_json
     suppresses_draft_content_store_502s
     accepts_root_path
-
-    def do_request(body: request_body)
-      put "/publish-intent#{base_path}", body
-    end
 
     def deep_stringify_keys(hash)
       JSON.parse(hash.to_json)

--- a/spec/support/request_helpers/actions.rb
+++ b/spec/support/request_helpers/actions.rb
@@ -1,6 +1,6 @@
 module RequestHelpers
   module Actions
-    def put_content_item(body: content_item.to_json)
+    def do_request(body: content_item.to_json)
       put request_path, body
     end
   end

--- a/spec/support/request_helpers/actions.rb
+++ b/spec/support/request_helpers/actions.rb
@@ -1,6 +1,6 @@
 module RequestHelpers
   module Actions
-    def do_request(body: content_item.to_json)
+    def do_request(body: request_body)
       put request_path, body
     end
   end

--- a/spec/support/request_helpers/derived_representations.rb
+++ b/spec/support/request_helpers/derived_representations.rb
@@ -2,7 +2,7 @@ module RequestHelpers
   module DerivedRepresentations
     def creates_no_derived_representations
       it "does not create any derived representations" do
-        put_content_item
+        do_request
 
         expect(DraftContentItem.count).to eq(0)
         expect(LiveContentItem.count).to eq(0)
@@ -12,12 +12,12 @@ module RequestHelpers
 
     def creates_a_link_representation
       it "creates the LinkSet derived representation" do
-        put_content_item
+        do_request
         expect(LinkSet.count).to eq(1)
       end
 
       it "gives the LinkSet derived representation a version of 1" do
-        put_content_item
+        do_request
         expect(LinkSet.first.version).to eq(1)
       end
 
@@ -25,13 +25,13 @@ module RequestHelpers
         before { LinkSet.create(content_id: content_item[:content_id], links: {}, version: 1) }
 
         it "updates the existing link record" do
-          put_content_item
+          do_request
           expect(LinkSet.count).to eq(1)
           expect(LinkSet.last.links).to eq(content_item[:links].deep_stringify_keys)
         end
 
         it "increments the version number to 2" do
-          put_content_item
+          do_request
           expect(LinkSet.first.version).to eq(2)
         end
       end
@@ -39,7 +39,7 @@ module RequestHelpers
 
     def creates_a_content_item_representation(representation_class, access_limited: false, immutable_base_path: false)
       it "creates the #{representation_class} derived representation" do
-        put_content_item(body: content_item.to_json)
+        do_request(body: content_item.to_json)
 
         expect(representation_class.count).to eq(1)
 
@@ -66,7 +66,7 @@ module RequestHelpers
       end
 
       it "gives the first #{representation_class} a version number of 1" do
-        put_content_item
+        do_request
 
         expect(representation_class.first.version).to eq(1)
       end
@@ -85,14 +85,14 @@ module RequestHelpers
         end
 
         it "updates the existing #{representation_class}" do
-          put_content_item
+          do_request
 
           expect(representation_class.count).to eq(1)
           expect(representation_class.last.title).to eq(content_item[:title])
         end
 
         it "increments the version number to 2" do
-          put_content_item
+          do_request
           expect(representation_class.first.version).to eq(2)
         end
 

--- a/spec/support/request_helpers/downstream_requests.rb
+++ b/spec/support/request_helpers/downstream_requests.rb
@@ -7,7 +7,7 @@ module RequestHelpers
           publishing_app: content_item[:publishing_app]
         )
 
-        put_content_item
+        do_request
       end
     end
 
@@ -29,7 +29,7 @@ module RequestHelpers
         end
 
         it "returns a 422 with the URL arbiter's response body" do
-          put_content_item
+          do_request
 
           expect(response.status).to eq(422)
           expect(response.body).to eq(url_arbiter_response_body)
@@ -52,7 +52,7 @@ module RequestHelpers
         end
 
         it "returns a 409 with the URL arbiter's response body" do
-          put_content_item
+          do_request
 
           expect(response.status).to eq(409)
           expect(response.body).to eq(url_arbiter_response_body)
@@ -65,7 +65,7 @@ module RequestHelpers
         end
 
         it "returns a 500 with a custom error message" do
-          put_content_item
+          do_request
 
           expect(response.status).to eq(500)
           expect(response.body).to eq({
@@ -85,7 +85,7 @@ module RequestHelpers
           )
           .ordered
 
-        put_content_item
+        do_request
       end
     end
   end

--- a/spec/support/request_helpers/downstream_timeouts.rb
+++ b/spec/support/request_helpers/downstream_timeouts.rb
@@ -7,13 +7,13 @@ module RequestHelpers
         end
 
         it "does not log an event in the event log" do
-          put_content_item
+          do_request
 
           expect(Event.count).to eq(0)
         end
 
         it "returns an error" do
-          put_content_item
+          do_request
 
           expect(response.status).to eq(500)
           expect(JSON.parse(response.body)).to eq({"message" => "Unexpected error from draft content store: GdsApi::TimedOutException"})
@@ -28,13 +28,13 @@ module RequestHelpers
         end
 
         it "does not log an event in the event log" do
-          put_content_item
+          do_request
 
           expect(Event.count).to eq(0)
         end
 
         it "returns an error" do
-          put_content_item
+          do_request
 
           expect(response.status).to eq(500)
           expect(JSON.parse(response.body)).to eq({"message" => "Unexpected error from content store: GdsApi::TimedOutException"})

--- a/spec/support/request_helpers/endpoint_behaviour.rb
+++ b/spec/support/request_helpers/endpoint_behaviour.rb
@@ -2,7 +2,7 @@ module RequestHelpers
   module EndpointBehaviour
     def returns_200_response
       it "responds with the content item as a 200" do
-        put_content_item
+        do_request
 
         expect(response.status).to eq(200)
         expect(response.body).to eq(content_item.to_json)
@@ -11,7 +11,7 @@ module RequestHelpers
 
     def returns_400_on_invalid_json
       it "returns a 400 if the JSON is invalid" do
-        put_content_item(body: "not a JSON")
+        do_request(body: "not a JSON")
 
         expect(response.status).to eq(400)
       end
@@ -28,7 +28,7 @@ module RequestHelpers
 
         it "returns the normal 200 response" do
           begin
-            put_content_item
+            do_request
 
             expect(response.status).to eq(200)
             expect(response.body).to eq(content_item.to_json)
@@ -47,7 +47,7 @@ module RequestHelpers
           expect(PublishingAPI.service(:draft_content_store)).to receive(:put_content_item)
             .with(hash_including(base_path: base_path))
 
-          put_content_item
+          do_request
         end
       end
     end
@@ -57,7 +57,7 @@ module RequestHelpers
         let(:base_path) { "/" }
 
         it "creates the content item" do
-          put_content_item
+          do_request
 
           expect(response.status).to eq(200)
           expect(a_request(:put, %r{.*/(content|publish-intent)/$})).to have_been_made.at_least_once

--- a/spec/support/request_helpers/endpoint_behaviour.rb
+++ b/spec/support/request_helpers/endpoint_behaviour.rb
@@ -5,7 +5,7 @@ module RequestHelpers
         do_request
 
         expect(response.status).to eq(200)
-        expect(response.body).to eq(content_item.to_json)
+        expect(response.body).to eq(request_body)
       end
     end
 
@@ -31,7 +31,7 @@ module RequestHelpers
             do_request
 
             expect(response.status).to eq(200)
-            expect(response.body).to eq(content_item.to_json)
+            expect(response.body).to eq(request_body)
           ensure
             PublishingAPI.swallow_draft_connection_errors = @swallow_draft_errors
           end

--- a/spec/support/request_helpers/event_logging.rb
+++ b/spec/support/request_helpers/event_logging.rb
@@ -1,6 +1,6 @@
 module RequestHelpers
   module EventLogging
-    def logs_event(event_class_name)
+    def logs_event(event_class_name, expected_payload:)
       it "logs a '#{event_class_name}' event in the event log" do
         do_request
 
@@ -8,7 +8,7 @@ module RequestHelpers
         expect(Event.first.action).to eq(event_class_name)
         expect(Event.first.user_uid).to eq(nil)
 
-        expected_payload = content_item.merge("base_path" => base_path).deep_stringify_keys
+        expected_payload = expected_payload.deep_stringify_keys.merge("base_path" => base_path)
         expect(Event.first.payload).to eq(expected_payload)
       end
     end

--- a/spec/support/request_helpers/event_logging.rb
+++ b/spec/support/request_helpers/event_logging.rb
@@ -2,7 +2,7 @@ module RequestHelpers
   module EventLogging
     def logs_event(event_class_name)
       it "logs a '#{event_class_name}' event in the event log" do
-        put_content_item
+        do_request
 
         expect(Event.count).to eq(1)
         expect(Event.first.action).to eq(event_class_name)

--- a/spec/support/request_helpers/mocks.rb
+++ b/spec/support/request_helpers/mocks.rb
@@ -1,12 +1,18 @@
 module RequestHelpers
   module Mocks
+    extend self
+
     def base_path
       "/vat-rates"
     end
 
+    def content_id
+      "582e1d3f-690e-4115-a948-e05b3c6b3d88"
+    end
+
     def content_item_without_access_limiting
       {
-        content_id: "582e1d3f-690e-4115-a948-e05b3c6b3d88",
+        content_id: content_id,
         title: "VAT rates",
         description: "VAT rates for goods and services",
         format: "guide",
@@ -18,9 +24,6 @@ module RequestHelpers
         phase: "beta",
         details: {
           body: "<p>Something about VAT</p>\n",
-        },
-        links: {
-          organisations: ["f17250b0-7540-0131-f036-005056030221"]
         },
         routes: [
           {
@@ -36,6 +39,15 @@ module RequestHelpers
           }
         ],
         update_type: "major",
+      }.merge(links_attributes)
+    end
+
+    def links_attributes
+      {
+        content_id: content_id,
+        links: {
+          organisations: ["f17250b0-7540-0131-f036-005056030221"]
+        },
       }
     end
 


### PR DESCRIPTION
In order to be able to re-use the test helpers for testing the new v2 API endpoints, they need to be made more generic.

Did the following:

* rename `put_content_item` to `do_request`. This is used by the test helpers to trigger the action under test
* rename `content_item` to `request_payload`. This was used throughout the test helpers both when making the request and when making assertions about stored values or values propagated to external services. Renaming it to request_payload again makes it more generic. Test helpers which used `content_item` for assertions were parameterised to make explicit what checks they perform.

I haven't done the refactoring to shift to using the rspec shared fixtures. I think these changes are sufficient to unblock further work. We can revisit the move to shared fixtures later.