### PR TITLE
Forward html content type only

### DIFF
--- a/app/models/draft_content_item.rb
+++ b/app/models/draft_content_item.rb
@@ -38,6 +38,26 @@ class DraftContentItem < ActiveRecord::Base
   validates :description, well_formed_content_types: { must_include: "text/html" }
   validates :details, well_formed_content_types: { must_include: "text/html" }
 
+  # Postgres's JSON columns have problems storing literal strings, so these
+  # getter/setter overrides wrap and unwrap those strings in hashes.
+  def description=(value)
+    if value.is_a?(String)
+      super(string: value)
+    else
+      super
+    end
+  end
+
+  def description
+    value = super
+
+    if value.is_a?(Hash) && value.key?(:string)
+      value.fetch(:string)
+    else
+      value
+    end
+  end
+
   def viewable_by?(user_uid)
     !access_limited? || authorised_user_uids.include?(user_uid)
   end

--- a/app/models/draft_content_item.rb
+++ b/app/models/draft_content_item.rb
@@ -35,6 +35,9 @@ class DraftContentItem < ActiveRecord::Base
   }
   validates_with RoutesAndRedirectsValidator
 
+  validates :description, well_formed_content_types: { must_include: "text/html" }
+  validates :details, well_formed_content_types: { must_include: "text/html" }
+
   def viewable_by?(user_uid)
     !access_limited? || authorised_user_uids.include?(user_uid)
   end

--- a/app/models/draft_content_item.rb
+++ b/app/models/draft_content_item.rb
@@ -39,22 +39,23 @@ class DraftContentItem < ActiveRecord::Base
   validates :details, well_formed_content_types: { must_include: "text/html" }
 
   # Postgres's JSON columns have problems storing literal strings, so these
-  # getter/setter overrides wrap and unwrap those strings in hashes.
+  # getter/setter wrap the description in a JSON object.
   def description=(value)
-    if value.is_a?(String)
-      super(string: value)
-    else
-      super
-    end
+    super(value: value)
   end
 
   def description
-    value = super
+    super.fetch(:value)
+  end
 
-    if value.is_a?(Hash) && value.key?(:string)
-      value.fetch(:string)
+  def attributes
+    attributes = super
+    description = attributes.delete("description")
+
+    if description
+      attributes.merge("description" => description.fetch("value"))
     else
-      value
+      attributes
     end
   end
 

--- a/app/models/live_content_item.rb
+++ b/app/models/live_content_item.rb
@@ -53,11 +53,31 @@ class LiveContentItem < ActiveRecord::Base
     true
   end
 
+  # Postgres's JSON columns have problems storing literal strings, so these
+  # getter/setter overrides wrap and unwrap those strings in hashes.
+  def description=(value)
+    if value.is_a?(String)
+      super(string: value)
+    else
+      super
+    end
+  end
+
+  def description
+    value = super
+
+    if value.is_a?(Hash) && value.key?(:string)
+      value.fetch(:string)
+    else
+      value
+    end
+  end
+
+private
   def self.query_keys
     [:content_id, :locale]
   end
 
-private
   def content_ids_match
     if draft_content_item && draft_content_item.content_id != content_id
       errors.add(:content_id, "id mismatch between draft and live content items")

--- a/app/models/live_content_item.rb
+++ b/app/models/live_content_item.rb
@@ -54,22 +54,23 @@ class LiveContentItem < ActiveRecord::Base
   end
 
   # Postgres's JSON columns have problems storing literal strings, so these
-  # getter/setter overrides wrap and unwrap those strings in hashes.
+  # getter/setter wrap the description in a JSON object.
   def description=(value)
-    if value.is_a?(String)
-      super(string: value)
-    else
-      super
-    end
+    super(value: value)
   end
 
   def description
-    value = super
+    super.fetch(:value)
+  end
 
-    if value.is_a?(Hash) && value.key?(:string)
-      value.fetch(:string)
+  def attributes
+    attributes = super
+    description = attributes.delete("description")
+
+    if description
+      attributes.merge("description" => description.fetch("value"))
     else
-      value
+      attributes
     end
   end
 

--- a/app/models/live_content_item.rb
+++ b/app/models/live_content_item.rb
@@ -46,6 +46,8 @@ class LiveContentItem < ActiveRecord::Base
     message: 'must be either alpha, beta, or live'
   }
   validates_with RoutesAndRedirectsValidator
+  validates :description, well_formed_content_types: { must_include: "text/html" }
+  validates :details, well_formed_content_types: { must_include: "text/html" }
 
   def published?
     true

--- a/app/presenters/content_type_resolver.rb
+++ b/app/presenters/content_type_resolver.rb
@@ -1,0 +1,47 @@
+module Presenters
+  class ContentTypeResolver
+    def initialize(content_type)
+      self.content_type = content_type
+    end
+
+    def resolve(object)
+      if object.is_a?(Hash)
+        resolve_hash(object)
+      elsif object.is_a?(Array)
+        resolve_array(object)
+      else
+        object
+      end
+    end
+
+    private
+
+    def resolve_hash(hash)
+      hash.inject({}) do |hash, (key, value)|
+        hash.merge(key => resolve(value))
+      end
+    end
+
+    def resolve_array(array)
+      if has_content_types?(array)
+        extract_content(array)
+      else
+        array.map { |e| resolve(e) }
+      end
+    end
+
+    def has_content_types?(array)
+      return false unless array.all? { |v| v.is_a?(Hash) }
+
+      hash_keys = array.flat_map(&:keys).map(&:to_sym)
+      hash_keys.include?(:content_type)
+    end
+
+    def extract_content(array)
+      array = array.map(&:symbolize_keys)
+      array.detect { |h| h[:content_type] == content_type }[:content]
+    end
+
+    attr_accessor :content_type
+  end
+end

--- a/app/presenters/downstream_presenter.rb
+++ b/app/presenters/downstream_presenter.rb
@@ -1,5 +1,7 @@
 module Presenters
   class DownstreamPresenter
+    RESOLVER = ContentTypeResolver.new("text/html")
+
     def self.present(content_item)
       link_set = LinkSet.find_by(content_id: content_item.content_id)
       new(content_item, link_set).present
@@ -16,6 +18,8 @@ module Presenters
         .merge(public_updated_at)
         .merge(links)
         .merge(transmitted_at)
+        .merge(description)
+        .merge(details)
     end
 
   private
@@ -47,6 +51,14 @@ module Presenters
 
     def transmitted_at
       { transmitted_at: DateTime.now.to_s(:nanoseconds) }
+    end
+
+    def description
+      { description: RESOLVER.resolve(content_item.description) }
+    end
+
+    def details
+      { details: RESOLVER.resolve(content_item.details) }
     end
 
     class V1

--- a/app/validators/well_formed_content_types_validator.rb
+++ b/app/validators/well_formed_content_types_validator.rb
@@ -1,0 +1,78 @@
+class WellFormedContentTypesValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    @error_messages = []
+
+    validate!(value)
+
+    if @error_messages.present?
+      record.errors[attribute] ||= []
+      record.errors[attribute].concat(@error_messages)
+    end
+  end
+
+  private
+
+  def validate!(object)
+    if object.is_a?(Hash)
+      validate_hash!(object)
+    elsif object.is_a?(Array)
+      validate_array!(object)
+    end
+  end
+
+  def validate_hash!(hash)
+    validate_array!(hash.values)
+  end
+
+  def validate_array!(array)
+    if has_content_types?(array)
+      validate_content!(array)
+    else
+      array.all? { |e| validate!(e) }
+    end
+  end
+
+  def has_content_types?(array)
+    return false unless array.all? { |v| v.is_a?(Hash) }
+
+    hash_keys = array.flat_map(&:keys).map(&:to_sym)
+    hash_keys.include?(:content_type)
+  end
+
+  def validate_content!(array)
+    array = array.map(&:symbolize_keys)
+
+    validate_that_content_is_present!(array) &&
+      validate_that_there_are_no_duplicates!(array) &&
+      validate_that_mandatory_content_type_is_present!(array)
+  end
+
+  def validate_that_content_is_present!(array)
+    array.each do |hash|
+      unless hash.key?(:content)
+        content_type = hash.fetch(:content_type)
+        @error_messages << "the '#{content_type}' content type does not contain content"
+      end
+    end
+  end
+
+  def validate_that_there_are_no_duplicates!(array)
+    groups = array.group_by { |hash| hash[:content_type] }
+    duplicates = groups.select { |_, hashes| hashes.size > 1 }
+
+    duplicates.each do |content_type, hashes|
+      @error_messages << "there are #{hashes.size} instances of the '#{content_type}' content type - there should be 1"
+    end
+  end
+
+  def validate_that_mandatory_content_type_is_present!(array)
+    mandatory_content_type = options[:must_include]
+    return true unless mandatory_content_type
+
+    hash = array.detect { |h| h[:content_type] == mandatory_content_type }
+
+    unless hash
+      @error_messages << "the '#{mandatory_content_type}' content type is mandatory and it is missing"
+    end
+  end
+end

--- a/db/migrate/20151119100750_change_description_column_types.rb
+++ b/db/migrate/20151119100750_change_description_column_types.rb
@@ -1,0 +1,16 @@
+class ChangeDescriptionColumnTypes < ActiveRecord::Migration
+  def change
+    [
+      [:draft_content_items, DraftContentItem],
+      [:live_content_items, LiveContentItem],
+    ].each do |table, model|
+      add_column table, :new_description, :json
+
+      # http://www.postgresql.org/docs/9.3/static/functions-json.html#FUNCTIONS-JSON-TABLE
+      ActiveRecord::Base.connection.execute("update #{table} set new_description = to_json(description)")
+
+      rename_column table, :description, :old_description
+      rename_column table, :new_description, :description
+    end
+  end
+end

--- a/db/migrate/20151119100750_change_description_column_types.rb
+++ b/db/migrate/20151119100750_change_description_column_types.rb
@@ -4,13 +4,18 @@ class ChangeDescriptionColumnTypes < ActiveRecord::Migration
       [:draft_content_items, DraftContentItem],
       [:live_content_items, LiveContentItem],
     ].each do |table, model|
-      add_column table, :new_description, :json, default: { value: nil }
+      add_column table, :new_description, :json
 
       # http://www.postgresql.org/docs/9.3/static/functions-json.html#FUNCTIONS-JSON-TABLE
       ActiveRecord::Base.connection.execute(%{
         update #{table} set new_description = concat('{"value":', to_json(description), '}')::json
         where description is not null
       })
+
+      change_column_default table, :new_description, { value: nil }
+      model.where(new_description: nil).find_each do |item|
+        item.update_column(:new_description, { value: nil }.to_json)
+      end
 
       rename_column table, :description, :old_description
       rename_column table, :new_description, :description

--- a/db/migrate/20151119100750_change_description_column_types.rb
+++ b/db/migrate/20151119100750_change_description_column_types.rb
@@ -4,10 +4,13 @@ class ChangeDescriptionColumnTypes < ActiveRecord::Migration
       [:draft_content_items, DraftContentItem],
       [:live_content_items, LiveContentItem],
     ].each do |table, model|
-      add_column table, :new_description, :json
+      add_column table, :new_description, :json, default: { value: nil }
 
       # http://www.postgresql.org/docs/9.3/static/functions-json.html#FUNCTIONS-JSON-TABLE
-      ActiveRecord::Base.connection.execute("update #{table} set new_description = to_json(description)")
+      ActiveRecord::Base.connection.execute(%{
+        update #{table} set new_description = concat('{"value":', to_json(description), '}')::json
+        where description is not null
+      })
 
       rename_column table, :description, :old_description
       rename_column table, :new_description, :description

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -34,7 +34,7 @@ ActiveRecord::Schema.define(version: 20151124113325) do
     t.string   "update_type"
     t.string   "phase",                default: "live"
     t.string   "analytics_identifier"
-    t.json     "description"
+    t.json     "description",          default: {"value"=>nil}
   end
 
   add_index "draft_content_items", ["base_path"], name: "index_draft_content_items_on_base_path", unique: true, using: :btree
@@ -73,7 +73,7 @@ ActiveRecord::Schema.define(version: 20151124113325) do
     t.string   "update_type"
     t.string   "phase",                 default: "live"
     t.string   "analytics_identifier"
-    t.json     "description"
+    t.json     "description",           default: {"value"=>nil}
   end
 
   add_index "live_content_items", ["base_path"], name: "index_live_content_items_on_base_path", unique: true, using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -21,7 +21,7 @@ ActiveRecord::Schema.define(version: 20151124113325) do
     t.string   "locale",               default: "en"
     t.string   "base_path"
     t.string   "title"
-    t.string   "description"
+    t.string   "old_description"
     t.string   "format"
     t.datetime "public_updated_at"
     t.json     "access_limited",       default: {}
@@ -34,6 +34,7 @@ ActiveRecord::Schema.define(version: 20151124113325) do
     t.string   "update_type"
     t.string   "phase",                default: "live"
     t.string   "analytics_identifier"
+    t.json     "description"
   end
 
   add_index "draft_content_items", ["base_path"], name: "index_draft_content_items_on_base_path", unique: true, using: :btree
@@ -59,7 +60,7 @@ ActiveRecord::Schema.define(version: 20151124113325) do
     t.string   "locale",                default: "en"
     t.string   "base_path"
     t.string   "title"
-    t.string   "description"
+    t.string   "old_description"
     t.string   "format"
     t.datetime "public_updated_at"
     t.json     "details",               default: {}
@@ -72,6 +73,7 @@ ActiveRecord::Schema.define(version: 20151124113325) do
     t.string   "update_type"
     t.string   "phase",                 default: "live"
     t.string   "analytics_identifier"
+    t.json     "description"
   end
 
   add_index "live_content_items", ["base_path"], name: "index_live_content_items_on_base_path", unique: true, using: :btree

--- a/doc/arch/representation-for-multiple-content-types.md
+++ b/doc/arch/representation-for-multiple-content-types.md
@@ -64,14 +64,14 @@ compact, but it means that JSON objects could store additional information if
 required, such as a Govspeak version. It was noted that this option may not
 be the easiest for Publishing Applications to work with.
 
-Option 2 was refuted on the basis that it doesn't clearly demonstrate which
+Option 2 was rejected on the basis that it doesn't clearly demonstrate which
 fields genuinely contain multiple representations, compared with those that
 could contain other properties. The Publishing API is responsible for only
 forwarding the text/html content type and ambiguity in the representation means
 that it would have to make a lot of assumptions about which fields contain
 multiple representations.
 
-Option 3 was refuted on the basis that it's more-or-less equivalent to Option 1,
+Option 3 was rejected on the basis that it's more-or-less equivalent to Option 1,
 but it lacks the ability to include additional properties in the future if
 required. Also, it isn't significantly easier for Publishing Applications to
 work with to justify choosing this option over Option 1.

--- a/doc/representation-for-multiple-content-types.md
+++ b/doc/representation-for-multiple-content-types.md
@@ -1,0 +1,81 @@
+## Decision Record: Representation for Multiple Content Types
+
+We have a requirement to represent multiple content types for some fields when
+sending content items back and forth between Publishing Applications and the
+Publishing API. This document captures the options that were considered and the
+reasons for why Option 1 was chosen.
+
+This decision is referenced in [RFC 35: Explicitly make the details hash non-opaque](https://gov-uk.atlassian.net/wiki/display/GOVUK/RFC+35%3A+Explicitly+make+the+details+hash+non-opaque?focusedCommentId=42827845#comment-42827845).
+
+## Option 1
+
+This option is the most verbose and nests an array of JSON objects. These
+objects have properties `content_type` and `content`.
+
+```json
+{
+  "details": {
+    "body": [
+      { "content_type": "text/html", "content": "<h1>content</h1>" },
+      { "content_type": "text/govspeak", "content": "# content" }
+    ]
+  }
+}
+```
+
+## Option 2
+
+This option is the least verbose and nests a JSON object that has properties for
+each of the content types.
+
+```json
+{
+  "details": {
+    "body": {
+      "text/html": "<h1>content</h1>",
+      "text/govspeak": "# content"
+    }
+  }
+}
+```
+
+## Option 3
+
+This is an alternative that doubly nests JSON objects. The inner object has
+properties for each of the content types.
+
+```json
+{
+  "details": {
+    "body": {
+      "multiple_representations": {
+        "text/html": "<h1>content</h1>",
+        "text/govspeak": "# content"
+      }
+    }
+  }
+}
+```
+
+## Decision
+
+The decision was made to choose Option 1. This representation is not very
+compact, but it means that JSON objects could store additional information if
+required, such as a Govspeak version. It was noted that this option may not
+be the easiest for Publishing Applications to work with.
+
+Option 2 was refuted on the basis that it doesn't clearly demonstrate which
+fields genuinely contain multiple representations, compared with those that
+could contain other properties. The Publishing API is responsible for only
+forwarding the text/html content type and ambiguity in the representation means
+that it would have to make a lot of assumptions about which fields contain
+multiple representations.
+
+Option 3 was refuted on the basis that it's more-or-less equivalent to Option 1,
+but it lacks the ability to include additional properties in the future if
+required. Also, it isn't significantly easier for Publishing Applications to
+work with to justify choosing this option over Option 1.
+
+## Status
+
+Accepted on 20/11/2015.

--- a/spec/models/draft_content_item_spec.rb
+++ b/spec/models/draft_content_item_spec.rb
@@ -266,4 +266,5 @@ RSpec.describe DraftContentItem do
   it_behaves_like DefaultAttributes
   it_behaves_like ImmutableBasePath
   it_behaves_like RoutesAndRedirectsValidator
+  it_behaves_like WellFormedContentTypesValidator
 end

--- a/spec/models/live_content_item_spec.rb
+++ b/spec/models/live_content_item_spec.rb
@@ -231,4 +231,5 @@ RSpec.describe LiveContentItem do
   it_behaves_like DefaultAttributes
   it_behaves_like ImmutableBasePath
   it_behaves_like RoutesAndRedirectsValidator
+  it_behaves_like WellFormedContentTypesValidator
 end

--- a/spec/presenters/content_type_resolver_spec.rb
+++ b/spec/presenters/content_type_resolver_spec.rb
@@ -1,0 +1,97 @@
+require "rails_helper"
+
+RSpec.describe Presenters::ContentTypeResolver do
+  subject { described_class.new("html") }
+
+  it "inlines content of the specified content type" do
+    result = subject.resolve(
+      body: [
+        { content_type: "html", content: "<p>body</p>" },
+        { content_type: "text", content: "body" },
+      ]
+    )
+
+    expect(result).to eq(
+      body: "<p>body</p>"
+    )
+  end
+
+  it "works for string keys as well as symbols" do
+    result = subject.resolve(
+      "body" => [
+        { "content_type" => "html", "content" => "<p>body</p>" },
+        { "content_type" => "text", "content" => "body" },
+      ]
+    )
+
+    expect(result).to eq(
+      "body" => "<p>body</p>"
+    )
+  end
+
+  it "does not affect other fields" do
+    result = subject.resolve(
+      string: "string",
+      array: [],
+      number: 123,
+    )
+
+    expect(result).to eq(
+      string: "string",
+      array: [],
+      number: 123,
+    )
+  end
+
+  it "recurses on nested hashes" do
+    result = subject.resolve(
+      details: {
+        foo: {
+          bar: {
+            content: [
+              { content_type: "html", content: "<p>body</p>" }
+            ]
+          }
+        }
+      }
+    )
+
+    expect(result).to eq(
+      details: {
+        foo: {
+          bar: {
+            content: "<p>body</p>"
+          }
+        }
+      }
+    )
+  end
+
+  it "recurses on nested arrays" do
+    result = subject.resolve(
+      paragraphs: [
+        [
+          [
+            {
+              body: [
+                { content_type: "html", content: "<p>body</p>" }
+              ]
+            }
+          ]
+        ]
+      ]
+    )
+
+    expect(result).to eq(
+      paragraphs: [
+        [
+          [
+            {
+              body: "<p>body</p>"
+            }
+          ]
+        ]
+      ]
+    )
+  end
+end

--- a/spec/presenters/downstream_presenter_spec.rb
+++ b/spec/presenters/downstream_presenter_spec.rb
@@ -100,6 +100,37 @@ RSpec.describe Presenters::DownstreamPresenter do
     end
   end
 
+  describe "content type resolution" do
+    let!(:content_item) { FactoryGirl.create(:live_content_item) }
+
+    describe "description" do
+      it "inlines the 'text/html' content type" do
+        content_item.description = [
+          { content_type: "text/html", content: "<p>content</p>" },
+          { content_type: "text/plain", content: "content" },
+        ]
+
+        result = described_class.present(content_item)
+        expect(result.fetch(:description)).to eq("<p>content</p>")
+      end
+    end
+
+    describe "details" do
+      it "inlines the 'text/html' content type" do
+        content_item.details = {
+          body: [
+            { content_type: "text/html", content: "<p>content</p>" },
+            { content_type: "text/plain", content: "content" },
+          ]
+        }
+
+        result = described_class.present(content_item)
+        description = result.fetch(:details).fetch(:body)
+        expect(description).to eq("<p>content</p>")
+      end
+    end
+  end
+
   describe described_class::V1 do
     let(:attributes) do
       {

--- a/spec/requests/content_item_requests/downstream_requests_spec.rb
+++ b/spec/requests/content_item_requests/downstream_requests_spec.rb
@@ -135,7 +135,7 @@ RSpec.describe "Downstream requests", type: :request do
     let(:content_item_for_live_content_store) {
       draft.attributes.deep_symbolize_keys
         .merge(public_updated_at: Time.zone.now.iso8601)
-        .except(:id, :access_limited, :update_type, :metadata, :version)
+        .except(:id, :access_limited, :update_type, :metadata, :version, :old_description)
     }
 
     sends_to_live_content_store

--- a/spec/requests/content_item_requests/downstream_requests_spec.rb
+++ b/spec/requests/content_item_requests/downstream_requests_spec.rb
@@ -140,4 +140,27 @@ RSpec.describe "Downstream requests", type: :request do
 
     sends_to_live_content_store
   end
+
+  describe "inlining the 'text/html' content type for downstream requests" do
+    let(:request_body) do
+      v2_content_item.merge(
+        description: [
+          { content_type: "text/html", content: v2_content_item.fetch(:description) },
+          { content_type: "text/plain", content: "plain content" },
+        ],
+        details: {
+          body: [
+            { content_type: "text/html", content: v2_content_item.fetch(:details).fetch(:body) },
+            { content_type: "text/plain", content: "plain content" },
+          ]
+        }
+      ).to_json
+    end
+    let(:request_path) { "/v2/content/#{content_id}" }
+    let(:request_method) { :put }
+
+    let(:content_item_for_draft_content_store) { v2_content_item.except(:update_type) }
+
+    sends_to_draft_content_store
+  end
 end

--- a/spec/requests/content_item_requests/message_bus_spec.rb
+++ b/spec/requests/content_item_requests/message_bus_spec.rb
@@ -145,4 +145,33 @@ RSpec.describe "Message bus", type: :request do
       end
     end
   end
+
+  context "/v2/publish" do
+    let(:request_body) { { update_type: "major" }.to_json }
+    let(:request_path) { "/v2/content/#{content_id}/publish" }
+    let(:request_method) { :post }
+
+    before do
+      draft = FactoryGirl.create(:draft_content_item, v2_content_item)
+      FactoryGirl.create(:version, target: draft, number: 1)
+    end
+
+    it "sends a message with the 'format.update_type' routing key" do
+      Timecop.freeze do
+        do_request
+
+        expect(response.status).to eq(200)
+
+        expected_payload = v2_content_item.except(:access_limited).merge(
+          update_type: "major",
+          transmitted_at: DateTime.now.to_s(:nanoseconds),
+        ).to_json
+
+        delivery_info, _, payload = wait_for_message_on(@queue)
+
+        expect(delivery_info.routing_key).to eq("guide.major")
+        expect(JSON.parse(payload)).to eq(JSON.parse(expected_payload))
+      end
+    end
+  end
 end

--- a/spec/requests/content_item_requests/message_bus_spec.rb
+++ b/spec/requests/content_item_requests/message_bus_spec.rb
@@ -165,12 +165,22 @@ RSpec.describe "Message bus", type: :request do
         expected_payload = v2_content_item.except(:access_limited).merge(
           update_type: "major",
           transmitted_at: DateTime.now.to_s(:nanoseconds),
+          public_updated_at: DateTime.now,
         ).to_json
 
         delivery_info, _, payload = wait_for_message_on(@queue)
 
         expect(delivery_info.routing_key).to eq("guide.major")
-        expect(JSON.parse(payload)).to eq(JSON.parse(expected_payload))
+
+        expected = JSON.parse(expected_payload)
+        actual = JSON.parse(payload)
+
+        expect(actual.except("public_updated_at")).to eq(
+          expected.except("public_updated_at")
+        )
+
+        expect(Time.parse(actual["public_updated_at"]))
+          .to be_within(1.second).of(Time.zone.now)
       end
     end
   end
@@ -205,12 +215,22 @@ RSpec.describe "Message bus", type: :request do
         expected_payload = v2_content_item.except(:access_limited).merge(
           update_type: "major",
           transmitted_at: DateTime.now.to_s(:nanoseconds),
+          public_updated_at: DateTime.now,
         ).to_json
 
         delivery_info, _, payload = wait_for_message_on(@queue)
 
         expect(delivery_info.routing_key).to eq("guide.major")
-        expect(JSON.parse(payload)).to eq(JSON.parse(expected_payload))
+
+        expected = JSON.parse(expected_payload)
+        actual = JSON.parse(payload)
+
+        expect(actual.except("public_updated_at")).to eq(
+          expected.except("public_updated_at")
+        )
+
+        expect(Time.parse(actual["public_updated_at"]))
+          .to be_within(1.second).of(Time.zone.now)
       end
     end
   end

--- a/spec/requests/publish_requests_spec.rb
+++ b/spec/requests/publish_requests_spec.rb
@@ -5,14 +5,10 @@ RSpec.describe "POST /v2/publish", type: :request do
   include MessageQueueHelpers
 
   let(:draft_content_item_attributes) do
-    attributes = draft_content_item
+    draft_content_item
       .attributes
       .deep_symbolize_keys
       .except(:id, :version, :metadata, :old_description)
-
-    attributes.merge(
-      description: attributes.delete(:description).fetch(:string)
-    )
   end
 
   let(:expected_live_content_item_derived_representation) {

--- a/spec/requests/publish_requests_spec.rb
+++ b/spec/requests/publish_requests_spec.rb
@@ -4,7 +4,17 @@ require "support/shared_context/message_queue_test_mode"
 RSpec.describe "POST /v2/publish", type: :request do
   include MessageQueueHelpers
 
-  let(:draft_content_item_attributes) { draft_content_item.attributes.deep_symbolize_keys.except(:id, :version, :metadata) }
+  let(:draft_content_item_attributes) do
+    attributes = draft_content_item
+      .attributes
+      .deep_symbolize_keys
+      .except(:id, :version, :metadata, :old_description)
+
+    attributes.merge(
+      description: attributes.delete(:description).fetch(:string)
+    )
+  end
+
   let(:expected_live_content_item_derived_representation) {
     draft_content_item_attributes
       .merge(public_updated_at: draft_content_item_attributes[:public_updated_at].iso8601)

--- a/spec/support/well_formed_content_types_validator.rb
+++ b/spec/support/well_formed_content_types_validator.rb
@@ -1,0 +1,65 @@
+RSpec.shared_examples_for WellFormedContentTypesValidator do
+  describe "validations" do
+    describe "description" do
+      it "is valid when the content types are well-formed" do
+        subject.description = [
+          { content_type: "text/html", content: "<p>content</p>" },
+          { content_type: "text/plain", content: "content" },
+        ]
+
+        expect(subject).to be_valid
+      end
+
+      it "is invalid when the content types are not well-formed" do
+        subject.description = [
+          { content_type: "text/html" },
+          { content_type: "text/plain", content: "content" },
+        ]
+
+        expect(subject).to be_invalid
+      end
+
+      it "is invalid when the text/html content type is not included" do
+        subject.description = [
+          { content_type: "text/plain", content: "content" },
+        ]
+
+        expect(subject).to be_invalid
+      end
+    end
+
+    describe "details" do
+      it "is valid when the content types are well-formed" do
+        subject.details = {
+          body: [
+            { content_type: "text/html", content: "<p>content</p>" },
+            { content_type: "text/plain", content: "content" },
+          ]
+        }
+
+        expect(subject).to be_valid
+      end
+
+      it "is invalid when the content types are not well-formed" do
+        subject.details = {
+          body: [
+            { content_type: "text/html" },
+            { content_type: "text/plain", content: "content" },
+          ]
+        }
+
+        expect(subject).to be_invalid
+      end
+
+      it "is invalid when the text/html content type is not included" do
+        subject.details = {
+          body: [
+            { content_type: "text/plain", content: "content" },
+          ]
+        }
+
+        expect(subject).to be_invalid
+      end
+    end
+  end
+end

--- a/spec/validators/well_formed_content_types_validator_spec.rb
+++ b/spec/validators/well_formed_content_types_validator_spec.rb
@@ -30,56 +30,56 @@ RSpec.describe WellFormedContentTypesValidator do
   end
 
   it "accepts well-formed content types" do
-    value = [{ content_type: "html", content: "<p>content</p>" }]
+    value = [{ content_type: "text/html", content: "<p>content</p>" }]
     subject.validate_each(record, attribute, value)
     expect(record.errors).to be_empty
 
-    value = { foo: [{ content_type: "html", content: "<p>content</p>" }] }
+    value = { foo: [{ content_type: "text/html", content: "<p>content</p>" }] }
     subject.validate_each(record, attribute, value)
     expect(record.errors).to be_empty
 
-    value = [{ "content_type" => "html", "content" => "<p>content</p>" }]
+    value = [{ "content_type" => "text/html", "content" => "<p>content</p>" }]
     subject.validate_each(record, attribute, value)
     expect(record.errors).to be_empty
   end
 
   it "rejects values where the content key is missing" do
-    value = [{ content_type: "html" }]
+    value = [{ content_type: "text/html" }]
     subject.validate_each(record, attribute, value)
     expect(record.errors).to be_present
-    expect(record.errors).to eq(some_attribute: ["the 'html' content type does not contain content"])
+    expect(record.errors).to eq(some_attribute: ["the 'text/html' content type does not contain content"])
 
     record.errors.clear
 
-    value = { foo: [{ content_type: "html" }] }
+    value = { foo: [{ content_type: "text/html" }] }
     subject.validate_each(record, attribute, value)
     expect(record.errors).to be_present
-    expect(record.errors).to eq(some_attribute: ["the 'html' content type does not contain content"])
+    expect(record.errors).to eq(some_attribute: ["the 'text/html' content type does not contain content"])
 
     record.errors.clear
 
-    value = [{ content_type: "text" }, { content_type: "html", content: "<p>content</p>" }]
+    value = [{ content_type: "text/plain" }, { content_type: "text/html", content: "<p>content</p>" }]
     subject.validate_each(record, attribute, value)
     expect(record.errors).to be_present
-    expect(record.errors).to eq(some_attribute: ["the 'text' content type does not contain content"])
+    expect(record.errors).to eq(some_attribute: ["the 'text/plain' content type does not contain content"])
   end
 
-  context "when the 'must_include' option is set to 'html'" do
-    let(:options) { { must_include: "html" } }
+  context "when the 'must_include' option is set to 'text/html'" do
+    let(:options) { { must_include: "text/html" } }
 
-    it "rejects values that do not have a content type of 'html'" do
-      value = [{ content_type: "text", content: "content" }]
+    it "rejects values that do not have a content type of 'text/html'" do
+      value = [{ content_type: "text/plain", content: "content" }]
       subject.validate_each(record, attribute, value)
       expect(record.errors).to be_present
-      expect(record.errors).to eq(some_attribute: ["the 'html' content type is mandatory and it is missing"])
+      expect(record.errors).to eq(some_attribute: ["the 'text/html' content type is mandatory and it is missing"])
     end
   end
 
   context "when the 'must_include' option is not set" do
     let(:options) { {} }
 
-    it "accepts values that do not have a content type of 'html'" do
-      value = [{ content_type: "text", content: "content" }]
+    it "accepts values that do not have a content type of 'text/html'" do
+      value = [{ content_type: "text/plain", content: "content" }]
       subject.validate_each(record, attribute, value)
       expect(record.errors).to be_empty
     end
@@ -87,36 +87,36 @@ RSpec.describe WellFormedContentTypesValidator do
 
   it "rejects values that have duplicate content types" do
     value = [
-      { content_type: "html", content: "<p>content</p>" },
-      { content_type: "html", content: "<p>content</p>" },
+      { content_type: "text/html", content: "<p>content</p>" },
+      { content_type: "text/html", content: "<p>content</p>" },
     ]
     subject.validate_each(record, attribute, value)
     expect(record.errors).to be_present
-    expect(record.errors).to eq(some_attribute: ["there are 2 instances of the 'html' content type - there should be 1"])
+    expect(record.errors).to eq(some_attribute: ["there are 2 instances of the 'text/html' content type - there should be 1"])
 
     record.errors.clear
 
     value = [
-      { content_type: "html", content: "<p>content</p>" },
-      { content_type: "text", content: "content" },
-      { content_type: "text", content: "content" },
+      { content_type: "text/html", content: "<p>content</p>" },
+      { content_type: "text/plain", content: "content" },
+      { content_type: "text/plain", content: "content" },
     ]
     subject.validate_each(record, attribute, value)
     expect(record.errors).to be_present
-    expect(record.errors).to eq(some_attribute: ["there are 2 instances of the 'text' content type - there should be 1"])
+    expect(record.errors).to eq(some_attribute: ["there are 2 instances of the 'text/plain' content type - there should be 1"])
   end
 
   context "when the value is invalid for more than one reason" do
-    let(:options) { { must_include: "html" } }
-    let(:value) { [{ content_type: "text" }] }
+    let(:options) { { must_include: "text/html" } }
+    let(:value) { [{ content_type: "text/plain" }] }
 
     it "communicates all of those reasons back to the programmer in one go" do
       subject.validate_each(record, attribute, value)
       expect(record.errors).to be_present
 
       error_messages = record.errors.fetch(attribute)
-      expect(error_messages).to include("the 'text' content type does not contain content")
-      expect(error_messages).to include("the 'html' content type is mandatory and it is missing")
+      expect(error_messages).to include("the 'text/plain' content type does not contain content")
+      expect(error_messages).to include("the 'text/html' content type is mandatory and it is missing")
     end
   end
 

--- a/spec/validators/well_formed_content_types_validator_spec.rb
+++ b/spec/validators/well_formed_content_types_validator_spec.rb
@@ -1,0 +1,134 @@
+require "rails_helper"
+
+RSpec.describe WellFormedContentTypesValidator do
+  let(:record) { double(:record, errors: {}) }
+  let(:attribute) { :some_attribute }
+
+  let(:options) { {} }
+  subject { described_class.new({ attributes: [attribute] }.merge(options)) }
+
+  it "accepts arbitrary values" do
+    value = "some_value"
+    subject.validate_each(record, attribute, value)
+    expect(record.errors).to be_empty
+
+    value = :some_symbol
+    subject.validate_each(record, attribute, value)
+    expect(record.errors).to be_empty
+
+    value = 123
+    subject.validate_each(record, attribute, value)
+    expect(record.errors).to be_empty
+
+    value = { some: "hash" }
+    subject.validate_each(record, attribute, value)
+    expect(record.errors).to be_empty
+
+    value = [{ an: "array"}, { of: "hashes" }]
+    subject.validate_each(record, attribute, value)
+    expect(record.errors).to be_empty
+  end
+
+  it "accepts well-formed content types" do
+    value = [{ content_type: "html", content: "<p>content</p>" }]
+    subject.validate_each(record, attribute, value)
+    expect(record.errors).to be_empty
+
+    value = { foo: [{ content_type: "html", content: "<p>content</p>" }] }
+    subject.validate_each(record, attribute, value)
+    expect(record.errors).to be_empty
+
+    value = [{ "content_type" => "html", "content" => "<p>content</p>" }]
+    subject.validate_each(record, attribute, value)
+    expect(record.errors).to be_empty
+  end
+
+  it "rejects values where the content key is missing" do
+    value = [{ content_type: "html" }]
+    subject.validate_each(record, attribute, value)
+    expect(record.errors).to be_present
+    expect(record.errors).to eq(some_attribute: ["the 'html' content type does not contain content"])
+
+    record.errors.clear
+
+    value = { foo: [{ content_type: "html" }] }
+    subject.validate_each(record, attribute, value)
+    expect(record.errors).to be_present
+    expect(record.errors).to eq(some_attribute: ["the 'html' content type does not contain content"])
+
+    record.errors.clear
+
+    value = [{ content_type: "text" }, { content_type: "html", content: "<p>content</p>" }]
+    subject.validate_each(record, attribute, value)
+    expect(record.errors).to be_present
+    expect(record.errors).to eq(some_attribute: ["the 'text' content type does not contain content"])
+  end
+
+  context "when the 'must_include' option is set to 'html'" do
+    let(:options) { { must_include: "html" } }
+
+    it "rejects values that do not have a content type of 'html'" do
+      value = [{ content_type: "text", content: "content" }]
+      subject.validate_each(record, attribute, value)
+      expect(record.errors).to be_present
+      expect(record.errors).to eq(some_attribute: ["the 'html' content type is mandatory and it is missing"])
+    end
+  end
+
+  context "when the 'must_include' option is not set" do
+    let(:options) { {} }
+
+    it "accepts values that do not have a content type of 'html'" do
+      value = [{ content_type: "text", content: "content" }]
+      subject.validate_each(record, attribute, value)
+      expect(record.errors).to be_empty
+    end
+  end
+
+  it "rejects values that have duplicate content types" do
+    value = [
+      { content_type: "html", content: "<p>content</p>" },
+      { content_type: "html", content: "<p>content</p>" },
+    ]
+    subject.validate_each(record, attribute, value)
+    expect(record.errors).to be_present
+    expect(record.errors).to eq(some_attribute: ["there are 2 instances of the 'html' content type - there should be 1"])
+
+    record.errors.clear
+
+    value = [
+      { content_type: "html", content: "<p>content</p>" },
+      { content_type: "text", content: "content" },
+      { content_type: "text", content: "content" },
+    ]
+    subject.validate_each(record, attribute, value)
+    expect(record.errors).to be_present
+    expect(record.errors).to eq(some_attribute: ["there are 2 instances of the 'text' content type - there should be 1"])
+  end
+
+  context "when the value is invalid for more than one reason" do
+    let(:options) { { must_include: "html" } }
+    let(:value) { [{ content_type: "text" }] }
+
+    it "communicates all of those reasons back to the programmer in one go" do
+      subject.validate_each(record, attribute, value)
+      expect(record.errors).to be_present
+
+      error_messages = record.errors.fetch(attribute)
+      expect(error_messages).to include("the 'text' content type does not contain content")
+      expect(error_messages).to include("the 'html' content type is mandatory and it is missing")
+    end
+  end
+
+  it "does not clobber existing errors for the attribute" do
+    record.errors[attribute] = ["some existing error"]
+
+    value = "some_value"
+    subject.validate_each(record, attribute, value)
+    expect(record.errors[attribute].size).to eq(1)
+
+    value = [{ content_type: "text/html" }]
+    subject.validate_each(record, attribute, value)
+    expect(record.errors[attribute].size).to eq(2)
+  end
+end


### PR DESCRIPTION
See [here](https://github.com/alphagov/publishing-api/blob/b532ef8c883598cc5faa91e45d4bba53a173bca2/doc/representation-for-multiple-content-types.md) for a decision record regarding the representation.

**Post deploy:**

- [ ] Document multiple representations in the content schemas
- [ ] Document multiple representations in the syntax / semantics docs
- [ ] Create a pull request to remove old_description columns

https://trello.com/c/nkofgTdj/372-add-raw-govspeak-to-publishing-api-payload