### PR TITLE
Capture authenticated user uuid in event log.

### DIFF
--- a/app/event_logger.rb
+++ b/app/event_logger.rb
@@ -5,7 +5,12 @@ module EventLogger
       response = nil
 
       Event.connection.transaction do
-        Event.create!(action: action(command_class), payload: payload)
+        Event.create!(
+          action: action(command_class),
+          payload: payload,
+          user_uid: GdsApi::GovukHeaders.headers[:x_govuk_authenticated_user]
+        )
+
         response = yield if block_given?
       end
 

--- a/spec/requests/publish_requests_spec.rb
+++ b/spec/requests/publish_requests_spec.rb
@@ -29,8 +29,8 @@ RSpec.describe "POST /v2/publish", type: :request do
   }
   let(:request_body) { payload.to_json }
 
-  def do_request(body: request_body)
-    post request_path, body
+  def do_request(body: request_body, headers: {})
+    post request_path, body, headers
   end
 
   context "a draft content item exists with version 1" do

--- a/spec/support/request_helpers/actions.rb
+++ b/spec/support/request_helpers/actions.rb
@@ -1,11 +1,11 @@
 module RequestHelpers
   module Actions
-    def do_request(body: request_body)
+    def do_request(body: request_body, headers: {})
       case request_method
       when :put
-        put request_path, body
+        put request_path, body, headers
       when :get
-        get request_path, body
+        get request_path, body, headers
       end
     end
   end

--- a/spec/support/request_helpers/event_logging.rb
+++ b/spec/support/request_helpers/event_logging.rb
@@ -12,6 +12,19 @@ module RequestHelpers
 
         expect(Event.first.payload).to eq(instance_exec(&expected_payload_proc))
       end
+
+      context "with the authenticated user header set" do
+        it "logs the user uuid from the header" do
+          do_request(headers: {
+            "HTTP_X_GOVUK_AUTHENTICATED_USER" => "user-uuid-1234"
+          })
+
+          expect(response.status).to eq(200)
+
+          expect(Event.count).to eq(1)
+          expect(Event.first.user_uid).to eq("user-uuid-1234")
+        end
+      end
     end
 
     def does_not_log_event


### PR DESCRIPTION
Pulls the user UUID from the `X-Govuk-Authenticated-User` header as per https://github.com/alphagov/gds-api-adapters/tree/dd88e2d062e6df825d7be426c78a7876ab5260af#middleware-for-identifying-authenticated-users

We will need to set the same header in all publishing applications (we've not found a good single place to do this) but this can be done in a similar manner using https://github.com/alphagov/gds-api-adapters/blob/dd88e2d062e6df825d7be426c78a7876ab5260af/lib/gds_api/govuk_headers.rb#L4-L6

https://trello.com/c/BXYNxPK4/335-propagate-user-uid-from-publishing-apps