### PR TITLE
Update get linked endpoint

### DIFF
--- a/app/queries/get_linked.rb
+++ b/app/queries/get_linked.rb
@@ -35,12 +35,20 @@ module Queries
 
     def validate_fields!
       invalid_fields = fields - permitted_fields
-      return unless invalid_fields.any?
+      return if invalid_fields.empty? && fields.any?
 
-      raise CommandError.new(code: 400, error_details: {
+      if fields.empty?
+        code = 422
+        message = "Fields must be provided"
+      else
+        code = 400
+        message = "Invalid column field(s): #{invalid_fields.to_sentence}"
+      end
+
+      raise CommandError.new(code: code, error_details: {
         error: {
-          code: 400,
-          message: "Invalid column name(s): #{invalid_fields.to_sentence}"
+          code: code,
+          message: message
         }
       })
     end

--- a/app/queries/get_linked.rb
+++ b/app/queries/get_linked.rb
@@ -23,7 +23,9 @@ module Queries
   private
 
     def validate_presence_of_item!
-      return if DraftContentItem.where(content_id: target_content_id).any?
+      return if DraftContentItem.exists?(content_id: target_content_id) ||
+                LiveContentItem.exists?(content_id: target_content_id)
+
 
       raise CommandError.new(code: 404, error_details: {
         error: {

--- a/spec/controllers/v2/link_sets_controller_spec.rb
+++ b/spec/controllers/v2/link_sets_controller_spec.rb
@@ -20,11 +20,23 @@ RSpec.describe V2::LinkSetsController do
       end
     end
 
+    context "called with empty fields parameter" do
+      it "is unsuccessful" do
+        get :get_linked, {
+          content_id: content_id,
+          link_type: "topic",
+          fields: []
+        }
+
+        expect(response.status).to eq(422)
+      end
+    end
+
     context "called without providing link_type parameter" do
       before do
         get :get_linked, {
           content_id: content_id,
-          fields: []
+          fields: ["content_id"]
         }
       end
 
@@ -38,7 +50,7 @@ RSpec.describe V2::LinkSetsController do
         get :get_linked, {
           content_id: content_id,
           link_type: "topic",
-          fields: []
+          fields: ["content_id"]
         }
       end
 
@@ -52,7 +64,7 @@ RSpec.describe V2::LinkSetsController do
         get :get_linked, {
           content_id: SecureRandom.uuid,
           link_type: "topic",
-          fields: []
+          fields: ["content_id"]
         }
       end
 

--- a/spec/queries/get_linked_spec.rb
+++ b/spec/queries/get_linked_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Queries::GetLinked do
           Queries::GetLinked.new(
             content_id: non_existing_content_id,
             link_type: "organisations",
-            fields: [],
+            fields: ["title"],
           ).call
         }.to raise_error(CommandError)
       end
@@ -30,7 +30,7 @@ RSpec.describe Queries::GetLinked do
             Queries::GetLinked.new(
               content_id: target_content_id,
               link_type: "organisations",
-              fields: [],
+              fields: ["title"],
             ).call
           ).to eq([ ])
         end
@@ -82,16 +82,6 @@ RSpec.describe Queries::GetLinked do
           end
         end
 
-        context "no fields requested" do
-          it "returns array of empty hashes" do
-            expect(
-              Queries::GetLinked.new(
-                content_id: target_content_id,
-                link_type: "organisations",
-                fields: [])
-              .call
-            ).to eq([ {}, {} ])
-          end
         end
       end
     end


### PR DESCRIPTION
I missed a couple of points when I've added this endpoint:

- Content items do not have always a draft version
- The query should not allow requests with an empty `fields` parameter

This PR is updating the endpoint to take care of them.