### PR TITLE
Versioning locale fix

### DIFF
--- a/app/controllers/v2/content_items_controller.rb
+++ b/app/controllers/v2/content_items_controller.rb
@@ -1,7 +1,7 @@
 module V2
   class ContentItemsController < ApplicationController
     def show
-      render json: Queries::GetContent.call(params[:content_id])
+      render json: Queries::GetContent.call(params[:content_id], params[:locale])
     end
 
     def put_content

--- a/app/models/draft_content_item.rb
+++ b/app/models/draft_content_item.rb
@@ -1,4 +1,6 @@
 class DraftContentItem < ActiveRecord::Base
+  DEFAULT_LOCALE = "en".freeze
+
   include Replaceable
   include DefaultAttributes
   include SymbolizeJSON

--- a/app/models/draft_content_item.rb
+++ b/app/models/draft_content_item.rb
@@ -21,7 +21,7 @@ class DraftContentItem < ActiveRecord::Base
 
   def refreshed_live_item
     if live_content_item
-      LiveContentItem.find_by(content_id: live_content_item.content_id) || live_content_item
+      LiveContentItem.find_by(content_id: live_content_item.content_id, locale: locale) || live_content_item
     end
   end
 

--- a/app/models/live_content_item.rb
+++ b/app/models/live_content_item.rb
@@ -36,7 +36,7 @@ class LiveContentItem < ActiveRecord::Base
 
   def refreshed_draft_item
     if draft_content_item
-      DraftContentItem.find_by(content_id: draft_content_item.content_id) || draft_content_item
+      DraftContentItem.find_by(content_id: draft_content_item.content_id, locale: locale) || draft_content_item
     end
   end
 

--- a/app/queries/get_content.rb
+++ b/app/queries/get_content.rb
@@ -1,7 +1,12 @@
 module Queries
   module GetContent
-    def self.call(content_id)
-      content_item = DraftContentItem.find_by(content_id: content_id)
+    def self.call(content_id, locale = nil)
+      locale ||= DraftContentItem::DEFAULT_LOCALE
+
+      content_item = DraftContentItem.find_by(
+        content_id: content_id,
+        locale: locale
+      )
 
       if content_item
         content_item

--- a/app/validators/base_path_validator.rb
+++ b/app/validators/base_path_validator.rb
@@ -1,7 +1,10 @@
 class BasePathValidator < ActiveModel::Validator
   def validate(record)
     unless record.mutable_base_path?
-      live_item = LiveContentItem.find_by(content_id: record.content_id)
+      live_item = LiveContentItem.find_by(
+        content_id: record.content_id,
+        locale: record.locale,
+      )
 
       if live_item.present? && live_item.base_path != record.base_path
         record.errors.add(:base_path, 'cannot be changed for published items')

--- a/db/migrate/20151022135849_reassociate_content_items.rb
+++ b/db/migrate/20151022135849_reassociate_content_items.rb
@@ -1,0 +1,25 @@
+class ReassociateContentItems < ActiveRecord::Migration
+  def change
+    # This migration fixes a problem introduced in this migration:
+    # AddDraftContentItemIdToLiveContentItem
+    #
+    # The DraftContentItem.find_by call should have scoped by locale.
+    #
+    # This migration re-assocates all incorrectly associated live content
+    # items with the draft item that matches the locale.
+
+    mismatches = LiveContentItem.all.select do |live_item|
+      draft_item = live_item.draft_content_item
+      live_item.locale != draft_item.locale
+    end
+
+    mismatches.each do |live_item|
+      draft_item = DraftContentItem.find_by!(
+        content_id: live_item.content_id,
+        locale: live_item.locale
+      )
+
+      live_item.update!(draft_content_item: draft_item)
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151016145941) do
+ActiveRecord::Schema.define(version: 20151022135849) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/spec/factories/live_content_item.rb
+++ b/spec/factories/live_content_item.rb
@@ -45,7 +45,8 @@ FactoryGirl.define do
       draft = FactoryGirl.build(
         :draft_content_item,
         content_id: live_content_item.content_id,
-        version: evaluator.draft_version - 1
+        version: evaluator.draft_version - 1,
+        locale: live_content_item.locale
       )
 
       live_content_item.draft_content_item = draft

--- a/spec/models/draft_content_item_spec.rb
+++ b/spec/models/draft_content_item_spec.rb
@@ -90,6 +90,21 @@ RSpec.describe DraftContentItem do
     end
   end
 
+  describe "#refreshed_live_item" do
+    let(:content_id) { SecureRandom.uuid }
+
+    let!(:arabic_live) { FactoryGirl.create(:live_content_item, locale: "ar", content_id: content_id) }
+    let!(:arabic_draft) { arabic_live.draft_content_item }
+
+    let!(:english_live) { FactoryGirl.create(:live_content_item, locale: "en", content_id: content_id) }
+    let!(:english_draft) { english_live.draft_content_item }
+
+    it "finds the corresponding live item scoped correctly to locale" do
+      expect(english_draft.refreshed_live_item).to eq(english_live)
+      expect(arabic_draft.refreshed_live_item).to eq(arabic_live)
+    end
+  end
+
   let(:existing) { FactoryGirl.create(:draft_content_item) }
 
   let(:content_id) { existing.content_id }

--- a/spec/models/live_content_item_spec.rb
+++ b/spec/models/live_content_item_spec.rb
@@ -63,6 +63,21 @@ RSpec.describe LiveContentItem do
     end
   end
 
+  describe "#refreshed_draft_item" do
+    let(:content_id) { SecureRandom.uuid }
+
+    let!(:arabic_live) { FactoryGirl.create(:live_content_item, locale: "ar", content_id: content_id) }
+    let!(:arabic_draft) { arabic_live.draft_content_item }
+
+    let!(:english_live) { FactoryGirl.create(:live_content_item, locale: "en", content_id: content_id) }
+    let!(:english_draft) { english_live.draft_content_item }
+
+    it "finds the corresponding draft item scoped correctly to locale" do
+      expect(english_live.refreshed_draft_item).to eq(english_draft)
+      expect(arabic_live.refreshed_draft_item).to eq(arabic_draft)
+    end
+  end
+
   let(:existing) { FactoryGirl.create(:live_content_item) }
 
   let(:draft) { existing.draft_content_item }

--- a/spec/queries/get_content_spec.rb
+++ b/spec/queries/get_content_spec.rb
@@ -17,4 +17,15 @@ RSpec.describe Queries::GetContent do
       }.to raise_error(CommandError, /with content_id: missing/)
     end
   end
+
+  context "when a locale is specified" do
+    before do
+      FactoryGirl.create(:draft_content_item, content_id: "foo", locale: "ar")
+    end
+
+    it "returns the content item in the specified locale" do
+      expect(subject.call("foo").locale).to eq("en")
+      expect(subject.call("foo", "ar").locale).to eq("ar")
+    end
+  end
 end

--- a/spec/requests/content_item_requests/endpoint_behaviour_spec.rb
+++ b/spec/requests/content_item_requests/endpoint_behaviour_spec.rb
@@ -80,6 +80,7 @@ RSpec.describe "Endpoint behaviour", type: :request do
 
       returns_200_response
       responds_with_content_item_body
+      responds_with_correct_locale_content_item
     end
 
     context "when the content item does not exist" do

--- a/spec/service_consumers/pact_helper.rb
+++ b/spec/service_consumers/pact_helper.rb
@@ -170,4 +170,14 @@ Pact.provider_states_for "GDS API Adapters" do
       stub_request(:put, Regexp.new('\A' + Regexp.escape(Plek.find('content-store')) + "/content"))
     end
   end
+
+  provider_state "a content item exists in multiple locales with content_id: bed722e6-db68-43e5-9079-063f623335a7" do
+    set_up do
+      DatabaseCleaner.clean_with :truncation
+
+      FactoryGirl.create(:draft_content_item, content_id: "bed722e6-db68-43e5-9079-063f623335a7", locale: "en")
+      FactoryGirl.create(:draft_content_item, content_id: "bed722e6-db68-43e5-9079-063f623335a7", locale: "fr")
+      FactoryGirl.create(:draft_content_item, content_id: "bed722e6-db68-43e5-9079-063f623335a7", locale: "ar")
+    end
+  end
 end

--- a/spec/service_consumers/pact_helper.rb
+++ b/spec/service_consumers/pact_helper.rb
@@ -161,4 +161,13 @@ Pact.provider_states_for "GDS API Adapters" do
       DatabaseCleaner.clean_with :truncation
     end
   end
+
+  provider_state "a draft content item exists with content_id: bed722e6-db68-43e5-9079-063f623335a7 and locale: fr" do
+    set_up do
+      DatabaseCleaner.clean_with :truncation
+
+      FactoryGirl.create(:draft_content_item, content_id: "bed722e6-db68-43e5-9079-063f623335a7", locale: "fr")
+      stub_request(:put, Regexp.new('\A' + Regexp.escape(Plek.find('content-store')) + "/content"))
+    end
+  end
 end

--- a/spec/support/immutable_base_path.rb
+++ b/spec/support/immutable_base_path.rb
@@ -20,6 +20,19 @@ RSpec.shared_examples ImmutableBasePath do
           expect(subject).to be_valid
         end
       end
+
+      it 'scopes the content item by locale correctly' do
+        FactoryGirl.create(
+          :live_content_item,
+          content_id: subject.content_id,
+          base_path: '/baz',
+          locale: 'ar'
+        )
+
+        subject.base_path = '/foo'
+
+        expect(subject).to be_valid
+      end
     end
   end
 end

--- a/spec/support/request_helpers/endpoint_behaviour.rb
+++ b/spec/support/request_helpers/endpoint_behaviour.rb
@@ -40,6 +40,16 @@ module RequestHelpers
       end
     end
 
+    def responds_with_correct_locale_content_item
+      it "responds with the body of the correct locale content item" do
+        FactoryGirl.create(:draft_content_item, content_id: content_id, locale: "ar")
+
+        do_request
+
+        expect(response.body).to eq(content_item.to_json)
+      end
+    end
+
     def suppresses_draft_content_store_502s
       context "when draft content store is not running but draft 502s are suppressed" do
         before do


### PR DESCRIPTION
We found a few problems with the scoping down of content items with regards to locale throughout the application. This includes the recent versioning work, but also some other endpoints such as publish and get_content. The base path validation also needed a change.

We've included a data migration in this pull request which should correct any data that has gone awry. We've pulled down a copy of preview data and verified that this works against that set.

Once this pull request has been merged, we can merge the adapters pull request here:
https://github.com/alphagov/gds-api-adapters/pull/373