### PR TITLE
Add publication state to the content item GET presenter.

### DIFF
--- a/app/presenters/queries/content_item_presenter.rb
+++ b/app/presenters/queries/content_item_presenter.rb
@@ -14,12 +14,19 @@ module Presenters
       def present
         content_item.as_json
           .symbolize_keys
-          .merge(version: version.number)
+          .merge(
+            version: version.number,
+            publication_state: publication_state,
+          )
       end
 
     private
 
       attr_accessor :content_item, :version
+
+      def publication_state
+        content_item.live_content_item.present? ? 'live' : 'draft'
+      end
     end
   end
 end

--- a/spec/presenters/queries/content_item_presenter_spec.rb
+++ b/spec/presenters/queries/content_item_presenter_spec.rb
@@ -17,5 +17,9 @@ RSpec.describe Presenters::Queries::ContentItemPresenter do
     it "exposes the version number of the content item" do
       expect(@result.fetch(:version)).to eq(101)
     end
+
+    it "exposes the publication state of the content item" do
+      expect(@result.fetch(:publication_state)).to eq("draft")
+    end
   end
 end


### PR DESCRIPTION
This matches the info provided by the index endpoint.