### PR TITLE
Import initial data

### DIFF
--- a/app/commands/put_content_with_links.rb
+++ b/app/commands/put_content_with_links.rb
@@ -1,17 +1,19 @@
 module Commands
   class PutContentWithLinks < BaseCommand
-    def call
+    def call(downstream: true)
       if content_item[:content_id]
         create_or_update_live_content_item!
         create_or_update_draft_content_item!
         create_or_update_links!
       end
 
-      Adapters::UrlArbiter.call(base_path, content_item[:publishing_app])
-      Adapters::DraftContentStore.call(base_path, content_item_without_access_limiting)
-      Adapters::ContentStore.call(base_path, content_item_without_access_limiting)
+      if downstream
+        Adapters::UrlArbiter.call(base_path, content_item[:publishing_app])
+        Adapters::DraftContentStore.call(base_path, content_item_without_access_limiting)
+        Adapters::ContentStore.call(base_path, content_item_without_access_limiting)
 
-      PublishingAPI.service(:queue_publisher).send_message(content_item_with_base_path)
+        PublishingAPI.service(:queue_publisher).send_message(content_item_with_base_path)
+      end
 
       Success.new(content_item_without_access_limiting)
     end

--- a/app/commands/put_draft_content_with_links.rb
+++ b/app/commands/put_draft_content_with_links.rb
@@ -1,13 +1,15 @@
 module Commands
   class PutDraftContentWithLinks < PutContentWithLinks
-    def call
+    def call(downstream: true)
       if content_item[:content_id]
         create_or_update_draft_content_item!
         create_or_update_links!
       end
 
-      Adapters::UrlArbiter.call(base_path, content_item[:publishing_app])
-      Adapters::DraftContentStore.call(base_path, content_item)
+      if downstream
+        Adapters::UrlArbiter.call(base_path, content_item[:publishing_app])
+        Adapters::DraftContentStore.call(base_path, content_item)
+      end
 
       Success.new(content_item)
     end

--- a/lib/tasks/import_data.rake
+++ b/lib/tasks/import_data.rake
@@ -1,0 +1,33 @@
+require "tasks/import_data"
+
+desc "Imports all content items from the provided JSON file (one doc per line)"
+task :import_content_items, [:json_file_path, :state] => :environment do |_, args|
+  file_path = args[:json_file_path]
+  state = args[:state]
+
+  usage = "rake import_content_items['tmp/content_items.json','draft']"
+
+  unless file_path && File.exist?(file_path)
+    puts "Could not find a file at '#{file_path}'"
+    puts "Please provide a path to a file with one JSON document per line"
+    puts "e.g. #{usage}"
+    exit
+  end
+
+  unless ["draft", "live"].include?(state)
+    puts "Please specify whether to import as 'draft' or 'live'"
+    puts "e.g. #{usage}"
+    exit
+  end
+
+  line_count = `wc -l #{file_path}`.strip.split(' ').first.to_i
+
+  File.open(file_path, "r") do |file|
+    Tasks::ImportData.new(
+      file: file,
+      total_lines: line_count,
+      stdout: STDOUT,
+      draft: state == "draft"
+    ).import_all
+  end
+end

--- a/lib/tasks/import_data.rb
+++ b/lib/tasks/import_data.rb
@@ -1,0 +1,72 @@
+require "json"
+
+module Tasks
+  class ImportData
+    def initialize(file:, total_lines:, stdout:, draft:)
+      @file = file
+      @total_lines = total_lines
+      @stdout = stdout
+      @draft = draft
+    end
+
+    def import_all
+      file.each.with_index(1) do |json, index|
+        parsed_json = JSON.parse(json).deep_symbolize_keys
+
+        updated_at = parsed_json.fetch(:updated_at)
+        content_item_hash = parsed_json.fetch(:content_item)
+        content_id = content_item_hash.fetch(:content_id)
+        locale = content_item_hash.fetch(:locale)
+
+        unless derived_content_class.where(content_id: content_id, locale: locale).exists?
+          Event.create!(
+            action: action,
+            payload: content_item_hash,
+            created_at: updated_at,
+            updated_at: updated_at,
+          )
+
+          command_class.new(content_item_hash).call(downstream: false)
+        end
+
+        print_progress(index, total_lines)
+      end
+
+      stdout.puts
+    end
+
+  private
+
+    attr_reader :file, :total_lines, :stdout, :draft
+
+    def print_progress(completed, total)
+      percent_complete = ((completed.to_f / total) * 100).round
+      percent_remaining = 100 - percent_complete
+
+      stdout.print "\r"
+      stdout.flush
+      stdout.print "Progress [#{"=" * percent_complete}>#{"." * percent_remaining}] (#{percent_complete}%)"
+      stdout.flush
+    end
+
+    def action
+      command_class.name.split("::")[-1]
+    end
+
+    def command_class
+      if draft
+        Commands::PutDraftContentWithLinks
+      else
+        Commands::PutContentWithLinks
+      end
+    end
+
+    def derived_content_class
+      if draft
+        DraftContentItem
+      else
+        LiveContentItem
+      end
+    end
+  end
+end


### PR DESCRIPTION
This requires a file with one JSON document per line
with each document having the structure:
```
{
  updated_at: "2015-10-14T15:07:09+01:00",
  content_item: {
    content_id: "2e2d3551-4147-4136-8c0d-f0904b69c8c6",
    etc..
  }
}
```

This file can be generated by the content store
using `rake data_hygiene:export_content_items:all`.

You also need to inform the task as to whether you
exported the data from the "live" or "draft"
content stores.

Example usage:
```
$ rake import_content_items['../content-store/tmp/content_items_2015-10-14_13-58-32.json','draft']
Progress [=====>...............................................................................................] (5%)
```

All downstream actions (sending to content stores, sending emails) are skipped.

Requires the output from https://github.com/alphagov/content-store/pull/155 to run but can be merged without.