### PR TITLE
Add discard draft endpoint

### DIFF
--- a/app/adapters/content_store.rb
+++ b/app/adapters/content_store.rb
@@ -3,7 +3,7 @@
 module Adapters
   class ContentStore
     def self.put_content_item(base_path, content_item)
-      with_error_handling do
+      CommandError.with_error_handling do
         PublishingAPI.service(:live_content_store).put_content_item(
           base_path: base_path,
           content_item: content_item.except(:access_limited),
@@ -12,33 +12,12 @@ module Adapters
     end
 
     def self.put_publish_intent(base_path, publish_intent)
-      with_error_handling do
+      CommandError.with_error_handling do
         PublishingAPI.service(:live_content_store).put_publish_intent(
           base_path: base_path,
           publish_intent: publish_intent,
         )
       end
-    end
-
-  private
-    def self.with_error_handling(&block)
-      block.call
-    rescue GdsApi::HTTPServerError => e
-      raise CommandError.new(code: e.code, message: e.message)
-    rescue GdsApi::HTTPClientError => e
-      raise CommandError.new(code: e.code, error_details: convert_error_details(e))
-    rescue GdsApi::BaseError => e
-      raise CommandError.new(code: 500, message: "Unexpected error from content store: #{e.message}")
-    end
-
-    def self.convert_error_details(upstream_error)
-      {
-        error: {
-          code: upstream_error.code,
-          message: upstream_error.message,
-          fields: upstream_error.error_details.fetch('errors', {})
-        }
-      }
     end
   end
 end

--- a/app/adapters/draft_content_store.rb
+++ b/app/adapters/draft_content_store.rb
@@ -8,5 +8,11 @@ module Adapters
         )
       end
     end
+
+    def self.delete_content_item(base_path)
+      CommandError.with_error_handling do
+        PublishingAPI.service(:draft_content_store).delete_content_item(base_path)
+      end
+    end
   end
 end

--- a/app/adapters/draft_content_store.rb
+++ b/app/adapters/draft_content_store.rb
@@ -1,31 +1,12 @@
 module Adapters
   class DraftContentStore
     def self.put_content_item(base_path, content_item)
-      PublishingAPI.service(:draft_content_store).put_content_item(
-        base_path: base_path,
-        content_item: content_item,
-      )
-    rescue GdsApi::HTTPServerError => e
-      raise CommandError.new(code: e.code, message: e.message) unless should_suppress?(e)
-    rescue GdsApi::HTTPClientError => e
-      raise CommandError.new(code: e.code, error_details: convert_error_details(e))
-    rescue GdsApi::BaseError => e
-      raise CommandError.new(code: 500, message: "Unexpected error from draft content store: #{e.message}")
-    end
-
-  private
-    def self.should_suppress?(error)
-      PublishingAPI.swallow_draft_connection_errors && error.code == 502
-    end
-
-    def self.convert_error_details(upstream_error)
-      {
-        error: {
-          code: upstream_error.code,
-          message: upstream_error.message,
-          fields: upstream_error.error_details.fetch('errors', {})
-        }
-      }
+      CommandError.with_error_handling do
+        PublishingAPI.service(:draft_content_store).put_content_item(
+          base_path: base_path,
+          content_item: content_item,
+        )
+      end
     end
   end
 end

--- a/app/clients/content_store_writer.rb
+++ b/app/clients/content_store_writer.rb
@@ -21,6 +21,10 @@ class ContentStoreWriter < GdsApi::ContentStore
     delete_json!(publish_intent_url(base_path))
   end
 
+  def delete_content_item(base_path)
+    delete_json!(content_item_url(base_path))
+  end
+
 private
 
   def publish_intent_url(base_path)

--- a/app/commands/v2/discard_draft.rb
+++ b/app/commands/v2/discard_draft.rb
@@ -1,0 +1,72 @@
+module Commands
+  module V2
+    class DiscardDraft < BaseCommand
+      def call
+        validate_version_lock!
+        raise_error_if_missing_draft!
+
+        if live
+          update_draft_from_live
+        else
+          delete_draft
+        end
+
+        Success.new(content_id: content_id)
+      end
+
+    private
+      def validate_version_lock!
+        super(DraftContentItem, content_id, payload[:previous_version])
+      end
+
+      def raise_error_if_missing_draft!
+        return if draft.present?
+
+        code = live.present? ? 422 : 404
+        message = "There is no draft content item to discard"
+
+        raise CommandError.new(code: code, message: message)
+      end
+
+      def update_draft_from_live
+        draft.update_attributes(live.attributes.except("id", "draft_content_item_id"))
+
+        ContentStoreWorker.perform_async(
+          content_store: Adapters::DraftContentStore,
+          base_path: draft.base_path,
+          payload: Presenters::ContentStorePresenter.present(live),
+        )
+      end
+
+      def delete_draft
+        draft.destroy
+
+        ContentStoreWorker.perform_async(
+          content_store: Adapters::DraftContentStore,
+          base_path: draft.base_path,
+          delete: true,
+        )
+      end
+
+      def draft
+        @draft ||= DraftContentItem.find_by(content_id: content_id, locale: locale)
+      end
+
+      def live
+        @live ||= LiveContentItem.find_by(content_id: content_id, locale: locale)
+      end
+
+      def content_id
+        payload[:content_id]
+      end
+
+      def locale
+        payload[:locale] || DraftContentItem::DEFAULT_LOCALE
+      end
+
+      def update_type
+        payload[:update_type]
+      end
+    end
+  end
+end

--- a/app/controllers/v2/content_items_controller.rb
+++ b/app/controllers/v2/content_items_controller.rb
@@ -26,6 +26,14 @@ module V2
       render status: response.code, json: response
     end
 
+    def discard_draft
+      response = with_event_logging(Commands::V2::DiscardDraft, content_item) do
+        Commands::V2::DiscardDraft.call(content_item)
+      end
+
+      render status: response.code, json: response
+    end
+
   private
     def content_item
       payload.merge(content_id: params[:content_id])

--- a/app/errors/command_error.rb
+++ b/app/errors/command_error.rb
@@ -1,6 +1,23 @@
 class CommandError < StandardError
   attr_reader :code, :error_details
 
+  def self.with_error_handling(&block)
+    block.call
+  rescue GdsApi::HTTPServerError => e
+    should_suppress = (PublishingAPI.swallow_connection_errors && e.code == 502)
+    raise CommandError.new(code: e.code, message: e.message) unless should_suppress
+  rescue GdsApi::HTTPClientError => e
+    raise CommandError.new(code: e.code, error_details: {
+      error: {
+        code: e.code,
+        message: e.message,
+        fields: e.error_details.fetch('errors', {})
+      }
+    })
+  rescue GdsApi::BaseError => e
+    raise CommandError.new(code: 500, message: "Unexpected error from the downstream application: #{e.message}")
+  end
+
   # error_details: Hash(field_name: String => [error_messages]: Array(String))
   def initialize(code:, message: nil, error_details: nil)
     raise "Invalid code #{code}" unless valid_code?(code)

--- a/app/workers/content_store_worker.rb
+++ b/app/workers/content_store_worker.rb
@@ -6,9 +6,14 @@ class ContentStoreWorker
 
     content_store = args.fetch(:content_store).constantize
     base_path = args.fetch(:base_path)
-    payload = args.fetch(:payload)
 
-    content_store.put_content_item(base_path, payload)
+    if args[:delete]
+      content_store.delete_content_item(base_path)
+    else
+      payload = args.fetch(:payload)
+      content_store.put_content_item(base_path, payload)
+    end
+
   rescue => e
     handle_error(e)
   end

--- a/config/initializers/services.rb
+++ b/config/initializers/services.rb
@@ -2,7 +2,7 @@ require "govuk/client/url_arbiter"
 
 module PublishingAPI
   # To be set in dev mode so that this can run when the draft content store isn't running.
-  cattr_accessor :swallow_draft_connection_errors
+  cattr_accessor :swallow_connection_errors
 
   def self.register_service(name:, client:)
     @services ||= {}
@@ -44,5 +44,5 @@ PublishingAPI.register_service(
 )
 
 if Rails.env.development?
-  PublishingAPI.swallow_draft_connection_errors = true
+  PublishingAPI.swallow_connection_errors = true
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,7 @@ Rails.application.routes.draw do
       put "/content/:content_id", to: "content_items#put_content"
       get "/content/:content_id", to: "content_items#show"
       post "/content/:content_id/publish", to: "content_items#publish"
+      post "/content/:content_id/discard-draft", to: "content_items#discard_draft"
 
       get "/links/:content_id", to: "link_sets#get_links"
       put "/links/:content_id", to: "link_sets#put_links"

--- a/spec/requests/content_item_requests/downstream_requests_spec.rb
+++ b/spec/requests/content_item_requests/downstream_requests_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe "Downstream requests", type: :request do
         FactoryGirl.create(:version, target: draft, number: 1)
       end
 
-      sends_to_draft_content_store(with_arbitration: false)
+      sends_to_draft_content_store
       does_not_send_to_live_content_store
     end
 
@@ -110,7 +110,7 @@ RSpec.describe "Downstream requests", type: :request do
         FactoryGirl.create(:version, target: live, number: 1)
       end
 
-      sends_to_draft_content_store(with_arbitration: false)
+      sends_to_draft_content_store
       sends_to_live_content_store
     end
 

--- a/spec/requests/discard_draft_request_spec.rb
+++ b/spec/requests/discard_draft_request_spec.rb
@@ -1,0 +1,94 @@
+require "rails_helper"
+
+RSpec.describe "Discard draft requests", type: :request do
+  let(:request_body) { {}.to_json }
+  let(:request_path) { "/v2/content/#{content_id}/discard-draft" }
+  let(:request_method) { :post }
+
+  let(:base_path) { "/vat-rates" }
+
+  describe "POST /v2/content/:content_id/discard-draft" do
+    context "when a draft content item exists" do
+      let!(:draft_content_item) do
+        FactoryGirl.create(:draft_content_item,
+          content_id: content_id,
+          title: "draft",
+        )
+      end
+
+      returns_200_response
+      logs_event("DiscardDraft", expected_payload_proc: -> { { content_id: "582e1d3f-690e-4115-a948-e05b3c6b3d88" } })
+      does_not_send_to_live_content_store
+
+      it "deletes the draft content item" do
+        do_request
+
+        draft = DraftContentItem.find_by(content_id: content_id)
+        expect(draft).to be_nil
+      end
+
+      it "deletes the content item from the draft content store" do
+        expect(PublishingAPI.service(:draft_content_store)).to receive(:delete_content_item)
+          .with(base_path)
+
+        do_request
+
+        expect(response.status).to eq(200), response.body
+      end
+
+      context "and a live content item exists" do
+        let!(:live_content_item) do
+          FactoryGirl.create(:live_content_item,
+            content_id: content_id,
+            draft_content_item: draft_content_item,
+            title: "live",
+          )
+        end
+
+        let(:content_item_for_draft_content_store) do
+          Presenters::ContentStorePresenter.present(live_content_item)
+        end
+
+        returns_200_response
+        logs_event("DiscardDraft", expected_payload_proc: -> { { content_id: "582e1d3f-690e-4115-a948-e05b3c6b3d88" } })
+
+        it "replaces the draft content item from the live content item" do
+          do_request
+
+          draft = DraftContentItem.find_by(content_id: content_id)
+          expect(draft.title).to eq("live")
+        end
+
+        sends_to_draft_content_store
+      end
+    end
+
+    context "when a draft content item does not exist" do
+      returns_404_response
+
+      does_not_log_event
+      does_not_send_to_draft_content_store
+      does_not_send_to_live_content_store
+
+      context "and a live content item exists" do
+        before do
+          FactoryGirl.create(:live_content_item,
+            content_id: content_id,
+          )
+        end
+
+        it "returns a 422" do
+          do_request
+
+          expect(response.status).to eq(422)
+        end
+
+        creates_no_derived_representations
+
+        does_not_log_event
+        does_not_send_to_draft_content_store
+        does_not_send_to_live_content_store
+      end
+    end
+  end
+end

--- a/spec/support/content_store.rb
+++ b/spec/support/content_store.rb
@@ -2,5 +2,6 @@ RSpec.configure do |c|
   c.before :each, :type => :request do
     stub_request(:put, Plek.find('content-store') + "/content#{base_path}")
     stub_request(:put, Plek.find('draft-content-store') + "/content#{base_path}")
+    stub_request(:delete, Plek.find('draft-content-store') + "/content#{base_path}")
   end
 end

--- a/spec/support/request_helpers/downstream_requests.rb
+++ b/spec/support/request_helpers/downstream_requests.rb
@@ -9,7 +9,6 @@ module RequestHelpers
               content_item: content_item_for_draft_content_store
                 .merge(transmitted_at: DateTime.now.to_s(:nanoseconds))
             )
-            .ordered
 
           do_request
 

--- a/spec/support/request_helpers/downstream_requests.rb
+++ b/spec/support/request_helpers/downstream_requests.rb
@@ -1,6 +1,6 @@
 module RequestHelpers
   module DownstreamRequests
-    def sends_to_draft_content_store(with_arbitration: true)
+    def sends_to_draft_content_store
       it "sends to draft content store" do
         Timecop.freeze do
           expect(PublishingAPI.service(:draft_content_store)).to receive(:put_content_item)

--- a/spec/support/request_helpers/downstream_timeouts.rb
+++ b/spec/support/request_helpers/downstream_timeouts.rb
@@ -19,7 +19,7 @@ module RequestHelpers
           expect(JSON.parse(response.body)).to eq(
             "error" => {
               "code" => 500,
-              "message" => "Unexpected error from draft content store: GdsApi::TimedOutException"
+              "message" => "Unexpected error from the downstream application: GdsApi::TimedOutException"
             }
           )
         end
@@ -45,7 +45,7 @@ module RequestHelpers
           expect(JSON.parse(response.body)).to eq(
             "error" => {
               "code" => 500,
-              "message" => "Unexpected error from content store: GdsApi::TimedOutException"
+              "message" => "Unexpected error from the downstream application: GdsApi::TimedOutException"
             }
           )
         end

--- a/spec/support/request_helpers/endpoint_behaviour.rb
+++ b/spec/support/request_helpers/endpoint_behaviour.rb
@@ -66,8 +66,8 @@ module RequestHelpers
     def suppresses_draft_content_store_502s
       context "when draft content store is not running but draft 502s are suppressed" do
         before do
-          @swallow_draft_errors = PublishingAPI.swallow_draft_connection_errors
-          PublishingAPI.swallow_draft_connection_errors = true
+          @swallow_connection_errors = PublishingAPI.swallow_connection_errors
+          PublishingAPI.swallow_connection_errors = true
           stub_request(:put, %r{^http://draft-content-store.*/content/.*})
             .to_return(status: 502)
         end
@@ -81,7 +81,7 @@ module RequestHelpers
             expect(parsed_response_body["content_id"]).to eq(content_item[:content_id])
             expect(parsed_response_body["title"]).to eq(content_item[:title])
           ensure
-            PublishingAPI.swallow_draft_connection_errors = @swallow_draft_errors
+            PublishingAPI.swallow_connection_errors = @swallow_connection_errors
           end
         end
       end

--- a/spec/support/request_helpers/event_logging.rb
+++ b/spec/support/request_helpers/event_logging.rb
@@ -34,15 +34,6 @@ module RequestHelpers
         do_request
 
         expect(Event.count).to eq(0)
-        expect(response.status).to eq(422)
-
-        parsed_response = JSON.parse(response.body).deep_symbolize_keys
-
-        expect(parsed_response).to have_key(:error)
-        parsed_error = parsed_response.fetch(:error)
-
-        expect(parsed_error[:code]).to eq(422)
-        expect(parsed_error[:fields]).to eq(error_details.fetch(:errors))
       end
     end
   end


### PR DESCRIPTION
This allows publishing applications to discard
drafts.  The main use cases for this in whitehall are:

1. A document is created in draft but never published,
   and then deleted, wherein the draft should be
   deleted entirely from the publishing API and the
   draft content store.
2. A document is created, published, and redrafted.
   The draft should be reset to be the same as the
   live content item and resent to the content store.

https://trello.com/c/d6trl2sb/431-add-discard-endpoint-to-publishing-api-for-throwing-away-non-published-drafts