### PR TITLE
Make error messages consistent.

### DIFF
--- a/app/adapters/content_store.rb
+++ b/app/adapters/content_store.rb
@@ -20,6 +20,7 @@ module Adapters
       {
         error: {
           code: upstream_error.code,
+          message: upstream_error.message,
           fields: upstream_error.error_details.fetch('errors', {})
         }
       }

--- a/app/commands/delete_publish_intent.rb
+++ b/app/commands/delete_publish_intent.rb
@@ -7,9 +7,20 @@ module Commands
     rescue GdsApi::HTTPServerError => e
       raise CommandError.new(code: e.code, message: e.message)
     rescue GdsApi::HTTPClientError => e
-      raise CommandError.new(code: e.code, error_details: e.error_details)
+      raise CommandError.new(code: e.code, error_details: convert_error_details(e))
     rescue GdsApi::BaseError => e
       raise CommandError.new(code: 500, message: "Unexpected error from content store: #{e.message}")
+    end
+
+  private
+    def convert_error_details(upstream_error)
+      {
+        error: {
+          code: upstream_error.code,
+          message: upstream_error.message,
+          fields: upstream_error.error_details.fetch('errors', {})
+        }
+      }
     end
   end
 end

--- a/spec/support/request_helpers/event_logging.rb
+++ b/spec/support/request_helpers/event_logging.rb
@@ -1,3 +1,5 @@
+require "json"
+
 module RequestHelpers
   module EventLogging
     def logs_event(event_class_name, expected_payload_proc:)
@@ -33,7 +35,14 @@ module RequestHelpers
 
         expect(Event.count).to eq(0)
         expect(response.status).to eq(422)
-        expect(response.body).to eq(error_details.to_json)
+
+        parsed_response = JSON.parse(response.body).deep_symbolize_keys
+
+        expect(parsed_response).to have_key(:error)
+        parsed_error = parsed_response.fetch(:error)
+
+        expect(parsed_error[:code]).to eq(422)
+        expect(parsed_error[:fields]).to eq(error_details.fetch(:errors))
       end
     end
   end


### PR DESCRIPTION
Bring all relevant error messages into our standard JSON format.

https://trello.com/c/G3kvrySZ/361-make-error-messages-consistent