### PR TITLE
Fix a race condition when implicitly saving records…

### DIFF
--- a/spec/support/replaceable.rb
+++ b/spec/support/replaceable.rb
@@ -71,12 +71,28 @@ RSpec.shared_examples Replaceable do
       draft.destroy if defined?(draft)
     end
 
-    it "raises a CommandRetryableError in case of a duplicate constraint violation" do
-      expect {
-        described_class.create_or_replace(payload) do |existing|
-          create(described_class, payload.slice(*described_class.query_keys))
-        end
-      }.to raise_error(CommandRetryableError)
+    context "for a single record" do
+      it "raises a CommandRetryableError in case of a duplicate constraint violation" do
+        expect {
+          described_class.create_or_replace(payload) do |existing|
+            create(described_class, payload.slice(*described_class.query_keys))
+          end
+        }.to raise_error(CommandRetryableError)
+      end
+    end
+
+    context "for an object graph" do
+      it "raises a CommandRetryableError in case of a duplicate constraint violation" do
+        expect {
+          described_class.create_or_replace(payload) do |existing|
+            create(described_class, payload.slice(*described_class.query_keys))
+
+            version = Version.new(target: existing)
+            version.increment
+            version.save!
+          end
+        }.to raise_error(CommandRetryableError)
+      end
     end
   end
 end


### PR DESCRIPTION
We were seeing unique constraint violations on
production (for base path) when saving link sets.
This was caused by the fact the saving the version
implicitly saves the associated link set and this
was happening outside of the retry strategy method
call.

This change fixes this problem by ensuring we make
all changes to the the record inside of the retry
strategy. This means that if we decide to save the
record ourselves (explicitly or implicitly) it
will be saved in the context of the retry
strategy and will not raise unique constraint
violations.