### PR TITLE
v2 Publish command

### DIFF
--- a/app/command/publish.rb
+++ b/app/command/publish.rb
@@ -33,11 +33,11 @@ private
   end
 
   def content_id
-    payload["content_id"]
+    payload[:content_id]
   end
 
   def update_type
-    payload['update_type']
+    payload[:update_type]
   end
 
   def draft_item
@@ -46,7 +46,7 @@ private
 
   def link_set_hash
     if link_set.present?
-      {"links" => link_set.links}
+      {links: link_set.links.deep_symbolize_keys}
     else
       {}
     end

--- a/app/command/publish.rb
+++ b/app/command/publish.rb
@@ -1,0 +1,26 @@
+class Command::Publish < Command::BaseCommand
+  def call
+    live_item = LiveContentItem.create_or_replace(draft_item.attributes.except("access_limited"))
+    Adapters::ContentStore.new(services: services).call(live_item.base_path, live_payload(live_item))
+    Command::Success.new(content_id: content_id)
+  end
+
+private
+  def content_id
+    payload["content_id"]
+  end
+
+  def draft_item
+    DraftContentItem.find_by(content_id: content_id)
+  end
+
+  def link_set
+    @link_set ||= LinkSet.find_by(content_id: content_id)
+  end
+
+  def live_payload(live_item)
+    live_item.as_json.tap do |item|
+      item["links"] = link_set.links if link_set.present?
+    end
+  end
+end

--- a/app/command/publish.rb
+++ b/app/command/publish.rb
@@ -3,7 +3,9 @@ class Command::Publish < Command::BaseCommand
 
   def call
     validate!
-    @live_item = LiveContentItem.create_or_replace(draft_item.attributes.except("access_limited"))
+    @live_item = LiveContentItem.create_or_replace(draft_item.attributes.except("access_limited")) do |live_item|
+      raise Command::Error.new(code: 400, message: "This item is already published") if live_item.version == draft_item.version
+    end
     @link_set = LinkSet.find_by(content_id: content_id)
 
     Adapters::ContentStore.new(services: services).call(live_item.base_path, live_payload)
@@ -16,9 +18,17 @@ class Command::Publish < Command::BaseCommand
 private
   def validate!
     raise Command::Error.new(
-      code: 400,
+      code: 422,
       message: "update_type is required",
-      error_details: { errors: { update_type: "is required" } }
+      error_details: {
+        error: {
+          code: 422,
+          message: "update_type is required",
+          fields: {
+            update_type: ["is required"],
+          }
+        }
+      }
     ) unless update_type.present?
   end
 

--- a/app/command/publish.rb
+++ b/app/command/publish.rb
@@ -1,7 +1,12 @@
 class Command::Publish < Command::BaseCommand
+  attr_reader :live_item
+
   def call
-    live_item = LiveContentItem.create_or_replace(draft_item.attributes.except("access_limited"))
-    Adapters::ContentStore.new(services: services).call(live_item.base_path, live_payload(live_item))
+    @live_item = LiveContentItem.create_or_replace(draft_item.attributes.except("access_limited"))
+
+    Adapters::ContentStore.new(services: services).call(live_item.base_path, live_payload)
+    queue_publisher.send_message(live_payload)
+
     Command::Success.new(content_id: content_id)
   end
 
@@ -18,9 +23,15 @@ private
     @link_set ||= LinkSet.find_by(content_id: content_id)
   end
 
-  def live_payload(live_item)
-    live_item.as_json.tap do |item|
-      item["links"] = link_set.links if link_set.present?
+  def link_set_hash
+    if link_set.present?
+      {"links" => link_set.links}
+    else
+      {}
     end
+  end
+
+  def live_payload
+    Presenters::ContentItemPresenter.new(@live_item).present.merge(link_set_hash)
   end
 end

--- a/app/command/publish.rb
+++ b/app/command/publish.rb
@@ -1,11 +1,13 @@
 class Command::Publish < Command::BaseCommand
-  attr_reader :live_item
+  attr_reader :live_item, :link_set
 
   def call
     @live_item = LiveContentItem.create_or_replace(draft_item.attributes.except("access_limited"))
+    @link_set = LinkSet.find_by(content_id: content_id)
 
     Adapters::ContentStore.new(services: services).call(live_item.base_path, live_payload)
-    queue_publisher.send_message(live_payload)
+
+    send_to_message_queue!
 
     Command::Success.new(content_id: content_id)
   end
@@ -16,11 +18,7 @@ private
   end
 
   def draft_item
-    DraftContentItem.find_by(content_id: content_id)
-  end
-
-  def link_set
-    @link_set ||= LinkSet.find_by(content_id: content_id)
+    DraftContentItem.find_by(content_id: content_id) or raise Command::Error.new(code: 404, message: "Item with content_id #{content_id} does not exist")
   end
 
   def link_set_hash
@@ -34,4 +32,10 @@ private
   def live_payload
     Presenters::ContentItemPresenter.new(@live_item).present.merge(link_set_hash)
   end
+
+  def send_to_message_queue!
+    message_payload = live_payload.merge(update_type: payload['update_type'])
+    queue_publisher.send_message(message_payload)
+  end
+
 end

--- a/app/command/v2/publish.rb
+++ b/app/command/v2/publish.rb
@@ -1,4 +1,4 @@
-class Command::Publish < Command::BaseCommand
+class Command::V2::Publish < Command::BaseCommand
   attr_reader :live_item, :link_set
 
   def call

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,10 @@
 class ApplicationController < ActionController::Base
+  class BadRequest < StandardError; end
+
   rescue_from Command::Error, with: :respond_with_command_error
+  rescue_from BadRequest do
+    head :bad_request
+  end
 
 private
   def respond_with_command_error(error)
@@ -10,11 +15,13 @@ private
     "/#{params[:base_path]}"
   end
 
-  def parse_content_item
-    @content_item = JSON.parse(request.body.read).deep_symbolize_keys
+  def payload
+    @payload ||= JSON.parse(request.body.read).deep_symbolize_keys
   rescue JSON::ParserError
-    head :bad_request
+    raise BadRequest
   end
 
-  attr_reader :content_item
+  def content_item
+    payload
+  end
 end

--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -11,6 +11,11 @@ class ContentItemsController < ApplicationController
     render status: response.code, json: response.as_json
   end
 
+  def publish
+    response = command_processor.publish(payload.merge("content_id" => params[:content_id]))
+    render status: response.code, json: response.as_json
+  end
+
 private
   def command_processor
     CommandProcessor.new(nil)

--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -1,5 +1,4 @@
 class ContentItemsController < ApplicationController
-  before_filter :parse_content_item
   before_filter :validate_routing_key_fields, only: [:put_live_content_item]
 
   def put_live_content_item

--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -11,11 +11,6 @@ class ContentItemsController < ApplicationController
     render status: response.code, json: response.as_json
   end
 
-  def publish
-    response = command_processor.publish(payload.merge("content_id" => params[:content_id]))
-    render status: response.code, json: response.as_json
-  end
-
 private
   def command_processor
     CommandProcessor.new(nil)

--- a/app/controllers/publish_intents_controller.rb
+++ b/app/controllers/publish_intents_controller.rb
@@ -1,8 +1,7 @@
 class PublishIntentsController < ApplicationController
-  before_filter :parse_content_item, only: [:create_or_update]
-
   def create_or_update
-    response = command_processor.put_publish_intent(content_item.merge(base_path: base_path))
+    item = content_item.merge(base_path: base_path)
+    response = command_processor.put_publish_intent(item)
     render status: response.code, json: response.as_json
   end
 

--- a/app/controllers/v2/content_items_controller.rb
+++ b/app/controllers/v2/content_items_controller.rb
@@ -1,7 +1,5 @@
 module V2
   class ContentItemsController < ApplicationController
-    before_filter :parse_content_item, only: [:put_content]
-
     def show
       render json: Query::GetContent.new(params[:content_id]).call
     end

--- a/app/controllers/v2/content_items_controller.rb
+++ b/app/controllers/v2/content_items_controller.rb
@@ -9,6 +9,11 @@ module V2
       render status: response.code, json: response.as_json
     end
 
+    def publish
+      response = command_processor.publish(payload.merge(content_id: params[:content_id]))
+      render status: response.code, json: response.as_json
+    end
+
   private
     def command_processor
       CommandProcessor.new(nil)

--- a/app/lib/adapters/content_store.rb
+++ b/app/lib/adapters/content_store.rb
@@ -16,9 +16,19 @@ module Adapters
     rescue GdsApi::HTTPServerError => e
       raise Command::Error.new(code: e.code, message: e.message)
     rescue GdsApi::HTTPClientError => e
-      raise Command::Error.new(code: e.code, error_details: e.error_details)
+      raise Command::Error.new(code: e.code, error_details: convert_error_details(e))
     rescue GdsApi::BaseError => e
       raise Command::Error.new(code: 500, message: "Unexpected error from content store: #{e.message}")
+    end
+
+  private
+    def convert_error_details(upstream_error)
+      {
+        error: {
+          code: upstream_error.code,
+          fields: upstream_error.error_details.fetch('errors', {})
+        }
+      }
     end
   end
 end

--- a/app/lib/command_processor.rb
+++ b/app/lib/command_processor.rb
@@ -27,7 +27,7 @@ class CommandProcessor
   end
 
   def publish(payload)
-    dispatch(Command::Publish, payload)
+    dispatch(Command::V2::Publish, payload)
   end
 
 private

--- a/app/lib/command_processor.rb
+++ b/app/lib/command_processor.rb
@@ -26,6 +26,10 @@ class CommandProcessor
     dispatch(Command::DeletePublishIntent, payload)
   end
 
+  def publish(payload)
+    dispatch(Command::Publish, payload)
+  end
+
 private
   def dispatch(command_class, payload)
     event_logger.log(command_name(command_class), user_id, payload) do |event|

--- a/app/lib/presenters/content_item_presenter.rb
+++ b/app/lib/presenters/content_item_presenter.rb
@@ -8,7 +8,7 @@ class Presenters::ContentItemPresenter
   end
 
   def present
-    raw_json.except("metadata", "id").merge(raw_json['metadata'])
+    raw_json.except("metadata", "id").merge(raw_json['metadata']).deep_symbolize_keys
   end
 
   def raw_json

--- a/app/lib/presenters/content_item_presenter.rb
+++ b/app/lib/presenters/content_item_presenter.rb
@@ -1,0 +1,17 @@
+Presenters = Module.new unless defined?(Presenters)
+
+class Presenters::ContentItemPresenter
+  attr_reader :content_item
+
+  def initialize(content_item)
+    @content_item = content_item
+  end
+
+  def present
+    raw_json.except("metadata").merge(raw_json['metadata'])
+  end
+
+  def raw_json
+    content_item.as_json
+  end
+end

--- a/app/lib/presenters/content_item_presenter.rb
+++ b/app/lib/presenters/content_item_presenter.rb
@@ -8,7 +8,7 @@ class Presenters::ContentItemPresenter
   end
 
   def present
-    raw_json.except("metadata").merge(raw_json['metadata'])
+    raw_json.except("metadata", "id").merge(raw_json['metadata'])
   end
 
   def raw_json

--- a/app/models/replaceable.rb
+++ b/app/models/replaceable.rb
@@ -3,9 +3,10 @@ module Replaceable
 
   included do
     def assign_attributes_with_defaults(attributes)
-      new_attributes = self.class.column_defaults.symbolize_keys
+      new_attributes = self.class.column_defaults.symbolize_keys.except(:id)
         .merge(attributes)
         .merge(attribute_overrides)
+        .merge(attributes.symbolize_keys)
       assign_attributes(new_attributes)
     end
 
@@ -13,7 +14,6 @@ module Replaceable
     def attribute_overrides
       {
         version: increment_version,
-        id: self.id
       }
     end
 
@@ -28,7 +28,7 @@ module Replaceable
       if block_given?
         yield(item)
       end
-      item.assign_attributes_with_defaults(payload)
+      item.assign_attributes_with_defaults(payload.except("id"))
 
       retry_strategy = if item.new_record?
         method(:retrying_on_unique_constraint_violation)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,5 +13,7 @@ Rails.application.routes.draw do
     end
   end
 
+  post '/v2/content/:content_id/publish', to: 'content_items#publish'
+
   get '/healthcheck', :to => proc { [200, {}, ['OK']] }
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,9 +11,9 @@ Rails.application.routes.draw do
       put "/content/:content_id", to: "content_items#put_content"
       get "/content/:content_id", to: "content_items#show"
     end
-  end
 
-  post '/v2/content/:content_id/publish', to: 'content_items#publish'
+    post '/v2/content/:content_id/publish', to: 'content_items#publish'
+  end
 
   get '/healthcheck', :to => proc { [200, {}, ['OK']] }
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,9 +10,9 @@ Rails.application.routes.draw do
     namespace :v2 do
       put "/content/:content_id", to: "content_items#put_content"
       get "/content/:content_id", to: "content_items#show"
+      post "/content/:content_id/publish", to: "content_items#publish"
     end
 
-    post '/v2/content/:content_id/publish', to: 'content_items#publish'
   end
 
   get '/healthcheck', :to => proc { [200, {}, ['OK']] }

--- a/lib/queue_publisher.rb
+++ b/lib/queue_publisher.rb
@@ -19,10 +19,15 @@ class QueuePublisher
   class PublishFailedError < StandardError
   end
 
-  def send_message(content_item)
+  def send_message(content_item, routing_key: nil)
     return if @noop
-    routing_key = "#{content_item[:format]}.#{content_item[:update_type]}"
+    routing_key ||= routing_key(content_item)
     publish_message(routing_key, content_item, content_type: 'application/json', persistent: true)
+  end
+
+  def routing_key(content_item)
+    normalised = content_item.symbolize_keys
+    "#{normalised[:format]}.#{normalised[:update_type]}"
   end
 
   def send_heartbeat

--- a/spec/controllers/content_items_controller_spec.rb
+++ b/spec/controllers/content_items_controller_spec.rb
@@ -39,18 +39,25 @@ RSpec.describe ContentItemsController do
     end
 
     describe "validating the fields used for the message routing key" do
+      valid_routing_keys = %w(
+        word
+        alpha12numeric
+        under_score
+        mixedCASE
+      )
+      invalid_routing_keys = [
+        'no spaces',
+        'dashed-item',
+        'puncutation!',
+      ]
+
       [
         "format",
         "update_type",
       ].each do |field|
-        it "requires #{field} to be suitable as a routing_key" do
-          %w(
-            word
-            alpha12numeric
-            under_score
-            mixedCASE
-          ).each do |value|
-            content_item = base_content_item.merge(field => value)
+        valid_routing_keys.each do |routing_key|
+          it "should respond with 200 if #{field} has value '#{routing_key}'" do
+            content_item = base_content_item.merge(field => routing_key)
 
             raw_json_put(
               action: :put_live_content_item,
@@ -60,13 +67,11 @@ RSpec.describe ContentItemsController do
 
             expect(response.status).to eq(200)
           end
+        end
 
-          [
-            'no spaces',
-            'dashed-item',
-            'puncutation!',
-          ].each do |value|
-            content_item = base_content_item.merge(field => value)
+        invalid_routing_keys.each do |routing_key|
+          it "should respond with 422 if #{field} has value '#{routing_key}'" do
+            content_item = base_content_item.merge(field => routing_key)
 
             raw_json_put(
               action: :put_live_content_item,

--- a/spec/lib/presenters/content_item_presenter_spec.rb
+++ b/spec/lib/presenters/content_item_presenter_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+RSpec.describe Presenters::ContentItemPresenter do
+  let(:content_item) { create(:draft_content_item) }
+
+  subject(:presented) { described_class.new(content_item).present }
+
+  it "includes the metadata fields in the top level of the presented item" do
+    content_item.metadata.keys.each do |key|
+      expect(presented[key]).to eq(content_item.metadata[key])
+    end
+  end
+
+  it "removes the metadata key" do
+    expect(presented).not_to have_key("metadata")
+  end
+
+  it "exports all other fields" do
+    content_item.attributes.each do |key, value|
+      next if key == 'metadata'
+      expect(presented[key]).to eq(value)
+    end
+  end
+end

--- a/spec/lib/presenters/content_item_presenter_spec.rb
+++ b/spec/lib/presenters/content_item_presenter_spec.rb
@@ -12,16 +12,16 @@ RSpec.describe Presenters::ContentItemPresenter do
   end
 
   it "removes the metadata key" do
-    expect(presented).not_to have_key("metadata")
+    expect(presented).not_to have_key(:metadata)
   end
 
   it "removes the id key" do
-    expect(presented).not_to have_key("id")
+    expect(presented).not_to have_key(:id)
   end
 
   it "exports all other fields" do
-    content_item.attributes.each do |key, value|
-      next if ['metadata', 'id'].include?(key)
+    content_item.attributes.deep_symbolize_keys.each do |key, value|
+      next if [:metadata, :id].include?(key)
       expect(presented[key]).to eq(value)
     end
   end

--- a/spec/lib/presenters/content_item_presenter_spec.rb
+++ b/spec/lib/presenters/content_item_presenter_spec.rb
@@ -15,9 +15,13 @@ RSpec.describe Presenters::ContentItemPresenter do
     expect(presented).not_to have_key("metadata")
   end
 
+  it "removes the id key" do
+    expect(presented).not_to have_key("id")
+  end
+
   it "exports all other fields" do
     content_item.attributes.each do |key, value|
-      next if key == 'metadata'
+      next if ['metadata', 'id'].include?(key)
       expect(presented[key]).to eq(value)
     end
   end

--- a/spec/lib/queue_publisher_spec.rb
+++ b/spec/lib/queue_publisher_spec.rb
@@ -84,6 +84,23 @@ RSpec.describe QueuePublisher do
         queue_publisher.send_message(content_item)
       end
 
+      context "content item using string keys" do
+        let(:content_item) { super().stringify_keys }
+
+        it "correctly calculates routing key" do
+          expect(mock_exchange).to receive(:publish).with(anything, hash_including(:routing_key => "#{content_item['format']}.#{content_item['update_type']}"))
+
+          queue_publisher.send_message(content_item)
+        end
+      end
+
+      it "allows the routing key to be overridden" do
+        custom_routing_key = "my_routing.key"
+        expect(mock_exchange).to receive(:publish).with(anything, hash_including(:routing_key => custom_routing_key))
+
+        queue_publisher.send_message(content_item, routing_key: custom_routing_key)
+      end
+
       it "sends the message as persistent" do
         expect(mock_exchange).to receive(:publish).with(anything, hash_including(:persistent => true))
 

--- a/spec/requests/content_item_requests/event_logging_spec.rb
+++ b/spec/requests/content_item_requests/event_logging_spec.rb
@@ -6,7 +6,9 @@ RSpec.describe "Event logging", type: :request do
     let(:request_path) { "/content#{base_path}" }
     let(:request_method) { :put }
 
-    logs_event('PutContentWithLinks', expected_payload: RequestHelpers::Mocks.content_item_without_access_limiting)
+    logs_event('PutContentWithLinks', expected_payload_proc: ->{
+      content_item_without_access_limiting.deep_stringify_keys.merge("base_path" => base_path)
+    })
   end
 
   context "/draft-content" do
@@ -14,7 +16,7 @@ RSpec.describe "Event logging", type: :request do
     let(:request_path) { "/draft-content#{base_path}" }
     let(:request_method) { :put }
 
-    logs_event('PutDraftContentWithLinks', expected_payload: RequestHelpers::Mocks.content_item_with_access_limiting)
+    logs_event('PutDraftContentWithLinks', expected_payload_proc: ->{ content_item_with_access_limiting.deep_stringify_keys.merge("base_path" => base_path) })
   end
 
   context "/v2/content" do

--- a/spec/requests/content_item_requests/event_logging_spec.rb
+++ b/spec/requests/content_item_requests/event_logging_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "Event logging", type: :request do
     let(:request_method) { :put }
 
     logs_event('PutContentWithLinks', expected_payload_proc: ->{
-      content_item_without_access_limiting.deep_stringify_keys.merge("base_path" => base_path)
+      content_item_without_access_limiting.deep_symbolize_keys.merge(base_path: base_path)
     })
   end
 
@@ -16,7 +16,7 @@ RSpec.describe "Event logging", type: :request do
     let(:request_path) { "/draft-content#{base_path}" }
     let(:request_method) { :put }
 
-    logs_event('PutDraftContentWithLinks', expected_payload_proc: ->{ content_item_with_access_limiting.deep_stringify_keys.merge("base_path" => base_path) })
+    logs_event('PutDraftContentWithLinks', expected_payload_proc: ->{ content_item_with_access_limiting.deep_symbolize_keys.merge(base_path: base_path) })
   end
 
   context "/v2/content" do
@@ -24,6 +24,6 @@ RSpec.describe "Event logging", type: :request do
     let(:request_path) { "/v2/content/#{content_id}" }
     let(:request_method) { :put }
 
-    logs_event('PutContent', expected_payload: RequestHelpers::Mocks.v2_content_item)
+    logs_event('PutContent', expected_payload_proc: -> { v2_content_item } )
   end
 end

--- a/spec/requests/publish_requests_spec.rb
+++ b/spec/requests/publish_requests_spec.rb
@@ -12,9 +12,9 @@ RSpec.describe "POST /v2/publish", type: :request do
   }
   let(:expected_live_content_item_hash) {
     expected_live_content_item_derived_representation
-      .deep_stringify_keys
+      .deep_symbolize_keys
       .merge(
-        "links" => link_set.links,
+        links: link_set.links,
       )
   }
 
@@ -23,7 +23,7 @@ RSpec.describe "POST /v2/publish", type: :request do
   let(:request_path) { "/v2/content/#{content_id}/publish"}
   let(:payload) {
     {
-      "update_type" => "major",
+      update_type: "major",
     }
   }
   let(:request_body) { payload.to_json }
@@ -35,7 +35,7 @@ RSpec.describe "POST /v2/publish", type: :request do
   context "a draft content item exists with version 1" do
     let(:draft_content_item) { create(:draft_content_item, version: 1) }
 
-    logs_event("Publish", expected_payload_proc: ->{ payload.merge("content_id" => content_id) })
+    logs_event("Publish", expected_payload_proc: ->{ payload.merge(content_id: content_id) })
 
     it "creates the LiveContentItem derived representation" do
       do_request
@@ -46,7 +46,7 @@ RSpec.describe "POST /v2/publish", type: :request do
 
       expect(item.base_path).to eq(base_path)
       expect(item.content_id).to eq(expected_live_content_item_derived_representation[:content_id])
-      expect(item.details).to eq(expected_live_content_item_derived_representation[:details].deep_stringify_keys)
+      expect(item.details).to eq(expected_live_content_item_derived_representation[:details].deep_symbolize_keys)
       expect(item.format).to eq(expected_live_content_item_derived_representation[:format])
       expect(item.locale).to eq(expected_live_content_item_derived_representation[:locale])
       expect(item.publishing_app).to eq(expected_live_content_item_derived_representation[:publishing_app])
@@ -54,10 +54,10 @@ RSpec.describe "POST /v2/publish", type: :request do
       expect(item.public_updated_at).to eq(expected_live_content_item_derived_representation[:public_updated_at])
       expect(item.description).to eq(expected_live_content_item_derived_representation[:description])
       expect(item.title).to eq(expected_live_content_item_derived_representation[:title])
-      expect(item.routes).to eq(expected_live_content_item_derived_representation[:routes].map(&:deep_stringify_keys))
-      expect(item.redirects).to eq(expected_live_content_item_derived_representation[:redirects].map(&:deep_stringify_keys))
-      expect(item.metadata["need_ids"]).to eq(expected_live_content_item_derived_representation[:need_ids])
-      expect(item.metadata["phase"]).to eq(expected_live_content_item_derived_representation[:phase])
+      expect(item.routes).to eq(expected_live_content_item_derived_representation[:routes].map(&:deep_symbolize_keys))
+      expect(item.redirects).to eq(expected_live_content_item_derived_representation[:redirects].map(&:deep_symbolize_keys))
+      expect(item.metadata[:need_ids]).to eq(expected_live_content_item_derived_representation[:need_ids])
+      expect(item.metadata[:phase]).to eq(expected_live_content_item_derived_representation[:phase])
     end
 
     it "gives the new LiveContentItem the same version number as the draft item" do
@@ -127,10 +127,10 @@ RSpec.describe "POST /v2/publish", type: :request do
       it "sends the item combined with the current link set on the message queue" do
         do_request
         delivery_info, _, message_json = wait_for_message_on(@queue)
-        expect(delivery_info.routing_key).to eq("#{draft_content_item.format}.#{payload['update_type']}")
+        expect(delivery_info.routing_key).to eq("#{draft_content_item.format}.#{payload[:update_type]}")
 
         message = JSON.parse(message_json)
-        expect(message).to eq(expected_live_content_item_hash.as_json.merge("update_type" => payload['update_type']))
+        expect(message).to eq(expected_live_content_item_hash.as_json.merge("update_type" => payload[:update_type]))
       end
     end
 

--- a/spec/requests/publish_requests_spec.rb
+++ b/spec/requests/publish_requests_spec.rb
@@ -4,10 +4,13 @@ RSpec.describe "POST /v2/publish", type: :request do
   context "a draft content item exists" do
     let(:draft_content_item) { create(:draft_content_item) }
     let(:draft_content_item_attributes) { draft_content_item.attributes.deep_symbolize_keys }
-    let(:expected_live_content_item_attributes) {
+    let(:expected_live_content_item_derived_representation) {
       draft_content_item_attributes
         .merge(draft_content_item_attributes[:metadata])
-        .except(:metadata)
+        .except(:metadata, :access_limited)
+    }
+    let(:expected_live_content_item_hash) {
+      expected_live_content_item_derived_representation.deep_stringify_keys.merge("links" => link_set.links)
     }
 
     let(:content_id) { draft_content_item.content_id }
@@ -25,15 +28,22 @@ RSpec.describe "POST /v2/publish", type: :request do
       post request_path, body
     end
 
-    creates_a_content_item_representation(LiveContentItem, expected_attributes_proc: ->() { expected_live_content_item_attributes })
+    creates_a_content_item_representation(LiveContentItem, expected_attributes_proc: ->() { expected_live_content_item_derived_representation })
     logs_event("Publish", expected_payload_proc: ->{ payload.merge("content_id" => content_id) })
 
     it "sends item to live content store including links" do
       expect(PublishingAPI.service(:live_content_store)).to receive(:put_content_item)
         .with(
           base_path: draft_content_item.base_path,
-          content_item: hash_including("content_id" => content_id, "links" => link_set.links)
+          content_item: expected_live_content_item_hash
         )
+      do_request
+    end
+
+    it "sends the item combined with the current link set on the message queue" do
+      expect(PublishingAPI.service(:queue_publisher)).to receive(:send_message)
+        .with(expected_live_content_item_hash)
+
       do_request
     end
   end

--- a/spec/requests/publish_requests_spec.rb
+++ b/spec/requests/publish_requests_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe "POST /v2/publish", type: :request do
   context "a draft content item exists" do
     let(:draft_content_item) { create(:draft_content_item) }
-    let(:draft_content_item_attributes) { draft_content_item.attributes.deep_symbolize_keys }
+    let(:draft_content_item_attributes) { draft_content_item.attributes.deep_symbolize_keys.except(:id) }
     let(:expected_live_content_item_derived_representation) {
       draft_content_item_attributes
         .merge(draft_content_item_attributes[:metadata])

--- a/spec/requests/publish_requests_spec.rb
+++ b/spec/requests/publish_requests_spec.rb
@@ -58,6 +58,16 @@ RSpec.describe "POST /v2/publish", type: :request do
         expect(message).to eq(expected_live_content_item_hash.as_json.merge("update_type" => payload['update_type']))
       end
     end
-  end
 
+    context "update_type is absent" do
+      let(:payload) { {} }
+
+      it "reports an error" do
+        do_request
+
+        expect(response.status).to eq(400)
+        expect(JSON.parse(response.body)).to match(hash_including("errors" => {"update_type" => "is required"}))
+      end
+    end
+  end
 end

--- a/spec/requests/publish_requests_spec.rb
+++ b/spec/requests/publish_requests_spec.rb
@@ -1,0 +1,40 @@
+require "rails_helper"
+
+RSpec.describe "POST /v2/publish", type: :request do
+  context "a draft content item exists" do
+    let(:draft_content_item) { create(:draft_content_item) }
+    let(:draft_content_item_attributes) { draft_content_item.attributes.deep_symbolize_keys }
+    let(:expected_live_content_item_attributes) {
+      draft_content_item_attributes
+        .merge(draft_content_item_attributes[:metadata])
+        .except(:metadata)
+    }
+
+    let(:content_id) { draft_content_item.content_id }
+    let(:link_set) { create(:link_set, content_id: content_id) }
+    let(:request_path) { "/v2/content/#{content_id}/publish"}
+    let(:payload) {
+      {
+        "change_note" => "This is the change note",
+        "update_type" => "major",
+      }
+    }
+    let(:request_body) { payload.to_json }
+
+    def do_request(body: request_body)
+      post request_path, body
+    end
+
+    creates_a_content_item_representation(LiveContentItem, expected_attributes_proc: ->() { expected_live_content_item_attributes })
+    logs_event("Publish", expected_payload_proc: ->{ payload.merge("content_id" => content_id) })
+
+    it "sends item to live content store including links" do
+      expect(PublishingAPI.service(:live_content_store)).to receive(:put_content_item)
+        .with(
+          base_path: draft_content_item.base_path,
+          content_item: hash_including("content_id" => content_id, "links" => link_set.links)
+        )
+      do_request
+    end
+  end
+end

--- a/spec/requests/publish_requests_spec.rb
+++ b/spec/requests/publish_requests_spec.rb
@@ -4,38 +4,113 @@ require "support/shared_context/message_queue_test_mode"
 RSpec.describe "POST /v2/publish", type: :request do
   include MessageQueueHelpers
 
-  context "a draft content item exists" do
-    let(:draft_content_item) { create(:draft_content_item) }
-    let(:draft_content_item_attributes) { draft_content_item.attributes.deep_symbolize_keys.except(:id) }
-    let(:expected_live_content_item_derived_representation) {
-      draft_content_item_attributes
-        .merge(draft_content_item_attributes[:metadata])
-        .except(:metadata, :access_limited)
-    }
-    let(:expected_live_content_item_hash) {
-      expected_live_content_item_derived_representation
-        .deep_stringify_keys
-        .merge(
-          "links" => link_set.links,
-        )
-    }
+  let(:draft_content_item_attributes) { draft_content_item.attributes.deep_symbolize_keys.except(:id) }
+  let(:expected_live_content_item_derived_representation) {
+    draft_content_item_attributes
+      .merge(draft_content_item_attributes[:metadata])
+      .except(:metadata, :access_limited)
+  }
+  let(:expected_live_content_item_hash) {
+    expected_live_content_item_derived_representation
+      .deep_stringify_keys
+      .merge(
+        "links" => link_set.links,
+      )
+  }
 
-    let(:content_id) { draft_content_item.content_id }
-    let!(:link_set) { create(:link_set, content_id: content_id) }
-    let(:request_path) { "/v2/content/#{content_id}/publish"}
-    let(:payload) {
-      {
-        "update_type" => "major",
-      }
+  let(:content_id) { draft_content_item.content_id }
+  let!(:link_set) { create(:link_set, content_id: content_id) }
+  let(:request_path) { "/v2/content/#{content_id}/publish"}
+  let(:payload) {
+    {
+      "update_type" => "major",
     }
-    let(:request_body) { payload.to_json }
+  }
+  let(:request_body) { payload.to_json }
 
-    def do_request(body: request_body)
-      post request_path, body
+  def do_request(body: request_body)
+    post request_path, body
+  end
+
+  context "a draft content item exists with version 1" do
+    let(:draft_content_item) { create(:draft_content_item, version: 1) }
+
+    logs_event("Publish", expected_payload_proc: ->{ payload.merge("content_id" => content_id) })
+
+    it "creates the LiveContentItem derived representation" do
+      do_request
+
+      expect(LiveContentItem.count).to eq(1)
+
+      item = LiveContentItem.first
+
+      expect(item.base_path).to eq(base_path)
+      expect(item.content_id).to eq(expected_live_content_item_derived_representation[:content_id])
+      expect(item.details).to eq(expected_live_content_item_derived_representation[:details].deep_stringify_keys)
+      expect(item.format).to eq(expected_live_content_item_derived_representation[:format])
+      expect(item.locale).to eq(expected_live_content_item_derived_representation[:locale])
+      expect(item.publishing_app).to eq(expected_live_content_item_derived_representation[:publishing_app])
+      expect(item.rendering_app).to eq(expected_live_content_item_derived_representation[:rendering_app])
+      expect(item.public_updated_at).to eq(expected_live_content_item_derived_representation[:public_updated_at])
+      expect(item.description).to eq(expected_live_content_item_derived_representation[:description])
+      expect(item.title).to eq(expected_live_content_item_derived_representation[:title])
+      expect(item.routes).to eq(expected_live_content_item_derived_representation[:routes].map(&:deep_stringify_keys))
+      expect(item.redirects).to eq(expected_live_content_item_derived_representation[:redirects].map(&:deep_stringify_keys))
+      expect(item.metadata["need_ids"]).to eq(expected_live_content_item_derived_representation[:need_ids])
+      expect(item.metadata["phase"]).to eq(expected_live_content_item_derived_representation[:phase])
     end
 
-    creates_a_content_item_representation(LiveContentItem, expected_attributes_proc: ->() { expected_live_content_item_derived_representation })
-    logs_event("Publish", expected_payload_proc: ->{ payload.merge("content_id" => content_id) })
+    it "gives the new LiveContentItem the same version number as the draft item" do
+      do_request
+
+      expect(LiveContentItem.first.version).to eq(draft_content_item.version)
+    end
+  end
+
+  context "a draft content item exists with version 2" do
+    let(:draft_content_item) { create(:draft_content_item, version: 2) }
+
+    context "a LiveContentItem exists with version 1" do
+      before do
+        LiveContentItem.create(
+          title: "An existing title",
+          content_id: expected_live_content_item_derived_representation[:content_id],
+          locale: expected_live_content_item_derived_representation[:locale],
+          details: expected_live_content_item_derived_representation[:details],
+          metadata: {},
+          base_path: base_path,
+          version: 1
+        )
+      end
+
+      it "updates the existing LiveContentItem" do
+        do_request
+
+        expect(LiveContentItem.count).to eq(1)
+        expect(LiveContentItem.last.title).to eq(expected_live_content_item_derived_representation[:title])
+      end
+
+      it "gives the updated LiveContentItem the same version number as the draft item" do
+        do_request
+
+        expect(LiveContentItem.first.version).to eq(draft_content_item.version)
+      end
+    end
+
+    context "the draft content item is already published" do
+      let!(:live_content_item) {
+        create(:live_content_item, draft_content_item.attributes.except("id", "access_limited"))
+      }
+
+      it "reports an error" do
+        expect(live_content_item.version).to eq(draft_content_item.version)
+
+        do_request
+
+        expect(response.status).to eq(400)
+        expect(JSON.parse(response.body)).to match("error" => hash_including("message" => /already published/))
+      end
+    end
 
     it "sends item to live content store including links" do
       expect(PublishingAPI.service(:live_content_store)).to receive(:put_content_item)
@@ -65,8 +140,8 @@ RSpec.describe "POST /v2/publish", type: :request do
       it "reports an error" do
         do_request
 
-        expect(response.status).to eq(400)
-        expect(JSON.parse(response.body)).to match(hash_including("errors" => {"update_type" => "is required"}))
+        expect(response.status).to eq(422)
+        expect(JSON.parse(response.body)).to match("error" => hash_including("fields" => {"update_type" => ["is required"]}))
       end
     end
   end

--- a/spec/support/replaceable.rb
+++ b/spec/support/replaceable.rb
@@ -25,9 +25,14 @@ RSpec.shared_examples Replaceable do
       verify_old_attributes_not_preserved
     end
 
-    it "increases the version number" do
-      described_class.create_or_replace(payload)
+    it "increases the version number if none was specified in the payload" do
+      described_class.create_or_replace(payload.except("version"))
       expect(described_class.first.version).to eq(2)
+    end
+
+    it "uses the provided version number in preference to calculating one if provided" do
+      described_class.create_or_replace(payload.merge("version" => 99))
+      expect(described_class.first.version).to eq(99)
     end
 
     it "returns the updated item" do
@@ -49,6 +54,11 @@ RSpec.shared_examples Replaceable do
     it "sets the version number to 1" do
       described_class.create_or_replace(payload)
       expect(described_class.first.version).to eq(1)
+    end
+
+    it "uses the provided version number in preference to calculating one if provided" do
+      described_class.create_or_replace(payload.merge("version" => 99))
+      expect(described_class.first.version).to eq(99)
     end
 
     it "returns the created item" do

--- a/spec/support/replaceable.rb
+++ b/spec/support/replaceable.rb
@@ -26,7 +26,7 @@ RSpec.shared_examples Replaceable do
     end
 
     it "increases the version number if none was specified in the payload" do
-      described_class.create_or_replace(payload.except("version"))
+      described_class.create_or_replace(payload.except(:version))
       expect(described_class.first.version).to eq(2)
     end
 

--- a/spec/support/request_helpers/event_logging.rb
+++ b/spec/support/request_helpers/event_logging.rb
@@ -1,6 +1,6 @@
 module RequestHelpers
   module EventLogging
-    def logs_event(event_class_name, expected_payload:)
+    def logs_event(event_class_name, expected_payload_proc:)
       it "logs a '#{event_class_name}' event in the event log" do
         do_request
 
@@ -8,8 +8,7 @@ module RequestHelpers
         expect(Event.first.action).to eq(event_class_name)
         expect(Event.first.user_uid).to eq(nil)
 
-        expected_payload = expected_payload.merge(base_path: base_path)
-        expect(Event.first.payload).to eq(expected_payload)
+        expect(Event.first.payload).to eq(instance_exec(&expected_payload_proc))
       end
     end
   end

--- a/spec/support/shared_context/message_queue_test_mode.rb
+++ b/spec/support/shared_context/message_queue_test_mode.rb
@@ -1,0 +1,24 @@
+RSpec.shared_context "using the message queue in test mode" do
+  before :all do
+    @config = YAML.load_file(Rails.root.join("config", "rabbitmq.yml"))[Rails.env].symbolize_keys
+    @old_publisher = PublishingAPI.service(:queue_publisher)
+    PublishingAPI.register_service(name: :queue_publisher, client: QueuePublisher.new(@config))
+  end
+
+  after :all do
+    PublishingAPI.register_service(name: :queue_publisher, client: @old_publisher)
+  end
+
+  around :each do |example|
+    conn = Bunny.new(@config)
+    conn.start
+    read_channel = conn.create_channel
+    ex = read_channel.topic(@config.fetch(:exchange), passive: true)
+    @queue = read_channel.queue("", :exclusive => true)
+    @queue.bind(ex, routing_key: '#')
+
+    example.run
+
+    read_channel.close
+  end
+end

--- a/spec/support/shared_context/message_queue_test_mode.rb
+++ b/spec/support/shared_context/message_queue_test_mode.rb
@@ -1,19 +1,22 @@
 RSpec.shared_context "using the message queue in test mode" do
+  old_publisher = nil
+  rabbitmq_config = nil
+
   before :all do
-    @config = YAML.load_file(Rails.root.join("config", "rabbitmq.yml"))[Rails.env].symbolize_keys
-    @old_publisher = PublishingAPI.service(:queue_publisher)
-    PublishingAPI.register_service(name: :queue_publisher, client: QueuePublisher.new(@config))
+    rabbitmq_config = YAML.load_file(Rails.root.join("config", "rabbitmq.yml"))[Rails.env].symbolize_keys
+    old_publisher = PublishingAPI.service(:queue_publisher)
+    PublishingAPI.register_service(name: :queue_publisher, client: QueuePublisher.new(rabbitmq_config))
   end
 
   after :all do
-    PublishingAPI.register_service(name: :queue_publisher, client: @old_publisher)
+    PublishingAPI.register_service(name: :queue_publisher, client: old_publisher)
   end
 
   around :each do |example|
-    conn = Bunny.new(@config)
+    conn = Bunny.new(rabbitmq_config)
     conn.start
     read_channel = conn.create_channel
-    ex = read_channel.topic(@config.fetch(:exchange), passive: true)
+    ex = read_channel.topic(rabbitmq_config.fetch(:exchange), passive: true)
     @queue = read_channel.queue("", :exclusive => true)
     @queue.bind(ex, routing_key: '#')
 


### PR DESCRIPTION
Support for the v2 publish command

The PR for the corresponding changes to gds-api-adapters is [here](https://github.com/alphagov/gds-api-adapters/pull/361)

During the implementation we realised that the versioning behaviour of the v1 api needs to be different than that of the v2 api. See 5f5859d for an discussion of the reasons and possible issues.




