### PR TITLE
Move #query_keys out of `private` scope

### DIFF
--- a/app/models/draft_content_item.rb
+++ b/app/models/draft_content_item.rb
@@ -43,11 +43,11 @@ class DraftContentItem < ActiveRecord::Base
     live_content_item.present?
   end
 
-private
   def self.query_keys
     [:content_id, :locale]
   end
 
+private
   def content_ids_match
     if live_content_item && live_content_item.content_id != content_id
       errors.add(:content_id, "id mismatch between draft and live content items")

--- a/app/models/link_set.rb
+++ b/app/models/link_set.rb
@@ -9,11 +9,11 @@ class LinkSet < ActiveRecord::Base
     super(links_hash || {})
   end
 
-private
   def self.query_keys
     [:content_id]
   end
 
+private
   def links_are_valid
     # Test that the `links` attribute, if set, is a hash from strings to lists
     # of UUIDs

--- a/app/models/live_content_item.rb
+++ b/app/models/live_content_item.rb
@@ -51,11 +51,11 @@ class LiveContentItem < ActiveRecord::Base
     true
   end
 
-private
   def self.query_keys
     [:content_id, :locale]
   end
 
+private
   def content_ids_match
     if draft_content_item && draft_content_item.content_id != content_id
       errors.add(:content_id, "id mismatch between draft and live content items")

--- a/app/models/path_reservation.rb
+++ b/app/models/path_reservation.rb
@@ -9,7 +9,6 @@ class PathReservation < ActiveRecord::Base
     self.create_or_replace(base_path: base_path, publishing_app: publishing_app)
   end
 
-private
   def self.query_keys
     [:base_path]
   end


### PR DESCRIPTION
Class methods are not set as private just by simply using the `private` keyword, see:
http://domon.cc/2013/12/25/private-class-methods-in-ruby/
http://stackoverflow.com/questions/4952980/creating-private-class-method

I tried setting them as private but I realised they're all used by the `Replaceable` module:
ie:
```
Failure/Error: command.call(substitute_payload)
     NoMethodError:
       private method `query_keys' called for LinkSet(id: integer, content_id: string, links: json):Class
     # ./app/models/replaceable.rb:8:in `create_or_replace'
```

These methods should be set as public. And seeing them under the `private` keyword is misleading.