### PR TITLE
Improve error message when sending a string as `previous_version`

### DIFF
--- a/app/commands/base_command.rb
+++ b/app/commands/base_command.rb
@@ -40,13 +40,17 @@ module Commands
 
       return unless current_versioned_item && current_version
 
+      friendly_message = "A version conflict occurred. The version you've sent " +
+        "(#{previous_version_number.inspect}) is not the same as the current " +
+        "version of the content item (#{current_version.number.inspect})."
+
       conflict_error = CommandError.new(
         code: 409,
         message: "Conflict",
         error_details: {
           error: {
             code: 409,
-            message: "Version conflict",
+            message: friendly_message,
             fields: {
               previous_version: ["does not match"],
             }


### PR DESCRIPTION
The current implementation of the version conflict checker assumes that `previous_version` is a integer. This isn't always the case, as clients will often send their version number as a string.

The following will currently work in client apps, because the integer type is preserved in the JSON:

```ruby
publishing_api.put_links(content_id, previous_version: 12, links: [])
```

The following will raise a HTTPConflict because `"12" != 12`:

```ruby
publishing_api.put_links(content_id, previous_version: "12", links: [])
```

This PR adds a better error message so that consumers can debug this class of errors more easily. 