### PR TITLE
Allow unpublishings to replace like gones or redirects.

### DIFF
--- a/app/commands/base_command.rb
+++ b/app/commands/base_command.rb
@@ -63,7 +63,7 @@ module Commands
 
     def clear_space_for(new_content)
       if (existing_content = DraftContentItem.find_by(base_path: new_content.base_path))
-        if existing_content.draft_or_redirect? || new_content.draft_or_redirect?
+        if existing_content.gone_unpublishing_or_redirect? || new_content.gone_unpublishing_or_redirect?
           existing_content.destroy
         end
       end

--- a/app/models/draft_content_item.rb
+++ b/app/models/draft_content_item.rb
@@ -39,8 +39,8 @@ class DraftContentItem < ActiveRecord::Base
     !access_limited? || authorised_user_uids.include?(user_uid)
   end
 
-  def draft_or_redirect?
-    ["gone", "redirect"].include?(format)
+  def gone_unpublishing_or_redirect?
+    ["gone", "unpublishing", "redirect"].include?(format)
   end
 
 private

--- a/app/models/live_content_item.rb
+++ b/app/models/live_content_item.rb
@@ -48,8 +48,8 @@ class LiveContentItem < ActiveRecord::Base
   }
   validates_with RoutesAndRedirectsValidator
 
-  def draft_or_redirect?
-    ["gone", "redirect"].include?(format)
+  def gone_unpublishing_or_redirect?
+    ["gone", "unpublishing", "redirect"].include?(format)
   end
 
 private

--- a/spec/commands/v2/put_content_spec.rb
+++ b/spec/commands/v2/put_content_spec.rb
@@ -85,6 +85,19 @@ RSpec.describe Commands::V2::PutContent do
       end
     end
 
+    context "when there's an existing unpublishing on the path already" do
+      before do
+        create(:draft_content_item, base_path: base_path, format: "unpublishing")
+      end
+
+      it "replaces the existing content" do
+        described_class.call(payload)
+
+        stored_content_item = DraftContentItem.find_by(base_path: base_path)
+        expect(stored_content_item.content_id).to eq(content_id)
+      end
+    end
+
     context "when a gone item wants to replace a content item" do
       before do
         create(:draft_content_item, base_path: base_path)
@@ -112,6 +125,27 @@ RSpec.describe Commands::V2::PutContent do
 
       let(:payload) {
         FactoryGirl.build(:redirect_draft_content_item,
+          content_id: content_id,
+          base_path: base_path
+        ).as_json.deep_symbolize_keys
+      }
+
+      it "replaces the existing content" do
+        described_class.call(payload)
+
+        stored_content_item = DraftContentItem.find_by(base_path: base_path)
+        expect(stored_content_item.content_id).to eq(content_id)
+      end
+    end
+
+    context "when an unpublishing item wants to replace a content item" do
+      before do
+        create(:draft_content_item, base_path: base_path)
+      end
+
+      let(:payload) {
+        FactoryGirl.build(:draft_content_item,
+          format: "unpublishing",
           content_id: content_id,
           base_path: base_path
         ).as_json.deep_symbolize_keys


### PR DESCRIPTION
This is a third representation of the same use case
where the application wants to handle informing the
user about the gone item itself, rather than
having the router do it via generic HTTP responses.