### PR TITLE
Update public_updated_at on publish

### DIFF
--- a/app/commands/v2/publish.rb
+++ b/app/commands/v2/publish.rb
@@ -90,6 +90,12 @@ module Commands
           .attributes
           .except("access_limited", "version")
           .merge(draft_content_item: draft_content_item)
+
+        unless attributes[:public_updated_at] || update_type != "major"
+          attributes = attributes.merge(public_updated_at: DateTime.now)
+        end
+
+        attributes
       end
     end
   end

--- a/spec/commands/v2/publish_spec.rb
+++ b/spec/commands/v2/publish_spec.rb
@@ -1,0 +1,75 @@
+require "rails_helper"
+
+RSpec.describe Commands::V2::Publish do
+  describe "call" do
+    before do
+      previous = FactoryGirl.create(:draft_content_item, content_id: content_id)
+      FactoryGirl.create(:version, target: previous, number: 2)
+    end
+
+    let(:content_id) { SecureRandom.uuid }
+    let(:payload) do
+      {
+        content_id: content_id,
+        update_type: "major",
+        previous_version: 2
+      }
+    end
+
+    context "with no update_type" do
+      let(:payload) { { content_id: content_id } }
+
+      it "raises an error" do
+        expect {
+          described_class.call(payload)
+        }.to raise_error(CommandError, /update_type is required/)
+      end
+    end
+
+
+    context "with a stale version" do
+
+      let(:payload) do
+        {
+          content_id: content_id,
+          update_type: "major",
+          previous_version: 3
+        }
+      end
+
+      it "raises an error" do
+        expect {
+          described_class.call(payload)
+        }.to raise_error(CommandError, /Conflict/)
+      end
+    end
+
+    context "with a valid payload" do
+      it "creates or replaces a live content item" do
+        stub_request(:put, %r{.*content-store.*/content/.*})
+        expect {
+          described_class.call(payload)
+        }.to change(LiveContentItem, :count).by(1)
+      end
+
+      it "sends a payload downstream asynchronously" do
+        presentation = {
+          content_id: content_id,
+          transmitted_at: Time.now.to_s(:nanoseconds),
+          title: "Something something"
+        }.to_json
+        allow(Presenters::ContentStorePresenter)
+          .to receive(:present)
+          .and_return(presentation)
+
+        expect(ContentStoreWorker)
+          .to receive(:perform_async)
+          .with(content_store: Adapters::ContentStore,
+               base_path: "/vat-rates",
+               payload: presentation)
+
+        described_class.call(payload)
+      end
+    end
+  end
+end

--- a/spec/requests/content_item_requests/downstream_requests_spec.rb
+++ b/spec/requests/content_item_requests/downstream_requests_spec.rb
@@ -119,6 +119,7 @@ RSpec.describe "Downstream requests", type: :request do
 
     let(:content_item_for_live_content_store) {
       draft.attributes.deep_symbolize_keys
+        .merge(public_updated_at: Time.zone.now.iso8601)
         .except(:id, :access_limited, :update_type, :metadata, :version)
     }
 

--- a/spec/requests/publish_requests_spec.rb
+++ b/spec/requests/publish_requests_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe "POST /v2/publish", type: :request do
   let(:request_path) { "/v2/content/#{content_id}/publish"}
   let(:payload) {
     {
-      update_type: "major",
+      update_type: "major"
     }
   }
   let(:request_body) { payload.to_json }
@@ -56,7 +56,7 @@ RSpec.describe "POST /v2/publish", type: :request do
       expect(item.locale).to eq(expected_live_content_item_derived_representation[:locale])
       expect(item.publishing_app).to eq(expected_live_content_item_derived_representation[:publishing_app])
       expect(item.rendering_app).to eq(expected_live_content_item_derived_representation[:rendering_app])
-      expect(item.public_updated_at).to eq(expected_live_content_item_derived_representation[:public_updated_at])
+      expect(item.public_updated_at).to be_within(1.second).of(DateTime.now)
       expect(item.description).to eq(expected_live_content_item_derived_representation[:description])
       expect(item.title).to eq(expected_live_content_item_derived_representation[:title])
       expect(item.routes).to eq(expected_live_content_item_derived_representation[:routes].map(&:deep_symbolize_keys))
@@ -116,7 +116,8 @@ RSpec.describe "POST /v2/publish", type: :request do
         .with(
           base_path: draft_content_item.base_path,
           content_item: expected_live_content_item_hash
-            .merge(transmitted_at: DateTime.now.to_s(:nanoseconds))
+            .merge(transmitted_at: DateTime.now.to_s(:nanoseconds),
+                   public_updated_at: DateTime.now.in_time_zone.iso8601)
         )
         do_request
       end
@@ -136,6 +137,7 @@ RSpec.describe "POST /v2/publish", type: :request do
           expected_live_content_item_hash.merge!(
             update_type: payload[:update_type],
             transmitted_at: DateTime.now.to_s(:nanoseconds),
+            public_updated_at: DateTime.now.in_time_zone.iso8601
           )
           expect(message).to eq(expected_live_content_item_hash.as_json)
         end


### PR DESCRIPTION
https://trello.com/c/BU5p5lG6/418-v2-publish-content-id-should-update-the-public-updated-at

Updates the `public_updated_at` timestamp on major updates.