### PR TITLE
Add links to payload sent to draft content store

### DIFF
--- a/app/commands/v2/put_content.rb
+++ b/app/commands/v2/put_content.rb
@@ -5,7 +5,7 @@ module Commands
         create_or_update_draft_content_item!
 
         Adapters::UrlArbiter.call(base_path, content_item[:publishing_app])
-        Adapters::DraftContentStore.call(base_path, content_item)
+        Adapters::DraftContentStore.call(base_path, draft_payload)
         Success.new(content_item)
       end
 
@@ -28,6 +28,22 @@ module Commands
 
       def metadata
         content_item.except(*DraftContentItem::TOP_LEVEL_FIELDS)
+      end
+
+      def link_set
+        @link_set ||= LinkSet.find_by(content_id: content_id)
+      end
+
+      def link_set_hash
+        if link_set.present?
+          {links: link_set.links}
+        else
+          {}
+        end
+      end
+
+      def draft_payload
+        content_item.merge(link_set_hash)
       end
     end
   end

--- a/spec/requests/content_item_requests/downstream_requests_spec.rb
+++ b/spec/requests/content_item_requests/downstream_requests_spec.rb
@@ -104,5 +104,32 @@ RSpec.describe "Downstream requests", type: :request do
 
       do_request(body: content_item.to_json)
     end
+
+    context "when a link set exists for the content item" do
+      it "includes links in the payload sent to draft content store" do
+        link_set = create(:link_set, content_id: content_item[:content_id])
+        expect(PublishingAPI.service(:draft_content_store)).to receive(:put_content_item)
+          .with(
+            base_path: base_path,
+            content_item: content_item.merge(links: link_set.links),
+          )
+          .and_return(json_response)
+
+        do_request(body: content_item.to_json)
+      end
+    end
+
+    context "when a link set does not exist for the content item" do
+      it "sends the payload without links to the draft content store" do
+        expect(LinkSet.count).to eq(0)
+        expect(PublishingAPI.service(:draft_content_store)).to receive(:put_content_item)
+          .with(
+            base_path: base_path,
+            content_item: content_item
+          )
+          .and_return(json_response)
+        do_request(body: content_item.to_json)
+      end
+    end
   end
 end


### PR DESCRIPTION
We need to ensure that the object sent to draft content store after PUT /v2/content also includes the links from the LinkSet object for that content_id, if it exists.