### PR TITLE
Wrap ReservePath in event logger.

### DIFF
--- a/app/controllers/path_reservations_controller.rb
+++ b/app/controllers/path_reservations_controller.rb
@@ -1,5 +1,14 @@
 class PathReservationsController < ApplicationController
   def reserve_path
-    render json: Commands::ReservePath.call(payload.merge(base_path: base_path))
+    response = with_event_logging(Commands::ReservePath, path_item) do
+      Commands::ReservePath.call(path_item)
+    end
+
+    render status: response.code, json: response
+  end
+
+private
+  def path_item
+    payload.merge(base_path: base_path)
   end
 end

--- a/spec/requests/reserve_path_requests_spec.rb
+++ b/spec/requests/reserve_path_requests_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe "PUT /paths", type: :request do
     put request_path, body, headers
   end
 
-  context "with path /foo" do
-    let(:request_path) { "/paths/foo" }
+  context "with path /vat-rates" do
+    let(:request_path) { "/paths#{base_path}" }
     let(:payload) {
       {
         publishing_app: "publisher",
@@ -28,7 +28,6 @@ RSpec.describe "PUT /paths", type: :request do
       }.to change(PathReservation, :count).by(1)
     end
 
+    logs_event('ReservePath', expected_payload_proc: -> { payload.merge(base_path: base_path) } )
   end
 end
-
-


### PR DESCRIPTION
As well as logging the event, this takes care of retrying in case of unique constraint violations.