### PR TITLE
Fix N+1 query in `GetContentCollection`

### DIFF
--- a/app/queries/get_content_collection.rb
+++ b/app/queries/get_content_collection.rb
@@ -22,6 +22,7 @@ module Queries
 
     def content_items
       draft_items = DraftContentItem
+        .includes(:live_content_item)
         .where(format: [content_format, "placeholder_#{content_format}"])
         .select(*fields + %i[id content_id])
 


### PR DESCRIPTION
To discover the `publication_state` of items returned by this query, `content_item.published?` is called. 

This in turn kicks off another query for the `live_content_item`. This means an extra query is performed for each item in the collection. We can avoid that by preloading the `live_content_item`.

cc @tuzz 