### PR TITLE
public_updated_at is not required for all content items

### DIFF
--- a/app/lib/presenters/content_item_presenter.rb
+++ b/app/lib/presenters/content_item_presenter.rb
@@ -1,11 +1,16 @@
 module Presenters
   module ContentItemPresenter
     def self.present(content_item_hash)
-      public_updated_at = content_item_hash.fetch(:public_updated_at).iso8601
+      content_item_hash = content_item_hash
+                            .except(:id, :version, :update_type)
 
-      content_item_hash
-        .except(:id, :version, :update_type)
-        .merge(public_updated_at: public_updated_at)
+      if content_item_hash[:public_updated_at].present?
+        content_item_hash.merge(
+          public_updated_at: content_item_hash[:public_updated_at].iso8601
+        )
+      else
+        content_item_hash
+      end
     end
   end
 end

--- a/spec/presenters/content_item_presenter_spec.rb
+++ b/spec/presenters/content_item_presenter_spec.rb
@@ -21,6 +21,11 @@ RSpec.describe Presenters::ContentItemPresenter do
     expect(presented[:public_updated_at]).to eq(content_item_hash[:public_updated_at].iso8601)
   end
 
+  it "does not require #public_updated_at" do
+    content_item_hash.delete(:public_updated_at)
+    expect(presented[:public_updated_at]).to eq nil
+  end
+
   it "exports all other fields" do
     content_item_hash.each do |key, value|
       next if [:id, :version, :public_updated_at, :update_type].include?(key)


### PR DESCRIPTION
Content items without `public_updated_at` could not be saved, because
Array#fetch was being used in the ContentItemPresenter.

public_updated_at is only validated on models when they are renderable,
and redirects are not renderable. This means that ContentItemPresenter
was crashing when `redirect` content items had no `public_updated_at`
field.