### PR TITLE
Serialise errors correctly

### DIFF
--- a/app/command/error.rb
+++ b/app/command/error.rb
@@ -8,9 +8,18 @@ class Command::Error < StandardError
     @error_details = if error_details
       error_details
     elsif message
-      { "message" => message }
+      {
+        "error" => {
+          "code" => code,
+          "message" => message,
+        }
+      }
     else
-      {}
+      {
+        "error" => {
+          "code" => code,
+        }
+      }
     end
     super(message || error_details.to_s)
   end

--- a/spec/support/request_helpers/downstream_requests.rb
+++ b/spec/support/request_helpers/downstream_requests.rb
@@ -69,7 +69,10 @@ module RequestHelpers
 
           expect(response.status).to eq(500)
           expect(response.body).to eq({
-            message: "Unexpected error whilst registering with url-arbiter: 506 Variant Also Negotiates"
+            "error" => {
+              "code" => 500,
+              "message" => "Unexpected error whilst registering with url-arbiter: 506 Variant Also Negotiates"
+            }
           }.to_json)
         end
       end

--- a/spec/support/request_helpers/downstream_timeouts.rb
+++ b/spec/support/request_helpers/downstream_timeouts.rb
@@ -16,7 +16,12 @@ module RequestHelpers
           do_request
 
           expect(response.status).to eq(500)
-          expect(JSON.parse(response.body)).to eq({"message" => "Unexpected error from draft content store: GdsApi::TimedOutException"})
+          expect(JSON.parse(response.body)).to eq(
+            "error" => {
+              "code" => 500,
+              "message" => "Unexpected error from draft content store: GdsApi::TimedOutException"
+            }
+          )
         end
       end
     end
@@ -37,7 +42,12 @@ module RequestHelpers
           do_request
 
           expect(response.status).to eq(500)
-          expect(JSON.parse(response.body)).to eq({"message" => "Unexpected error from content store: GdsApi::TimedOutException"})
+          expect(JSON.parse(response.body)).to eq(
+            "error" => {
+              "code" => 500,
+              "message" => "Unexpected error from content store: GdsApi::TimedOutException"
+            }
+          )
         end
       end
     end


### PR DESCRIPTION
our pact tests expect errors to be serialised with a nested error hash
structure matching this pattern:

```
{
  "error" => {
    "code" => nnn,
    "message" => "some message",
  }
}
```

adjust the standard error serialisation and tests to match this.