### PR TITLE
Protect alpha_taxons from being overwritten

### DIFF
--- a/app/commands/put_content_with_links.rb
+++ b/app/commands/put_content_with_links.rb
@@ -82,7 +82,11 @@ module Commands
         version.increment
         version.save! if link_set.valid?
 
-        link_set.links.delete_all
+        # The "alpha_taxonomy" is a prototype for the new taxonomy on GOV.UK. It
+        # is being managed exclusively via the V2 API. While in the migration,
+        # we need to prevent these tags from being overwritten.
+        protected_tag_types = ['alpha_taxons']
+        link_set.links.where('link_type NOT IN (?)', protected_tag_types).delete_all
 
         if content_item[:links]
           content_item[:links].each do |link_type, links|

--- a/spec/commands/put_content_with_links_spec.rb
+++ b/spec/commands/put_content_with_links_spec.rb
@@ -1,0 +1,28 @@
+require "rails_helper"
+
+RSpec.describe Commands::PutContentWithLinks do
+  describe "#call" do
+    it "protects certain links from being overwritten" do
+      stub_request(:put, "http://draft-content-store.dev.gov.uk/content/foo")
+      stub_request(:put, "http://content-store.dev.gov.uk/content/foo")
+
+      link_set = create(:link_set, content_id: '60d81299-6ae7-4bab-b4fe-4235d518d50a')
+      protected_link = create(:link, link_set: link_set, link_type: 'alpha_taxons')
+      normal_link = create(:link, link_set: link_set, link_type: 'topics')
+
+      Commands::PutContentWithLinks.call({
+        title: 'Test Title',
+        format: 'placeholder',
+        content_id: '60d81299-6ae7-4bab-b4fe-4235d518d50a',
+        base_path: '/foo',
+        publishing_app: 'whitehall',
+        rendering_app: 'whitehall',
+        public_updated_at: Time.now,
+        routes: [{ path: '/foo', type: "exact" }],
+      })
+
+      expect { normal_link.reload }.to raise_error(ActiveRecord::RecordNotFound)
+      expect { protected_link.reload }.not_to raise_error
+    end
+  end
+end


### PR DESCRIPTION
The "alpha_taxonomy" is a prototype for the new taxonomy on GOV.UK. It is being managed exclusively via the V2 API. While in the migration, we need to prevent these tags from being overwritten by applications using the V1 endpoint.

It should be noted that this is a temporary "hack", because this code will be removed with the `/v1` endpoint once all apps have been upgraded.

Trello: https://trello.com/c/bsZAwZ35