### PR TITLE
Validate live content base_path changes

### DIFF
--- a/app/models/draft_content_item.rb
+++ b/app/models/draft_content_item.rb
@@ -3,6 +3,8 @@ class DraftContentItem < ActiveRecord::Base
   include DefaultAttributes
   include SymbolizeJSON
 
+  validates_with BasePathValidator
+
   TOP_LEVEL_FIELDS = (LiveContentItem::TOP_LEVEL_FIELDS + [
     :access_limited,
   ]).freeze

--- a/app/validators/base_path_validator.rb
+++ b/app/validators/base_path_validator.rb
@@ -1,0 +1,9 @@
+class BasePathValidator < ActiveModel::Validator
+  def validate(record)
+    live_item = LiveContentItem.find_by(content_id: record.content_id)
+
+    if live_item.present? && live_item.base_path != record.base_path
+      record.errors.add(:base_path, 'is immutable for published items')
+    end
+  end
+end

--- a/spec/commands/v2/put_content_spec.rb
+++ b/spec/commands/v2/put_content_spec.rb
@@ -1,0 +1,52 @@
+require 'rails_helper'
+require "govuk/client/test_helpers/url_arbiter"
+
+RSpec.describe Commands::V2::PutContent do
+
+  include GOVUK::Client::TestHelpers::URLArbiter
+
+  describe 'call' do
+    let(:content_id) { SecureRandom.uuid }
+    let(:base_path) { '/vat-rates' }
+
+    let(:payload) {
+      build(DraftContentItem)
+        .as_json
+        .deep_symbolize_keys
+        .except(:format, :routes)
+        .merge(content_id: content_id,
+               title: 'The title',
+               base_path: base_path)
+    }
+
+    describe 'validation' do
+      before do
+        create(:live_content_item, content_id: content_id, base_path: base_path)
+      end
+
+      context 'given a base_path change on a published item' do
+        let(:updated_payload) { payload.merge(base_path: '/vatrates') }
+
+        it 'raises an error' do
+          expect { Commands::V2::PutContent.call(updated_payload) }.to raise_error(
+            CommandError, 'Base path is immutable for published items')
+        end
+      end
+
+      context 'given a field change on a published item' do
+        before do
+          stub_default_url_arbiter_responses
+          stub_request(:put, %r{.*content-store.*/content/.*})
+        end
+
+        let(:updated_payload) { payload.merge(title: 'A better title') }
+
+        it 'passes validation' do
+          expect(Commands::Success).to receive(:new).with(updated_payload)
+
+          Commands::V2::PutContent.call(updated_payload)
+        end
+      end
+    end
+  end
+end

--- a/spec/models/draft_content_item_spec.rb
+++ b/spec/models/draft_content_item_spec.rb
@@ -7,6 +7,11 @@ RSpec.describe DraftContentItem do
     expect(described_class.first.title).to eq("New title")
   end
 
+  def validates_base_path
+    create(:live_content_item, content_id: '123', base_path: '/foo')
+    build(:draft_content_item, content_id: '123', base_path: '/bar').should_not be_valid
+  end
+
   let(:new_attributes) {
     {
       content_id: content_id,


### PR DESCRIPTION
[Story detail](https://trello.com/c/SQ7uHbIc/358-v2-endpoints-don-t-allow-base-path-of-live-items-to-change)

Ensure that, given content which has been published, subsequent drafts do
not alter `base_path`.

As discussed with @tuzz there's further scope for adding the same validator to `LiveContentItem`.
