### PR TITLE
Update import task to use downstream named param...

### DIFF
--- a/lib/tasks/import_data.rb
+++ b/lib/tasks/import_data.rb
@@ -26,7 +26,7 @@ module Tasks
             updated_at: updated_at,
           )
 
-          command_class.new(content_item_hash).call(downstream: false)
+          command_class.call(content_item_hash, downstream: false)
         end
 
         print_progress(index, total_lines)


### PR DESCRIPTION
This importer should use the modified way of switching off downstream service calls.