### PR TITLE
Defensive programming in exception handler

### DIFF
--- a/app/models/replaceable.rb
+++ b/app/models/replaceable.rb
@@ -23,7 +23,7 @@ module Replaceable
   end
 
   class_methods do
-    def create_or_replace(payload)
+    def create_or_replace(payload, &block)
       payload = payload.stringify_keys
       item = self.lock.find_or_initialize_by(payload.slice(*self.query_keys))
       if block_given?


### PR DESCRIPTION
We were getting an error checking for `item.persisted?` in the exception
handler because it was nil. It wasn't clear how that could happen, but
in order to avoid this possibility, only apply the exception handling
behaviour in the specific scenario of a new item being saved.
