### PR TITLE
Make the draft_content_item_id column a foreign key

### DIFF
--- a/db/migrate/20151016145941_add_foreign_key_to_link_content_items.rb
+++ b/db/migrate/20151016145941_add_foreign_key_to_link_content_items.rb
@@ -1,0 +1,5 @@
+class AddForeignKeyToLinkContentItems < ActiveRecord::Migration
+  def change
+    add_foreign_key :live_content_items, :draft_content_items
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151014133602) do
+ActiveRecord::Schema.define(version: 20151016145941) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -73,4 +73,5 @@ ActiveRecord::Schema.define(version: 20151014133602) do
   add_index "live_content_items", ["content_id", "locale"], name: "index_live_content_items_on_content_id_and_locale", unique: true, using: :btree
   add_index "live_content_items", ["draft_content_item_id"], name: "index_live_content_items_on_draft_content_item_id", using: :btree
 
+  add_foreign_key "live_content_items", "draft_content_items"
 end


### PR DESCRIPTION
Add a database constraint to enforce the reference [defined here](https://github.com/alphagov/publishing-api/commit/16199f75c33403e597e1037376b0cbef969b5201#diff-3d932e2a46d1c80a7dea735590363d86R10).
Existing data has already been migrated to [associate live and draft items](https://github.com/alphagov/publishing-api/commit/16199f75c33403e597e1037376b0cbef969b5201#diff-3d932e2a46d1c80a7dea735590363d86R12).