### PR TITLE
Put links endpoint

### DIFF
--- a/app/commands/put_content_with_links.rb
+++ b/app/commands/put_content_with_links.rb
@@ -42,19 +42,28 @@ module Commands
     end
 
     def create_or_update_live_content_item!
-      LiveContentItem.create_or_replace(content_item_attributes)
+      LiveContentItem.create_or_replace(content_item_attributes) do |item|
+        item.assign_attributes_with_defaults(content_item_attributes)
+      end
     end
 
     def create_or_update_draft_content_item!
-      DraftContentItem.create_or_replace(content_item_attributes)
+      DraftContentItem.create_or_replace(content_item_attributes) do |item|
+        item.assign_attributes_with_defaults(content_item_attributes)
+      end
     end
 
     def content_item_attributes
-      content_item_with_base_path.slice(*content_item_top_level_fields).merge(metadata: metadata)
+      content_item_with_base_path
+        .slice(*content_item_top_level_fields)
+        .merge(metadata: metadata)
+        .except(:version)
     end
 
     def create_or_update_links!
-      LinkSet.create_or_replace(content_id: content_id, links: content_item[:links])
+      LinkSet.create_or_replace(content_id: content_id, links: content_item[:links]) do |link_set|
+        link_set.version += 1
+      end
     end
   end
 end

--- a/app/commands/v2/publish.rb
+++ b/app/commands/v2/publish.rb
@@ -4,8 +4,12 @@ module Commands
       def call
         validate!
 
-        live_content_item = LiveContentItem.create_or_replace(draft_item.attributes.except("access_limited")) do |live_item|
-          raise CommandError.new(code: 400, message: "This item is already published") if live_item.version == draft_item.version
+        live_content_item = LiveContentItem.create_or_replace(draft_item.attributes.except("access_limited", "version")) do |live_item|
+          if live_item.version == draft_item.version
+            raise CommandError.new(code: 400, message: "This item is already published")
+          else
+            live_item.version = draft_item.version
+          end
         end
 
         item_for_content_store = live_payload(live_content_item)

--- a/app/commands/v2/put_content.rb
+++ b/app/commands/v2/put_content.rb
@@ -15,11 +15,16 @@ module Commands
       end
 
       def create_or_update_draft_content_item!
-        DraftContentItem.create_or_replace(content_item_attributes)
+        DraftContentItem.create_or_replace(content_item_attributes) do |item|
+          item.assign_attributes_with_defaults(content_item_attributes)
+        end
       end
 
       def content_item_attributes
-        payload.slice(*DraftContentItem::TOP_LEVEL_FIELDS).merge(metadata: metadata)
+        payload
+          .slice(*DraftContentItem::TOP_LEVEL_FIELDS)
+          .merge(metadata: metadata)
+          .except(:version)
       end
 
       def metadata

--- a/app/commands/v2/put_content.rb
+++ b/app/commands/v2/put_content.rb
@@ -2,20 +2,16 @@ module Commands
   module V2
     class PutContent < BaseCommand
       def call
-        create_or_update_draft_content_item!
+        content_item = create_or_update_draft_content_item!
 
-        Adapters::UrlArbiter.call(base_path, content_item[:publishing_app])
-        Adapters::DraftContentStore.call(base_path, draft_payload)
-        Success.new(content_item)
+        Adapters::UrlArbiter.call(base_path, payload[:publishing_app])
+        Adapters::DraftContentStore.call(base_path, draft_payload(content_item))
+        Success.new(payload)
       end
 
     private
-      def content_item
-        payload
-      end
-
       def content_id
-        content_item.fetch(:content_id)
+        payload.fetch(:content_id)
       end
 
       def create_or_update_draft_content_item!
@@ -23,27 +19,16 @@ module Commands
       end
 
       def content_item_attributes
-        content_item.slice(*DraftContentItem::TOP_LEVEL_FIELDS).merge(metadata: metadata)
+        payload.slice(*DraftContentItem::TOP_LEVEL_FIELDS).merge(metadata: metadata)
       end
 
       def metadata
-        content_item.except(*DraftContentItem::TOP_LEVEL_FIELDS)
+        payload.except(*DraftContentItem::TOP_LEVEL_FIELDS)
       end
 
-      def link_set
-        @link_set ||= LinkSet.find_by(content_id: content_id)
-      end
-
-      def link_set_hash
-        if link_set.present?
-          {links: link_set.links}
-        else
-          {}
-        end
-      end
-
-      def draft_payload
-        content_item.merge(link_set_hash)
+      def draft_payload(content_item)
+        draft_item_hash = LinkSetMerger.merge_links_into(content_item)
+        Presenters::ContentItemPresenter.present(draft_item_hash)
       end
     end
   end

--- a/app/commands/v2/put_link_set.rb
+++ b/app/commands/v2/put_link_set.rb
@@ -6,10 +6,7 @@ module Commands
 
         link_set = LinkSet.create_or_replace(link_params.except(:links)) do |link_set|
           link_set.version += 1
-
-          link_set.links = link_set.links
-            .merge(link_params.fetch(:links))
-            .reject {|_, links| links.empty? }
+          link_set.links = merge_links(link_set.links, link_params.fetch(:links))
         end
 
         Success.new(links: link_set.links)
@@ -34,6 +31,12 @@ module Commands
 
       def link_params
         payload
+      end
+
+      def merge_links(base_links, new_links)
+        base_links
+          .merge(new_links)
+          .reject {|_, links| links.empty? }
       end
     end
   end

--- a/app/commands/v2/put_link_set.rb
+++ b/app/commands/v2/put_link_set.rb
@@ -9,6 +9,14 @@ module Commands
           link_set.links = merge_links(link_set.links, link_params.fetch(:links))
         end
 
+        if (draft_content_item = DraftContentItem.find_by(content_id: link_params.fetch(:content_id)))
+          Adapters::DraftContentStore.call(draft_content_item.base_path, content_store_payload(draft_content_item))
+        end
+
+        if (live_content_item = LiveContentItem.find_by(content_id: link_params.fetch(:content_id)))
+          Adapters::ContentStore.call(live_content_item.base_path, content_store_payload(live_content_item))
+        end
+
         Success.new(links: link_set.links)
       end
 
@@ -37,6 +45,12 @@ module Commands
         base_links
           .merge(new_links)
           .reject {|_, links| links.empty? }
+      end
+
+      def content_store_payload(content_item)
+        content_item_hash = LinkSetMerger.merge_links_into(content_item)
+        content_item_hash = content_item_hash.merge(update_type: "links")
+        Presenters::ContentItemPresenter.present(content_item_hash)
       end
     end
   end

--- a/app/commands/v2/put_link_set.rb
+++ b/app/commands/v2/put_link_set.rb
@@ -4,22 +4,17 @@ module Commands
       def call
         validate!
 
-        content_id = links_params.fetch(:content_id)
+        content_id = link_params.fetch(:content_id)
 
-        if (link_set = LinkSet.find_by(content_id: content_id))
-          link_set.links = link_set.links
-            .merge(links_params.fetch(:links))
-            .reject {|_, links| links.empty? }
+        link_set = LinkSet.find_or_initialize_by(content_id: content_id)
 
-          link_set.save!
+        link_set.links = link_set.links
+          .merge(link_params.fetch(:links))
+          .reject {|_, links| links.empty? }
 
-          Success.new(links: link_set.links)
-        else
-          raise CommandError.new(
-            code: 404,
-            message: "Link set with content_id '#{content_id}' not found"
-          )
-        end
+        link_set.save!
+
+        Success.new(links: link_set.links)
       end
 
     private
@@ -36,10 +31,10 @@ module Commands
               }
             }
           }
-        ) unless links_params[:links].present?
+        ) unless link_params[:links].present?
       end
 
-      def links_params
+      def link_params
         payload
       end
     end

--- a/app/commands/v2/put_link_set.rb
+++ b/app/commands/v2/put_link_set.rb
@@ -8,6 +8,8 @@ module Commands
 
         link_set = LinkSet.find_or_initialize_by(content_id: content_id)
 
+        link_set.version += 1
+
         link_set.links = link_set.links
           .merge(link_params.fetch(:links))
           .reject {|_, links| links.empty? }

--- a/app/commands/v2/put_link_set.rb
+++ b/app/commands/v2/put_link_set.rb
@@ -1,0 +1,47 @@
+module Commands
+  module V2
+    class PutLinkSet < BaseCommand
+      def call
+        validate!
+
+        content_id = links_params.fetch(:content_id)
+
+        if (link_set = LinkSet.find_by(content_id: content_id))
+          link_set.links = link_set.links
+            .merge(links_params.fetch(:links))
+            .reject {|_, links| links.empty? }
+
+          link_set.save!
+
+          Success.new(links: link_set.links)
+        else
+          raise CommandError.new(
+            code: 404,
+            message: "Link set with content_id '#{content_id}' not found"
+          )
+        end
+      end
+
+    private
+      def validate!
+        raise CommandError.new(
+          code: 422,
+          message: "Links are required",
+          error_details: {
+            error: {
+              code: 422,
+              message: "Links are required",
+              fields: {
+                links: ["are required"],
+              }
+            }
+          }
+        ) unless links_params[:links].present?
+      end
+
+      def links_params
+        payload
+      end
+    end
+  end
+end

--- a/app/commands/v2/put_link_set.rb
+++ b/app/commands/v2/put_link_set.rb
@@ -4,17 +4,13 @@ module Commands
       def call
         validate!
 
-        content_id = link_params.fetch(:content_id)
+        link_set = LinkSet.create_or_replace(link_params.except(:links)) do |link_set|
+          link_set.version += 1
 
-        link_set = LinkSet.find_or_initialize_by(content_id: content_id)
-
-        link_set.version += 1
-
-        link_set.links = link_set.links
-          .merge(link_params.fetch(:links))
-          .reject {|_, links| links.empty? }
-
-        link_set.save!
+          link_set.links = link_set.links
+            .merge(link_params.fetch(:links))
+            .reject {|_, links| links.empty? }
+        end
 
         Success.new(links: link_set.links)
       end

--- a/app/commands/v2/put_link_set.rb
+++ b/app/commands/v2/put_link_set.rb
@@ -14,7 +14,10 @@ module Commands
         end
 
         if (live_content_item = LiveContentItem.find_by(content_id: link_params.fetch(:content_id)))
-          Adapters::ContentStore.call(live_content_item.base_path, content_store_payload(live_content_item))
+          content_store_payload = content_store_payload(live_content_item)
+
+          Adapters::ContentStore.call(live_content_item.base_path, content_store_payload)
+          PublishingAPI.service(:queue_publisher).send_message(content_store_payload)
         end
 
         Success.new(links: link_set.links)

--- a/app/controllers/v2/link_sets_controller.rb
+++ b/app/controllers/v2/link_sets_controller.rb
@@ -1,7 +1,24 @@
 module V2
   class LinkSetsController < ApplicationController
     def get_links
-      render json: Queries::GetLinkSet.call(params[:content_id])
+      render json: Queries::GetLinkSet.call(content_id)
+    end
+
+    def put_links
+      response = with_event_logging(Commands::V2::PutLinkSet, links_params) do
+        Commands::V2::PutLinkSet.call(links_params)
+      end
+
+      render status: response.code, json: response
+    end
+
+  private
+    def links_params
+      payload.merge(content_id: content_id)
+    end
+
+    def content_id
+      params.fetch(:content_id)
     end
   end
 end

--- a/app/lib/presenters/content_item_presenter.rb
+++ b/app/lib/presenters/content_item_presenter.rb
@@ -1,17 +1,13 @@
 module Presenters
-  class ContentItemPresenter
-    attr_reader :content_item
+  module ContentItemPresenter
+    def self.present(content_item_hash)
+      metadata = content_item_hash.fetch(:metadata)
+      public_updated_at = content_item_hash.fetch(:public_updated_at).iso8601
 
-    def initialize(content_item)
-      @content_item = content_item
-    end
-
-    def present
-      raw_json.except("metadata", "id").merge(raw_json['metadata']).deep_symbolize_keys
-    end
-
-    def raw_json
-      content_item.as_json
+      content_item_hash
+        .except(:metadata, :id, :version)
+        .merge(metadata)
+        .merge(public_updated_at: public_updated_at)
     end
   end
 end

--- a/app/link_set_merger.rb
+++ b/app/link_set_merger.rb
@@ -1,0 +1,10 @@
+module LinkSetMerger
+  def self.merge_links_into(content_item)
+    merged_result = content_item.as_json
+
+    link_set = LinkSet.find_by(content_id: content_item.content_id)
+    merged_result.merge!(links: link_set.links) if link_set
+
+    merged_result.deep_symbolize_keys
+  end
+end

--- a/app/models/default_attributes.rb
+++ b/app/models/default_attributes.rb
@@ -1,0 +1,13 @@
+module DefaultAttributes
+  extend ActiveSupport::Concern
+
+  included do
+    def assign_attributes_with_defaults(attributes)
+      new_attributes = self.class.column_defaults.symbolize_keys
+        .merge(version: self.version + 1)
+        .merge(attributes.symbolize_keys)
+        .except(:id)
+      assign_attributes(new_attributes)
+    end
+  end
+end

--- a/app/models/draft_content_item.rb
+++ b/app/models/draft_content_item.rb
@@ -1,5 +1,6 @@
 class DraftContentItem < ActiveRecord::Base
   include Replaceable
+  include DefaultAttributes
   include SymbolizeJSON
 
   TOP_LEVEL_FIELDS = (LiveContentItem::TOP_LEVEL_FIELDS + [

--- a/app/models/link_set.rb
+++ b/app/models/link_set.rb
@@ -1,5 +1,6 @@
 class LinkSet < ActiveRecord::Base
   include Replaceable
+  include DefaultAttributes
   include SymbolizeJSON
 
 private

--- a/app/models/live_content_item.rb
+++ b/app/models/live_content_item.rb
@@ -1,5 +1,6 @@
 class LiveContentItem < ActiveRecord::Base
   include Replaceable
+  include DefaultAttributes
   include SymbolizeJSON
 
   TOP_LEVEL_FIELDS = [

--- a/app/models/replaceable.rb
+++ b/app/models/replaceable.rb
@@ -13,12 +13,8 @@ module Replaceable
   private
     def attribute_overrides
       {
-        version: increment_version,
+        version: self.version + 1,
       }
-    end
-
-    def increment_version
-      (self.version || 0) + 1
     end
   end
 

--- a/app/models/replaceable.rb
+++ b/app/models/replaceable.rb
@@ -1,31 +1,16 @@
 module Replaceable
   extend ActiveSupport::Concern
 
-  included do
-    def assign_attributes_with_defaults(attributes)
-      new_attributes = self.class.column_defaults.symbolize_keys
-        .merge(attribute_overrides)
-        .merge(attributes.symbolize_keys)
-        .except(:id)
-      assign_attributes(new_attributes)
-    end
-
-  private
-    def attribute_overrides
-      {
-        version: self.version + 1,
-      }
-    end
-  end
-
   class_methods do
     def create_or_replace(payload, &block)
       payload = payload.deep_symbolize_keys
+
       item = self.lock.find_or_initialize_by(payload.slice(*self.query_keys))
+      item.assign_attributes(payload.except(:id))
+
       if block_given?
         yield(item)
       end
-      item.assign_attributes_with_defaults(payload.except(:id))
 
       retry_strategy = if item.new_record?
         method(:retrying_on_unique_constraint_violation)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,7 @@ Rails.application.routes.draw do
       post "/content/:content_id/publish", to: "content_items#publish"
 
       get "/links/:content_id", to: "link_sets#get_links"
+      put "/links/:content_id", to: "link_sets#put_links"
     end
   end
 

--- a/db/migrate/20151012094145_set_empty_default_for_json_fields.rb
+++ b/db/migrate/20151012094145_set_empty_default_for_json_fields.rb
@@ -1,0 +1,18 @@
+class SetEmptyDefaultForJsonFields < ActiveRecord::Migration
+  def change
+    change_column_default(:events, :payload, {})
+
+    change_column_default(:draft_content_items, :access_limited, {})
+    change_column_default(:draft_content_items, :details, {})
+    change_column_default(:draft_content_items, :metadata, {})
+    change_column_default(:draft_content_items, :redirects, [])
+    change_column_default(:draft_content_items, :routes, [])
+
+    change_column_default(:live_content_items, :details, {})
+    change_column_default(:live_content_items, :metadata, {})
+    change_column_default(:live_content_items, :redirects, [])
+    change_column_default(:live_content_items, :routes, [])
+
+    change_column_default(:link_sets, :links, {})
+  end
+end

--- a/db/migrate/20151012095129_set_default_version_to_zero.rb
+++ b/db/migrate/20151012095129_set_default_version_to_zero.rb
@@ -1,0 +1,7 @@
+class SetDefaultVersionToZero < ActiveRecord::Migration
+  def change
+    change_column_default(:draft_content_items, :version, 0)
+    change_column_default(:live_content_items, :version, 0)
+    change_column_default(:link_sets, :version, 0)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -47,7 +47,7 @@ ActiveRecord::Schema.define(version: 20151012095129) do
   create_table "link_sets", force: :cascade do |t|
     t.string  "content_id"
     t.integer "version",    default: 0,  null: false
-    t.json    "links",      default: {}, null: false
+    t.json    "links",      default: {}
   end
 
   add_index "link_sets", ["content_id"], name: "index_link_sets_on_content_id", unique: true, using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150922125847) do
+ActiveRecord::Schema.define(version: 20151012095129) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -19,17 +19,17 @@ ActiveRecord::Schema.define(version: 20150922125847) do
   create_table "draft_content_items", force: :cascade do |t|
     t.string   "content_id"
     t.string   "locale"
-    t.integer  "version",           null: false
+    t.integer  "version",           default: 0,  null: false
     t.string   "base_path"
     t.string   "title"
     t.string   "description"
     t.string   "format"
     t.datetime "public_updated_at"
-    t.json     "access_limited"
-    t.json     "metadata"
-    t.json     "details"
-    t.json     "routes"
-    t.json     "redirects"
+    t.json     "access_limited",    default: {}
+    t.json     "metadata",          default: {}
+    t.json     "details",           default: {}
+    t.json     "routes",            default: []
+    t.json     "redirects",         default: []
     t.string   "publishing_app"
     t.string   "rendering_app"
   end
@@ -37,8 +37,8 @@ ActiveRecord::Schema.define(version: 20150922125847) do
   add_index "draft_content_items", ["content_id", "locale"], name: "index_draft_content_items_on_content_id_and_locale", unique: true, using: :btree
 
   create_table "events", force: :cascade do |t|
-    t.string   "action",     null: false
-    t.json     "payload",    null: false
+    t.string   "action",                  null: false
+    t.json     "payload",    default: {}, null: false
     t.string   "user_uid"
     t.datetime "created_at"
     t.datetime "updated_at"
@@ -46,8 +46,8 @@ ActiveRecord::Schema.define(version: 20150922125847) do
 
   create_table "link_sets", force: :cascade do |t|
     t.string  "content_id"
-    t.integer "version",    null: false
-    t.json    "links"
+    t.integer "version",    default: 0,  null: false
+    t.json    "links",      default: {}, null: false
   end
 
   add_index "link_sets", ["content_id"], name: "index_link_sets_on_content_id", unique: true, using: :btree
@@ -55,16 +55,16 @@ ActiveRecord::Schema.define(version: 20150922125847) do
   create_table "live_content_items", force: :cascade do |t|
     t.string   "content_id"
     t.string   "locale"
-    t.integer  "version",           null: false
+    t.integer  "version",           default: 0,  null: false
     t.string   "base_path"
     t.string   "title"
     t.string   "description"
     t.string   "format"
     t.datetime "public_updated_at"
-    t.json     "metadata"
-    t.json     "details"
-    t.json     "routes"
-    t.json     "redirects"
+    t.json     "metadata",          default: {}
+    t.json     "details",           default: {}
+    t.json     "routes",            default: []
+    t.json     "redirects",         default: []
     t.string   "publishing_app"
     t.string   "rendering_app"
   end

--- a/spec/commands/v2/put_link_set_spec.rb
+++ b/spec/commands/v2/put_link_set_spec.rb
@@ -1,6 +1,26 @@
 require "rails_helper"
 
 RSpec.describe Commands::V2::PutLinkSet do
+  let(:content_id) { "a5f715f9-a0b3-4186-823d-d31f6af4b060" }
+  let(:link_params) {
+    {
+      content_id: content_id,
+      links: {
+        organisations: ["some-new-uuid"],
+      }
+    }
+  }
+
+  before do
+    @existing_link_set = FactoryGirl.create(:link_set,
+      content_id: content_id,
+      links: {
+        organisations: ["some-original-uuid"],
+        topics: ["some-topic-uuid"],
+      }
+    )
+  end
+
   it "validates the link params" do
     link_params_with_missing_links = {}
 
@@ -10,21 +30,9 @@ RSpec.describe Commands::V2::PutLinkSet do
   end
 
   it "updates the LinkSet on disk" do
-    link_set = FactoryGirl.create(:link_set, links: {
-      organisations: ["some-original-uuid"],
-      topics: ["some-topic-uuid"],
-    })
-
-    link_params = {
-      content_id: link_set.content_id,
-      links: {
-        organisations: ["some-new-uuid"],
-      }
-    }
-
     described_class.call(link_params)
 
-    expect(LinkSet.last.links).to eq(
+    expect(@existing_link_set.reload.links).to eq(
       organisations: ["some-new-uuid"],
       topics: ["some-topic-uuid"],
     )

--- a/spec/commands/v2/put_link_set_spec.rb
+++ b/spec/commands/v2/put_link_set_spec.rb
@@ -1,0 +1,32 @@
+require "rails_helper"
+
+RSpec.describe Commands::V2::PutLinkSet do
+  it "validates the link params" do
+    link_params_with_missing_links = {}
+
+    expect {
+      described_class.call(link_params_with_missing_links)
+    }.to raise_error(CommandError, "Links are required")
+  end
+
+  it "updates the LinkSet on disk" do
+    link_set = FactoryGirl.create(:link_set, links: {
+      organisations: ["some-original-uuid"],
+      topics: ["some-topic-uuid"],
+    })
+
+    link_params = {
+      content_id: link_set.content_id,
+      links: {
+        organisations: ["some-new-uuid"],
+      }
+    }
+
+    described_class.call(link_params)
+
+    expect(LinkSet.last.links).to eq(
+      organisations: ["some-new-uuid"],
+      topics: ["some-topic-uuid"],
+    )
+  end
+end

--- a/spec/link_set_merger_spec.rb
+++ b/spec/link_set_merger_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+RSpec.describe LinkSetMerger do
+  describe ".merge_links_into(content_id)" do
+    let(:content_id) { "727ef350-81ed-4b46-9e46-ff3dc83303d5" }
+    let!(:content_item) {
+      FactoryGirl.create(:draft_content_item, content_id: content_id)
+    }
+
+    context "when a link set exists" do
+      let!(:link_set) {
+        FactoryGirl.create(:link_set, content_id: content_id)
+      }
+
+      it "returns a hash representing the merged content item and link set" do
+        merged_result = subject.merge_links_into(content_item)
+
+        DraftContentItem::TOP_LEVEL_FIELDS.each do |field|
+          expect(merged_result[field]).to eq(content_item.public_send(field))
+        end
+
+        expect(merged_result[:links]).to eq(link_set.links)
+      end
+    end
+
+    context "when a link set does not exist" do
+      it "returns a hash representing the content item" do
+        merged_result = subject.merge_links_into(content_item)
+
+        DraftContentItem::TOP_LEVEL_FIELDS.each do |field|
+          expect(merged_result[field]).to eq(content_item.public_send(field))
+        end
+      end
+    end
+  end
+end

--- a/spec/models/draft_content_item_spec.rb
+++ b/spec/models/draft_content_item_spec.rb
@@ -1,13 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe DraftContentItem do
+  subject { FactoryGirl.build(:draft_content_item) }
+
   def verify_new_attributes_set
     expect(described_class.first.title).to eq("New title")
-  end
-
-  def verify_old_attributes_not_preserved
-    expect(described_class.first.format).to be_nil
-    expect(described_class.first.routes).to eq([])
   end
 
   let(:new_attributes) {
@@ -18,4 +15,5 @@ RSpec.describe DraftContentItem do
   }
 
   it_behaves_like Replaceable
+  it_behaves_like DefaultAttributes
 end

--- a/spec/models/draft_content_item_spec.rb
+++ b/spec/models/draft_content_item_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe DraftContentItem do
 
   def verify_old_attributes_not_preserved
     expect(described_class.first.format).to be_nil
-    expect(described_class.first.routes).to be_nil
+    expect(described_class.first.routes).to eq([])
   end
 
   let(:new_attributes) {

--- a/spec/models/live_content_item_spec.rb
+++ b/spec/models/live_content_item_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe LiveContentItem do
 
   def verify_old_attributes_not_preserved
     expect(described_class.first.format).to be_nil
-    expect(described_class.first.routes).to be_nil
+    expect(described_class.first.routes).to eq([])
   end
 
   let(:new_attributes) {

--- a/spec/models/live_content_item_spec.rb
+++ b/spec/models/live_content_item_spec.rb
@@ -1,21 +1,19 @@
 require 'rails_helper'
 
 RSpec.describe LiveContentItem do
+  subject { FactoryGirl.build(:live_content_item) }
+
   def verify_new_attributes_set
     expect(described_class.first.title).to eq("New title")
-  end
-
-  def verify_old_attributes_not_preserved
-    expect(described_class.first.format).to be_nil
-    expect(described_class.first.routes).to eq([])
   end
 
   let(:new_attributes) {
     {
       content_id: content_id,
-      title: "New title"
+      title: "New title",
     }
   }
 
   it_behaves_like Replaceable
+  it_behaves_like DefaultAttributes
 end

--- a/spec/presenters/content_item_presenter_spec.rb
+++ b/spec/presenters/content_item_presenter_spec.rb
@@ -1,13 +1,14 @@
 require 'rails_helper'
 
 RSpec.describe Presenters::ContentItemPresenter do
-  let(:content_item) { create(:draft_content_item) }
+  let(:content_item_hash) { create(:draft_content_item).as_json.deep_symbolize_keys }
+  let(:content_item_metadata) { content_item_hash.fetch(:metadata) }
 
-  subject(:presented) { described_class.new(content_item).present }
+  let(:presented) { subject.present(content_item_hash) }
 
   it "includes the metadata fields in the top level of the presented item" do
-    content_item.metadata.keys.each do |key|
-      expect(presented[key]).to eq(content_item.metadata[key])
+    content_item_metadata.keys.each do |key|
+      expect(presented[key]).to eq(content_item_metadata[key])
     end
   end
 
@@ -19,9 +20,18 @@ RSpec.describe Presenters::ContentItemPresenter do
     expect(presented).not_to have_key(:id)
   end
 
+  it "removes the version" do
+    expect(presented).not_to have_key(:version)
+  end
+
+  it "exports date fields as ISO 8601" do
+    expect(presented[:public_updated_at]).to be_a(String)
+    expect(presented[:public_updated_at]).to eq(content_item_hash[:public_updated_at].iso8601)
+  end
+
   it "exports all other fields" do
-    content_item.attributes.deep_symbolize_keys.each do |key, value|
-      next if [:metadata, :id].include?(key)
+    content_item_hash.each do |key, value|
+      next if [:metadata, :id, :version, :public_updated_at].include?(key)
       expect(presented[key]).to eq(value)
     end
   end

--- a/spec/requests/content_item_requests/derived_representations_spec.rb
+++ b/spec/requests/content_item_requests/derived_representations_spec.rb
@@ -28,4 +28,12 @@ RSpec.describe "Derived representations", type: :request do
 
     creates_a_content_item_representation(DraftContentItem, expected_attributes_proc: -> { v2_content_item }, access_limited: true)
   end
+
+  context "/v2/links" do
+    let(:request_body) { links_attributes.to_json }
+    let(:request_path) { "/v2/links/#{content_id}" }
+    let(:request_method) { :put }
+
+    creates_a_link_representation(expected_attributes: RequestHelpers::Mocks.links_attributes)
+  end
 end

--- a/spec/requests/content_item_requests/downstream_requests_spec.rb
+++ b/spec/requests/content_item_requests/downstream_requests_spec.rb
@@ -57,13 +57,7 @@ RSpec.describe "Downstream requests", type: :request do
     url_registration_happens
     url_registration_failures_422
     sends_to_draft_content_store
-
-    it "does not send anything to the live content store" do
-      expect(PublishingAPI.service(:live_content_store)).to receive(:put_content_item).never
-      expect(WebMock).not_to have_requested(:any, /draft-content-store.*/)
-
-      do_request
-    end
+    does_not_send_to_live_content_store
 
     it "leaves access limiting metadata in the document" do
       expect(PublishingAPI.service(:draft_content_store)).to receive(:put_content_item)
@@ -86,13 +80,7 @@ RSpec.describe "Downstream requests", type: :request do
     url_registration_happens
     url_registration_failures_422
     sends_to_draft_content_store
-
-    it "does not send anything to the live content store" do
-      expect(PublishingAPI.service(:live_content_store)).to receive(:put_content_item).never
-      expect(WebMock).not_to have_requested(:any, /draft-content-store.*/)
-
-      do_request
-    end
+    does_not_send_to_live_content_store
 
     it "leaves access limiting metadata in the document" do
       expect(PublishingAPI.service(:draft_content_store)).to receive(:put_content_item)
@@ -130,6 +118,42 @@ RSpec.describe "Downstream requests", type: :request do
           .and_return(json_response)
         do_request(body: content_item.to_json)
       end
+    end
+  end
+
+  context "/v2/links" do
+    let(:content_item) {
+      v2_content_item.merge(
+        links: links_attributes[:links],
+        update_type: "links",
+      )
+    }
+    let(:request_body) { links_attributes.to_json }
+    let(:request_path) { "/v2/links/#{content_id}" }
+    let(:request_method) { :put }
+
+    context "when only a draft content item exists for the link set" do
+      before do
+        FactoryGirl.create(:draft_content_item, v2_content_item.slice(*DraftContentItem::TOP_LEVEL_FIELDS))
+      end
+
+      sends_to_draft_content_store(with_arbitration: false)
+      does_not_send_to_live_content_store
+    end
+
+    context "when draft and live content items exists for the link set" do
+      before do
+        FactoryGirl.create(:draft_content_item, v2_content_item.slice(*DraftContentItem::TOP_LEVEL_FIELDS))
+        FactoryGirl.create(:live_content_item, v2_content_item.slice(*LiveContentItem::TOP_LEVEL_FIELDS))
+      end
+
+      sends_to_draft_content_store(with_arbitration: false)
+      sends_to_live_content_store
+    end
+
+    context "when a content item does not exist for the link set" do
+      does_not_send_to_draft_content_store
+      does_not_send_to_live_content_store
     end
   end
 end

--- a/spec/requests/content_item_requests/downstream_timeouts_spec.rb
+++ b/spec/requests/content_item_requests/downstream_timeouts_spec.rb
@@ -25,4 +25,17 @@ RSpec.describe "Downstream timeouts", type: :request do
 
     behaves_well_when_draft_content_store_times_out
   end
+
+  context "/v2/links" do
+    let(:request_body) { links_attributes.to_json }
+    let(:request_path) { "/v2/links/#{content_id}" }
+    let(:request_method) { :put }
+
+    before do
+      FactoryGirl.create(:draft_content_item, v2_content_item.slice(*DraftContentItem::TOP_LEVEL_FIELDS))
+      FactoryGirl.create(:live_content_item, v2_content_item.slice(*LiveContentItem::TOP_LEVEL_FIELDS))
+    end
+
+    behaves_well_when_draft_content_store_times_out
+  end
 end

--- a/spec/requests/content_item_requests/event_logging_spec.rb
+++ b/spec/requests/content_item_requests/event_logging_spec.rb
@@ -26,4 +26,12 @@ RSpec.describe "Event logging", type: :request do
 
     logs_event('PutContent', expected_payload_proc: -> { v2_content_item } )
   end
+
+  context "/v2/links" do
+    let(:request_body) { links_attributes.to_json }
+    let(:request_path) { "/v2/links/#{content_id}" }
+    let(:request_method) { :put }
+
+    logs_event('PutLinkSet', expected_payload_proc: -> { links_attributes } )
+  end
 end

--- a/spec/requests/content_item_requests/invalid_requests_spec.rb
+++ b/spec/requests/content_item_requests/invalid_requests_spec.rb
@@ -17,14 +17,7 @@ RSpec.describe "Invalid content requests", type: :request do
     let(:request_path) { "/content#{base_path}" }
     let(:request_method) { :put }
 
-    it "does not log an event in the event log" do
-      do_request
-
-      expect(Event.count).to eq(0)
-      expect(response.status).to eq(422)
-      expect(response.body).to eq(error_details.to_json)
-    end
-
+    does_not_log_event
     creates_no_derived_representations
   end
 
@@ -33,14 +26,7 @@ RSpec.describe "Invalid content requests", type: :request do
     let(:request_path) { "/draft-content#{base_path}" }
     let(:request_method) { :put }
 
-    it "does not log an event in the event log" do
-      do_request
-
-      expect(Event.count).to eq(0)
-      expect(response.status).to eq(422)
-      expect(response.body).to eq(error_details.to_json)
-    end
-
+    does_not_log_event
     creates_no_derived_representations
   end
 
@@ -49,14 +35,21 @@ RSpec.describe "Invalid content requests", type: :request do
     let(:request_path) { "/v2/content/#{content_id}" }
     let(:request_method) { :put }
 
-    it "does not log an event in the event log" do
-      do_request
+    does_not_log_event
+    creates_no_derived_representations
+  end
 
-      expect(Event.count).to eq(0)
-      expect(response.status).to eq(422)
-      expect(response.body).to eq(error_details.to_json)
+  context "/v2/links" do
+    let(:request_body) { links_attributes.to_json }
+    let(:request_path) { "/v2/links/#{content_id}" }
+    let(:request_method) { :put }
+
+    before do
+      FactoryGirl.create(:draft_content_item, v2_content_item.slice(*DraftContentItem::TOP_LEVEL_FIELDS))
+      FactoryGirl.create(:live_content_item, v2_content_item.slice(*LiveContentItem::TOP_LEVEL_FIELDS))
     end
 
+    does_not_log_event
     creates_no_derived_representations
   end
 end

--- a/spec/requests/content_item_requests/message_bus_spec.rb
+++ b/spec/requests/content_item_requests/message_bus_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe "Message bus", type: :request do
   end
 
   context "/draft-content" do
-    let(:request_body) { content_item_with_access_limiting }
+    let(:request_body) { content_item_with_access_limiting.to_json }
     let(:request_path) { "/draft-content#{base_path}" }
     let(:request_method) { :put }
 
@@ -70,11 +70,13 @@ RSpec.describe "Message bus", type: :request do
       expect(PublishingAPI.service(:queue_publisher)).not_to receive(:send_message)
 
       do_request
+
+      expect(response.status).to eq(200)
     end
   end
 
   context "/v2/content" do
-    let(:request_body) { v2_content_item }
+    let(:request_body) { v2_content_item.to_json }
     let(:request_path) { "/v2/content/#{content_id}" }
     let(:request_method) { :put }
 
@@ -82,6 +84,10 @@ RSpec.describe "Message bus", type: :request do
       expect(PublishingAPI.service(:queue_publisher)).not_to receive(:send_message)
 
       do_request
+
+      expect(response.status).to eq(200)
+    end
+  end
     end
   end
 end

--- a/spec/requests/content_item_requests/message_bus_spec.rb
+++ b/spec/requests/content_item_requests/message_bus_spec.rb
@@ -1,5 +1,6 @@
 require "rails_helper"
 require "support/shared_context/message_queue_test_mode"
+require "json"
 
 RSpec.describe "Message bus", type: :request do
   include MessageQueueHelpers
@@ -88,6 +89,45 @@ RSpec.describe "Message bus", type: :request do
       expect(response.status).to eq(200)
     end
   end
+
+  context "/v2/links" do
+    let(:request_body) { links_attributes.to_json }
+    let(:request_path) { "/v2/links/#{content_id}" }
+    let(:request_method) { :put }
+
+    context "with a live content item" do
+      let!(:live_content_item) {
+        FactoryGirl.create(:live_content_item, v2_content_item.slice(*LiveContentItem::TOP_LEVEL_FIELDS))
+      }
+
+      it "sends a message with a 'links' routing key" do
+        do_request
+
+        expect(response.status).to eq(200)
+
+        expected_payload = v2_content_item.except(:access_limited).merge(
+          links: links_attributes.fetch(:links),
+          update_type: "links",
+        ).to_json
+
+        delivery_info, _, payload = wait_for_message_on(@queue)
+        expect(delivery_info.routing_key).to eq("#{live_content_item.format}.links")
+        expect(JSON.parse(payload)).to eq(JSON.parse(expected_payload))
+      end
+    end
+
+    context "with a draft content item" do
+      let!(:draft_content_item) {
+        FactoryGirl.create(:draft_content_item, v2_content_item.slice(*DraftContentItem::TOP_LEVEL_FIELDS))
+      }
+
+      it "doesn't send any messages" do
+        expect(PublishingAPI.service(:queue_publisher)).not_to receive(:send_message)
+
+        do_request
+
+        expect(response.status).to eq(200)
+      end
     end
   end
 end

--- a/spec/requests/publish_requests_spec.rb
+++ b/spec/requests/publish_requests_spec.rb
@@ -4,10 +4,11 @@ require "support/shared_context/message_queue_test_mode"
 RSpec.describe "POST /v2/publish", type: :request do
   include MessageQueueHelpers
 
-  let(:draft_content_item_attributes) { draft_content_item.attributes.deep_symbolize_keys.except(:id) }
+  let(:draft_content_item_attributes) { draft_content_item.attributes.deep_symbolize_keys.except(:id, :version) }
   let(:expected_live_content_item_derived_representation) {
     draft_content_item_attributes
       .merge(draft_content_item_attributes[:metadata])
+      .merge(public_updated_at: draft_content_item_attributes[:public_updated_at].iso8601)
       .except(:metadata, :access_limited)
   }
   let(:expected_live_content_item_hash) {

--- a/spec/service_consumers/pact_helper.rb
+++ b/spec/service_consumers/pact_helper.rb
@@ -133,7 +133,7 @@ Pact.provider_states_for "GDS API Adapters" do
     end
   end
 
-  provider_state "links exist for content_id bed722e6-db68-43e5-9079-063f623335a7" do
+  provider_state "organisation links exist for content_id bed722e6-db68-43e5-9079-063f623335a7" do
     set_up do
       DatabaseCleaner.clean_with :truncation
 

--- a/spec/support/default_attributes.rb
+++ b/spec/support/default_attributes.rb
@@ -1,0 +1,35 @@
+RSpec.shared_examples DefaultAttributes do
+  before do
+    subject.format = "something that should be cleared"
+    subject.routes = ["foo"]
+    subject.version = 1
+  end
+
+  let(:attributes) {
+    {
+      title: "New title",
+    }
+  }
+
+  it "does not preserve any information from the existing item" do
+    subject.assign_attributes_with_defaults(attributes)
+
+    expect(subject.format).to be_nil
+    expect(subject.routes).to eq([])
+  end
+
+  it "assigns the new attributes" do
+    subject.assign_attributes_with_defaults(attributes)
+    expect(subject.title).to eq("New title")
+  end
+
+  it "increases the version number if none was specified in the payload" do
+    subject.assign_attributes_with_defaults(attributes)
+    expect(subject.version).to eq(2)
+  end
+
+  it "uses the provided version number in preference to calculating one if provided" do
+    subject.assign_attributes_with_defaults(attributes.merge(version: 99))
+    expect(subject.version).to eq(99)
+  end
+end

--- a/spec/support/replaceable.rb
+++ b/spec/support/replaceable.rb
@@ -20,19 +20,11 @@ RSpec.shared_examples Replaceable do
       verify_new_attributes_set
     end
 
-    it "does not preserve any information from the existing item" do
-      described_class.create_or_replace(payload)
-      verify_old_attributes_not_preserved
-    end
-
-    it "increases the version number if none was specified in the payload" do
-      described_class.create_or_replace(payload.except(:version))
-      expect(described_class.first.version).to eq(2)
-    end
-
-    it "uses the provided version number in preference to calculating one if provided" do
-      described_class.create_or_replace(payload.merge("version" => 99))
-      expect(described_class.first.version).to eq(99)
+    it "provides a mechanism to mutate the object before it is saved" do
+      described_class.create_or_replace(payload) do |item|
+        item.version = 123
+      end
+      expect(described_class.last.version).to eq(123)
     end
 
     it "returns the updated item" do

--- a/spec/support/request_helpers/derived_representations.rb
+++ b/spec/support/request_helpers/derived_representations.rb
@@ -2,11 +2,15 @@ module RequestHelpers
   module DerivedRepresentations
     def creates_no_derived_representations
       it "does not create any derived representations" do
+        draft_count = DraftContentItem.count
+        live_count = LiveContentItem.count
+        link_count = LinkSet.count
+
         do_request
 
-        expect(DraftContentItem.count).to eq(0)
-        expect(LiveContentItem.count).to eq(0)
-        expect(LinkSet.count).to eq(0)
+        expect(DraftContentItem.count).to eq(draft_count)
+        expect(LiveContentItem.count).to eq(live_count)
+        expect(LinkSet.count).to eq(link_count)
       end
     end
 

--- a/spec/support/request_helpers/downstream_requests.rb
+++ b/spec/support/request_helpers/downstream_requests.rb
@@ -81,15 +81,49 @@ module RequestHelpers
       end
     end
 
-    def sends_to_draft_content_store
+    def sends_to_draft_content_store(with_arbitration: true)
       it "sends to draft content store after registering the URL" do
-        expect(PublishingAPI.service(:url_arbiter)).to receive(:reserve_path).ordered
+        expect(PublishingAPI.service(:url_arbiter)).to receive(:reserve_path).ordered if with_arbitration
         expect(PublishingAPI.service(:draft_content_store)).to receive(:put_content_item)
           .with(
             base_path: base_path,
             content_item: content_item,
           )
           .ordered
+
+        do_request
+
+        expect(response.status).to eq(200), response.body
+      end
+    end
+
+    def sends_to_live_content_store
+      it "sends to live content store after registering the URL" do
+        expect(PublishingAPI.service(:live_content_store)).to receive(:put_content_item)
+          .with(
+            base_path: base_path,
+            content_item: content_item.except(:access_limited),
+          )
+
+        do_request
+
+        expect(response.status).to eq(200), response.body
+      end
+    end
+
+    def does_not_send_to_live_content_store
+      it "does not send anything to the live content store" do
+        expect(PublishingAPI.service(:live_content_store)).to receive(:put_content_item).never
+        expect(WebMock).not_to have_requested(:any, /[^-]content-store.*/)
+
+        do_request
+      end
+    end
+
+    def does_not_send_to_draft_content_store
+      it "does not send anything to the draft content store" do
+        expect(PublishingAPI.service(:draft_content_store)).to receive(:put_content_item).never
+        expect(WebMock).not_to have_requested(:any, /draft-content-store.*/)
 
         do_request
       end

--- a/spec/support/request_helpers/event_logging.rb
+++ b/spec/support/request_helpers/event_logging.rb
@@ -4,6 +4,8 @@ module RequestHelpers
       it "logs a '#{event_class_name}' event in the event log" do
         do_request
 
+        expect(response.status).to eq(200)
+
         expect(Event.count).to eq(1)
         expect(Event.first.action).to eq(event_class_name)
         expect(Event.first.user_uid).to eq(nil)

--- a/spec/support/request_helpers/event_logging.rb
+++ b/spec/support/request_helpers/event_logging.rb
@@ -13,6 +13,16 @@ module RequestHelpers
         expect(Event.first.payload).to eq(instance_exec(&expected_payload_proc))
       end
     end
+
+    def does_not_log_event
+      it "does not log an event in the event log" do
+        do_request
+
+        expect(Event.count).to eq(0)
+        expect(response.status).to eq(422)
+        expect(response.body).to eq(error_details.to_json)
+      end
+    end
   end
 end
 


### PR DESCRIPTION
Part of https://trello.com/c/SPLM0ANz/318-support-links-endpoints-in-publishing-api

Adds all the database related code needed for the PUT links endpoint.