### PR TITLE
Refactor LinkSetPresenter

### DIFF
--- a/app/commands/v2/put_link_set.rb
+++ b/app/commands/v2/put_link_set.rb
@@ -33,7 +33,8 @@ module Commands
           PublishingAPI.service(:queue_publisher).send_message(queue_payload)
         end
 
-        Success.new(links: link_set.links)
+        presented = Presenters::Queries::LinkSetPresenter.new(link_set).present
+        Success.new(presented)
       end
 
     private

--- a/app/presenters/downstream_presenter.rb
+++ b/app/presenters/downstream_presenter.rb
@@ -27,10 +27,14 @@ module Presenters
 
     def links
       if link_set
-        { links: link_set.links }
+        { links: link_set_presenter.links }
       else
         {}
       end
+    end
+
+    def link_set_presenter
+      Presenters::Queries::LinkSetPresenter.new(link_set)
     end
 
     def public_updated_at

--- a/app/presenters/queries/link_set_presenter.rb
+++ b/app/presenters/queries/link_set_presenter.rb
@@ -6,15 +6,23 @@ module Presenters
         new(link_set, version).present
       end
 
-      def initialize(link_set, version)
+      def initialize(link_set, version = nil)
         self.link_set = link_set
         self.version = version
       end
 
       def present
-        link_set.as_json
-          .symbolize_keys
-          .merge(version: version.number)
+        base = link_set.as_json.symbolize_keys
+
+        if version
+          base.merge(version: version.number)
+        else
+          base
+        end
+      end
+
+      def links
+        present[:links]
       end
 
     private

--- a/spec/presenters/queries/link_set_presenter_spec.rb
+++ b/spec/presenters/queries/link_set_presenter_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe Presenters::Queries::LinkSetPresenter do
-  describe "present" do
+  describe ".present" do
     before do
       FactoryGirl.create(:version, target: link_set, number: 101)
       @result = Presenters::Queries::LinkSetPresenter.present(link_set)
@@ -15,6 +15,16 @@ RSpec.describe Presenters::Queries::LinkSetPresenter do
 
     it "exposes the version of the link set" do
       expect(@result.fetch(:version)).to eq(101)
+    end
+  end
+
+  describe "#links" do
+    it "exposes the version of the link set" do
+      link_set = create(:link_set, links: { "topics" => ["778decfb-3e9c-490d-bbd5-9eeb76ee9016"]})
+
+      presenter = Presenters::Queries::LinkSetPresenter.new(link_set)
+
+      expect(presenter.links).to eq({ topics: ["778decfb-3e9c-490d-bbd5-9eeb76ee9016"] })
     end
   end
 end


### PR DESCRIPTION
This is a change to make future changes easier.

Currently the `LinkSetPresenter` is only used when presenting the links for the `GET /v2/links/:content_id` endpoint. This commit makes it so that it is used in all instances where we send the links hash to the user:

- When setting the links (PUT /v2/links/:content_id)
- When presenting a document (/v2/content/:content_id)

This will make it easier to change what we present as `links` when we change the way links are stored in the database (#137).

Paired with @jackscotti on this.