### PR TITLE
Version invariants (part 1)

### DIFF
--- a/app/commands/put_content_with_links.rb
+++ b/app/commands/put_content_with_links.rb
@@ -2,8 +2,8 @@ module Commands
   class PutContentWithLinks < BaseCommand
     def call(downstream: true)
       if content_item[:content_id]
-        create_or_update_live_content_item!
-        create_or_update_draft_content_item!
+        draft_content_item = create_or_update_draft_content_item!
+        create_or_update_live_content_item!(draft_content_item)
         create_or_update_links!
       end
 
@@ -43,9 +43,13 @@ module Commands
       content_item_without_access_limiting.except(*content_item_top_level_fields)
     end
 
-    def create_or_update_live_content_item!
-      LiveContentItem.create_or_replace(content_item_attributes) do |item|
-        item.assign_attributes_with_defaults(content_item_attributes)
+    def create_or_update_live_content_item!(draft_content_item)
+      attributes = content_item_attributes.merge(
+        draft_content_item: draft_content_item
+      )
+
+      LiveContentItem.create_or_replace(attributes) do |item|
+        item.assign_attributes_with_defaults(attributes)
       end
     end
 

--- a/app/commands/v2/publish.rb
+++ b/app/commands/v2/publish.rb
@@ -4,7 +4,7 @@ module Commands
       def call
         validate!
 
-        live_content_item = LiveContentItem.create_or_replace(draft_item.attributes.except("access_limited", "version")) do |live_item|
+        live_content_item = LiveContentItem.create_or_replace(live_item_attributes) do |live_item|
           if live_item.version == draft_item.version
             raise CommandError.new(code: 400, message: "This item is already published")
           else
@@ -43,6 +43,13 @@ module Commands
 
       def update_type
         payload[:update_type]
+      end
+
+      def live_item_attributes
+        attributes = draft_item
+          .attributes
+          .except("access_limited", "version")
+          .merge(draft_content_item: draft_item)
       end
 
       def draft_item

--- a/app/lib/presenters/content_item_presenter.rb
+++ b/app/lib/presenters/content_item_presenter.rb
@@ -5,7 +5,7 @@ module Presenters
       public_updated_at = content_item_hash.fetch(:public_updated_at).iso8601
 
       content_item_hash
-        .except(:metadata, :id, :version)
+        .except(:metadata, :id, :version, :draft_content_item_id)
         .merge(metadata)
         .merge(public_updated_at: public_updated_at)
     end

--- a/app/models/draft_content_item.rb
+++ b/app/models/draft_content_item.rb
@@ -8,10 +8,19 @@ class DraftContentItem < ActiveRecord::Base
     :access_limited,
   ]).freeze
 
+  has_one :live_content_item
+
   validates :content_id, presence: true
+  validate :content_ids_match
 
 private
   def self.query_keys
     [:content_id, :locale]
+  end
+
+  def content_ids_match
+    if live_content_item && live_content_item.content_id != content_id
+      errors.add(:content_id, "id mismatch between draft and live content items")
+    end
   end
 end

--- a/app/models/draft_content_item.rb
+++ b/app/models/draft_content_item.rb
@@ -13,6 +13,7 @@ class DraftContentItem < ActiveRecord::Base
   validates :content_id, presence: true
   validate :content_ids_match
   validates :version, presence: true
+  validates_with VersionValidator::Draft
 
 private
   def self.query_keys

--- a/app/models/draft_content_item.rb
+++ b/app/models/draft_content_item.rb
@@ -8,6 +8,8 @@ class DraftContentItem < ActiveRecord::Base
     :access_limited,
   ]).freeze
 
+  validates :content_id, presence: true
+
 private
   def self.query_keys
     [:content_id, :locale]

--- a/app/models/draft_content_item.rb
+++ b/app/models/draft_content_item.rb
@@ -12,6 +12,7 @@ class DraftContentItem < ActiveRecord::Base
 
   validates :content_id, presence: true
   validate :content_ids_match
+  validates :version, presence: true
 
 private
   def self.query_keys

--- a/app/models/live_content_item.rb
+++ b/app/models/live_content_item.rb
@@ -19,8 +19,22 @@ class LiveContentItem < ActiveRecord::Base
     :title,
   ].freeze
 
+  belongs_to :draft_content_item
+
+  validates :draft_content_item, presence: true
+  validates :content_id, presence: true
+  validate :content_ids_match
+  validates :version, presence: true
+  validates_with VersionValidator
+
 private
   def self.query_keys
     [:content_id, :locale]
+  end
+
+  def content_ids_match
+    if draft_content_item && draft_content_item.content_id != content_id
+      errors.add(:content_id, "id mismatch between draft and live content items")
+    end
   end
 end

--- a/app/models/live_content_item.rb
+++ b/app/models/live_content_item.rb
@@ -25,7 +25,7 @@ class LiveContentItem < ActiveRecord::Base
   validates :content_id, presence: true
   validate :content_ids_match
   validates :version, presence: true
-  validates_with VersionValidator
+  validates_with VersionValidator::Live
 
 private
   def self.query_keys

--- a/app/validators/version_validator.rb
+++ b/app/validators/version_validator.rb
@@ -1,0 +1,13 @@
+class VersionValidator < ActiveModel::Validator
+  def validate(live_item)
+    draft_item = live_item.draft_content_item
+    return unless live_item.version && draft_item && draft_item.version
+
+    if live_item.version > draft_item.version
+      mismatch = "(#{live_item.version} > #{draft_item.version})"
+      message = "cannot be greater than draft version #{mismatch}"
+
+      live_item.errors.add(:version, message)
+    end
+  end
+end

--- a/app/validators/version_validator.rb
+++ b/app/validators/version_validator.rb
@@ -1,13 +1,27 @@
-class VersionValidator < ActiveModel::Validator
-  def validate(live_item)
-    draft_item = live_item.draft_content_item
-    return unless live_item.version && draft_item && draft_item.version
+module VersionValidator
+  class Draft < ActiveModel::Validator
+    def validate(draft_item)
+      live_item = draft_item.live_content_item
+      message = VersionValidator.validate(draft_item, live_item)
+      draft_item.errors.add(:version, message) if message
+    end
+  end
+
+  class Live < ActiveModel::Validator
+    def validate(live_item)
+      draft_item = live_item.draft_content_item
+      message = VersionValidator.validate(draft_item, live_item)
+      live_item.errors.add(:version, message) if message
+    end
+  end
+
+  def self.validate(draft_item, live_item)
+    return unless draft_item && live_item
+    return unless draft_item.version && live_item.version
 
     if live_item.version > draft_item.version
       mismatch = "(#{live_item.version} > #{draft_item.version})"
-      message = "cannot be greater than draft version #{mismatch}"
-
-      live_item.errors.add(:version, message)
+      "cannot be greater than draft version #{mismatch}"
     end
   end
 end

--- a/db/migrate/20151014133602_add_draft_content_item_id_to_live_content_item.rb
+++ b/db/migrate/20151014133602_add_draft_content_item_id_to_live_content_item.rb
@@ -1,0 +1,21 @@
+class AddDraftContentItemIdToLiveContentItem < ActiveRecord::Migration
+  class DraftContentItem < ActiveRecord::Base
+  end
+
+  class LiveContentItem < ActiveRecord::Base
+    belongs_to :draft_content_item
+  end
+
+  def change
+    add_reference :live_content_items, :draft_content_item, index: true
+
+    LiveContentItem.all.each do |live_item|
+      draft_item = DraftContentItem.find_by(content_id: live_item.content_id)
+
+      live_item.draft_content_item = draft_item
+      live_item.save!
+    end
+
+    change_column_null :live_content_items, :draft_content_item_id, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151012095129) do
+ActiveRecord::Schema.define(version: 20151014133602) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -55,20 +55,22 @@ ActiveRecord::Schema.define(version: 20151012095129) do
   create_table "live_content_items", force: :cascade do |t|
     t.string   "content_id"
     t.string   "locale"
-    t.integer  "version",           default: 0,  null: false
+    t.integer  "version",               default: 0,  null: false
     t.string   "base_path"
     t.string   "title"
     t.string   "description"
     t.string   "format"
     t.datetime "public_updated_at"
-    t.json     "metadata",          default: {}
-    t.json     "details",           default: {}
-    t.json     "routes",            default: []
-    t.json     "redirects",         default: []
+    t.json     "metadata",              default: {}
+    t.json     "details",               default: {}
+    t.json     "routes",                default: []
+    t.json     "redirects",             default: []
     t.string   "publishing_app"
     t.string   "rendering_app"
+    t.integer  "draft_content_item_id",              null: false
   end
 
   add_index "live_content_items", ["content_id", "locale"], name: "index_live_content_items_on_content_id_and_locale", unique: true, using: :btree
+  add_index "live_content_items", ["draft_content_item_id"], name: "index_live_content_items_on_draft_content_item_id", using: :btree
 
 end

--- a/spec/event_logger_spec.rb
+++ b/spec/event_logger_spec.rb
@@ -31,14 +31,14 @@ RSpec.describe EventLogger do
     call_counter = 0
     EventLogger.log_command(command_class, payload) do
       if call_counter == 0
-        LiveContentItem.create(content_id: "1234", locale: "en", version: 1)
+        FactoryGirl.create(:live_content_item, content_id: "1234", locale: "en", version: 1)
         call_counter += 1
         raise CommandRetryableError
       else
         # The original transaction should have been rolled back, so there should be no
         # corresponding LiveContentItem in the database
         expect(LiveContentItem.where(content_id: "1234", locale: "en").count).to eq(0)
-        LiveContentItem.create(content_id: "1234", locale: "en", version: 1)
+        FactoryGirl.create(:live_content_item, content_id: "1234", locale: "en", version: 1)
       end
     end
 

--- a/spec/factories/live_content_item.rb
+++ b/spec/factories/live_content_item.rb
@@ -39,7 +39,8 @@ FactoryGirl.define do
     after(:build) do |live_content_item|
       draft = FactoryGirl.build(
         :draft_content_item,
-        content_id: live_content_item.content_id
+        content_id: live_content_item.content_id,
+        version: live_content_item.version
       )
 
       live_content_item.draft_content_item = draft

--- a/spec/factories/live_content_item.rb
+++ b/spec/factories/live_content_item.rb
@@ -36,5 +36,13 @@ FactoryGirl.define do
         }
       ]
     }
+    after(:build) do |live_content_item|
+      draft = FactoryGirl.build(
+        :draft_content_item,
+        content_id: live_content_item.content_id
+      )
+
+      live_content_item.draft_content_item = draft
+    end
   end
 end

--- a/spec/models/draft_content_item_spec.rb
+++ b/spec/models/draft_content_item_spec.rb
@@ -30,6 +30,11 @@ RSpec.describe DraftContentItem do
       subject.content_id = "something else"
       expect(subject).to be_invalid
     end
+
+    it "requires a version" do
+      subject.version = nil
+      expect(subject).to be_invalid
+    end
   end
 
   let!(:existing) { create(described_class) }

--- a/spec/models/draft_content_item_spec.rb
+++ b/spec/models/draft_content_item_spec.rb
@@ -35,6 +35,16 @@ RSpec.describe DraftContentItem do
       subject.version = nil
       expect(subject).to be_invalid
     end
+
+    context "given a version number less than the live" do
+      let(:live) { FactoryGirl.create(:live_content_item, version: 6) }
+      let(:draft) { live.draft_content_item }
+
+      it "is invalid" do
+        draft.version = 5
+        expect(draft).to be_invalid
+      end
+    end
   end
 
   let!(:existing) { create(described_class) }

--- a/spec/models/draft_content_item_spec.rb
+++ b/spec/models/draft_content_item_spec.rb
@@ -11,6 +11,17 @@ RSpec.describe DraftContentItem do
     expect(described_class.first.title).to eq("New title")
   end
 
+  describe "validations" do
+    it "is valid for the default factory" do
+      expect(subject).to be_valid
+    end
+
+    it "requires a content_id" do
+      subject.content_id = nil
+      expect(subject).to be_invalid
+    end
+  end
+
   let!(:existing) { create(described_class) }
   let!(:content_id) { existing.content_id }
 

--- a/spec/models/draft_content_item_spec.rb
+++ b/spec/models/draft_content_item_spec.rb
@@ -3,16 +3,25 @@ require 'rails_helper'
 RSpec.describe DraftContentItem do
   subject { FactoryGirl.build(:draft_content_item) }
 
+  def set_new_attributes(item)
+    item.title = "New title"
+  end
+
   def verify_new_attributes_set
     expect(described_class.first.title).to eq("New title")
   end
 
-  let(:new_attributes) {
-    {
+  let!(:existing) { create(described_class) }
+  let!(:content_id) { existing.content_id }
+
+  let!(:payload) do
+    build(described_class)
+    .as_json
+    .merge(
       content_id: content_id,
-      title: "New title",
-    }
-  }
+      title: "New title"
+    )
+  end
 
   it_behaves_like Replaceable
   it_behaves_like DefaultAttributes

--- a/spec/models/draft_content_item_spec.rb
+++ b/spec/models/draft_content_item_spec.rb
@@ -20,6 +20,16 @@ RSpec.describe DraftContentItem do
       subject.content_id = nil
       expect(subject).to be_invalid
     end
+
+    it "requires that the content_ids match" do
+      FactoryGirl.create(
+        :live_content_item,
+        draft_content_item: subject
+      )
+
+      subject.content_id = "something else"
+      expect(subject).to be_invalid
+    end
   end
 
   let!(:existing) { create(described_class) }

--- a/spec/models/link_set_spec.rb
+++ b/spec/models/link_set_spec.rb
@@ -1,22 +1,31 @@
 require 'rails_helper'
 
 RSpec.describe LinkSet do
+  def set_new_attributes(item)
+    item.links = { foo: ["bar"] }
+  end
+
   def verify_new_attributes_set
-    expect(described_class.first.links[:policies].length).to eq(2)
+    expect(described_class.first.links).to eq(foo: ["bar"])
   end
 
   def verify_old_attributes_not_preserved
     expect(described_class.first.links[:organisations]).to be_nil
   end
 
-  let(:new_attributes) {
-    {
+  let!(:existing) { create(described_class) }
+  let!(:content_id) { existing.content_id }
+
+  let!(:payload) do
+    build(described_class)
+    .as_json
+    .merge(
       content_id: content_id,
       links: {
-        policies: [ SecureRandom.uuid, SecureRandom.uuid ]
+        foo: ["bar"]
       }
-    }
-  }
+    )
+  end
 
   it_behaves_like Replaceable
 end

--- a/spec/models/live_content_item_spec.rb
+++ b/spec/models/live_content_item_spec.rb
@@ -37,11 +37,11 @@ RSpec.describe LiveContentItem do
     end
 
     context "given a version number greater than the draft" do
-      let(:draft) { create(:draft_content_item, version: 6) }
+      let(:live) { FactoryGirl.create(:live_content_item, version: 6) }
 
       it "is invalid" do
-        live_item = build(:live_content_item, draft_content_item: draft, version: 7)
-        expect(live_item).to be_invalid
+        live.version = 7
+        expect(live).to be_invalid
       end
     end
   end

--- a/spec/models/live_content_item_spec.rb
+++ b/spec/models/live_content_item_spec.rb
@@ -22,8 +22,6 @@ RSpec.describe LiveContentItem do
     end
 
     it "requires a content_id" do
-      subject.draft_content_item.update!(content_id: nil)
-
       subject.content_id = nil
       expect(subject).to be_invalid
     end

--- a/spec/models/live_content_item_spec.rb
+++ b/spec/models/live_content_item_spec.rb
@@ -1,18 +1,67 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe LiveContentItem do
   subject { FactoryGirl.build(:live_content_item) }
+
+  def set_new_attributes(item)
+    item.title = "New title"
+  end
 
   def verify_new_attributes_set
     expect(described_class.first.title).to eq("New title")
   end
 
-  let(:new_attributes) {
-    {
+  describe "validations" do
+    it "is valid for the default factory" do
+      expect(subject).to be_valid
+    end
+
+    it "requires a draft_content_item" do
+      subject.draft_content_item = nil
+      expect(subject).to be_invalid
+    end
+
+    it "requires a content_id" do
+      subject.draft_content_item.update!(content_id: nil)
+
+      subject.content_id = nil
+      expect(subject).to be_invalid
+    end
+
+    it "requires that the content_ids match" do
+      subject.content_id = "something else"
+      expect(subject).to be_invalid
+    end
+
+    it "requires a version" do
+      subject.version = nil
+      expect(subject).to be_invalid
+    end
+
+    context "given a version number greater than the draft" do
+      let(:draft) { create(:draft_content_item, version: 6) }
+
+      it "is invalid" do
+        live_item = build(:live_content_item, draft_content_item: draft, version: 7)
+        expect(live_item).to be_invalid
+      end
+    end
+  end
+
+
+  let(:existing) { create(described_class) }
+  let(:draft) { existing.draft_content_item }
+  let(:content_id) { existing.content_id }
+
+  let(:payload) do
+    build(described_class)
+    .as_json
+    .merge(
       content_id: content_id,
       title: "New title",
-    }
-  }
+      draft_content_item: draft
+    )
+  end
 
   it_behaves_like Replaceable
   it_behaves_like DefaultAttributes

--- a/spec/requests/content_item_requests/downstream_requests_spec.rb
+++ b/spec/requests/content_item_requests/downstream_requests_spec.rb
@@ -143,8 +143,8 @@ RSpec.describe "Downstream requests", type: :request do
 
     context "when draft and live content items exists for the link set" do
       before do
-        FactoryGirl.create(:draft_content_item, v2_content_item.slice(*DraftContentItem::TOP_LEVEL_FIELDS))
         FactoryGirl.create(:live_content_item, v2_content_item.slice(*LiveContentItem::TOP_LEVEL_FIELDS))
+        DraftContentItem.last.update(access_limited: v2_content_item.fetch(:access_limited))
       end
 
       sends_to_draft_content_store(with_arbitration: false)

--- a/spec/requests/content_item_requests/downstream_timeouts_spec.rb
+++ b/spec/requests/content_item_requests/downstream_timeouts_spec.rb
@@ -32,8 +32,8 @@ RSpec.describe "Downstream timeouts", type: :request do
     let(:request_method) { :put }
 
     before do
-      FactoryGirl.create(:draft_content_item, v2_content_item.slice(*DraftContentItem::TOP_LEVEL_FIELDS))
       FactoryGirl.create(:live_content_item, v2_content_item.slice(*LiveContentItem::TOP_LEVEL_FIELDS))
+      DraftContentItem.last.update!(access_limited: v2_content_item.fetch(:access_limited))
     end
 
     behaves_well_when_draft_content_store_times_out

--- a/spec/requests/content_item_requests/invalid_requests_spec.rb
+++ b/spec/requests/content_item_requests/invalid_requests_spec.rb
@@ -45,8 +45,8 @@ RSpec.describe "Invalid content requests", type: :request do
     let(:request_method) { :put }
 
     before do
-      FactoryGirl.create(:draft_content_item, v2_content_item.slice(*DraftContentItem::TOP_LEVEL_FIELDS))
       FactoryGirl.create(:live_content_item, v2_content_item.slice(*LiveContentItem::TOP_LEVEL_FIELDS))
+      DraftContentItem.last.update!(access_limited: v2_content_item.fetch(:access_limited))
     end
 
     does_not_log_event

--- a/spec/requests/publish_requests_spec.rb
+++ b/spec/requests/publish_requests_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe "POST /v2/publish", type: :request do
   end
 
   context "a draft content item exists with version 1" do
-    let(:draft_content_item) { create(:draft_content_item, version: 1) }
+    let(:draft_content_item) { FactoryGirl.create(:draft_content_item, version: 1) }
 
     logs_event("Publish", expected_payload_proc: ->{ payload.merge(content_id: content_id) })
 
@@ -99,9 +99,8 @@ RSpec.describe "POST /v2/publish", type: :request do
     end
 
     context "the draft content item is already published" do
-      let!(:live_content_item) {
-        create(:live_content_item, draft_content_item.attributes.except("id", "access_limited"))
-      }
+      let!(:live_content_item) { FactoryGirl.create(:live_content_item) }
+      let!(:draft_content_item) { live_content_item.draft_content_item }
 
       it "reports an error" do
         expect(live_content_item.version).to eq(draft_content_item.version)

--- a/spec/service_consumers/pact_helper.rb
+++ b/spec/service_consumers/pact_helper.rb
@@ -104,8 +104,7 @@ Pact.provider_states_for "GDS API Adapters" do
     set_up do
       DatabaseCleaner.clean_with :truncation
 
-      draft_item = FactoryGirl.create(:draft_content_item, content_id: "bed722e6-db68-43e5-9079-063f623335a7")
-      FactoryGirl.create(:live_content_item, draft_item.attributes.except("id", "access_limited"))
+      FactoryGirl.create(:live_content_item, content_id: "bed722e6-db68-43e5-9079-063f623335a7")
       stub_default_url_arbiter_responses
       stub_request(:put, Regexp.new('\A' + Regexp.escape(Plek.find('content-store')) + "/content"))
     end

--- a/spec/support/immutable_base_path.rb
+++ b/spec/support/immutable_base_path.rb
@@ -1,14 +1,11 @@
 RSpec.shared_examples ImmutableBasePath do
   describe 'validations' do
-    it 'is valid for the default factory' do
-      expect(subject).to be_valid
-    end
-
     context 'when a live content item exists' do
       before do
-        create(:live_content_item, content_id: '123', base_path: '/foo')
+        create(:live_content_item,
+               content_id: subject.content_id,
+               base_path: '/foo')
 
-        subject.content_id = '123'
         subject.base_path = '/bar'
       end
 

--- a/spec/support/request_helpers/derived_representations.rb
+++ b/spec/support/request_helpers/derived_representations.rb
@@ -81,7 +81,10 @@ module RequestHelpers
 
       context "a #{representation_class} already exists" do
         before do
-          representation_class.create(
+          factory_name = representation_class.to_s.underscore.to_sym
+
+          FactoryGirl.create(
+            factory_name,
             title: "An existing title",
             content_id: expected_attributes[:content_id],
             locale: expected_attributes[:locale],
@@ -138,17 +141,8 @@ module RequestHelpers
         let(:new_base_path) { "/something-else" }
 
         before do
-          DraftContentItem.create!(
-            title: "An existing title",
-            content_id: expected_attributes[:content_id],
-            locale: expected_attributes[:locale],
-            details: expected_attributes[:details],
-            metadata: {},
-            base_path: base_path,
-            version: 1
-          )
-
-          LiveContentItem.create!(
+          FactoryGirl.create(
+            :live_content_item,
             title: "An existing title",
             content_id: expected_attributes[:content_id],
             locale: expected_attributes[:locale],
@@ -177,7 +171,8 @@ module RequestHelpers
         let(:new_base_path) { "/something-else" }
 
         before do
-          LiveContentItem.create!(
+          FactoryGirl.create(
+            :live_content_item,
             title: "An existing title",
             content_id: expected_attributes[:content_id],
             locale: expected_attributes[:locale],


### PR DESCRIPTION
This pull request implements these two invariants from the https://trello.com/c/Uv9ZgQs8/356-ensure-consistent-version-numbering story. We thought it would make sense to pull request this separately as there's already a sizeable chunk of work in here and it can go in as a standalone piece of functionality.

```
1) There must always be a draft content item for every live content with the same content id.

2) The version number for every live content item must always be less than, or equal to, the version number of its associated draft content item.
```

Note: Given a LiveContentItem can only ever be created from a DraftContentItem, we added an association connecting the two and a validation on this column. We ran this past @danielroseman first.