### PR TITLE
Add V2::ContentItemsController spec

### DIFF
--- a/app/validators/dns_hostname_validator.rb
+++ b/app/validators/dns_hostname_validator.rb
@@ -2,7 +2,7 @@ class DnsHostnameValidator < ActiveModel::EachValidator
   DNS_HOSTNAME_PATTERN = /\A[a-z0-9\-_]*\z/
 
   def validate_each(record, attribute, value)
-    unless value.match(DNS_HOSTNAME_PATTERN)
+    unless value && value.match(DNS_HOSTNAME_PATTERN)
       record.errors[attribute] << "is not a valid dns hostname"
     end
   end

--- a/spec/controllers/v2/content_items_controller_spec.rb
+++ b/spec/controllers/v2/content_items_controller_spec.rb
@@ -1,0 +1,119 @@
+require "rails_helper"
+
+RSpec.describe V2::ContentItemsController do
+  let(:content_id) { SecureRandom.uuid }
+
+  before do
+    stub_request(:any, /content-store/)
+    @draft = FactoryGirl.create(:draft_content_item, content_id: content_id)
+    FactoryGirl.create(:version, target: @draft, number: 2)
+  end
+
+  describe "show" do
+    context "for an existing content item" do
+      before do
+        get :show, content_id: content_id
+      end
+
+      it "is successful" do
+        expect(response.status).to eq(200)
+      end
+
+      it "responds with the content item as json" do
+        parsed_response_body = JSON.parse(response.body)
+        expect(parsed_response_body.fetch("content_id")).to eq("#{content_id}")
+      end
+    end
+
+    context "with a non-existant content_id" do
+      it "responds with 404" do
+        get :show, content_id: "missing"
+
+        expect(response.status).to eq(404)
+      end
+    end
+  end
+
+  describe "put_content" do
+
+    context "with valid request params for a new content item" do
+      before do
+        content_item_hash = @draft.as_json
+        content_item_hash = content_item_hash
+          .merge("base_path" => "/that-rates")
+          .merge("routes" => [{"path" => "/that-rates", "type" => "exact"}])
+        request.env["CONTENT_TYPE"] = "application/json"
+        request.env["RAW_POST_DATA"] = content_item_hash.to_json
+        put :put_content, content_id: SecureRandom.uuid
+      end
+
+      it "responds with 200" do
+        expect(response.status).to eq(200)
+      end
+
+      it "responds with the content item" do
+        parsed_response_body = JSON.parse(response.body)
+        expect(parsed_response_body["base_path"]).to eq("/that-rates")
+      end
+    end
+
+    context "with valid request params for an existing content item" do
+      before do
+        request.env["CONTENT_TYPE"] = "application/json"
+        request.env["RAW_POST_DATA"] = @draft.to_json
+        put :put_content, content_id: content_id
+      end
+
+      it "responds with 200" do
+        expect(response.status).to eq(200)
+      end
+
+      it "responds with the content item" do
+        parsed_response_body = JSON.parse(response.body)
+        expect(parsed_response_body["content_id"]).to eq(content_id)
+      end
+    end
+
+    context "with invalid request body" do
+      before do
+        request.env["CONTENT_TYPE"] = "application/json"
+        request.env["RAW_POST_DATA"] = ""
+        put :put_content, content_id: content_id
+      end
+
+      it "responds with 400" do
+        expect(response.status).to eq(400)
+      end
+    end
+  end
+
+  describe "publish" do
+    context "for an existing draft content item" do
+      before do
+        request.env["CONTENT_TYPE"] = "application/json"
+        request.env["RAW_POST_DATA"] = { update_type: "major" }.to_json
+        post :publish, content_id: content_id
+      end
+
+      it "is successful" do
+        expect(response.status).to eq(200)
+      end
+
+      it "responds with the content_id of the published item" do
+        parsed_response_body = JSON.parse(response.body)
+        expect(parsed_response_body.keys).to include("content_id")
+        expect(parsed_response_body["content_id"]).not_to be_nil
+      end
+    end
+
+    context "with a non-existant content_id" do
+      it "responds with 404" do
+        request.env["CONTENT_TYPE"] = "application/json"
+        request.env["RAW_POST_DATA"] = { update_type: "major" }.to_json
+        post :publish, content_id: "missing"
+
+        expect(response.status).to eq(404)
+      end
+    end
+  end
+end

--- a/spec/controllers/v2/content_items_controller_spec.rb
+++ b/spec/controllers/v2/content_items_controller_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe V2::ContentItemsController do
       end
     end
 
-    context "with a non-existant content_id" do
+    context "for a non-existent content item" do
       it "responds with 404" do
         get :show, content_id: "missing"
 
@@ -35,7 +35,6 @@ RSpec.describe V2::ContentItemsController do
   end
 
   describe "put_content" do
-
     context "with valid request params for a new content item" do
       before do
         content_item_hash = @draft.as_json
@@ -106,7 +105,7 @@ RSpec.describe V2::ContentItemsController do
       end
     end
 
-    context "with a non-existant content_id" do
+    context "for a non-existent content item" do
       it "responds with 404" do
         request.env["CONTENT_TYPE"] = "application/json"
         request.env["RAW_POST_DATA"] = { update_type: "major" }.to_json

--- a/spec/models/draft_content_item_spec.rb
+++ b/spec/models/draft_content_item_spec.rb
@@ -60,6 +60,11 @@ RSpec.describe DraftContentItem do
       end
 
       it "requires a rendering_app" do
+        subject.rendering_app = nil
+        expect(subject).to be_invalid
+      end
+
+      it "requires a rendering_app to have a valid hostname" do
         subject.rendering_app = ""
         expect(subject).to be_invalid
       end


### PR DESCRIPTION
While documenting the v2 API endpoints I found a few responses which
weren't adequately covered and one scenario where a validation class raised an uncaught error.
This change adds some coverage specific to the V2 content items controller and remedies the uncaught error scenario.