### PR TITLE
Fix replaying events import...

### DIFF
--- a/app/commands/base_command.rb
+++ b/app/commands/base_command.rb
@@ -1,17 +1,18 @@
 module Commands
   class BaseCommand
-    def self.call(payload)
-      self.new(payload).call
+    def self.call(payload, downstream: true)
+      self.new(payload, downstream: downstream).call
     rescue ActiveRecord::RecordInvalid => e
       raise_validation_command_error(e)
     end
 
-    def initialize(payload)
+    def initialize(payload, downstream: true)
       @payload = payload
+      @downstream = downstream
     end
 
   private
-    attr_reader :payload
+    attr_reader :payload, :downstream
 
     def base_path
       payload[:base_path]

--- a/app/commands/delete_publish_intent.rb
+++ b/app/commands/delete_publish_intent.rb
@@ -1,7 +1,9 @@
 module Commands
   class DeletePublishIntent < BaseCommand
     def call
-      PublishingAPI.service(:live_content_store).delete_publish_intent(base_path)
+      if downstream
+        PublishingAPI.service(:live_content_store).delete_publish_intent(base_path)
+      end
 
       Success.new({})
     rescue GdsApi::HTTPServerError => e

--- a/app/commands/put_content_with_links.rb
+++ b/app/commands/put_content_with_links.rb
@@ -1,6 +1,6 @@
 module Commands
   class PutContentWithLinks < BaseCommand
-    def call(downstream: true)
+    def call
       if content_item[:content_id]
         draft_content_item = create_or_update_draft_content_item!
         create_or_update_live_content_item!(draft_content_item)

--- a/app/commands/put_draft_content_with_links.rb
+++ b/app/commands/put_draft_content_with_links.rb
@@ -1,6 +1,6 @@
 module Commands
   class PutDraftContentWithLinks < PutContentWithLinks
-    def call(downstream: true)
+    def call
       if content_item[:content_id]
         create_or_update_draft_content_item!
         create_or_update_links!

--- a/app/commands/put_publish_intent.rb
+++ b/app/commands/put_publish_intent.rb
@@ -3,8 +3,10 @@ module Commands
     def call
       PathReservation.reserve_base_path!(base_path, payload[:publishing_app])
 
-      payload = Presenters::DownstreamPresenter::V1.present(publish_intent, transmitted_at: false)
-      Adapters::ContentStore.put_publish_intent(base_path, payload)
+      if downstream
+        payload = Presenters::DownstreamPresenter::V1.present(publish_intent, transmitted_at: false)
+        Adapters::ContentStore.put_publish_intent(base_path, payload)
+      end
 
       Success.new(payload)
     end

--- a/app/commands/v2/discard_draft.rb
+++ b/app/commands/v2/discard_draft.rb
@@ -31,21 +31,25 @@ module Commands
       def update_draft_from_live
         draft.update_attributes(live.attributes.except("id", "draft_content_item_id"))
 
-        ContentStoreWorker.perform_async(
-          content_store: Adapters::DraftContentStore,
-          base_path: draft.base_path,
-          payload: Presenters::ContentStorePresenter.present(live),
-        )
+        if downstream
+          ContentStoreWorker.perform_async(
+            content_store: Adapters::DraftContentStore,
+            base_path: draft.base_path,
+            payload: Presenters::ContentStorePresenter.present(live),
+          )
+        end
       end
 
       def delete_draft
         draft.destroy
 
-        ContentStoreWorker.perform_async(
-          content_store: Adapters::DraftContentStore,
-          base_path: draft.base_path,
-          delete: true,
-        )
+        if downstream
+          ContentStoreWorker.perform_async(
+            content_store: Adapters::DraftContentStore,
+            base_path: draft.base_path,
+            delete: true,
+          )
+        end
       end
 
       def draft

--- a/app/commands/v2/publish.rb
+++ b/app/commands/v2/publish.rb
@@ -76,15 +76,17 @@ module Commands
           end
         end
 
-        live_payload = Presenters::ContentStorePresenter.present(live_content_item)
-        ContentStoreWorker.perform_async(
-          content_store: Adapters::ContentStore,
-          base_path: live_content_item.base_path,
-          payload: live_payload,
-        )
+        if downstream
+          live_payload = Presenters::ContentStorePresenter.present(live_content_item)
+          ContentStoreWorker.perform_async(
+            content_store: Adapters::ContentStore,
+            base_path: live_content_item.base_path,
+            payload: live_payload,
+          )
 
-        queue_payload = Presenters::MessageQueuePresenter.present(live_content_item, update_type: update_type)
-        PublishingAPI.service(:queue_publisher).send_message(queue_payload)
+          queue_payload = Presenters::MessageQueuePresenter.present(live_content_item, update_type: update_type)
+          PublishingAPI.service(:queue_publisher).send_message(queue_payload)
+        end
       end
 
       def build_live_attributes(draft_content_item)

--- a/app/commands/v2/put_content.rb
+++ b/app/commands/v2/put_content.rb
@@ -8,12 +8,14 @@ module Commands
 
         PathReservation.reserve_base_path!(base_path, content_item[:publishing_app])
 
-        draft_payload = Presenters::ContentStorePresenter.present(content_item)
-        ContentStoreWorker.perform_async(
-          content_store: Adapters::DraftContentStore,
-          base_path: base_path,
-          payload: draft_payload,
-        )
+        if downstream
+          draft_payload = Presenters::ContentStorePresenter.present(content_item)
+          ContentStoreWorker.perform_async(
+            content_store: Adapters::DraftContentStore,
+            base_path: base_path,
+            payload: draft_payload,
+          )
+        end
 
         response_hash = Presenters::Queries::ContentItemPresenter.present(content_item)
         Success.new(response_hash)


### PR DESCRIPTION
Ensure that events import will not attempt to call downstream services
by stubbing these. Also logs newly created events to file.

This is necessary for the successful import of publishing api data from content store.