### PR TITLE
Improve base path validation

### DIFF
--- a/app/commands/base_command.rb
+++ b/app/commands/base_command.rb
@@ -19,7 +19,7 @@ module Commands
 
     def self.raise_validation_command_error(e)
       errors = e.record.errors
-      full_message = errors.full_messages.join
+      full_message = errors.full_messages.join(', ')
 
       raise CommandError.new(
         code: 422,

--- a/app/models/draft_content_item.rb
+++ b/app/models/draft_content_item.rb
@@ -18,7 +18,7 @@ class DraftContentItem < ActiveRecord::Base
 
   validates :content_id, presence: true, uuid: true
   validate :content_ids_match
-  validates :base_path, absolute_path: true
+  validates :base_path, presence: true, absolute_path: true
   validates :format, presence: true
   validates :publishing_app, presence: true
   validates :title, presence: true, if: :renderable_content?

--- a/app/models/live_content_item.rb
+++ b/app/models/live_content_item.rb
@@ -32,7 +32,7 @@ class LiveContentItem < ActiveRecord::Base
   validates :draft_content_item, presence: true
   validates :content_id, presence: true, uuid: true
   validate :content_ids_match
-  validates :base_path, absolute_path: true
+  validates :base_path, presence: true, absolute_path: true
   validates :format, presence: true
   validates :publishing_app, presence: true
   validates :title, presence: true, if: :renderable_content?

--- a/spec/models/draft_content_item_spec.rb
+++ b/spec/models/draft_content_item_spec.rb
@@ -106,11 +106,11 @@ RSpec.describe DraftContentItem do
       it "should be required" do
         subject.base_path = nil
         expect(subject).not_to be_valid
-        expect(subject.errors[:base_path].size).to eq(1)
+        expect(subject.errors[:base_path].size).to eq(2)
 
         subject.base_path = ''
         expect(subject).not_to be_valid
-        expect(subject.errors[:base_path].size).to eq(1)
+        expect(subject.errors[:base_path].size).to eq(2)
       end
 
       it "should be an absolute path" do

--- a/spec/models/live_content_item_spec.rb
+++ b/spec/models/live_content_item_spec.rb
@@ -108,11 +108,11 @@ RSpec.describe LiveContentItem do
       it "should be required" do
         subject.base_path = nil
         expect(subject).not_to be_valid
-        expect(subject.errors[:base_path].size).to eq(1)
+        expect(subject.errors[:base_path].size).to eq(2)
 
         subject.base_path = ''
         expect(subject).not_to be_valid
-        expect(subject.errors[:base_path].size).to eq(1)
+        expect(subject.errors[:base_path].size).to eq(2)
       end
 
       it "should be an absolute path" do


### PR DESCRIPTION
When migrating smart-answers to V2 (alphagov/smart-answers#2057), I got the error that my `base_path` wasn't valid, which threw me off.

Having a presence validation will also tell the user when a `base_path` is missing from the payload, liek it was in my case. This will ease migration, as base_path was previously not required and not-adding it during the upgrade will be a common error.

Also fixes formatting of the error message.