### PR TITLE
Refactor create content item test helper

### DIFF
--- a/app/models/replaceable.rb
+++ b/app/models/replaceable.rb
@@ -31,6 +31,7 @@ module Replaceable
       end
       item.assign_attributes_with_defaults(payload)
       item.save!
+      item
     rescue ActiveRecord::StatementInvalid => e
       if !item.persisted? && e.original_exception.is_a?(PG::UniqueViolation)
         raise Command::Retry.new("Race condition in create_or_replace, retrying (original error: '#{e.message}')")

--- a/spec/requests/content_item_requests/derived_representations_spec.rb
+++ b/spec/requests/content_item_requests/derived_representations_spec.rb
@@ -6,7 +6,8 @@ RSpec.describe "Derived representations", type: :request do
     let(:request_path) { "/content#{base_path}" }
 
     creates_a_link_representation(expected_attributes: RequestHelpers::Mocks.links_attributes)
-    creates_a_content_item_representation(LiveContentItem, expected_attributes: RequestHelpers::Mocks.content_item_without_access_limiting, immutable_base_path: true)
+    creates_a_content_item_representation(LiveContentItem, expected_attributes_proc: -> { content_item_without_access_limiting })
+    prevents_base_path_from_being_changed(LiveContentItem)
   end
 
   context "/draft-content" do
@@ -14,6 +15,7 @@ RSpec.describe "Derived representations", type: :request do
     let(:request_path) { "/draft-content#{base_path}" }
 
     creates_a_link_representation(expected_attributes: RequestHelpers::Mocks.links_attributes)
-    creates_a_content_item_representation(DraftContentItem, expected_attributes: RequestHelpers::Mocks.content_item_with_access_limiting, access_limited: true)
+    creates_a_content_item_representation(DraftContentItem, expected_attributes_proc: -> { content_item_with_access_limiting }, access_limited: true)
+    allows_base_path_to_be_changed(DraftContentItem)
   end
 end

--- a/spec/support/replaceable.rb
+++ b/spec/support/replaceable.rb
@@ -27,6 +27,11 @@ RSpec.shared_examples Replaceable do
       described_class.create_or_replace(payload)
       expect(described_class.first.version).to eq(2)
     end
+
+    it "returns the updated item" do
+      item = described_class.create_or_replace(payload)
+      expect(item).to be_a(described_class)
+    end
   end
 
   context "no item exists with that content_id" do
@@ -42,6 +47,11 @@ RSpec.shared_examples Replaceable do
     it "sets the version number to 1" do
       described_class.create_or_replace(payload)
       expect(described_class.first.version).to eq(1)
+    end
+
+    it "returns the created item" do
+      item = described_class.create_or_replace(payload)
+      expect(item).to be_a(described_class)
     end
   end
 


### PR DESCRIPTION
Some more refactorings to make tests helpers more generic/reusable