### PR TITLE
Use Replaceable mixin in LinkSets.

### DIFF
--- a/app/command/put_content_with_links.rb
+++ b/app/command/put_content_with_links.rb
@@ -74,13 +74,6 @@ private
   end
 
   def create_or_update_links!
-    existing = LinkSet.find_by(content_id: content_id)
-    if existing
-      existing.update_attributes(links: content_item[:links])
-      existing.version += 1
-      existing.save!
-    else
-      LinkSet.create!(content_id: content_id, links: content_item[:links], version: 1)
-    end
+    LinkSet.create_or_replace(content_id: content_id, links: content_item[:links])
   end
 end

--- a/app/models/draft_content_item.rb
+++ b/app/models/draft_content_item.rb
@@ -1,3 +1,8 @@
 class DraftContentItem < ActiveRecord::Base
   include Replaceable
+
+private
+  def self.query_keys
+    ["content_id", "locale"]
+  end
 end

--- a/app/models/link_set.rb
+++ b/app/models/link_set.rb
@@ -1,2 +1,8 @@
 class LinkSet < ActiveRecord::Base
+  include Replaceable
+
+private
+  def self.query_keys
+    ["content_id"]
+  end
 end

--- a/app/models/live_content_item.rb
+++ b/app/models/live_content_item.rb
@@ -1,3 +1,8 @@
 class LiveContentItem < ActiveRecord::Base
   include Replaceable
+
+private
+  def self.query_keys
+    ["content_id", "locale"]
+  end
 end

--- a/app/models/replaceable.rb
+++ b/app/models/replaceable.rb
@@ -25,7 +25,7 @@ module Replaceable
   class_methods do
     def create_or_replace(payload)
       payload = payload.stringify_keys
-      item = self.lock.find_or_initialize_by(content_id: payload["content_id"], locale: payload["locale"])
+      item = self.lock.find_or_initialize_by(payload.slice(*self.query_keys))
       if block_given?
         yield(item)
       end

--- a/spec/models/draft_content_item_spec.rb
+++ b/spec/models/draft_content_item_spec.rb
@@ -1,5 +1,20 @@
 require 'rails_helper'
 
 RSpec.describe DraftContentItem do
+  def verify_new_attributes_set
+    expect(described_class.first.title).to eq("New title")
+  end
+
+  def verify_old_attributes_not_preserved
+    expect(described_class.first.format).to be_nil
+    expect(described_class.first.routes).to be_nil
+  end
+
+  let(:new_attributes) {
+    {
+      "content_id" => content_id, "title" => "New title"
+    }
+  }
+
   it_behaves_like Replaceable
 end

--- a/spec/models/link_set_spec.rb
+++ b/spec/models/link_set_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+RSpec.describe LinkSet do
+  def verify_new_attributes_set
+    expect(described_class.first.links["policies"].length).to eq(2)
+  end
+
+  def verify_old_attributes_not_preserved
+    expect(described_class.first.links["organisations"]).to be_nil
+  end
+
+  let(:new_attributes) {
+    {
+      "content_id" => content_id,
+      "links" => {
+        "policies" => [ SecureRandom.uuid, SecureRandom.uuid ]
+      }
+    }
+  }
+
+  it_behaves_like Replaceable
+end

--- a/spec/models/live_content_item_spec.rb
+++ b/spec/models/live_content_item_spec.rb
@@ -1,5 +1,20 @@
 require 'rails_helper'
 
 RSpec.describe LiveContentItem do
+  def verify_new_attributes_set
+    expect(described_class.first.title).to eq("New title")
+  end
+
+  def verify_old_attributes_not_preserved
+    expect(described_class.first.format).to be_nil
+    expect(described_class.first.routes).to be_nil
+  end
+
+  let(:new_attributes) {
+    {
+      "content_id" => content_id, "title" => "New title"
+    }
+  }
+
   it_behaves_like Replaceable
 end


### PR DESCRIPTION
LinkSets need to behave the same as live and draft content items, in that they
need to fully replace existing entities on update, and retry correctly on
unique key violations.

This has involved some refactoring of the Replaceable mixin and specs, to
parameterise the keys used for the unique query and some of the expectations
in the tests themselves.