### PR TITLE
Expose version number in get links and get content endpoints...

### DIFF
--- a/app/presenters/queries/content_item_presenter.rb
+++ b/app/presenters/queries/content_item_presenter.rb
@@ -12,11 +12,12 @@ module Presenters
       end
 
       def present
-        content_item.as_json.deep_symbolize_keys
+        content_item.as_json
+          .symbolize_keys
           .merge(version: version.number)
       end
 
-      private
+    private
 
       attr_accessor :content_item, :version
     end

--- a/app/presenters/queries/content_item_presenter.rb
+++ b/app/presenters/queries/content_item_presenter.rb
@@ -1,0 +1,24 @@
+module Presenters
+  module Queries
+    class ContentItemPresenter
+      def self.present(content_item)
+        version = Version.find_by(target: content_item)
+        new(content_item, version).present
+      end
+
+      def initialize(content_item, version)
+        self.content_item = content_item
+        self.version = version
+      end
+
+      def present
+        content_item.as_json.deep_symbolize_keys
+          .merge(version: version.number)
+      end
+
+      private
+
+      attr_accessor :content_item, :version
+    end
+  end
+end

--- a/app/presenters/queries/link_set_presenter.rb
+++ b/app/presenters/queries/link_set_presenter.rb
@@ -12,11 +12,12 @@ module Presenters
       end
 
       def present
-        link_set.as_json.deep_symbolize_keys
+        link_set.as_json
+          .symbolize_keys
           .merge(version: version.number)
       end
 
-      private
+    private
 
       attr_accessor :link_set, :version
     end

--- a/app/presenters/queries/link_set_presenter.rb
+++ b/app/presenters/queries/link_set_presenter.rb
@@ -1,0 +1,24 @@
+module Presenters
+  module Queries
+    class LinkSetPresenter
+      def self.present(link_set)
+        version = Version.find_by(target: link_set)
+        new(link_set, version).present
+      end
+
+      def initialize(link_set, version)
+        self.link_set = link_set
+        self.version = version
+      end
+
+      def present
+        link_set.as_json.deep_symbolize_keys
+          .merge(version: version.number)
+      end
+
+      private
+
+      attr_accessor :link_set, :version
+    end
+  end
+end

--- a/app/queries/get_content.rb
+++ b/app/queries/get_content.rb
@@ -9,7 +9,7 @@ module Queries
       )
 
       if content_item
-        content_item
+        Presenters::Queries::ContentItemPresenter.present(content_item)
       else
         error_details = {
           error: {

--- a/app/queries/get_link_set.rb
+++ b/app/queries/get_link_set.rb
@@ -2,7 +2,7 @@ module Queries
   module GetLinkSet
     def self.call(content_id)
       if (link_set = LinkSet.find_by(content_id: content_id))
-        link_set
+        Presenters::Queries::LinkSetPresenter.present(link_set)
       else
         error_details = {
           error: {

--- a/spec/presenters/queries/content_item_presenter_spec.rb
+++ b/spec/presenters/queries/content_item_presenter_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.describe Presenters::Queries::ContentItemPresenter do
+  describe "present" do
+    let(:content_id) { SecureRandom.uuid }
+
+    before do
+      content_item = FactoryGirl.create(:draft_content_item, content_id: content_id)
+      FactoryGirl.create(:version, target: content_item, number: 101)
+      @result = Presenters::Queries::ContentItemPresenter.present(content_item)
+    end
+
+    it "presents content item attributes as a hash" do
+      expect(@result.fetch(:content_id)).to eq(content_id)
+    end
+
+    it "exposes the version number of the content item" do
+      expect(@result.fetch(:version)).to eq(101)
+    end
+  end
+end

--- a/spec/presenters/queries/link_set_presenter_spec.rb
+++ b/spec/presenters/queries/link_set_presenter_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+RSpec.describe Presenters::Queries::LinkSetPresenter do
+  describe "present" do
+    before do
+      FactoryGirl.create(:version, target: link_set, number: 101)
+      @result = Presenters::Queries::LinkSetPresenter.present(link_set)
+    end
+
+    let(:link_set) { FactoryGirl.create(:link_set, content_id: "foo") }
+
+    it "returns link set attributes as a hash" do
+      expect(@result.fetch(:content_id)).to eq("foo")
+    end
+
+    it "exposes the version of the link set" do
+      expect(@result.fetch(:version)).to eq(101)
+    end
+  end
+end

--- a/spec/queries/get_content_spec.rb
+++ b/spec/queries/get_content_spec.rb
@@ -5,12 +5,17 @@ RSpec.describe Queries::GetContent do
   let(:bar) { SecureRandom.uuid }
 
   before do
-    FactoryGirl.create(:draft_content_item, content_id: foo, base_path: "/foo")
+    draft = FactoryGirl.create(:draft_content_item, content_id: foo, base_path: "/foo")
+    FactoryGirl.create(:version, target: draft, number: 3)
     FactoryGirl.create(:draft_content_item, content_id: bar, base_path: "/bar")
   end
 
   it "returns the latest content item for a given content_id" do
-    expect(subject.call(foo).content_id).to eq(foo)
+    expect(subject.call(foo).fetch(:content_id)).to eq(foo)
+  end
+
+  it "returns the content version for a given content_id" do
+    expect(subject.call(foo).fetch(:version)).to eq(3)
   end
 
   context "when the content item does not exist" do
@@ -23,12 +28,13 @@ RSpec.describe Queries::GetContent do
 
   context "when a locale is specified" do
     before do
-      FactoryGirl.create(:draft_content_item, content_id: foo, locale: "ar", base_path: "/foo.ar")
+      arabic_draft = FactoryGirl.create(:draft_content_item, content_id: foo, locale: "ar", base_path: "/foo.ar")
+      FactoryGirl.create(:version, target: arabic_draft, number: 3)
     end
 
     it "returns the content item in the specified locale" do
-      expect(subject.call(foo).locale).to eq("en")
-      expect(subject.call(foo, "ar").locale).to eq("ar")
+      expect(subject.call(foo).fetch(:locale)).to eq("en")
+      expect(subject.call(foo, "ar").fetch(:locale)).to eq("ar")
     end
   end
 end

--- a/spec/queries/get_link_set_spec.rb
+++ b/spec/queries/get_link_set_spec.rb
@@ -2,12 +2,17 @@ require "rails_helper"
 
 RSpec.describe Queries::GetLinkSet do
   before do
-    FactoryGirl.create(:link_set, content_id: "foo")
+    foo = FactoryGirl.create(:link_set, content_id: "foo")
+    FactoryGirl.create(:version, target: foo, number: 2)
     FactoryGirl.create(:link_set, content_id: "bar")
   end
 
   it "returns the link set for a given content_id" do
-    expect(subject.call("foo").content_id).to eq("foo")
+    expect(subject.call("foo").fetch(:content_id)).to eq("foo")
+  end
+
+  it "returns the version of the link set" do
+    expect(subject.call("foo").fetch(:version)).to eq(2)
   end
 
   context "when the link set does not exist" do

--- a/spec/requests/content_item_requests/endpoint_behaviour_spec.rb
+++ b/spec/requests/content_item_requests/endpoint_behaviour_spec.rb
@@ -81,9 +81,13 @@ RSpec.describe "Endpoint behaviour", type: :request do
         FactoryGirl.create(:draft_content_item, content_id: content_id)
       }
 
+      before do
+        FactoryGirl.create(:version, target: content_item, number: 2)
+      end
+
       returns_200_response
-      responds_with_content_item_body
-      responds_with_correct_locale_content_item
+      responds_with_presented_content_item
+      responds_with_presented_correct_locale_content_item
     end
 
     context "when the content item does not exist" do

--- a/spec/service_consumers/pact_helper.rb
+++ b/spec/service_consumers/pact_helper.rb
@@ -129,12 +129,13 @@ Pact.provider_states_for "GDS API Adapters" do
     set_up do
       DatabaseCleaner.clean_with :truncation
 
-      FactoryGirl.create(:link_set,
+      link_set = FactoryGirl.create(:link_set,
         content_id: "bed722e6-db68-43e5-9079-063f623335a7",
         links: {
           organisations: ["20583132-1619-4c68-af24-77583172c070"],
         },
       )
+      FactoryGirl.create(:version, target: link_set, number: 2)
     end
   end
 
@@ -142,10 +143,11 @@ Pact.provider_states_for "GDS API Adapters" do
     set_up do
       DatabaseCleaner.clean_with :truncation
 
-      FactoryGirl.create(:link_set,
+      link_set = FactoryGirl.create(:link_set,
         content_id: "bed722e6-db68-43e5-9079-063f623335a7",
         links: {},
       )
+      FactoryGirl.create(:version, target: link_set, number: 2)
     end
   end
 

--- a/spec/support/request_helpers/endpoint_behaviour.rb
+++ b/spec/support/request_helpers/endpoint_behaviour.rb
@@ -32,6 +32,16 @@ module RequestHelpers
       end
     end
 
+    def responds_with_presented_content_item
+      it "responds with the presentation of the content item and version" do
+        presented_content_item = Presenters::Queries::ContentItemPresenter.present(content_item)
+
+        do_request
+
+        expect(response.body).to eq(presented_content_item.to_json)
+      end
+    end
+
     def returns_400_on_invalid_json
       it "returns a 400 if the JSON is invalid" do
         do_request(body: "not a JSON")
@@ -40,13 +50,15 @@ module RequestHelpers
       end
     end
 
-    def responds_with_correct_locale_content_item
-      it "responds with the body of the correct locale content item" do
+    def responds_with_presented_correct_locale_content_item
+      it "responds with the presentation of content item and version in the correct locale" do
         FactoryGirl.create(:draft_content_item, content_id: content_id, locale: "ar")
+
+        presented_content_item = Presenters::Queries::ContentItemPresenter.present(content_item)
 
         do_request
 
-        expect(response.body).to eq(content_item.to_json)
+        expect(response.body).to eq(presented_content_item.to_json)
       end
     end
 


### PR DESCRIPTION
https://trello.com/c/GiuptR4Q/398-expose-version-in-v2-get-endpoints

Versioning is no longer a concern of the `DraftContentItem`, `LiveContentItem` or `LinkSet` models.
A side effect of this change is that the link set version number is no longer exposed via the get endpoints. 
This version number will be used to ensure optimistic locking of these models.
This change exposes the version number on both endpoints.

I've opted to use presenters to merge the version number into the command response, to achieve this I've added some presenters specific to the `Presenters::Queries` module, this was a workaround to a namespace collision with the current `Presenters::ContentItemPresenter` which should go away with this PR: https://github.com/alphagov/publishing-api/pull/127