### PR TITLE
Remove update type from payload send to content stores.

### DIFF
--- a/app/commands/put_draft_content_with_links.rb
+++ b/app/commands/put_draft_content_with_links.rb
@@ -8,15 +8,15 @@ module Commands
 
       if downstream
         Adapters::UrlArbiter.call(base_path, content_item[:publishing_app])
-        Adapters::DraftContentStore.call(base_path, content_item)
+        Adapters::DraftContentStore.call(base_path, content_item_for_content_store)
       end
 
       Success.new(content_item)
     end
 
   private
-    def content_item_with_base_path
-      content_item.merge(base_path: base_path)
+    def content_item_for_content_store
+      content_item.except(:update_type)
     end
 
     def content_item_top_level_fields

--- a/app/commands/v2/put_link_set.rb
+++ b/app/commands/v2/put_link_set.rb
@@ -14,10 +14,8 @@ module Commands
         end
 
         if (live_content_item = LiveContentItem.find_by(content_id: link_params.fetch(:content_id)))
-          content_store_payload = content_store_payload(live_content_item)
-
-          Adapters::ContentStore.call(live_content_item.base_path, content_store_payload)
-          PublishingAPI.service(:queue_publisher).send_message(content_store_payload)
+          Adapters::ContentStore.call(live_content_item.base_path, content_store_payload(live_content_item))
+          PublishingAPI.service(:queue_publisher).send_message(message_bus_payload(live_content_item))
         end
 
         Success.new(links: link_set.links)
@@ -52,8 +50,11 @@ module Commands
 
       def content_store_payload(content_item)
         content_item_hash = LinkSetMerger.merge_links_into(content_item)
-        content_item_hash = content_item_hash.merge(update_type: "links")
         Presenters::ContentItemPresenter.present(content_item_hash)
+      end
+
+      def message_bus_payload(content_item)
+        content_store_payload(content_item).merge(update_type: "links")
       end
     end
   end

--- a/app/lib/presenters/content_item_presenter.rb
+++ b/app/lib/presenters/content_item_presenter.rb
@@ -1,7 +1,7 @@
 module Presenters
   module ContentItemPresenter
     def self.present(content_item_hash)
-      metadata = content_item_hash.fetch(:metadata)
+      metadata = content_item_hash.fetch(:metadata).except(:update_type)
       public_updated_at = content_item_hash.fetch(:public_updated_at).iso8601
 
       content_item_hash

--- a/spec/factories/draft_content_item.rb
+++ b/spec/factories/draft_content_item.rb
@@ -21,6 +21,7 @@ FactoryGirl.define do
       {
         need_ids: ["100123", "100124"],
         phase: "beta",
+        update_type: "minor",
       }
     }
     routes {

--- a/spec/factories/live_content_item.rb
+++ b/spec/factories/live_content_item.rb
@@ -16,6 +16,7 @@ FactoryGirl.define do
       {
         need_ids: ["100123", "100124"],
         phase: "beta",
+        update_type: "minor",
       }
     }
     routes {

--- a/spec/presenters/content_item_presenter_spec.rb
+++ b/spec/presenters/content_item_presenter_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Presenters::ContentItemPresenter do
 
   it "includes the metadata fields in the top level of the presented item" do
     content_item_metadata.keys.each do |key|
+      next if key == :update_type
       expect(presented[key]).to eq(content_item_metadata[key])
     end
   end
@@ -24,6 +25,10 @@ RSpec.describe Presenters::ContentItemPresenter do
     expect(presented).not_to have_key(:version)
   end
 
+  it "removes the update_type" do
+    expect(presented).not_to have_key(:update_type)
+  end
+
   it "exports date fields as ISO 8601" do
     expect(presented[:public_updated_at]).to be_a(String)
     expect(presented[:public_updated_at]).to eq(content_item_hash[:public_updated_at].iso8601)
@@ -31,7 +36,7 @@ RSpec.describe Presenters::ContentItemPresenter do
 
   it "exports all other fields" do
     content_item_hash.each do |key, value|
-      next if [:metadata, :id, :version, :public_updated_at].include?(key)
+      next if [:metadata, :id, :version, :public_updated_at, :update_type].include?(key)
       expect(presented[key]).to eq(value)
     end
   end

--- a/spec/requests/content_item_requests/derived_representations_spec.rb
+++ b/spec/requests/content_item_requests/derived_representations_spec.rb
@@ -2,22 +2,22 @@ require "rails_helper"
 
 RSpec.describe "Derived representations", type: :request do
   context "/content" do
-    let(:request_body) { content_item_without_access_limiting.to_json }
+    let(:request_body) { content_item_params.to_json }
     let(:request_path) { "/content#{base_path}" }
     let(:request_method) { :put }
 
     creates_a_link_representation(expected_attributes: RequestHelpers::Mocks.links_attributes)
-    creates_a_content_item_representation(LiveContentItem, expected_attributes_proc: -> { content_item_without_access_limiting })
+    creates_a_content_item_representation(LiveContentItem, expected_attributes_proc: -> { content_item_params })
     allows_live_base_path_to_be_changed
   end
 
   context "/draft-content" do
-    let(:request_body) { content_item_with_access_limiting.to_json }
+    let(:request_body) { content_item_params.to_json }
     let(:request_path) { "/draft-content#{base_path}" }
     let(:request_method) { :put }
 
     creates_a_link_representation(expected_attributes: RequestHelpers::Mocks.links_attributes)
-    creates_a_content_item_representation(DraftContentItem, expected_attributes_proc: -> { content_item_with_access_limiting }, access_limited: true)
+    creates_a_content_item_representation(DraftContentItem, expected_attributes_proc: -> { content_item_params }, access_limited: true)
     allows_draft_base_path_to_be_changed
   end
 

--- a/spec/requests/content_item_requests/downstream_timeouts_spec.rb
+++ b/spec/requests/content_item_requests/downstream_timeouts_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe "Downstream timeouts", type: :request do
   context "/content" do
-    let(:request_body) { content_item_without_access_limiting.to_json }
+    let(:request_body) { content_item_params.to_json }
     let(:request_path) { "/content#{base_path}" }
     let(:request_method) { :put }
 
@@ -11,7 +11,7 @@ RSpec.describe "Downstream timeouts", type: :request do
   end
 
   context "/draft-content" do
-    let(:request_body) { content_item_with_access_limiting.to_json }
+    let(:request_body) { content_item_params.to_json }
     let(:request_path) { "/draft-content#{base_path}" }
     let(:request_method) { :put }
 

--- a/spec/requests/content_item_requests/endpoint_behaviour_spec.rb
+++ b/spec/requests/content_item_requests/endpoint_behaviour_spec.rb
@@ -2,8 +2,8 @@ require "rails_helper"
 
 RSpec.describe "Endpoint behaviour", type: :request do
   context "/content" do
-    let(:content_item) { content_item_without_access_limiting }
-    let(:request_body) { content_item.to_json }
+    let(:content_item) { content_item_params }
+    let(:request_body) { content_item_params.to_json }
     let(:request_path) { "/content#{base_path}" }
     let(:request_method) { :put }
 
@@ -24,8 +24,8 @@ RSpec.describe "Endpoint behaviour", type: :request do
   end
 
   context "/draft-content" do
-    let(:content_item) { content_item_with_access_limiting }
-    let(:request_body) { content_item.to_json }
+    let(:content_item) { content_item_params }
+    let(:request_body) { content_item_params.to_json }
     let(:request_path) { "/draft-content#{base_path}" }
     let(:request_method) { :put }
 

--- a/spec/requests/content_item_requests/event_logging_spec.rb
+++ b/spec/requests/content_item_requests/event_logging_spec.rb
@@ -2,21 +2,21 @@ require "rails_helper"
 
 RSpec.describe "Event logging", type: :request do
   context "/content" do
-    let(:request_body) { content_item_without_access_limiting.to_json }
+    let(:request_body) { content_item_params.to_json }
     let(:request_path) { "/content#{base_path}" }
     let(:request_method) { :put }
 
     logs_event('PutContentWithLinks', expected_payload_proc: ->{
-      content_item_without_access_limiting.deep_symbolize_keys.merge(base_path: base_path)
+      content_item_params.merge(base_path: base_path)
     })
   end
 
   context "/draft-content" do
-    let(:request_body) { content_item_with_access_limiting.to_json }
+    let(:request_body) { content_item_params.to_json }
     let(:request_path) { "/draft-content#{base_path}" }
     let(:request_method) { :put }
 
-    logs_event('PutDraftContentWithLinks', expected_payload_proc: ->{ content_item_with_access_limiting.deep_symbolize_keys.merge(base_path: base_path) })
+    logs_event('PutDraftContentWithLinks', expected_payload_proc: ->{ content_item_params.merge(base_path: base_path) })
   end
 
   context "/v2/content" do

--- a/spec/requests/content_item_requests/invalid_requests_spec.rb
+++ b/spec/requests/content_item_requests/invalid_requests_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "Invalid content requests", type: :request do
   end
 
   context "/content" do
-    let(:request_body) { content_item_without_access_limiting.to_json }
+    let(:request_body) { content_item_params.to_json }
     let(:request_path) { "/content#{base_path}" }
     let(:request_method) { :put }
 
@@ -22,7 +22,7 @@ RSpec.describe "Invalid content requests", type: :request do
   end
 
   context "/draft-content" do
-    let(:request_body) { content_item_with_access_limiting.to_json }
+    let(:request_body) { content_item_params.to_json }
     let(:request_path) { "/draft-content#{base_path}" }
     let(:request_method) { :put }
 

--- a/spec/requests/content_item_requests/message_bus_spec.rb
+++ b/spec/requests/content_item_requests/message_bus_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "Message bus", type: :request do
   include_context "using the message queue in test mode"
 
   context "/content" do
-    let(:request_body) { content_item_without_access_limiting.to_json }
+    let(:request_body) { content_item_params.to_json }
     let(:request_path) { "/content#{base_path}" }
     let(:request_method) { :put }
 
@@ -35,7 +35,7 @@ RSpec.describe "Message bus", type: :request do
     end
 
     context "minor update type" do
-      let(:request_body) { content_item_without_access_limiting.merge(update_type: "minor").to_json }
+      let(:request_body) { content_item_params.merge(update_type: "minor").to_json }
 
       it 'uses the update type for the routing key' do
         do_request
@@ -45,7 +45,7 @@ RSpec.describe "Message bus", type: :request do
     end
 
     context "detailed_guide format" do
-      let(:request_body) { content_item_without_access_limiting.merge(format: "detailed_guide").to_json }
+      let(:request_body) { content_item_params.merge(format: "detailed_guide").to_json }
 
       it "uses the format for the routing key" do
         do_request
@@ -63,7 +63,7 @@ RSpec.describe "Message bus", type: :request do
   end
 
   context "/draft-content" do
-    let(:request_body) { content_item_with_access_limiting.to_json }
+    let(:request_body) { content_item_params.to_json }
     let(:request_path) { "/draft-content#{base_path}" }
     let(:request_method) { :put }
 

--- a/spec/requests/publish_requests_spec.rb
+++ b/spec/requests/publish_requests_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe "POST /v2/publish", type: :request do
       .merge(
         links: link_set.links,
       )
+      .except(:update_type)
   }
 
   let(:content_id) { draft_content_item.content_id }

--- a/spec/support/request_helpers/downstream_requests.rb
+++ b/spec/support/request_helpers/downstream_requests.rb
@@ -4,7 +4,7 @@ module RequestHelpers
       it "registers the URL with the URL arbiter" do
         expect(PublishingAPI.service(:url_arbiter)).to receive(:reserve_path).with(
           "/vat-rates",
-          publishing_app: content_item[:publishing_app]
+          publishing_app: content_item_params[:publishing_app]
         )
 
         do_request
@@ -87,7 +87,7 @@ module RequestHelpers
         expect(PublishingAPI.service(:draft_content_store)).to receive(:put_content_item)
           .with(
             base_path: base_path,
-            content_item: content_item,
+            content_item: content_item_for_draft_content_store,
           )
           .ordered
 
@@ -102,7 +102,7 @@ module RequestHelpers
         expect(PublishingAPI.service(:live_content_store)).to receive(:put_content_item)
           .with(
             base_path: base_path,
-            content_item: content_item.except(:access_limited),
+            content_item: content_item_for_live_content_store,
           )
 
         do_request

--- a/spec/support/request_helpers/mocks.rb
+++ b/spec/support/request_helpers/mocks.rb
@@ -10,7 +10,7 @@ module RequestHelpers
       "582e1d3f-690e-4115-a948-e05b3c6b3d88"
     end
 
-    def content_item_without_access_limiting
+    def content_item_params
       {
         content_id: content_id,
         title: "VAT rates",
@@ -39,6 +39,12 @@ module RequestHelpers
           }
         ],
         update_type: "major",
+        access_limited: {
+          users: [
+            "f17250b0-7540-0131-f036-005056030202",
+            "74c7d700-5b4a-0131-7a8e-005056030037",
+          ],
+        },
       }.merge(links_attributes)
     end
 
@@ -49,17 +55,6 @@ module RequestHelpers
           organisations: ["f17250b0-7540-0131-f036-005056030221"]
         },
       }
-    end
-
-    def content_item_with_access_limiting
-      content_item_without_access_limiting.merge(
-        access_limited: {
-          users: [
-            "f17250b0-7540-0131-f036-005056030202",
-            "74c7d700-5b4a-0131-7a8e-005056030037",
-          ],
-        },
-      )
     end
 
     def redirect_content_item
@@ -80,7 +75,7 @@ module RequestHelpers
     end
 
     def v2_content_item
-      content_item_with_access_limiting
+      content_item_params
         .except(:links)
         .merge(base_path: base_path)
     end


### PR DESCRIPTION
Retains update type when send on message bus.

There's some more work to be done around access
limiting on the v2 endpoints as we are currently
sending access limiting to the draft content store
even if the equivalent version has been published
(at which point it should become access-limit-free
until another access limited draft is saved: https://trello.com/c/PPZFbP8w/373-tweak-access-limiting-on-v2-endpoints).