### PR TITLE
CommandRetryable retries 5 times then raises 400.

### DIFF
--- a/app/event_logger.rb
+++ b/app/event_logger.rb
@@ -1,6 +1,6 @@
 module EventLogger
   def self.log_command(command_class, payload, &block)
-    tries = 3
+    tries = 5
     begin
       response = nil
 
@@ -19,7 +19,7 @@ module EventLogger
       if (tries -= 1) > 0
         retry
       else
-        raise CommandError.new(code: 500, message: "Too many retries - #{e.message}")
+        raise CommandError.new(code: 400, message: "Too many retries - #{e.message}")
       end
     end
   end

--- a/spec/event_logger_spec.rb
+++ b/spec/event_logger_spec.rb
@@ -50,10 +50,10 @@ RSpec.describe EventLogger do
     expect(LiveContentItem.count).to eq(1)
   end
 
-  it "retries three times in case if a CommandRetryableError is thrown, then raises CommandError" do
+  it "retries five times in case if a CommandRetryableError is thrown, then raises CommandError" do
     command = double()
     error = CommandRetryableError.new("something went wrong")
-    expect(command).to receive(:do_something).exactly(3).times.and_raise(error)
+    expect(command).to receive(:do_something).exactly(5).times.and_raise(error)
     expect {
       EventLogger.log_command(command_class, payload) do
         command.do_something


### PR DESCRIPTION
If the command still fails after five retries, we can be pretty sure that it is an error with the request itself, rather than with publishing-api.