### PR TITLE
Fix issue in PutLinkSet

### DIFF
--- a/app/commands/v2/put_link_set.rb
+++ b/app/commands/v2/put_link_set.rb
@@ -21,7 +21,9 @@ module Commands
               link_set.links.where(link_type: link_type, target_content_id: ids_to_be_deleted).delete_all
 
               ids_to_be_created = target_content_ids - old_target_ids
-              link_set.links.where(link_type: link_type, target_content_id: ids_to_be_created).create!
+              ids_to_be_created.each do |target_content_id|
+                link_set.links.create!(link_type: link_type, target_content_id: target_content_id)
+              end
             end
           end
         end


### PR DESCRIPTION
The `PutLinkSet` command has two bugs:

- it prevents link sets to be saved when there are no additional links to be created
- doesn't save multiple links

Because this should've been caught in tests, this commit refactors the specs for the `PutLinkSet` command. It now covers all behaviour.

Best reviewed in split-view.