### PR TITLE
Force text error template when exceptions occur

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,6 +6,11 @@ class ApplicationController < ActionController::Base
     head :bad_request
   end
 
+  before_action do
+    # Force Rails to show text-error pages
+    request.env['HTTP_X_REQUESTED_WITH'] = 'XMLHttpRequest'
+  end
+
 private
   def respond_with_command_error(error)
     render status: error.code, json: error


### PR DESCRIPTION
Rails by default shows nice error pages, with a lot of markup, css and javascript. This is cool when you visit the page in the browser, but not helpful when you consume the app as an API. Rails' HTML response then makes it really hard find the error when it's displayed as part of the exception message.

But Rails will [render a text-based exception](https://github.com/rails/rails/blob/master/actionpack/lib/action_dispatch/middleware/debug_exceptions.rb#L93-L99) when doing AJAX requests. By setting the `X-Requested-With` header we can make Rails show the text template for all requests.

Note that there's still some markup in the error. This is a Rails bug, addressed in https://github.com/rails/rails/pull/22172.

This is the result saving something in Panopticon that triggers an exception in publishing-api (in this case because I hadn't run the migrations). 

## Before

![screen shot 2015-11-05 at 14 34 27](https://cloud.githubusercontent.com/assets/233676/10975602/b76e80a0-83df-11e5-8bee-9b82cf84a613.png)
(and much more scrolling)

## After

![screen shot 2015-11-05 at 14 36 27](https://cloud.githubusercontent.com/assets/233676/10975603/b7732588-83df-11e5-8807-7d5be65b75cc.png)

I feel this is not a great solution. I'm considering a PR on Rails to show the text-template for all non-HTML requests, or make it configurable.
