### PR TITLE
Add import_path_reservations task.

### DIFF
--- a/lib/tasks/import_data.rake
+++ b/lib/tasks/import_data.rake
@@ -1,4 +1,5 @@
 require "tasks/import_data"
+require "tasks/import_path_reservations"
 
 desc "Imports all content items from the provided JSON file (one doc per line)"
 task :import_content_items, [:json_file_path, :state] => :environment do |_, args|
@@ -28,6 +29,32 @@ task :import_content_items, [:json_file_path, :state] => :environment do |_, arg
       total_lines: line_count,
       stdout: STDOUT,
       draft: state == "draft"
+    ).import_all
+  end
+end
+
+
+desc "Imports all path reservations from the provided JSON file (one doc per line)"
+task :import_path_reservations, [:json_file_path] => :environment do |_, args|
+  file_path = args[:json_file_path]
+  state = args[:state]
+
+  usage = "rake import_url_reservations['tmp/reservations.json']"
+
+  unless file_path && File.exist?(file_path)
+    puts "Could not find a file at '#{file_path}'"
+    puts "Please provide a path to a file with one JSON document per line"
+    puts "e.g. #{usage}"
+    exit
+  end
+
+  line_count = `wc -l #{file_path}`.strip.split(' ').first.to_i
+
+  File.open(file_path, "r") do |file|
+    Tasks::ImportPathReservations.new(
+      file: file,
+      total_lines: line_count,
+      stdout: STDOUT
     ).import_all
   end
 end

--- a/lib/tasks/import_path_reservations.rb
+++ b/lib/tasks/import_path_reservations.rb
@@ -1,0 +1,51 @@
+require "json"
+
+module Tasks
+  class ImportPathReservations
+    def initialize(file:, total_lines:, stdout:)
+      @file = file
+      @total_lines = total_lines
+      @stdout = stdout
+    end
+
+    def import_all
+      PathReservation.delete_all
+
+      file.each.with_index(1) do |json, index|
+        parsed_json = JSON.parse(json).deep_symbolize_keys
+
+        updated_at = parsed_json.fetch(:updated_at)
+        created_at = parsed_json.fetch(:created_at)
+        publishing_app = parsed_json.fetch(:publishing_app)
+        path = parsed_json.fetch(:path)
+
+        PathReservation.create!(
+          publishing_app: publishing_app,
+          base_path: path,
+          created_at: created_at,
+          updated_at: updated_at,
+        )
+
+        print_progress(index, total_lines)
+      end
+
+      stdout.puts
+    end
+
+  private
+
+    attr_reader :file, :total_lines, :stdout, :draft
+
+    def print_progress(completed, total)
+      percent_complete = ((completed.to_f / total) * 100).round
+      return if percent_complete == @percent_complete
+      @percent_complete = percent_complete
+      percent_remaining = 100 - percent_complete
+
+      stdout.print "\r"
+      stdout.flush
+      stdout.print "Progress [#{"=" * percent_complete}>#{"." * percent_remaining}] (#{percent_complete}%)"
+      stdout.flush
+    end
+  end
+end


### PR DESCRIPTION
This imports path reservations previously exported from URL Arbiter. Note that
all existing path reservations will be deleted before import; this is because
URL Arbiter will always contain the canonical data.