### PR TITLE
Use Replaceable mixin in PathReservation

### DIFF
--- a/app/models/path_reservation.rb
+++ b/app/models/path_reservation.rb
@@ -1,9 +1,16 @@
 class PathReservation < ActiveRecord::Base
-  validates :base_path, :uniqueness => true, :absolute_path => true
+  include Replaceable
+
+  validates :base_path, :absolute_path => true
   validates :publishing_app, :presence => true
   validates_with PublishingAppValidator
 
   def self.reserve_base_path!(base_path, publishing_app)
-    self.find_or_initialize_by(base_path: base_path).update_attributes!(publishing_app: publishing_app)
+    self.create_or_replace(base_path: base_path, publishing_app: publishing_app)
+  end
+
+private
+  def self.query_keys
+    [:base_path]
   end
 end

--- a/spec/models/draft_content_item_spec.rb
+++ b/spec/models/draft_content_item_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe DraftContentItem do
     end
   end
 
-  let(:existing) { FactoryGirl.create(:draft_content_item) }
+  let!(:existing) { FactoryGirl.create(:draft_content_item) }
 
   let(:content_id) { existing.content_id }
   let(:payload) do

--- a/spec/models/live_content_item_spec.rb
+++ b/spec/models/live_content_item_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe LiveContentItem do
     end
   end
 
-  let(:existing) { FactoryGirl.create(:live_content_item) }
+  let!(:existing) { FactoryGirl.create(:live_content_item) }
 
   let(:draft) { existing.draft_content_item }
   let(:content_id) { existing.content_id }

--- a/spec/models/path_reservation_spec.rb
+++ b/spec/models/path_reservation_spec.rb
@@ -8,20 +8,13 @@ RSpec.describe PathReservation, :type => :model do
 
       it "is required" do
         reservation.base_path = ''
-        expect(reservation).not_to be_valid
+        expect(reservation).to be_invalid
         expect(reservation.errors[:base_path].size).to eq(1)
       end
 
       it "is a valid absolute URL base_path" do
         reservation.base_path = "not a URL"
-        expect(reservation).not_to be_valid
-        expect(reservation.errors[:base_path].size).to eq(1)
-      end
-
-      it "is unique" do
-        create(:path_reservation, :base_path => "/foo/bar")
-        reservation.base_path = "/foo/bar"
-        expect(reservation).not_to be_valid
+        expect(reservation).to be_invalid
         expect(reservation.errors[:base_path].size).to eq(1)
       end
 
@@ -37,14 +30,14 @@ RSpec.describe PathReservation, :type => :model do
     describe "on publishing_app" do
       it "is required" do
         reservation.publishing_app = ''
-        expect(reservation).not_to be_valid
+        expect(reservation).to be_invalid
         expect(reservation.errors[:publishing_app].size).to eq(1)
       end
 
       it "cannot be changed" do
         reservation.save!
         reservation.publishing_app = 'another_app'
-        expect(reservation).not_to be_valid
+        expect(reservation).to be_invalid
         expect(reservation.errors[:base_path].size).to eq(1)
       end
     end
@@ -57,4 +50,29 @@ RSpec.describe PathReservation, :type => :model do
       reservation.save!
     }.not_to raise_error
   end
+
+  let(:payload) {
+    FactoryGirl.build(:path_reservation)
+    .as_json
+    .symbolize_keys
+  }
+
+  let(:another_payload) {
+    FactoryGirl.build(:path_reservation)
+    .as_json
+    .symbolize_keys
+    .merge(publishing_app: "not-publisher")
+  }
+
+  let!(:existing) { create(:path_reservation, payload) }
+
+  def set_new_attributes(item)
+    # empty because there are no changeable attributes
+  end
+
+  def verify_new_attributes_set
+    # empty because there are no changeable attributes
+  end
+
+  it_behaves_like Replaceable
 end

--- a/spec/support/replaceable.rb
+++ b/spec/support/replaceable.rb
@@ -1,8 +1,10 @@
 RSpec.shared_examples Replaceable do
   context "an item exists with that content_id" do
     it "replaces an existing instance by content id" do
-      described_class.create_or_replace(payload)
-      expect(described_class.count).to eq(1)
+      expect {
+        described_class.create_or_replace(payload)
+      }.not_to change(described_class, :count)
+
       item = described_class.first
       expect(item.content_id).to eq(content_id)
       expect(item.id).to eq(existing.id)

--- a/spec/support/replaceable.rb
+++ b/spec/support/replaceable.rb
@@ -1,12 +1,14 @@
 RSpec.shared_examples Replaceable do
-  context "an item exists with that content_id" do
-    it "replaces an existing instance by content id" do
+  context "an item exists with these query_keys" do
+    it "replaces an existing instance by query_keys" do
       expect {
         described_class.create_or_replace(payload)
       }.not_to change(described_class, :count)
 
       item = described_class.first
-      expect(item.content_id).to eq(content_id)
+      described_class.query_keys do |key|
+        expect(item.send(key)).to eq(payload[key.to_s])
+      end
       expect(item.id).to eq(existing.id)
       verify_new_attributes_set
     end
@@ -30,8 +32,10 @@ RSpec.shared_examples Replaceable do
         described_class.create_or_replace(another_payload)
       }.to change(described_class, :count).by(1)
 
-      content_id = another_payload.fetch(:content_id)
-      expect(described_class.last.content_id).to eq(content_id)
+      instance = described_class.last
+      described_class.query_keys.each do |key|
+        expect(instance.send(key)).to eq(another_payload.fetch(key))
+      end
       verify_new_attributes_set
     end
 
@@ -44,9 +48,11 @@ RSpec.shared_examples Replaceable do
   # We should not let users of our API specify the version number for the
   # record to be saved. This should be handled by our application as it is
   # a workflow consideration.
-  it "does not assign a version from the payload if one is provided" do
-    described_class.create_or_replace(payload.merge(version: 123))
-    expect(described_class.last.version).to_not eq(123)
+  if described_class.column_names.include?("version")
+    it "does not assign a version from the payload if one is provided" do
+      described_class.create_or_replace(payload.merge(version: 123))
+      expect(described_class.last.version).to_not eq(123)
+    end
   end
 
   describe "retrying on race condition when inserting" do


### PR DESCRIPTION
This solves an issue with occasional unique constraint violations due to race conditions. 

Also fix some tests in the mixin that were always passing, or made too-specific assumptions about the models.