### PR TITLE
[RFC - WIP]Add get linked endpoint

### DIFF
--- a/app/commands/put_content_with_links.rb
+++ b/app/commands/put_content_with_links.rb
@@ -5,6 +5,7 @@ module Commands
         draft_content_item = create_or_update_draft_content_item!
         create_or_update_live_content_item!(draft_content_item)
         create_or_update_links!
+        create_or_update_content_item_links!
       end
 
       PathReservation.reserve_base_path!(base_path, content_item[:publishing_app])
@@ -76,6 +77,10 @@ module Commands
         version.increment
         version.save! if link_set.valid?
       end
+    end
+
+    def create_or_update_content_item_links!
+      ContentItemLinkPopulator.create_or_replace(content_id, content_item[:links] || {})
     end
   end
 end

--- a/app/commands/v2/put_link_set.rb
+++ b/app/commands/v2/put_link_set.rb
@@ -21,6 +21,8 @@ module Commands
           PublishingAPI.service(:queue_publisher).send_message(message_bus_payload(live_content_item))
         end
 
+        create_or_update_content_item_links!
+
         Success.new(links: link_set.links)
       end
 
@@ -69,6 +71,10 @@ module Commands
 
       def message_bus_payload(content_item)
         live_content_store_payload(content_item).merge(update_type: "links")
+      end
+
+      def create_or_update_content_item_links!
+        ContentItemLinkPopulator.create_or_replace(link_params[:content_id], link_params[:links])
       end
     end
   end

--- a/app/controllers/v2/link_sets_controller.rb
+++ b/app/controllers/v2/link_sets_controller.rb
@@ -12,6 +12,10 @@ module V2
       render status: response.code, json: response
     end
 
+    def get_linked
+      render json: Queries::GetLinked.call(content_id, params.fetch(:link_type))
+    end
+
   private
     def links_params
       payload.merge(content_id: content_id)

--- a/app/lib/content_item_link_populator.rb
+++ b/app/lib/content_item_link_populator.rb
@@ -1,0 +1,26 @@
+class ContentItemLinkPopulator
+  def self.create_or_replace(source_content_id, links)
+    content_item_links = ContentItemLink.where(source: source_content_id)
+
+    if links.nil? || links.empty?
+      delete_old_content_item_links(source_content_id)
+    elsif content_item_links.empty?
+      add_content_item_links(source_content_id, links)
+    else
+      delete_old_content_item_links(source_content_id)
+      add_content_item_links(source_content_id, links)
+    end
+  end
+
+  def self.add_content_item_links(source_content_id, links)
+    links.each do |link_type, links|
+      links.each do |link|
+        ContentItemLink.new(source: source_content_id, link_type: link_type, target: link).save!
+      end
+    end
+  end
+
+  def self.delete_old_content_item_links(source_content_id)
+    ContentItemLink.where(source: source_content_id).delete_all
+  end
+end

--- a/app/models/content_item_link.rb
+++ b/app/models/content_item_link.rb
@@ -1,0 +1,2 @@
+class ContentItemLink < ActiveRecord::Base
+end

--- a/app/queries/get_linked.rb
+++ b/app/queries/get_linked.rb
@@ -1,0 +1,20 @@
+module Queries
+  module GetLinked
+    def self.call(content_id, link_type)
+      content_item_links = ContentItemLink.where(target: content_id, link_type: link_type)
+
+      if content_item_links.empty?
+        error_details = {
+          error: {
+            code: 404,
+            message: "Could not find any item with a link of type '#{link_type}' linked to this item: '#{content_id}'"
+          }
+        }
+
+        raise CommandError.new(code: 404, error_details: error_details)
+      else
+        content_item_links
+      end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,8 @@ Rails.application.routes.draw do
 
       get "/links/:content_id", to: "link_sets#get_links"
       put "/links/:content_id", to: "link_sets#put_links"
+
+      get "/linked/:link_type/:content_id", to: "link_sets#get_linked"
     end
   end
 

--- a/db/migrate/20151029140010_add_content_item_links.rb
+++ b/db/migrate/20151029140010_add_content_item_links.rb
@@ -1,0 +1,9 @@
+class AddContentItemLinks < ActiveRecord::Migration
+  create_table :content_item_links do |t|
+    t.string :source, :null => false
+    t.string :link_type
+    t.string :target, :null => false
+  end
+
+  add_index :content_item_links, [:source, :target]
+end

--- a/db/migrate/20151102110431_populate_content_item_links.rb
+++ b/db/migrate/20151102110431_populate_content_item_links.rb
@@ -1,0 +1,8 @@
+class PopulateContentItemLinks < ActiveRecord::Migration
+  def change
+    LinkSet.all.each do |link_set|
+      puts "Adding linked items for #{link_set.content_id}"
+      ContentItemLinkPopulator.create_or_replace(link_set.content_id, link_set.links)
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151029144554) do
+ActiveRecord::Schema.define(version: 20151102110431) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -16,6 +16,14 @@ ActiveRecord::Schema.define(version: 20151029144554) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
+  create_table "content_item_links", force: :cascade do |t|
+    t.string "source",    null: false
+    t.string "link_type"
+    t.string "target",    null: false
+  end
+
+  add_index "content_item_links", ["source", "target"], name: "index_content_item_links_on_source_and_target", using: :btree
+
   create_table "draft_content_items", force: :cascade do |t|
     t.string   "content_id"
     t.string   "locale",               default: "en"

--- a/spec/commands/put_content_with_links_spec.rb
+++ b/spec/commands/put_content_with_links_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.describe Commands::PutContentWithLinks do
+
+  describe 'call with content_item_links' do
+    let(:content_id) { SecureRandom.uuid }
+    let(:org_content_id) { SecureRandom.uuid }
+
+    let(:payload) {
+      build(DraftContentItem)
+        .as_json
+        .deep_symbolize_keys
+        .merge(
+          content_id: content_id,
+          links:    { organisation: [ org_content_id] },
+        )
+    }
+
+    it "saves a ContentItemLink" do
+      expect { Commands::PutContentWithLinks.new(payload).call(downstream: false) }.to_not raise_error
+
+      expect(ContentItemLink.where(source: content_id).first.target).to eq(org_content_id)
+    end
+  end
+end

--- a/spec/commands/v2/put_link_set_spec.rb
+++ b/spec/commands/v2/put_link_set_spec.rb
@@ -42,4 +42,15 @@ RSpec.describe Commands::V2::PutLinkSet do
       topics: [topic_uuid],
     )
   end
+
+  it "creates related ContentItemLinks" do
+    described_class.call(link_params)
+
+    first_link = ContentItemLink.first
+    second_link = ContentItemLink.last
+
+    expect(first_link.source).to eq content_id
+    expect(first_link.link_type).to eq "organisations"
+    expect(first_link.target).to eq new_uuid
+  end
 end

--- a/spec/factories/content_item_link.rb
+++ b/spec/factories/content_item_link.rb
@@ -1,0 +1,7 @@
+FactoryGirl.define do
+  factory :content_item_link do
+    source    { SecureRandom.uuid }
+    link_type { "organisations" }
+    target    { SecureRandom.uuid }
+  end
+end

--- a/spec/lib/content_item_link_populator_spec.rb
+++ b/spec/lib/content_item_link_populator_spec.rb
@@ -1,0 +1,142 @@
+require 'rails_helper'
+
+RSpec.describe ContentItemLinkPopulator do
+
+  let!(:source_content_id) { SecureRandom.uuid }
+
+  let!(:link_content_id_1) { SecureRandom.uuid }
+  let!(:link_content_id_2) { SecureRandom.uuid }
+
+  describe "adding linked items with same key" do
+
+    let!(:links) {
+      { organisations: [ link_content_id_1, link_content_id_2 ] }
+    }
+
+    it "creates 2 linked items with same link_type" do
+      ContentItemLinkPopulator.create_or_replace(source_content_id, links)
+      first_link = ContentItemLink.first
+      second_link = ContentItemLink.last
+
+      expect(first_link.source).to eq source_content_id
+      expect(first_link.link_type).to eq "organisations"
+      expect(first_link.target).to eq link_content_id_1
+
+      expect(second_link.source).to eq source_content_id
+      expect(second_link.link_type).to eq "organisations"
+      expect(second_link.target).to eq link_content_id_2
+    end
+  end
+
+  describe "adding linked items with different keys" do
+    let!(:links) {
+      {
+        organisations: [ link_content_id_1 ],
+        related_links: [ link_content_id_2 ],
+      }
+    }
+
+    it "creates 2 linked items with different link_type" do
+      ContentItemLinkPopulator.create_or_replace(source_content_id, links)
+      first_link = ContentItemLink.first
+      second_link = ContentItemLink.last
+
+      expect(first_link.source).to eq source_content_id
+      expect(first_link.link_type).to eq "organisations"
+      expect(first_link.target).to eq link_content_id_1
+
+
+      expect(second_link.source).to eq source_content_id
+      expect(second_link.link_type).to eq "related_links"
+      expect(second_link.target).to eq link_content_id_2
+    end
+  end
+
+  describe "adding the same set of linked items twice" do
+    let!(:links) {
+      {
+        organisations: [ link_content_id_1 ],
+        related_links: [ link_content_id_2 ],
+      }
+    }
+
+    it "copies are not stored to the database" do
+      ContentItemLinkPopulator.create_or_replace(source_content_id, links)
+      ContentItemLinkPopulator.create_or_replace(source_content_id, links)
+      first_link = ContentItemLink.first
+      second_link = ContentItemLink.last
+
+      expect(first_link.source).to eq source_content_id
+      expect(first_link.link_type).to eq "organisations"
+      expect(first_link.target).to eq link_content_id_1
+
+
+      expect(second_link.source).to eq source_content_id
+      expect(second_link.link_type).to eq "related_links"
+      expect(second_link.target).to eq link_content_id_2
+
+      expect(ContentItemLink.all.count).to eq 2
+    end
+  end
+
+  describe "updating an existent set of linked items" do
+    let!(:first_set) {
+      {
+        organisations: [ link_content_id_1 ],
+        related_links: [ link_content_id_2 ],
+      }
+    }
+
+    describe "with different keys" do
+      let!(:second_set) {
+        {
+          organisations: [ link_content_id_1, link_content_id_2 ],
+        }
+      }
+
+      it "updates the links" do
+        ContentItemLinkPopulator.create_or_replace(source_content_id, first_set)
+        ContentItemLinkPopulator.create_or_replace(source_content_id, second_set)
+        first_link = ContentItemLink.first
+        second_link = ContentItemLink.last
+
+        expect(first_link.source).to eq source_content_id
+        expect(first_link.link_type).to eq "organisations"
+        expect(first_link.target).to eq link_content_id_1
+
+
+        expect(second_link.source).to eq source_content_id
+        expect(second_link.link_type).to eq "organisations"
+        expect(second_link.target).to eq link_content_id_2
+
+        expect(ContentItemLink.all.count).to eq 2
+      end
+    end
+
+    describe "with an empty set of links" do
+      let!(:second_set) { {} }
+
+      it "removes linked items" do
+        ContentItemLinkPopulator.create_or_replace(source_content_id, first_set)
+
+        expect(ContentItemLink.all.count).to eq 2
+
+        ContentItemLinkPopulator.create_or_replace(source_content_id, second_set)
+
+        expect(ContentItemLink.all.count).to eq 0
+      end
+    end
+  end
+
+  describe "handling a nil value for links" do
+
+    let!(:links_1) { nil }
+
+    it "does not create new linked items" do
+      ContentItemLinkPopulator.create_or_replace(source_content_id, links_1)
+
+      expect(ContentItemLink.all.count).to eq 0
+    end
+  end
+
+end

--- a/spec/queries/get_linked_spec.rb
+++ b/spec/queries/get_linked_spec.rb
@@ -1,0 +1,18 @@
+require "rails_helper"
+
+RSpec.describe Queries::GetLinked do
+  before do
+    FactoryGirl.create(:content_item_link, source: "foo", link_type: "organisations", target: "1111-1111-1111-1111")
+    FactoryGirl.create(:content_item_link, source: "foo", link_type: "related-links", target: "2222-2222-2222-2222")
+  end
+
+  it "returns linked" do
+    expect(subject.call("1111-1111-1111-1111", "organisations").map(&:source)).to eq(["foo"])
+  end
+
+  it "raises an error when no linked items are found" do
+    expect {
+      subject.call("1111-1111-1111-1111", "councils")
+    }.to raise_error(CommandError)
+  end
+end


### PR DESCRIPTION
#### This is a WIP branch, only opened for obtaining some feedback on whether I am approaching this problem correctly. The code requires refactoring.

We need an endpoint to get a list of the content which has a link of the given type to the given content-id.  This is needed to support the https://trello.com/c/DLakGcP0/351-add-a-way-to-monitor-that-the-taggings-in-panopticon-and-content-store-are-the-same story.

It is the `publisher-get-linked` endpoint [described in the RFC](https://gov-uk.atlassian.net/wiki/display/FS/RFC+31%3A+Requirements+for+tagging+architecture).

What the output of the endpoint looks like:
![screen shot 2015-11-04 at 10 27 46](https://cloud.githubusercontent.com/assets/5038475/10935558/c81497fc-82de-11e5-9879-21dc89c7de2a.png)

