### PR TITLE
Fix broken migrations

### DIFF
--- a/db/migrate/20151026170157_set_empty_links_to_hash.rb
+++ b/db/migrate/20151026170157_set_empty_links_to_hash.rb
@@ -1,6 +1,8 @@
 class SetEmptyLinksToHash < ActiveRecord::Migration
   def change
-    LinkSet.where(links: nil).update_all(links: {})
-    raise "There are LinkSet records with links=nil, this should not happen!" if LinkSet.where(links: nil).any?
+    if LinkSet.column_names.include?("link_set_id")
+      LinkSet.where(links: nil).update_all(links: {})
+      raise "There are LinkSet records with links=nil, this should not happen!" if LinkSet.where(links: nil).any?
+    end
   end
 end


### PR DESCRIPTION
LinkSet doesn't have 'link_set_id' column, which breaks older migrations. Only
conditionally execute this migration if LinkSet has this column.