### PR TITLE
Task to verify pacts for a gds-api-adapters branch

### DIFF
--- a/jenkins.sh
+++ b/jenkins.sh
@@ -1,14 +1,13 @@
 #!/bin/bash
 
-REPO_NAME=${REPO_NAME:-"alphagov/publishing-api"}
+GH_STATUS_REPO_NAME=${INITIATING_REPO_NAME:-"alphagov/publishing-api"}
 CONTEXT_MESSAGE=${CONTEXT_MESSAGE:-"default"}
-GH_STATUS_GIT_COMMIT=${SCHEMA_GIT_COMMIT:-${GIT_COMMIT}}
+GH_STATUS_GIT_COMMIT=${INITIATING_GIT_COMMIT:-${GIT_COMMIT}}
 
 function github_status {
-  REPO_NAME="$1"
-  STATUS="$2"
-  MESSAGE="$3"
-  gh-status "$REPO_NAME" "$GH_STATUS_GIT_COMMIT" "$STATUS" -d "Build #${BUILD_NUMBER} ${MESSAGE}" -u "$BUILD_URL" -c "$CONTEXT_MESSAGE" >/dev/null
+  STATUS="$1"
+  MESSAGE="$2"
+  gh-status "$GH_STATUS_REPO_NAME" "$GH_STATUS_GIT_COMMIT" "$STATUS" -d "Build #${BUILD_NUMBER} ${MESSAGE}" -u "$BUILD_URL" -c "$CONTEXT_MESSAGE" >/dev/null
 }
 
 function error_handler {
@@ -21,12 +20,12 @@ function error_handler {
   else
     echo "Error on or near line ${parent_lineno}; exiting with status ${code}"
   fi
-  github_status "$REPO_NAME" error "errored on Jenkins"
+  github_status error "errored on Jenkins"
   exit "${code}"
 }
 
 trap 'error_handler ${LINENO}' ERR
-github_status "$REPO_NAME" pending "is running on Jenkins"
+github_status pending "is running on Jenkins"
 
 # Cleanup anything left from previous test runs
 git clean -fdx
@@ -42,8 +41,8 @@ bundle install --path "${HOME}/bundles/${JOB_NAME}" --deployment --without devel
 bundle exec rake db:drop db:create db:schema:load
 
 if bundle exec rake ${TEST_TASK:-"default"}; then
-  github_status "$REPO_NAME" success "succeeded on Jenkins"
+  github_status success "succeeded on Jenkins"
 else
-  github_status "$REPO_NAME" failure "failed on Jenkins"
+  github_status failure "failed on Jenkins"
   exit 1
 fi

--- a/lib/tasks/pact.rake
+++ b/lib/tasks/pact.rake
@@ -19,6 +19,18 @@ unless Rails.env.production?
 
   task :default => "pact:verify"
 
+  task "pact:verify:branch", [:branch_name] do |t, args|
+    abort "Please provide a branch name. eg rake #{t.name}[my_feature_branch]" unless args[:branch_name]
+
+    require 'pact/tasks/task_helper'
+
+    with_temporary_env('GDS_API_PACT_VERSION', "branch-#{args[:branch_name]}") do
+      Pact::TaskHelper.handle_verification_failure do
+        Pact::TaskHelper.execute_pact_verify
+      end
+    end
+  end
+
   def with_temporary_env(key, value)
     original_value = ENV[key]
     ENV[key] = value


### PR DESCRIPTION
This will be used in a separate CI job to run as a downstram from the
gds-api-adapters branch builds.

This also includes some refactoring to the jenkins.sh script to make it more general. See 097311c for details.