### PR TITLE
Populate new links table

### DIFF
--- a/db/migrate/20151207154727_populate_links.rb
+++ b/db/migrate/20151207154727_populate_links.rb
@@ -1,0 +1,15 @@
+class PopulateLinks < ActiveRecord::Migration
+  def up
+    link_sets_with_populated_links = LinkSet.includes(:links).where("legacy_links::text <> '{}'::text")
+    link_sets_with_populated_links.find_each do |link_set|
+      # Only copy the links for items that haven't been touched since deploy.
+      next unless link_set.links.size == 0
+
+      link_set.legacy_links.each do |link_type, content_ids|
+        content_ids.each do |content_id|
+          link_set.links.create! link_type: link_type, target_content_id: content_id
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
https://github.com/alphagov/publishing-api/pull/137 added a new data database structure for the links. However, the data has not been migrated. This PR fixes that omission.

We don't copy the links for content items that already have `links`. These must have been added after #137 was deployed, and are therefore up-to-date.

Thanks @danielroseman for noticing this. 