### PR TITLE
Increment version after assigning default attributes...

### DIFF
--- a/app/commands/v2/put_content.rb
+++ b/app/commands/v2/put_content.rb
@@ -32,11 +32,11 @@ module Commands
         DraftContentItem.create_or_replace(content_item_attributes) do |item|
           SubstitutionHelper.clear_draft!(item)
 
+          item.assign_attributes_with_defaults(content_item_attributes)
+
           version = Version.find_or_initialize_by(target: item)
           version.increment
           version.save! if item.valid?
-
-          item.assign_attributes_with_defaults(content_item_attributes)
         end
       end
 

--- a/spec/commands/v2/put_content_spec.rb
+++ b/spec/commands/v2/put_content_spec.rb
@@ -76,6 +76,7 @@ RSpec.describe Commands::V2::PutContent do
           described_class.call(updated_payload)
 
           expect(version.reload.number).to eq(3)
+          expect(draft.reload.format).to eq("redirect")
         end
       end
     end

--- a/spec/commands/v2/put_content_spec.rb
+++ b/spec/commands/v2/put_content_spec.rb
@@ -1,13 +1,13 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe Commands::V2::PutContent do
-  describe 'call' do
+  describe "call" do
     before do
       stub_request(:put, %r{.*content-store.*/content/.*})
     end
 
     let(:content_id) { SecureRandom.uuid }
-    let(:base_path) { '/vat-rates' }
+    let(:base_path) { "/vat-rates" }
 
     let(:payload) {
       FactoryGirl.build(:draft_content_item)
@@ -15,41 +15,67 @@ RSpec.describe Commands::V2::PutContent do
         .deep_symbolize_keys
         .merge(
           content_id: content_id,
-          title: 'The title',
+          title: "The title",
           base_path: base_path
         )
     }
 
-    describe 'validation' do
+    describe "validation" do
       before do
         create(:path_reservation, publishing_app: payload[:publishing_app], base_path: base_path)
         create(:live_content_item, content_id: content_id, base_path: base_path)
       end
 
-      context 'given a base_path change on a published item' do
-        let(:updated_payload) { payload.merge(base_path: '/vatrates') }
+      context "given a base_path change on a published item" do
+        let(:updated_payload) { payload.merge(base_path: "/vatrates") }
 
-        it 'raises an error' do
+        it "raises an error" do
           expect { described_class.call(updated_payload) }.to raise_error(
             CommandError, /Base path cannot be changed for published items/)
         end
       end
 
-      context 'given a publishing_app change on a published item' do
-        let(:updated_payload) { payload.merge(publishing_app: 'new-publishing-app') }
-        it 'raises an error' do
+      context "given a publishing_app change on a published item" do
+        let(:updated_payload) { payload.merge(publishing_app: "new-publishing-app") }
+        it "raises an error" do
           expect { described_class.call(updated_payload) }.to raise_error(
-            CommandError, 'Base path is already registered by mainstream_publisher')
+            CommandError, "Base path is already registered by mainstream_publisher")
         end
       end
 
-      context 'given a field change on a published item' do
-        let(:updated_payload) { payload.merge(title: 'A better title') }
+      context "given a field change on a published item" do
+        let(:updated_payload) { payload.merge(title: "A better title") }
 
-        it 'passes validation' do
+        it "passes validation" do
           expect(Commands::Success).to receive(:new)
 
           described_class.call(updated_payload)
+        end
+      end
+
+      context "given a payload which invalidates an existing content item" do
+        let!(:draft) do
+          FactoryGirl.create(:draft_content_item, content_id: content_id, base_path: base_path)
+        end
+
+        let!(:version) { FactoryGirl.create(:version, target: draft, number: 2) }
+
+        # This payload will invalidate the existing item when the
+        # attributes are merged as redirects do not have routes.
+        let(:updated_payload) do
+          payload.except(:routes)
+            .merge(format: "redirect",
+                   redirects: [{
+                     type: "exact",
+                     path: "/vat-rates",
+                     destination: "/vat-rates/overview"
+                    }])
+        end
+
+        it "assigns attribute defaults before incrementing the version" do
+          described_class.call(updated_payload)
+
+          expect(version.reload.number).to eq(3)
         end
       end
     end


### PR DESCRIPTION
An edge case was discovered where a payload which changes the format of
an existing content item from a renderable format to a redirect may
invalidate the content item. This will cause version increment to be
bypassed as we check content item validity before assigning defaults.