### PR TITLE
Remove version columns.

### DIFF
--- a/db/migrate/20151105154759_remove_version_fields.rb
+++ b/db/migrate/20151105154759_remove_version_fields.rb
@@ -1,0 +1,7 @@
+class RemoveVersionFields < ActiveRecord::Migration
+  def change
+    remove_column :draft_content_items, :version
+    remove_column :live_content_items, :version
+    remove_column :link_sets, :version
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151105154432) do
+ActiveRecord::Schema.define(version: 20151105154759) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -19,7 +19,6 @@ ActiveRecord::Schema.define(version: 20151105154432) do
   create_table "draft_content_items", force: :cascade do |t|
     t.string   "content_id"
     t.string   "locale",               default: "en"
-    t.integer  "version",              default: 0,      null: false
     t.string   "base_path"
     t.string   "title"
     t.string   "description"
@@ -49,9 +48,8 @@ ActiveRecord::Schema.define(version: 20151105154432) do
   end
 
   create_table "link_sets", force: :cascade do |t|
-    t.string  "content_id"
-    t.integer "version",    default: 0,  null: false
-    t.json    "links",      default: {}, null: false
+    t.string "content_id"
+    t.json   "links",      default: {}, null: false
   end
 
   add_index "link_sets", ["content_id"], name: "index_link_sets_on_content_id", unique: true, using: :btree
@@ -59,7 +57,6 @@ ActiveRecord::Schema.define(version: 20151105154432) do
   create_table "live_content_items", force: :cascade do |t|
     t.string   "content_id"
     t.string   "locale",                default: "en"
-    t.integer  "version",               default: 0,      null: false
     t.string   "base_path"
     t.string   "title"
     t.string   "description"

--- a/spec/factories/link_set.rb
+++ b/spec/factories/link_set.rb
@@ -1,7 +1,6 @@
 FactoryGirl.define do
   factory :link_set do
     content_id { SecureRandom.uuid }
-    version 1
     links {
       {
         organisations: [ SecureRandom.uuid ]


### PR DESCRIPTION
These have been replaced by the `versions` table.

https://trello.com/c/N484LgfF/385-remove-the-version-columns-from-content-items-and-link-sets