### PR TITLE
Using sidekiq-statsd gem to plot sidekiq activity

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,7 @@ gem 'bunny', '2.0.0'
 gem 'whenever', '0.9.4', :require => false
 gem "sidekiq", "3.5.1"
 gem "sidekiq-logging-json", "0.0.14"
+gem "sidekiq-statsd", "0.1.5"
 
 group :development do
   # Access an IRB console on exception pages or by using <%= console %> in views

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -244,6 +244,10 @@ GEM
       redis-namespace (~> 1.5, >= 1.5.2)
     sidekiq-logging-json (0.0.14)
       sidekiq (~> 3)
+    sidekiq-statsd (0.1.5)
+      activesupport
+      sidekiq (>= 2.6)
+      statsd-ruby (>= 1.1.0)
     simplecov (0.10.0)
       docile (~> 1.1.0)
       json (~> 1.8)
@@ -258,6 +262,7 @@ GEM
       actionpack (>= 3.0)
       activesupport (>= 3.0)
       sprockets (>= 2.8, < 4.0)
+    statsd-ruby (1.2.1)
     term-ansicolor (1.3.2)
       tins (~> 1.0)
     thor (0.19.1)
@@ -313,6 +318,7 @@ DEPENDENCIES
   sass-rails (~> 5.0)
   sidekiq (= 3.5.1)
   sidekiq-logging-json (= 0.0.14)
+  sidekiq-statsd (= 0.1.5)
   simplecov (= 0.10.0)
   simplecov-rcov (= 0.2.3)
   timecop
@@ -321,3 +327,6 @@ DEPENDENCIES
   web-console (~> 2.0)
   webmock
   whenever (= 0.9.4)
+
+BUNDLED WITH
+   1.10.6

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -7,6 +7,10 @@ redis_config = {
 Sidekiq.configure_server do |config|
   config.redis = redis_config
   config.error_handlers << Proc.new {|ex, context_hash| Airbrake.notify(ex, context_hash) }
+
+  config.server_middleware do |chain|
+    chain.add Sidekiq::Statsd::ServerMiddleware, env: 'govuk.app.publishing-api', prefix: 'workers'
+  end
 end
 
 Sidekiq.configure_client do |config|


### PR DESCRIPTION
In order to improve tracking of what's going on with Sidekiq workers, add `sidekiq-statsd` gem and configuration.

Part of https://trello.com/c/z2aHqwS8/48-add-sidekiq-statsd-to-apps-that-use-sidekiq