### PR TITLE
Allow slug changes for published items in v1 api

### DIFF
--- a/app/command/put_content_with_links.rb
+++ b/app/command/put_content_with_links.rb
@@ -37,15 +37,7 @@ private
   end
 
   def create_or_update_live_content_item!
-    LiveContentItem.create_or_replace(content_item_attributes) do |existing|
-      if existing.persisted? && existing.base_path != base_path
-        raise Command::Error.new(
-          code: 400,
-          message: "Cannot change base path",
-          error_details: { errors: { base_path: "cannot change once item is live" } }
-        )
-      end
-    end
+    LiveContentItem.create_or_replace(content_item_attributes)
   end
 
   def create_or_update_draft_content_item!

--- a/spec/requests/content_item_requests/derived_representations_spec.rb
+++ b/spec/requests/content_item_requests/derived_representations_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "Derived representations", type: :request do
 
     creates_a_link_representation(expected_attributes: RequestHelpers::Mocks.links_attributes)
     creates_a_content_item_representation(LiveContentItem, expected_attributes_proc: -> { content_item_without_access_limiting })
-    prevents_base_path_from_being_changed(LiveContentItem)
+    allows_base_path_to_be_changed(LiveContentItem)
   end
 
   context "/draft-content" do

--- a/spec/support/request_helpers/derived_representations.rb
+++ b/spec/support/request_helpers/derived_representations.rb
@@ -147,6 +147,9 @@ module RequestHelpers
           new_base_path = "/something-else"
 
           stub_request(:put, Plek.find('draft-content-store') + "/content#{new_base_path}")
+          if representation_class == LiveContentItem
+            stub_request(:put, Plek.find('content-store') + "/content#{new_base_path}")
+          end
 
           put request_path.gsub(base_path, new_base_path), request_body
 


### PR DESCRIPTION
We need to preserve this functionality because it is currently permitted in the existing API. We do want to prevent slug changes via the v2/content endpoint, and will probably provide a separate endpoint for this specific use.