### PR TITLE
Add GetLinked query

### DIFF
--- a/app/controllers/v2/link_sets_controller.rb
+++ b/app/controllers/v2/link_sets_controller.rb
@@ -1,5 +1,8 @@
 module V2
   class LinkSetsController < ApplicationController
+
+    rescue_from ActionController::ParameterMissing, with: :parameter_missing_error
+
     def get_links
       render json: Queries::GetLinkSet.call(content_id)
     end
@@ -12,6 +15,14 @@ module V2
       render status: response.code, json: response
     end
 
+    def get_linked
+      render json: Queries::GetLinked.new(
+        content_id: content_id,
+        link_type: params.fetch(:link_type),
+        fields: params.fetch(:fields),
+      ).call
+    end
+
   private
     def links_params
       payload.merge(content_id: content_id)
@@ -19,6 +30,17 @@ module V2
 
     def content_id
       params.fetch(:content_id)
+    end
+
+    def parameter_missing_error(e)
+      error = CommandError.new(code: 422, error_details: {
+        error: {
+          code: 422,
+          message: e.message
+        }
+      })
+
+      respond_with_command_error(error)
     end
   end
 end

--- a/app/queries/get_linked.rb
+++ b/app/queries/get_linked.rb
@@ -1,0 +1,66 @@
+module Queries
+  class GetLinked
+    attr_reader :target_content_id, :link_type, :fields
+
+    def initialize(content_id:, link_type:, fields:)
+      @target_content_id = content_id
+      @link_type = link_type
+      @fields = fields
+    end
+
+    def call
+      validate_presence_of_item!
+      validate_fields!
+
+      content_items.map do |content_item|
+        hash = content_item.as_json(only: fields)
+        publication_state = content_item.published? ? 'live' : 'draft'
+        hash['publication_state'] = publication_state if fields.any?
+        hash
+      end
+    end
+
+  private
+
+    def validate_presence_of_item!
+      return if DraftContentItem.where(content_id: target_content_id).any?
+
+      raise CommandError.new(code: 404, error_details: {
+        error: {
+          code: 404,
+          message: "No item with content_id: '#{target_content_id}'"
+        }
+      })
+    end
+
+    def validate_fields!
+      invalid_fields = fields - permitted_fields
+      return unless invalid_fields.any?
+
+      raise CommandError.new(code: 400, error_details: {
+        error: {
+          code: 400,
+          message: "Invalid column name(s): #{invalid_fields.to_sentence}"
+        }
+      })
+    end
+
+    def content_items
+      content_ids = Link.select("link_sets.content_id")
+                      .joins(:link_set)
+                      .where(target_content_id: target_content_id, link_type: link_type)
+
+      draft_items = DraftContentItem.includes(:live_content_item).where(content_id: content_ids)
+
+      live_items_without_draft = LiveContentItem
+                                  .where(content_id: content_ids)
+                                  .where.not(content_id: draft_items.map(&:content_id))
+
+      draft_items + live_items_without_draft
+    end
+
+    def permitted_fields
+      DraftContentItem.column_names
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,8 @@ Rails.application.routes.draw do
 
       get "/links/:content_id", to: "link_sets#get_links"
       put "/links/:content_id", to: "link_sets#put_links"
+
+      get "/linked/:content_id", to: "link_sets#get_linked"
     end
   end
 

--- a/spec/controllers/v2/link_sets_controller_spec.rb
+++ b/spec/controllers/v2/link_sets_controller_spec.rb
@@ -1,0 +1,64 @@
+require "rails_helper"
+
+RSpec.describe V2::LinkSetsController do
+  let(:content_id) { SecureRandom.uuid }
+
+  before do
+    create(:draft_content_item, content_id: content_id)
+    stub_request(:any, /content-store/)
+  end
+
+  describe "get_linked" do
+    context "called without providing fields parameter" do
+      it "is unsuccessful" do
+        get :get_linked, {
+          content_id: content_id,
+          link_type: "topic",
+        }
+
+        expect(response.status).to eq(422)
+      end
+    end
+
+    context "called without providing link_type parameter" do
+      before do
+        get :get_linked, {
+          content_id: content_id,
+          fields: []
+        }
+      end
+
+      it "is unsuccessful" do
+        expect(response.status).to eq(422)
+      end
+    end
+
+    context "for an existing content item" do
+      before do
+        get :get_linked, {
+          content_id: content_id,
+          link_type: "topic",
+          fields: []
+        }
+      end
+
+      it "is successful" do
+        expect(response.status).to eq(200)
+      end
+    end
+
+    context "for a non-existing content item" do
+      before do
+        get :get_linked, {
+          content_id: SecureRandom.uuid,
+          link_type: "topic",
+          fields: []
+        }
+      end
+
+      it "is unsuccessful" do
+        expect(response.status).to eq(404)
+      end
+    end
+  end
+end

--- a/spec/factories/live_content_item.rb
+++ b/spec/factories/live_content_item.rb
@@ -29,7 +29,7 @@ FactoryGirl.define do
       after(:build) do |live_content_item, evaluator|
         draft = FactoryGirl.build(
           :draft_content_item,
-          live_content_item.as_json(only: %i[content_id locale base_path format routes redirects]),
+          live_content_item.as_json(only: %i[title content_id locale base_path format routes redirects]),
         )
 
         raise "Draft is not valid: #{draft.errors.full_messages}" unless draft.valid?

--- a/spec/queries/get_linked_spec.rb
+++ b/spec/queries/get_linked_spec.rb
@@ -1,0 +1,99 @@
+require "rails_helper"
+
+RSpec.describe Queries::GetLinked do
+  let(:content_id) { SecureRandom.uuid }
+  let(:target_content_id) { SecureRandom.uuid }
+
+  describe "#call" do
+    context "item with given content id does not exist" do
+      it "raises not found error" do
+        non_existing_content_id = "39599c18-c7b8-4fd3-ae2d-a3c3cb310dd5"
+
+        expect {
+          Queries::GetLinked.new(
+            content_id: non_existing_content_id,
+            link_type: "organisations",
+            fields: [],
+          ).call
+        }.to raise_error(CommandError)
+      end
+    end
+
+    context "when content item exists "do
+      before do
+        create(:live_content_item, :with_draft, content_id: target_content_id, base_path: "/pay-now")
+      end
+
+      context "but no content item links to it" do
+        it "returns an empty array" do
+          expect(
+            Queries::GetLinked.new(
+              content_id: target_content_id,
+              link_type: "organisations",
+              fields: [],
+            ).call
+          ).to eq([ ])
+        end
+      end
+
+      context "but requested fields are invalid" do
+        it "raises an error" do
+          expect {
+            Queries::GetLinked.new(
+              content_id: target_content_id,
+              link_type: "organisations",
+              fields: ['not_existing'],
+            ).call
+          }.to raise_error(CommandError)
+        end
+      end
+
+      context "an item has a link of given type to it" do
+        before do
+          create(:live_content_item, :with_draft, content_id: content_id, title: "VAT and VATy things")
+          link_set = create(:link_set, content_id: content_id)
+          create(:link, link_set: link_set, link_type: "organisations", target_content_id: target_content_id)
+
+          content_item = create(:live_content_item, :with_draft, base_path: '/vatty', content_id: SecureRandom.uuid, title: "Another VATTY thing")
+          link_set = create(:link_set, content_id: content_item.content_id)
+          create(:link, link_set: link_set, link_type: "organisations", target_content_id: target_content_id)
+
+          create(:link, link_set: link_set, link_type: "related_links", target_content_id: SecureRandom.uuid)
+        end
+
+        context "custom fields have been requested" do
+          it "returns array of hashes, with requested fields" do
+            expect(
+              Queries::GetLinked.new(
+                content_id: target_content_id,
+                link_type: "organisations",
+                fields: ["title"])
+              .call
+            ).to match_array([
+              {
+                "title" => "Another VATTY thing",
+                "publication_state" => "live",
+              },
+              {
+                "title" => "VAT and VATy things",
+                "publication_state" => "live",
+              }
+            ])
+          end
+        end
+
+        context "no fields requested" do
+          it "returns array of empty hashes" do
+            expect(
+              Queries::GetLinked.new(
+                content_id: target_content_id,
+                link_type: "organisations",
+                fields: [])
+              .call
+            ).to eq([ {}, {} ])
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Get a list of the content which has a link of the given type to the given
content-id. This is the reverse lookup from the "get-links" lookup - find the
things which link to a piece of content.

Ticket:
https://trello.com/c/zppxFP6p/345-implement-the-publisher-get-linked-endpoint-and-refactor-how-links-are-stored-in-publishing-api