### PR TITLE
Support optimistic locking on v2 endpoints.

### DIFF
--- a/app/commands/base_command.rb
+++ b/app/commands/base_command.rb
@@ -33,5 +33,28 @@ module Commands
         }
       )
     end
+
+    def validate_version_lock!(versioned_item_class, content_id, previous_version_number)
+      current_versioned_item = versioned_item_class.find_by(content_id: content_id)
+      current_version = Version.find_by(target: current_versioned_item)
+
+      return unless current_versioned_item && current_version
+
+      conflict_error = CommandError.new(
+        code: 409,
+        message: "Conflict",
+        error_details: {
+          error: {
+            code: 409,
+            message: "Version conflict",
+            fields: {
+              previous_version: ["does not match"],
+            }
+          }
+        }
+      )
+
+      raise conflict_error if current_version.conflicts_with?(previous_version_number)
+    end
   end
 end

--- a/app/commands/v2/publish.rb
+++ b/app/commands/v2/publish.rb
@@ -12,6 +12,11 @@ module Commands
 
     private
       def validate!
+        validate_update_type!
+        validate_version_lock!
+      end
+
+      def validate_update_type!
         raise CommandError.new(
           code: 422,
           message: "update_type is required",
@@ -25,6 +30,10 @@ module Commands
             }
           }
         ) unless update_type.present?
+      end
+
+      def validate_version_lock!
+        super(DraftContentItem, content_id, payload[:previous_version])
       end
 
       def content_id

--- a/app/commands/v2/put_content.rb
+++ b/app/commands/v2/put_content.rb
@@ -2,6 +2,8 @@ module Commands
   module V2
     class PutContent < BaseCommand
       def call
+        validate_version_lock!
+
         content_item = create_or_update_draft_content_item!
 
         PathReservation.reserve_base_path!(base_path, content_item[:publishing_app])
@@ -10,6 +12,10 @@ module Commands
       end
 
     private
+      def validate_version_lock!
+        super(DraftContentItem, content_id, payload[:previous_version])
+      end
+
       def content_id
         payload.fetch(:content_id)
       end

--- a/app/commands/v2/put_link_set.rb
+++ b/app/commands/v2/put_link_set.rb
@@ -26,6 +26,11 @@ module Commands
 
     private
       def validate!
+        validate_links!
+        validate_version_lock!
+      end
+
+      def validate_links!
         raise CommandError.new(
           code: 422,
           message: "Links are required",
@@ -41,8 +46,12 @@ module Commands
         ) unless link_params[:links].present?
       end
 
+      def validate_version_lock!
+        super(LinkSet, link_params.fetch(:content_id), payload[:previous_version])
+      end
+
       def link_params
-        payload
+        payload.except(:previous_version)
       end
 
       def merge_links(base_links, new_links)

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -13,6 +13,12 @@ class Version < ActiveRecord::Base
     self.number = version.number
   end
 
+  def conflicts_with?(previous_version_number)
+    return false if previous_version_number.nil?
+
+    self.number != previous_version_number
+  end
+
 private
 
   def numbers_must_increase

--- a/spec/models/version_spec.rb
+++ b/spec/models/version_spec.rb
@@ -71,4 +71,42 @@ RSpec.describe Version do
       end
     end
   end
+
+  describe "#conflicts_with?(previous_version_number)" do
+    before do
+      subject.number = 2
+    end
+
+    context "when the previous version is lower than the current version" do
+      let(:previous_version_number) { subject.number - 1 }
+
+      it "conflicts" do
+        expect(subject.conflicts_with?(previous_version_number)).to eq(true)
+      end
+    end
+
+    context "when the previous version matches the current version number" do
+      let(:previous_version_number) { subject.number }
+
+      it "does not conflict" do
+        expect(subject.conflicts_with?(previous_version_number)).to eq(false)
+      end
+    end
+
+    context "when the previous version is larger than the current version number" do
+      let(:previous_version_number) { subject.number + 1 }
+
+      it "conflicts, and something really weird is going on" do
+        expect(subject.conflicts_with?(previous_version_number)).to eq(true)
+      end
+    end
+
+    context "when the previous version is absent" do
+      let(:previous_version_number) { nil }
+
+      it "does not conflict" do
+        expect(subject.conflicts_with?(previous_version_number)).to eq(false)
+      end
+    end
+  end
 end

--- a/spec/requests/optimistic_locking_spec.rb
+++ b/spec/requests/optimistic_locking_spec.rb
@@ -1,0 +1,145 @@
+require "rails_helper"
+
+RSpec.describe "Optimistic locking", type: :request do
+  context "content endpoints" do
+    let(:content_item) { v2_content_item }
+
+    before do
+      @existing_content_item = FactoryGirl.create(:draft_content_item, content_item)
+      @existing_version = FactoryGirl.create(:version,
+        target: @existing_content_item,
+        number: 2,
+      )
+    end
+
+    context "with a matching previous_version" do
+      context "PUT /v2/content" do
+        let(:request_path) { "/v2/content/#{content_id}" }
+        let(:request_method) { :put }
+        let(:request_body) {
+          v2_content_item.merge(
+            title: "A new title",
+            previous_version: 2,
+          ).to_json
+        }
+
+        it "updates the existing content item" do
+          do_request
+
+          expect(response.status).to eq(200)
+          expect(@existing_content_item.reload.title).to eq("A new title")
+          expect(@existing_version.reload.number).to eq(3)
+          expect(WebMock).to have_requested(:put, /draft-content-store/)
+        end
+      end
+
+      context "POST /v2/content/:content_id/publish" do
+        let(:request_path) { "/v2/content/#{content_id}/publish" }
+        let(:request_method) { :post }
+        let(:request_body) {
+          {
+            update_type: "minor",
+            previous_version: 2,
+          }.to_json
+        }
+
+        it "publishes the existing content item" do
+          do_request
+
+          expect(response.status).to eq(200)
+          expect(LiveContentItem.where(content_id: content_id).count).to eq(1)
+          expect(WebMock).to have_requested(:put, %r{http://content-store})
+        end
+      end
+    end
+
+    context "with a mismatched previous_version" do
+      context "PUT /v2/content" do
+        let(:request_path) { "/v2/content/#{content_id}" }
+        let(:request_method) { :put }
+        let(:request_body) {
+          v2_content_item.merge(
+            title: "A new title",
+            previous_version: 1,
+          ).to_json
+        }
+
+        it "does not update the existing content item" do
+          do_request
+
+          expect(response.status).to eq(409)
+          expect(@existing_content_item.reload.title).to eq(v2_content_item[:title])
+          expect(@existing_version.reload.number).to eq(2)
+          expect(WebMock).not_to have_requested(:put, /draft-content-store/)
+        end
+      end
+
+      context "POST /v2/content/:content_id/publish" do
+        let(:request_path) { "/v2/content/#{content_id}/publish" }
+        let(:request_method) { :post }
+        let(:request_body) {
+          {
+            update_type: "minor",
+            previous_version: 1,
+          }.to_json
+        }
+
+        it "does not publish the existing content item" do
+          do_request
+
+          expect(response.status).to eq(409)
+          expect(LiveContentItem.where(content_id: content_id).count).to eq(0)
+          expect(WebMock).not_to have_requested(:put, %r{http://content-store})
+        end
+      end
+    end
+  end
+
+  context "PUT /v2/links" do
+    before do
+      FactoryGirl.create(:live_content_item, content_id: content_id)
+      existing_link_set = FactoryGirl.create(:link_set, links_attributes)
+      @existing_version = FactoryGirl.create(:version,
+        target: existing_link_set,
+        number: 2,
+      )
+    end
+
+    let(:request_path) { "/v2/links/#{content_id}" }
+    let(:request_method) { :put }
+
+    context "with a matching previous_version" do
+      let(:request_body) {
+        links_attributes.merge(
+          previous_version: 2,
+        ).to_json
+      }
+
+      it "updates the link set" do
+        do_request
+
+        expect(response.status).to eq(200)
+        expect(@existing_version.reload.number).to eq(3)
+        expect(WebMock).to have_requested(:put, /draft-content-store/)
+        expect(WebMock).to have_requested(:put, %r{http://content-store})
+      end
+    end
+
+    context "with a mismatched previous_version" do
+      let(:request_body) {
+        links_attributes.merge(
+          previous_version: 1,
+        ).to_json
+      }
+
+      it "does not update the link set" do
+        do_request
+
+        expect(response.status).to eq(409)
+        expect(@existing_version.reload.number).to eq(2)
+        expect(WebMock).not_to have_requested(:put, /draft-content-store/)
+        expect(WebMock).not_to have_requested(:put, %r{http://content-store})
+      end
+    end
+  end
+end

--- a/spec/service_consumers/pact_helper.rb
+++ b/spec/service_consumers/pact_helper.rb
@@ -233,4 +233,36 @@ Pact.provider_states_for "GDS API Adapters" do
       FactoryGirl.create(:version, target: arabic_draft, number: 1)
     end
   end
+
+  provider_state "the content item bed722e6-db68-43e5-9079-063f623335a7 is at version 3" do
+    set_up do
+      DatabaseCleaner.clean_with :truncation
+
+      draft = FactoryGirl.create(:draft_content_item, content_id: "bed722e6-db68-43e5-9079-063f623335a7")
+      FactoryGirl.create(:version, target: draft, number: 3)
+
+      stub_default_url_arbiter_responses
+      stub_request(:put, Regexp.new('\A' + Regexp.escape(Plek.find("content-store")) + "/content"))
+      stub_request(:put, Regexp.new('\A' + Regexp.escape(Plek.find("draft-content-store")) + "/content"))
+    end
+  end
+
+  provider_state "the linkset for bed722e6-db68-43e5-9079-063f623335a7 is at version 3" do
+    set_up do
+      DatabaseCleaner.clean_with :truncation
+
+      FactoryGirl.create(:draft_content_item, content_id: "bed722e6-db68-43e5-9079-063f623335a7")
+
+      linkset = FactoryGirl.create(:link_set,
+        content_id: "bed722e6-db68-43e5-9079-063f623335a7",
+        links: {},
+      )
+
+      FactoryGirl.create(:version, target: linkset, number: 3)
+
+      stub_default_url_arbiter_responses
+      stub_request(:put, Regexp.new('\A' + Regexp.escape(Plek.find("content-store")) + "/content"))
+      stub_request(:put, Regexp.new('\A' + Regexp.escape(Plek.find("draft-content-store")) + "/content"))
+    end
+  end
 end

--- a/spec/support/request_helpers/actions.rb
+++ b/spec/support/request_helpers/actions.rb
@@ -6,6 +6,8 @@ module RequestHelpers
         put request_path, body, headers
       when :get
         get request_path, body, headers
+      when :post
+        post request_path, body, headers
       end
     end
   end


### PR DESCRIPTION
This allows publisher applications to detect conflicts
when (for example) a user has left their edit page
open for a long time and someone else has updated
the item in the meantime.

If the version the app thinks it's updating does
not match the version in the Publishing API, a 409
Conflict is returned.

If the `previous_version` key is not provided, no
checking is performed.  This makes this locking
opt-in on the part of the publisher application.

https://trello.com/c/s3dN4eDP/336-optimistic-locking

Client changes here: https://github.com/alphagov/gds-api-adapters/pull/383