### PR TITLE
Add downstream workers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,8 @@ gem "gds-api-adapters", "22.0.0"
 
 gem 'bunny', '2.0.0'
 gem 'whenever', '0.9.4', :require => false
+gem "sidekiq", "3.5.1"
+gem "sidekiq-logging-json", "0.0.14"
 
 group :development do
   # Access an IRB console on exception pages or by using <%= console %> in views

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -51,8 +51,26 @@ GEM
       amq-protocol (>= 1.9.2)
     byebug (5.0.0)
       columnize (= 0.9.0)
+    celluloid (0.17.2)
+      celluloid-essentials
+      celluloid-extras
+      celluloid-fsm
+      celluloid-pool
+      celluloid-supervision
+      timers (>= 4.1.1)
+    celluloid-essentials (0.20.5)
+      timers (>= 4.1.1)
+    celluloid-extras (0.20.5)
+      timers (>= 4.1.1)
+    celluloid-fsm (0.20.5)
+      timers (>= 4.1.1)
+    celluloid-pool (0.20.5)
+      timers (>= 4.1.1)
+    celluloid-supervision (0.20.5)
+      timers (>= 4.1.1)
     chronic (0.10.2)
     columnize (0.9.0)
+    connection_pool (2.2.0)
     crack (0.4.2)
       safe_yaml (~> 1.0.0)
     database_cleaner (1.3.0)
@@ -82,6 +100,7 @@ GEM
       multi_json (~> 1.0)
       plek (~> 1.8)
       rest-client (~> 1.6)
+    hitimes (1.2.3)
     http-cookie (1.0.2)
       domain_name (~> 0.5)
     i18n (0.7.0)
@@ -171,6 +190,9 @@ GEM
     raindrops (0.15.0)
     rake (10.4.2)
     randexp (0.1.7)
+    redis (3.2.1)
+    redis-namespace (1.5.2)
+      redis (~> 3.0, >= 3.0.4)
     request_store (1.2.0)
     rest-client (1.8.0)
       http-cookie (>= 1.0.2, < 2.0)
@@ -205,6 +227,14 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (~> 1.1)
+    sidekiq (3.5.1)
+      celluloid (~> 0.17.2)
+      connection_pool (~> 2.2, >= 2.2.0)
+      json (~> 1.0)
+      redis (~> 3.2, >= 3.2.1)
+      redis-namespace (~> 1.5, >= 1.5.2)
+    sidekiq-logging-json (0.0.14)
+      sidekiq (~> 3)
     simplecov (0.10.0)
       docile (~> 1.1.0)
       json (~> 1.8)
@@ -224,6 +254,8 @@ GEM
     thread_safe (0.3.5)
     tilt (1.4.1)
     timecop (0.8.0)
+    timers (4.1.1)
+      hitimes
     tins (1.6.0)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
@@ -268,6 +300,8 @@ DEPENDENCIES
   rspec
   rspec-rails (~> 3.3)
   sass-rails (~> 5.0)
+  sidekiq (= 3.5.1)
+  sidekiq-logging-json (= 0.0.14)
   simplecov (= 0.10.0)
   simplecov-rcov (= 0.2.3)
   timecop
@@ -276,3 +310,6 @@ DEPENDENCIES
   web-console (~> 2.0)
   webmock
   whenever (= 0.9.4)
+
+BUNDLED WITH
+   1.10.6

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -310,6 +310,3 @@ DEPENDENCIES
   web-console (~> 2.0)
   webmock
   whenever (= 0.9.4)
-
-BUNDLED WITH
-   1.10.6

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,2 @@
+web: bundle exec rails s -p 3093
+worker: bundle exec sidekiq -C ./config/sidekiq.yml

--- a/app/commands/v2/publish.rb
+++ b/app/commands/v2/publish.rb
@@ -67,7 +67,12 @@ module Commands
         end
 
         item_for_content_store = content_store_payload(live_content_item)
-        Adapters::ContentStore.call(live_content_item.base_path, item_for_content_store)
+
+        ContentStoreWorker.perform_async(
+          content_store: Adapters::ContentStore,
+          base_path: live_content_item.base_path,
+          payload: item_for_content_store,
+        )
 
         send_to_message_queue!(item_for_content_store)
       end

--- a/app/commands/v2/put_content.rb
+++ b/app/commands/v2/put_content.rb
@@ -5,7 +5,13 @@ module Commands
         content_item = create_or_update_draft_content_item!
 
         PathReservation.reserve_base_path!(base_path, content_item[:publishing_app])
-        Adapters::DraftContentStore.call(base_path, draft_payload(content_item))
+
+        ContentStoreWorker.perform_async(
+          content_store: Adapters::DraftContentStore,
+          base_path: base_path,
+          payload: draft_payload(content_item),
+        )
+
         Success.new(payload)
       end
 

--- a/app/workers/content_store_worker.rb
+++ b/app/workers/content_store_worker.rb
@@ -1,0 +1,13 @@
+class ContentStoreWorker
+  include Sidekiq::Worker
+
+  def perform(args = {})
+    args = args.deep_symbolize_keys
+
+    content_store = args.fetch(:content_store).constantize
+    base_path = args.fetch(:base_path)
+    payload = args.fetch(:payload)
+
+    content_store.call(base_path, payload)
+  end
+end

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,0 +1,17 @@
+redis_config = {
+  host: ENV["REDIS_HOST"] || "127.0.0.1",
+  port: ENV["REDIS_PORT"] || 6379,
+  namespace: "publishing_api",
+}
+
+Sidekiq.configure_server do |config|
+  config.redis = redis_config
+  config.error_handlers << Proc.new {|ex, context_hash| Airbrake.notify(ex, context_hash) }
+end
+
+Sidekiq.configure_client do |config|
+  config.redis = redis_config
+end
+
+require 'sidekiq/logging/json'
+Sidekiq.logger.formatter = Sidekiq::Logging::Json::Logger.new

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,0 +1,6 @@
+---
+:verbose: true
+:concurrency:  2
+:logfile: ./log/sidekiq.json.log
+:queues:
+  - default

--- a/spec/service_consumers/pact_helper.rb
+++ b/spec/service_consumers/pact_helper.rb
@@ -103,8 +103,6 @@ Pact.provider_states_for "GDS API Adapters" do
 
       draft = FactoryGirl.create(:draft_content_item, content_id: "bed722e6-db68-43e5-9079-063f623335a7")
       FactoryGirl.create(:version, target: draft, number: 1)
-
-      stub_request(:put, Regexp.new('\A' + Regexp.escape(Plek.find('content-store')) + "/content"))
     end
   end
 
@@ -116,30 +114,19 @@ Pact.provider_states_for "GDS API Adapters" do
 
       FactoryGirl.create(:version, target: live, number: 1)
       FactoryGirl.create(:version, target: live.draft_content_item, number: 1)
-
-      stub_request(:put, Regexp.new('\A' + Regexp.escape(Plek.find('content-store')) + "/content"))
     end
   end
 
   provider_state "a draft content item exists with content_id: bed722e6-db68-43e5-9079-063f623335a7 which does not have a publishing_app" do
     set_up do
       DatabaseCleaner.clean_with :truncation
-      draft_content_item = FactoryGirl.create(:draft_content_item, content_id: "bed722e6-db68-43e5-9079-063f623335a7")
-      FactoryGirl.create(:version, target: draft_content_item, number: 1)
+      draft_content_item = FactoryGirl.create(:draft_content_item,
+        content_id: "bed722e6-db68-43e5-9079-063f623335a7",
+      )
 
-      error_response = {
-        "errors" => {
-          "publishing_app"=>["can't be blank"],
-        }
-      }
-      stub_request(:put, Regexp.new('\A' + Regexp.escape(Plek.find('content-store')) + "/content"))
-      stub_request(:put, Plek.find('content-store') + "/content#{draft_content_item.base_path}")
-        .to_return(status: 422, body: error_response.to_json, headers: {})
-      stub_request(:put, Regexp.new('\A' + Regexp.escape(Plek.find('draft-content-store')) + "/content"))
-      stub_request(:delete, Regexp.new('\A' + Regexp.escape(Plek.find('content-store')) + "/publish-intent"))
-        .to_return(status: 404, body: "{}", headers: {"Content-Type" => "application/json"} )
-      stub_request(:put, Regexp.new('\A' + Regexp.escape(Plek.find('content-store')) + "/publish-intent"))
-        .to_return(status: 200, body: "{}", headers: {"Content-Type" => "application/json"} )
+      draft_content_item.update_columns(publishing_app: nil)
+
+      FactoryGirl.create(:version, target: draft_content_item, number: 1)
     end
   end
 
@@ -179,8 +166,6 @@ Pact.provider_states_for "GDS API Adapters" do
 
       draft = FactoryGirl.create(:draft_content_item, content_id: "bed722e6-db68-43e5-9079-063f623335a7", locale: "fr")
       FactoryGirl.create(:version, target: draft, number: 1)
-
-      stub_request(:put, Regexp.new('\A' + Regexp.escape(Plek.find('content-store')) + "/content"))
     end
   end
 

--- a/spec/support/sidekiq.rb
+++ b/spec/support/sidekiq.rb
@@ -1,0 +1,2 @@
+require 'sidekiq/testing'
+Sidekiq::Testing.inline!


### PR DESCRIPTION
Adds sidekiq workers to make downstream requests (content store and rabbitmq) asynchronous.

Requires https://github.gds/gds/puppet/pull/3574 to be deployed first.

https://trello.com/c/b266seNO/333-make-calls-from-publishing-api-to-content-store-be-asynchronous