### PR TITLE
Respond with updated content item when putting content

### DIFF
--- a/app/commands/v2/put_content.rb
+++ b/app/commands/v2/put_content.rb
@@ -15,7 +15,8 @@ module Commands
           payload: draft_payload,
         )
 
-        Success.new(payload)
+        response_hash = Presenters::Queries::ContentItemPresenter.present(content_item)
+        Success.new(response_hash)
       end
 
     private

--- a/spec/requests/content_item_requests/endpoint_behaviour_spec.rb
+++ b/spec/requests/content_item_requests/endpoint_behaviour_spec.rb
@@ -55,14 +55,14 @@ RSpec.describe "Endpoint behaviour", type: :request do
     returns_200_response
   end
 
-  context "GET /v2/content/:content_id" do
+  context "PUT /v2/content/:content_id" do
     let(:content_item) { v2_content_item }
     let(:request_body) { content_item.to_json }
     let(:request_path) { "/v2/content/#{content_id}" }
     let(:request_method) { :put }
 
     returns_200_response
-    responds_with_request_body
+    responds_with_presented_content_item
     returns_400_on_invalid_json
     suppresses_draft_content_store_502s
     forwards_locale_extension

--- a/spec/support/request_helpers/endpoint_behaviour.rb
+++ b/spec/support/request_helpers/endpoint_behaviour.rb
@@ -34,9 +34,10 @@ module RequestHelpers
 
     def responds_with_presented_content_item
       it "responds with the presentation of the content item and version" do
-        presented_content_item = Presenters::Queries::ContentItemPresenter.present(content_item)
-
         do_request
+
+        updated_content_item = DraftContentItem.find_by!(content_id: content_id)
+        presented_content_item = Presenters::Queries::ContentItemPresenter.present(updated_content_item)
 
         expect(response.body).to eq(presented_content_item.to_json)
       end
@@ -75,8 +76,10 @@ module RequestHelpers
           begin
             do_request
 
+            parsed_response_body = JSON.parse(response.body)
             expect(response.status).to eq(200)
-            expect(response.body).to eq(request_body)
+            expect(parsed_response_body["content_id"]).to eq(content_item[:content_id])
+            expect(parsed_response_body["title"]).to eq(content_item[:title])
           ensure
             PublishingAPI.swallow_draft_connection_errors = @swallow_draft_errors
           end


### PR DESCRIPTION
https://trello.com/c/nmYZppPC/416-expose-version-in-v2-put-content-endpoint

The v2 put_content endpoint arbitrarily echos the request body in the
response. This change responds with the full presentation of the updated
content item identical to the response from the v2 GET content endpoint.

It might be worth discussing if POST to publish should respond with more info ie version number. 