### PR TITLE
Version Invariants: Part Two

### DIFF
--- a/app/commands/v2/publish.rb
+++ b/app/commands/v2/publish.rb
@@ -7,8 +7,6 @@ module Commands
         live_content_item = LiveContentItem.create_or_replace(live_item_attributes) do |live_item|
           if live_item.version == draft_item.version
             raise CommandError.new(code: 400, message: "This item is already published")
-          else
-            live_item.version = draft_item.version
           end
         end
 

--- a/app/models/default_attributes.rb
+++ b/app/models/default_attributes.rb
@@ -4,9 +4,8 @@ module DefaultAttributes
   included do
     def assign_attributes_with_defaults(attributes)
       new_attributes = self.class.column_defaults.symbolize_keys
-        .merge(version: self.version + 1)
         .merge(attributes.symbolize_keys)
-        .except(:id)
+        .except(:id, :version)
       assign_attributes(new_attributes)
     end
   end

--- a/app/models/draft_content_item.rb
+++ b/app/models/draft_content_item.rb
@@ -10,6 +10,8 @@ class DraftContentItem < ActiveRecord::Base
 
   has_one :live_content_item
 
+  before_validation :increment_version
+
   validates :content_id, presence: true
   validate :content_ids_match
   validates :version, presence: true
@@ -24,5 +26,10 @@ private
     if live_content_item && live_content_item.content_id != content_id
       errors.add(:content_id, "id mismatch between draft and live content items")
     end
+  end
+
+  def increment_version
+    self.version ||= 0
+    self.version += 1
   end
 end

--- a/app/models/draft_content_item.rb
+++ b/app/models/draft_content_item.rb
@@ -17,6 +17,12 @@ class DraftContentItem < ActiveRecord::Base
   validates :version, presence: true
   validates_with VersionValidator::Draft
 
+  def refreshed_live_item
+    if live_content_item
+      LiveContentItem.find_by(content_id: live_content_item.content_id) || live_content_item
+    end
+  end
+
 private
   def self.query_keys
     [:content_id, :locale]

--- a/app/models/live_content_item.rb
+++ b/app/models/live_content_item.rb
@@ -34,6 +34,12 @@ class LiveContentItem < ActiveRecord::Base
     raise UnassignableVersionError, message
   end
 
+  def refreshed_draft_item
+    if draft_content_item
+      DraftContentItem.find_by(content_id: draft_content_item.content_id) || draft_content_item
+    end
+  end
+
 private
   def self.query_keys
     [:content_id, :locale]
@@ -46,7 +52,7 @@ private
   end
 
   def copy_version_from_draft
-    self[:version] = draft_content_item.version if draft_content_item
+    self[:version] = refreshed_draft_item.version if draft_content_item
   end
 
   class ::UnassignableVersionError < StandardError; end

--- a/app/models/live_content_item.rb
+++ b/app/models/live_content_item.rb
@@ -21,11 +21,18 @@ class LiveContentItem < ActiveRecord::Base
 
   belongs_to :draft_content_item
 
+  before_validation :copy_version_from_draft
+
   validates :draft_content_item, presence: true
   validates :content_id, presence: true
   validate :content_ids_match
   validates :version, presence: true
   validates_with VersionValidator::Live
+
+  def version=(_)
+    message = "Cannot set version manually. It is automatically set from the draft."
+    raise UnassignableVersionError, message
+  end
 
 private
   def self.query_keys
@@ -37,4 +44,10 @@ private
       errors.add(:content_id, "id mismatch between draft and live content items")
     end
   end
+
+  def copy_version_from_draft
+    self[:version] = draft_content_item.version if draft_content_item
+  end
+
+  class ::UnassignableVersionError < StandardError; end
 end

--- a/app/models/replaceable.rb
+++ b/app/models/replaceable.rb
@@ -6,7 +6,7 @@ module Replaceable
       payload = payload.deep_symbolize_keys
 
       item = self.lock.find_or_initialize_by(payload.slice(*self.query_keys))
-      item.assign_attributes(payload.except(:id))
+      item.assign_attributes(payload.except(:id, :version))
 
       if block_given?
         yield(item)

--- a/app/validators/version_validator.rb
+++ b/app/validators/version_validator.rb
@@ -13,8 +13,8 @@ module VersionValidator
     def versions_cant_go_backwards(draft_item)
       return unless draft_item.version && draft_item.version_was
 
-      if draft_item.version < draft_item.version_was
-        difference = "(#{draft_item.version} < #{draft_item.version_was})"
+      if draft_item.version <= draft_item.version_was
+        difference = "(#{draft_item.version} <= #{draft_item.version_was})"
         message = "cannot be less than the previous version #{difference}"
 
         draft_item.errors.add(:version, message)

--- a/app/validators/version_validator.rb
+++ b/app/validators/version_validator.rb
@@ -1,21 +1,31 @@
 module VersionValidator
   class Draft < ActiveModel::Validator
     def validate(draft_item)
-      live_item = draft_item.live_content_item
-      message = VersionValidator.validate(draft_item, live_item)
-      draft_item.errors.add(:version, message) if message
-
+      version_is_greater_than_live(draft_item)
       versions_cant_go_backwards(draft_item)
     end
 
     private
+
+    def version_is_greater_than_live(draft_item)
+      live_item = draft_item.refreshed_live_item
+
+      return unless draft_item && live_item
+      return unless draft_item.version && live_item.version
+
+      if draft_item.version <= live_item.version
+        mismatch = "(#{draft_item.version} <= #{live_item.version})"
+        message = "cannot be less than or equal to live version #{mismatch}"
+        draft_item.errors.add(:version, message)
+      end
+    end
 
     def versions_cant_go_backwards(draft_item)
       return unless draft_item.version && draft_item.version_was
 
       if draft_item.version <= draft_item.version_was
         difference = "(#{draft_item.version} <= #{draft_item.version_was})"
-        message = "cannot be less than the previous version #{difference}"
+        message = "cannot be less than or equal to the previous draft version #{difference}"
 
         draft_item.errors.add(:version, message)
       end
@@ -24,19 +34,20 @@ module VersionValidator
 
   class Live < ActiveModel::Validator
     def validate(live_item)
-      draft_item = live_item.draft_content_item
-      message = VersionValidator.validate(draft_item, live_item)
-      live_item.errors.add(:version, message) if message
+      versions_are_equal(live_item)
     end
-  end
 
-  def self.validate(draft_item, live_item)
-    return unless draft_item && live_item
-    return unless draft_item.version && live_item.version
+    def versions_are_equal(live_item)
+      draft_item = live_item.refreshed_draft_item
 
-    if live_item.version > draft_item.version
-      mismatch = "(#{live_item.version} > #{draft_item.version})"
-      "cannot be greater than draft version #{mismatch}"
+      return unless draft_item && live_item
+      return unless draft_item.version && live_item.version
+
+      if live_item.version != draft_item.version
+        mismatch = "(#{live_item.version} != #{draft_item.version})"
+        message = "live and draft versions must be equal #{mismatch}"
+        live_item.errors.add(:version, message)
+      end
     end
   end
 end

--- a/app/validators/version_validator.rb
+++ b/app/validators/version_validator.rb
@@ -4,6 +4,21 @@ module VersionValidator
       live_item = draft_item.live_content_item
       message = VersionValidator.validate(draft_item, live_item)
       draft_item.errors.add(:version, message) if message
+
+      versions_cant_go_backwards(draft_item)
+    end
+
+    private
+
+    def versions_cant_go_backwards(draft_item)
+      return unless draft_item.version && draft_item.version_was
+
+      if draft_item.version < draft_item.version_was
+        difference = "(#{draft_item.version} < #{draft_item.version_was})"
+        message = "cannot be less than the previous version #{difference}"
+
+        draft_item.errors.add(:version, message)
+      end
     end
   end
 

--- a/spec/event_logger_spec.rb
+++ b/spec/event_logger_spec.rb
@@ -31,14 +31,14 @@ RSpec.describe EventLogger do
     call_counter = 0
     EventLogger.log_command(command_class, payload) do
       if call_counter == 0
-        FactoryGirl.create(:live_content_item, content_id: "1234", locale: "en", version: 1)
+        FactoryGirl.create(:live_content_item, content_id: "1234", locale: "en")
         call_counter += 1
         raise CommandRetryableError
       else
         # The original transaction should have been rolled back, so there should be no
         # corresponding LiveContentItem in the database
         expect(LiveContentItem.where(content_id: "1234", locale: "en").count).to eq(0)
-        FactoryGirl.create(:live_content_item, content_id: "1234", locale: "en", version: 1)
+        FactoryGirl.create(:live_content_item, content_id: "1234", locale: "en")
       end
     end
 

--- a/spec/factories/draft_content_item.rb
+++ b/spec/factories/draft_content_item.rb
@@ -9,7 +9,6 @@ FactoryGirl.define do
     publishing_app "mainstream_publisher"
     rendering_app "mainstream_frontend"
     locale "en"
-    version 1
     details {
       { body: "<p>Something about VAT</p>\n", }
     }

--- a/spec/factories/live_content_item.rb
+++ b/spec/factories/live_content_item.rb
@@ -1,5 +1,5 @@
 FactoryGirl.define do
-  factory :live_content_item do
+  factory :live_content_item do |args|
     content_id { SecureRandom.uuid }
     base_path "/vat-rates"
     title "VAT rates"
@@ -9,7 +9,6 @@ FactoryGirl.define do
     publishing_app "mainstream_publisher"
     rendering_app "mainstream_frontend"
     locale "en"
-    version 1
     details {
       { body: "<p>Something about VAT</p>\n", }
     }
@@ -36,11 +35,16 @@ FactoryGirl.define do
         }
       ]
     }
-    after(:build) do |live_content_item|
+
+    transient do
+      draft_version 1
+    end
+
+    after(:build) do |live_content_item, evaluator|
       draft = FactoryGirl.build(
         :draft_content_item,
         content_id: live_content_item.content_id,
-        version: live_content_item.version
+        version: evaluator.draft_version - 1
       )
 
       live_content_item.draft_content_item = draft

--- a/spec/models/draft_content_item_spec.rb
+++ b/spec/models/draft_content_item_spec.rb
@@ -45,16 +45,22 @@ RSpec.describe DraftContentItem do
       expect(subject).to be_invalid
     end
 
-    context "given a version number less than the live" do
+    describe "version comparison between draft and live" do
       let(:live) { FactoryGirl.create(:live_content_item, draft_version: 6) }
       let(:draft) { live.draft_content_item }
 
-      # Draft versions are auto-incremented before_validation.
-      it "is invalid" do
+      it "is invalid if the draft version is less than the live version" do
         draft.version = 4
         expect(draft).to be_invalid
+      end
 
+      it "is invalid if the draft version is equal to the live version" do
         draft.version = 5
+        expect(draft).to be_invalid
+      end
+
+      it "is valid if the draft version is greater than the live version" do
+        draft.version = 6
         expect(draft).to be_valid
       end
     end

--- a/spec/models/draft_content_item_spec.rb
+++ b/spec/models/draft_content_item_spec.rb
@@ -72,6 +72,22 @@ RSpec.describe DraftContentItem do
       subject.version = 4
       expect(subject).to be_invalid
     end
+
+    describe "comparing versions when the live content item is stale" do
+      let(:live) { FactoryGirl.create(:live_content_item) }
+      let(:draft) { live.draft_content_item }
+
+      before do
+        another_instance = described_class.find(draft.id)
+        another_instance.save!
+        another_instance.live_content_item.save!
+      end
+
+      it "checks the version of live against the database" do
+        expect(draft).to be_invalid,
+          "The live version has not been checked against the persisted record."
+      end
+    end
   end
 
   let(:existing) { FactoryGirl.create(:draft_content_item) }

--- a/spec/models/draft_content_item_spec.rb
+++ b/spec/models/draft_content_item_spec.rb
@@ -45,6 +45,14 @@ RSpec.describe DraftContentItem do
         expect(draft).to be_invalid
       end
     end
+
+    it "requires that the version number be higher than its predecessor" do
+      subject.version = 5
+      subject.save!
+
+      subject.version = 4
+      expect(subject).to be_invalid
+    end
   end
 
   let!(:existing) { create(described_class) }

--- a/spec/models/link_set_spec.rb
+++ b/spec/models/link_set_spec.rb
@@ -6,21 +6,32 @@ RSpec.describe LinkSet do
   end
 
   def verify_new_attributes_set
-    expect(described_class.first.links).to eq(foo: ["bar"])
+    expect(described_class.last.links).to eq(foo: ["bar"])
   end
 
   def verify_old_attributes_not_preserved
-    expect(described_class.first.links[:organisations]).to be_nil
+    expect(described_class.last.links[:organisations]).to be_nil
   end
 
   let!(:existing) { create(described_class) }
   let!(:content_id) { existing.content_id }
 
   let!(:payload) do
-    build(described_class)
+    FactoryGirl.build(:link_set)
     .as_json
     .merge(
       content_id: content_id,
+      links: {
+        foo: ["bar"]
+      }
+    )
+  end
+
+  let!(:another_payload) do
+    FactoryGirl.build(:link_set)
+    .as_json
+    .symbolize_keys
+    .merge(
       links: {
         foo: ["bar"]
       }

--- a/spec/models/live_content_item_spec.rb
+++ b/spec/models/live_content_item_spec.rb
@@ -46,8 +46,22 @@ RSpec.describe LiveContentItem do
         subject.version = 123
       }.to raise_error(UnassignableVersionError)
     end
-  end
 
+    describe "comparing versions when the draft content item is stale" do
+      let(:live) { FactoryGirl.create(:live_content_item) }
+      let(:draft) { live.draft_content_item }
+
+      before do
+        another_instance = described_class.find(live.id)
+        another_instance.draft_content_item.save!
+      end
+
+      it "sets the live version from the latest persisted draft version" do
+        live.save!
+        expect(live.version).to eq(DraftContentItem.last.version)
+      end
+    end
+  end
 
   let(:existing) { FactoryGirl.create(:live_content_item) }
 

--- a/spec/models/symbolize_json_spec.rb
+++ b/spec/models/symbolize_json_spec.rb
@@ -5,14 +5,12 @@ RSpec.describe SymbolizeJSON do
 
   it "doesn't affect non-json columns" do
     subject.content_id = "content_id"
-    subject.version = 123
     subject.public_updated_at = Date.new(2000, 1, 1)
 
     subject.save!
     subject.reload
 
     expect(subject.content_id).to eq("content_id")
-    expect(subject.version).to eq(123)
     expect(subject.public_updated_at).to eq(Date.new(2000, 1, 1))
   end
 

--- a/spec/support/default_attributes.rb
+++ b/spec/support/default_attributes.rb
@@ -2,7 +2,6 @@ RSpec.shared_examples DefaultAttributes do
   before do
     subject.format = "something that should be cleared"
     subject.routes = ["foo"]
-    subject.version = 1
   end
 
   let(:attributes) {
@@ -21,15 +20,5 @@ RSpec.shared_examples DefaultAttributes do
   it "assigns the new attributes" do
     subject.assign_attributes_with_defaults(attributes)
     expect(subject.title).to eq("New title")
-  end
-
-  it "increases the version number if none was specified in the payload" do
-    subject.assign_attributes_with_defaults(attributes)
-    expect(subject.version).to eq(2)
-  end
-
-  it "uses the provided version number in preference to calculating one if provided" do
-    subject.assign_attributes_with_defaults(attributes.merge(version: 99))
-    expect(subject.version).to eq(99)
   end
 end

--- a/spec/support/immutable_base_path.rb
+++ b/spec/support/immutable_base_path.rb
@@ -2,7 +2,7 @@ RSpec.shared_examples ImmutableBasePath do
   describe 'validations' do
     context 'when a live content item exists' do
       before do
-        create(:live_content_item,
+        FactoryGirl.create(:live_content_item,
                content_id: subject.content_id,
                base_path: '/foo')
 

--- a/spec/support/replaceable.rb
+++ b/spec/support/replaceable.rb
@@ -41,6 +41,14 @@ RSpec.shared_examples Replaceable do
     end
   end
 
+  # We should not let users of our API specify the version number for the
+  # record to be saved. This should be handled by our application as it is
+  # a workflow consideration.
+  it "does not assign a version from the payload if one is provided" do
+    described_class.create_or_replace(payload.merge(version: 123))
+    expect(described_class.last.version).to_not eq(123)
+  end
+
   describe "retrying on race condition when inserting" do
     # There is a race condition when inserting a new entry. Between the read
     # query which is to check whether an item exists and the write of the new

--- a/spec/support/replaceable.rb
+++ b/spec/support/replaceable.rb
@@ -24,19 +24,17 @@ RSpec.shared_examples Replaceable do
 
   context "no item exists with that content_id" do
     it "creates a new instance" do
-      described_class.create_or_replace(payload)
-      expect(described_class.count).to eq(1)
-      expect(described_class.first.content_id).to eq(content_id)
+      expect {
+        described_class.create_or_replace(another_payload)
+      }.to change(described_class, :count).by(1)
+
+      content_id = another_payload.fetch(:content_id)
+      expect(described_class.last.content_id).to eq(content_id)
       verify_new_attributes_set
     end
 
-    it "sets the version number to 1" do
-      described_class.create_or_replace(payload)
-      expect(described_class.first.version).to eq(1)
-    end
-
     it "returns the created item" do
-      item = described_class.create_or_replace(payload)
+      item = described_class.create_or_replace(another_payload)
       expect(item).to be_a(described_class)
     end
   end

--- a/spec/support/request_helpers/derived_representations.rb
+++ b/spec/support/request_helpers/derived_representations.rb
@@ -90,8 +90,7 @@ module RequestHelpers
             locale: expected_attributes[:locale],
             details: expected_attributes[:details],
             metadata: {},
-            base_path: base_path,
-            version: 1
+            base_path: base_path
           )
         end
 
@@ -118,8 +117,7 @@ module RequestHelpers
             locale: expected_attributes[:locale],
             details: expected_attributes[:details],
             metadata: {},
-            base_path: base_path,
-            version: 1
+            base_path: base_path
           )
         end
 
@@ -148,8 +146,7 @@ module RequestHelpers
             locale: expected_attributes[:locale],
             details: expected_attributes[:details],
             metadata: {},
-            base_path: base_path,
-            version: 1
+            base_path: base_path
           )
 
           stub_request(:put, Plek.find('draft-content-store') + "/content#{new_base_path}")
@@ -178,8 +175,7 @@ module RequestHelpers
             locale: expected_attributes[:locale],
             details: expected_attributes[:details],
             metadata: {},
-            base_path: base_path,
-            version: 1
+            base_path: base_path
           )
 
           stub_request(:put, Plek.find('draft-content-store') + "/content#{new_base_path}")


### PR DESCRIPTION
This pull request enforces the invariants:

```
3) When the version number of the draft content item
and the live content item are the same, the attributes
of those content items must be identical, where equality
is specified by some subset of fields on the content item models.

4) When creating a new draft content item, its version must
always be greater than the version of an existing draft content
item with the same content id, if one exists.
```

Trello: [ensure-consistent-version-numbering](https://trello.com/c/Uv9ZgQs8/356-ensure-consistent-version-numbering)

This completes the work on adding in version invariants.

**Implementation notes**

We decided to encapsulate the responsibility of versioning at the model layer. This means that the models are responsible for managing their own versions and they will raise an error if the application tries to do this manually. This simplifies the application code as it no longer needs to worry about maintaining version consistency.

We achieved this through the use of a number of validations and ActiveRecord callbacks that run before these validations are checked.