### PR TITLE
Avoid setting LinkSet#links to nils

### DIFF
--- a/app/commands/put_content_with_links.rb
+++ b/app/commands/put_content_with_links.rb
@@ -69,7 +69,7 @@ module Commands
     end
 
     def create_or_update_links!
-      LinkSet.create_or_replace(content_id: content_id, links: content_item[:links]) do |link_set|
+      LinkSet.create_or_replace(content_id: content_id, links: content_item[:links] || {}) do |link_set|
         link_set.version += 1
       end
     end

--- a/app/link_set_merger.rb
+++ b/app/link_set_merger.rb
@@ -3,7 +3,7 @@ module LinkSetMerger
     merged_result = content_item.as_json
 
     link_set = LinkSet.find_by(content_id: content_item.content_id)
-    merged_result.merge!(links: link_set.links) if link_set
+    merged_result.merge!(links: link_set.links) if link_set && link_set.links
 
     merged_result.deep_symbolize_keys
   end

--- a/db/migrate/20151026170157_set_empty_links_to_hash.rb
+++ b/db/migrate/20151026170157_set_empty_links_to_hash.rb
@@ -1,0 +1,6 @@
+class SetEmptyLinksToHash < ActiveRecord::Migration
+  def change
+    LinkSet.where(links: nil).update_all(links: {})
+    raise "There are LinkSet records with links=nil, this should not happen!" if LinkSet.where(links: nil).any?
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151022135849) do
+ActiveRecord::Schema.define(version: 20151026170157) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/spec/commands/put_content_with_links_spec.rb
+++ b/spec/commands/put_content_with_links_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+RSpec.describe Commands::PutContentWithLinks do
+
+  describe 'call' do
+    let(:content_id) { SecureRandom.uuid }
+
+    let(:payload) {
+      build(DraftContentItem)
+        .as_json
+        .deep_symbolize_keys
+        .except(:format, :routes)
+        .merge(content_id: content_id)
+    }
+
+    it "set empty links in LinkSet to an empty hash by default" do
+      expect { Commands::PutContentWithLinks.new(payload.except(:links)).call(downstream: false) }.to_not raise_error
+
+      expect(LinkSet.find_by_content_id(content_id).links).to eq({})
+    end
+  end
+end

--- a/spec/link_set_merger_spec.rb
+++ b/spec/link_set_merger_spec.rb
@@ -23,6 +23,18 @@ RSpec.describe LinkSetMerger do
       end
     end
 
+    context "when a link set exists but has nil value in the links field (regression)" do
+      let!(:link_set) {
+        FactoryGirl.create(:link_set, content_id: content_id, links: nil)
+      }
+
+      it "does not merge the links" do
+        merged_result = subject.merge_links_into(content_item)
+
+        expect(merged_result.key?(:links)).to eq false
+      end
+    end
+
     context "when a link set does not exist" do
       it "returns a hash representing the content item" do
         merged_result = subject.merge_links_into(content_item)


### PR DESCRIPTION
I've encountered a bug while migrating github.com/alphagov/service-manual-publisher from V1 to V2. After some investigation I've uncovered that the V1 API sets LinkSet#links to nil values in some cases (see commit notes). V2 code does not expect that and as a result accidentally posts `links: nil` to the content store, that then breaks because #empty? is not defined on nils ([see here](https://github.com/alphagov/content-store/blob/0a263ada809ae5064bd73dcc0dc91314917cb7bc/app/models/content_item.rb#L205))

This is my approach at fixing the problem in this repo, but once this is merged we could make the code in content-store more robust too, also, perhaps we can consider validating against nil values in LinkSet#links?

I haven't worked on this repo and appreciate there could be better ways to solve this problem, so I'm fine if you want to throw this away and provide a better fix :) Otherwise I'm happy to modify this PR based on your comments.

/cc @alext 