### PR TITLE
Add Pact state for multiple publishing apps.

### DIFF
--- a/spec/service_consumers/pact_helper.rb
+++ b/spec/service_consumers/pact_helper.rb
@@ -201,4 +201,12 @@ Pact.provider_states_for "GDS API Adapters" do
       FactoryGirl.create(:draft_content_item, title: 'Content Item B', base_path: '/another-base-path', format: 'topic')
     end
   end
+
+  provider_state "there is content with format 'topic' for multiple publishing apps" do
+    set_up do
+      FactoryGirl.create(:draft_content_item, title: 'Content Item A', base_path: '/a-base-path', format: 'topic')
+      FactoryGirl.create(:draft_content_item, title: 'Content Item B', base_path: '/another-base-path', format: 'topic')
+      FactoryGirl.create(:draft_content_item, title: 'Content Item C', base_path: '/yet-another-base-path', format: 'topic', publishing_app: 'whitehall')
+    end
+  end
 end


### PR DESCRIPTION
This is a precondition for adding functionality here and in gds-api-adapters to filter the get_content_items endpoint by the publishing_app field.