### PR TITLE
Implement the "publisher-bulk-get" endpoint

### DIFF
--- a/app/controllers/v2/content_items_controller.rb
+++ b/app/controllers/v2/content_items_controller.rb
@@ -1,5 +1,11 @@
 module V2
   class ContentItemsController < ApplicationController
+    def index
+      content_format = params.fetch(:content_format)
+      fields = params.fetch(:fields)
+      render json: Queries::GetContentCollection.new(content_format: content_format, fields: fields).call
+    end
+
     def show
       render json: Queries::GetContent.call(params[:content_id], params[:locale])
     end

--- a/app/queries/get_content_collection.rb
+++ b/app/queries/get_content_collection.rb
@@ -1,0 +1,46 @@
+module Queries
+  class GetContentCollection
+    attr_reader :content_format, :fields
+
+    def initialize(content_format:, fields:)
+      @content_format = content_format
+      @fields = fields
+    end
+
+    def call
+      validate_fields!
+
+      content_items.map do |content_item|
+        hash = content_item.as_json(only: fields)
+        publication_state = content_item.live_content_item.present? ? 'live' : 'draft'
+        hash['publication_state'] = publication_state
+        hash
+      end
+    end
+
+  private
+
+    def content_items
+      DraftContentItem
+        .includes(:live_content_item)
+        .where(format: [content_format, "placeholder_#{content_format}"])
+        .select(*fields + %i[id])
+    end
+
+    def validate_fields!
+      invalid_fields = fields - permitted_fields
+      return unless invalid_fields.any?
+
+      raise CommandError.new(code: 400, error_details: {
+        error: {
+          code: 400,
+          message: "Invalid column name(s): #{invalid_fields.to_sentence}"
+        }
+      })
+    end
+
+    def permitted_fields
+      DraftContentItem.column_names
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,7 @@ Rails.application.routes.draw do
     put "/paths(/*base_path)", to: "path_reservations#reserve_path"
 
     namespace :v2 do
+      get "/content", to: "content_items#index"
       put "/content/:content_id", to: "content_items#put_content"
       get "/content/:content_id", to: "content_items#show"
       post "/content/:content_id/publish", to: "content_items#publish"

--- a/spec/factories/live_content_item.rb
+++ b/spec/factories/live_content_item.rb
@@ -33,10 +33,10 @@ FactoryGirl.define do
 
       draft = FactoryGirl.build(
         :draft_content_item,
-        content_id: live_content_item.content_id,
-        locale: live_content_item.locale,
-        base_path: live_content_item.base_path,
+        live_content_item.as_json(only: %i[content_id locale base_path format routes redirects]),
       )
+
+      raise "Draft is not valid: #{draft.errors.full_messages}" unless draft.valid?
 
       live_content_item.draft_content_item = draft
     end

--- a/spec/queries/get_content_collection_spec.rb
+++ b/spec/queries/get_content_collection_spec.rb
@@ -1,0 +1,63 @@
+require "rails_helper"
+
+RSpec.describe Queries::GetContentCollection do
+  it "returns the content items of the given format" do
+    create(:draft_content_item, base_path: '/a', format: 'topic')
+    create(:draft_content_item, base_path: '/b',  format: 'topic')
+    create(:draft_content_item, base_path: '/c',  format: 'mainstream_browse_page')
+
+    expect(Queries::GetContentCollection.new(
+      content_format: 'topic',
+      fields: ['base_path'],
+    ).call).to eq([
+      { "base_path" => "/a", "publication_state" => "draft" },
+      { "base_path" => "/b", "publication_state" => "draft" },
+    ])
+  end
+
+  it "returns the content items of the given format, and placeholder_format" do
+    create(:draft_content_item, base_path: '/a', format: 'topic')
+    create(:draft_content_item, base_path: '/b', format: 'placeholder_topic')
+
+    expect(Queries::GetContentCollection.new(
+      content_format: 'topic',
+      fields: ['base_path'],
+    ).call).to eq([
+      { "base_path" => "/a", "publication_state" => "draft" },
+      { "base_path" => "/b", "publication_state" => "draft" },
+    ])
+  end
+
+  it "includes the publishing state of the item" do
+    create(:draft_content_item, base_path: '/draft', format: 'topic')
+    item = create(:live_content_item, base_path: '/live',  format: 'topic')
+
+    expect(Queries::GetContentCollection.new(
+      content_format: 'topic',
+      fields: ['base_path'],
+    ).call).to eq([
+      { "base_path" => "/draft", "publication_state" => "draft"},
+      { "base_path" => "/live", "publication_state" => "live" },
+    ])
+  end
+
+  context "when there's no items for the format" do
+    it "returns an empty array" do
+      expect(Queries::GetContentCollection.new(
+        content_format: 'topic',
+        fields: ['base_path'],
+      ).call).to eq([])
+    end
+  end
+
+  context "when unknown fields are requested" do
+    it "raises an error" do
+      expect {
+        Queries::GetContentCollection.new(
+          content_format: 'topic',
+          fields: ['not_existing'],
+        ).call
+      }.to raise_error(CommandError)
+    end
+  end
+end

--- a/spec/requests/content_item_requests/endpoint_behaviour_spec.rb
+++ b/spec/requests/content_item_requests/endpoint_behaviour_spec.rb
@@ -47,7 +47,15 @@ RSpec.describe "Endpoint behaviour", type: :request do
     end
   end
 
-  context "/v2/content" do
+  context "GET /v2/content" do
+    let(:request_path) { "/v2/content?content_format=topic&fields[]=title&fields[]=description" }
+    let(:request_body) { "" }
+    let(:request_method) { :get }
+
+    returns_200_response
+  end
+
+  context "GET /v2/content/:content_id" do
     let(:content_item) { v2_content_item }
     let(:request_body) { content_item.to_json }
     let(:request_path) { "/v2/content/#{content_id}" }

--- a/spec/service_consumers/pact_helper.rb
+++ b/spec/service_consumers/pact_helper.rb
@@ -248,4 +248,11 @@ Pact.provider_states_for "GDS API Adapters" do
       stub_request(:put, Regexp.new('\A' + Regexp.escape(Plek.find("draft-content-store")) + "/content"))
     end
   end
+
+  provider_state "there is content with format 'topic'" do
+    set_up do
+      FactoryGirl.create(:draft_content_item, title: 'Content Item A', base_path: '/a-base-path', format: 'topic')
+      FactoryGirl.create(:draft_content_item, title: 'Content Item B', base_path: '/another-base-path', format: 'topic')
+    end
+  end
 end


### PR DESCRIPTION
This commit adds an endpoint to fetch all content-items for a given format. It will be used to populate the select-boxes in the tagging interfaces.

For example:

```
/v2/content?format=topic&fields=base_path,title
```

will return:

```json
[
  {
    "base_path": "/browse/benefits/entitlement",
    "title": "Benefits entitlement"
  }
]
```

This endpoint is described in https://gov-uk.atlassian.net/wiki/display/FS/RFC+31%3A+Requirements+for+tagging+architecture.

> Example: GET http://publishing-api/bulk format=topic&fields=title,content_id,base_path,draft,links.parent.title
> Get information about all content items of a particular format, including draft items.
> Only a limited set of fields need to be returned, but these may include:
> - fields from the top-level of the content item
> - whether the item is in draft state or not
> - fields from within the details hash
> - fields from within the expanded links hash
> The endpoint may also need to support pagination / filtering for efficiency.

Not all features described here have been implemented, because we might not need those yet/at all.