### PR TITLE
Allow gone/redirect replacement.

### DIFF
--- a/app/commands/base_command.rb
+++ b/app/commands/base_command.rb
@@ -60,5 +60,13 @@ module Commands
 
       raise conflict_error if current_version.conflicts_with?(previous_version_number)
     end
+
+    def clear_space_for(new_content)
+      if (existing_content = DraftContentItem.find_by(base_path: new_content.base_path))
+        if existing_content.draft_or_redirect? || new_content.draft_or_redirect?
+          existing_content.destroy
+        end
+      end
+    end
   end
 end

--- a/app/commands/put_content_with_links.rb
+++ b/app/commands/put_content_with_links.rb
@@ -48,6 +48,8 @@ module Commands
       )
 
       LiveContentItem.create_or_replace(attributes) do |item|
+        clear_space_for(item) if item.new_record?
+
         version = Version.find_or_initialize_by(target: item)
         version.copy_version_from(draft_content_item)
         version.save! if item.valid?

--- a/app/commands/v2/put_content.rb
+++ b/app/commands/v2/put_content.rb
@@ -30,6 +30,8 @@ module Commands
 
       def create_or_update_draft_content_item!
         DraftContentItem.create_or_replace(content_item_attributes) do |item|
+          clear_space_for(item) if item.new_record?
+
           version = Version.find_or_initialize_by(target: item)
           version.increment
           version.save! if item.valid?

--- a/app/models/draft_content_item.rb
+++ b/app/models/draft_content_item.rb
@@ -39,6 +39,10 @@ class DraftContentItem < ActiveRecord::Base
     !access_limited? || authorised_user_uids.include?(user_uid)
   end
 
+  def draft_or_redirect?
+    ["gone", "redirect"].include?(format)
+  end
+
 private
   def self.query_keys
     [:content_id, :locale]

--- a/app/models/live_content_item.rb
+++ b/app/models/live_content_item.rb
@@ -48,6 +48,10 @@ class LiveContentItem < ActiveRecord::Base
   }
   validates_with RoutesAndRedirectsValidator
 
+  def draft_or_redirect?
+    ["gone", "redirect"].include?(format)
+  end
+
 private
   def self.query_keys
     [:content_id, :locale]


### PR DESCRIPTION
This allows gones and redirects to replace content
and also allows content to replace gones and redirects
for republishing.

It does not allow normal content to overwrite other
normal content, reducing the chance of accidentally
blatting something important.

Half of https://trello.com/c/MtnVvpID/420-allow-overwriting-of-redirects-and-gones