### PR TITLE
Expose redrafted status and live_version

### DIFF
--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -19,6 +19,11 @@ class Version < ActiveRecord::Base
     self.number != previous_version_number
   end
 
+  def self.in_bulk(items, type)
+    id_list = items.reject(&:blank?).map(&:id)
+    self.where(target: id_list, target_type: type.to_s).index_by(&:target_id)
+  end
+
 private
 
   def numbers_must_increase

--- a/app/presenters/queries/content_item_presenter.rb
+++ b/app/presenters/queries/content_item_presenter.rb
@@ -3,12 +3,14 @@ module Presenters
     class ContentItemPresenter
       def self.present(content_item)
         version = Version.find_by(target: content_item)
-        new(content_item, version).present
+        live_version = Version.find_by(target: content_item.live_content_item)
+        new(content_item, version, live_version).present
       end
 
-      def initialize(content_item, version)
+      def initialize(content_item, version, live_version)
         self.content_item = content_item
         self.version = version
+        self.live_version = live_version
       end
 
       def present
@@ -17,15 +19,19 @@ module Presenters
           .merge(
             version: version.number,
             publication_state: publication_state,
-          )
+          ).tap { |h| h[:live_version] = live_version.number if live_version.present? }
       end
 
     private
 
-      attr_accessor :content_item, :version
+      attr_accessor :content_item, :version, :live_version
 
       def publication_state
-        content_item.live_content_item.present? ? 'live' : 'draft'
+        if live_version.nil?
+          'draft'
+        else
+          version.number > live_version.number ? 'redrafted' : 'live'
+        end
       end
     end
   end

--- a/app/presenters/queries/content_item_presenter.rb
+++ b/app/presenters/queries/content_item_presenter.rb
@@ -17,9 +17,11 @@ module Presenters
         content_item.as_json
           .symbolize_keys
           .merge(
-            version: version.number,
             publication_state: publication_state,
-          ).tap { |h| h[:live_version] = live_version.number if live_version.present? }
+          ).tap do |h| 
+            h[:live_version] = live_version.number if live_version.present?
+            h[:version] = version.number if version.present?
+          end
       end
 
     private
@@ -29,6 +31,8 @@ module Presenters
       def publication_state
         if live_version.nil?
           'draft'
+        elsif version.nil?
+          'live'
         else
           version.number > live_version.number ? 'redrafted' : 'live'
         end

--- a/app/queries/get_content_collection.rb
+++ b/app/queries/get_content_collection.rb
@@ -14,8 +14,8 @@ module Queries
       content_items.map do |content_item|
         hash = Presenters::Queries::ContentItemPresenter.new(
           content_item,
-          draft_versions[content_item.id],
-          live_versions[content_item.live_content_item.try(:id)]
+          draft_version(content_item),
+          live_version(content_item)
         )
         hash.present.as_json(only: output_fields)
       end
@@ -65,6 +65,24 @@ module Queries
 
     def permitted_fields
       DraftContentItem.column_names
+    end
+
+    def draft_version(item)
+      case item
+      when DraftContentItem
+        @draft_versions[item.id]
+      when LiveContentItem
+        @draft_versions[item.draft_content_item.try(:id)]
+      end
+    end
+
+    def live_version(item)
+      case item
+      when DraftContentItem
+        @live_versions[item.live_content_item.try(:id)]
+      when LiveContentItem
+        @live_versions[item.id]
+      end
     end
   end
 end

--- a/app/queries/get_linked.rb
+++ b/app/queries/get_linked.rb
@@ -15,8 +15,8 @@ module Queries
       content_items.map do |content_item|
         hash = Presenters::Queries::ContentItemPresenter.new(
           content_item,
-          draft_versions[content_item.id],
-          live_versions[content_item.live_content_item.try(:id)]
+          draft_version(content_item),
+          live_version(content_item)
         )
         hash.present.as_json(only: output_fields)
       end
@@ -84,6 +84,24 @@ module Queries
 
     def permitted_fields
       DraftContentItem.column_names
+    end
+
+    def draft_version(item)
+      case item
+      when DraftContentItem
+        @draft_versions[item.id]
+      when LiveContentItem
+        @draft_versions[item.draft_content_item.try(:id)]
+      end
+    end
+
+    def live_version(item)
+      case item
+      when DraftContentItem
+        @live_versions[item.live_content_item.try(:id)]
+      when LiveContentItem
+        @live_versions[item.id]
+      end
     end
   end
 end

--- a/spec/factories/draft_content_item.rb
+++ b/spec/factories/draft_content_item.rb
@@ -28,6 +28,12 @@ FactoryGirl.define do
         }
       ]
     }
+
+    trait :with_version do
+      after(:create) do |item, evaluator|
+        FactoryGirl.create(:version, target: item)
+      end
+    end
   end
 
   factory :redirect_draft_content_item, parent: :draft_content_item do

--- a/spec/factories/live_content_item.rb
+++ b/spec/factories/live_content_item.rb
@@ -25,6 +25,12 @@ FactoryGirl.define do
       ]
     }
 
+    trait :with_version do
+      after(:create) do |item, evaluator|
+        FactoryGirl.create(:version, target: item)
+      end
+    end
+
     trait :with_draft do
       after(:build) do |live_content_item, evaluator|
         draft = FactoryGirl.build(
@@ -35,6 +41,13 @@ FactoryGirl.define do
         raise "Draft is not valid: #{draft.errors.full_messages}" unless draft.valid?
 
         live_content_item.draft_content_item = draft
+      end
+    end
+
+    trait :with_draft_version do
+      with_draft
+      after(:create) do |live_content_item, evaluator|
+        FactoryGirl.create(:version, target: live_content_item.draft_content_item)
       end
     end
   end

--- a/spec/models/version_spec.rb
+++ b/spec/models/version_spec.rb
@@ -124,4 +124,15 @@ RSpec.describe Version do
       end
     end
   end
+
+  describe "::in_bulk" do
+    it "returns a hash of Versions for a set of items, keyed by item id" do
+      items = 5.times.map do |i|
+        FactoryGirl.create(:draft_content_item, :with_version, base_path: "/page-#{i}")
+      end
+      
+      versions = Version.in_bulk(items, DraftContentItem)
+      expect(versions.keys).to eq(items.map(&:id))
+    end
+  end
 end

--- a/spec/presenters/queries/content_item_presenter_spec.rb
+++ b/spec/presenters/queries/content_item_presenter_spec.rb
@@ -56,5 +56,15 @@ RSpec.describe Presenters::Queries::ContentItemPresenter do
         expect(result.fetch(:live_version)).to eq(100)
       end
     end
+
+    context "with a live version only" do
+      let(:content_item) { FactoryGirl.create(:live_content_item, content_id: content_id ) }
+      let!(:version) { FactoryGirl.create(:version, target: content_item, number: 100) }
+      let(:result) { Presenters::Queries::ContentItemPresenter.new(content_item, nil, version).present }
+
+      it "shows the publication state of the content item as live" do
+        expect(result.fetch(:publication_state)).to eq("live")
+      end
+    end
   end
 end

--- a/spec/presenters/queries/content_item_presenter_spec.rb
+++ b/spec/presenters/queries/content_item_presenter_spec.rb
@@ -3,23 +3,58 @@ require 'rails_helper'
 RSpec.describe Presenters::Queries::ContentItemPresenter do
   describe "present" do
     let(:content_id) { SecureRandom.uuid }
-
-    before do
-      content_item = FactoryGirl.create(:draft_content_item, content_id: content_id)
-      FactoryGirl.create(:version, target: content_item, number: 101)
-      @result = Presenters::Queries::ContentItemPresenter.present(content_item)
-    end
+    let(:content_item) { FactoryGirl.create(:draft_content_item, content_id: content_id) }
+    let!(:version) { FactoryGirl.create(:version, target: content_item, number: 101) }
+    let(:result) { Presenters::Queries::ContentItemPresenter.present(content_item) }
 
     it "presents content item attributes as a hash" do
-      expect(@result.fetch(:content_id)).to eq(content_id)
+      expect(result.fetch(:content_id)).to eq(content_id)
     end
 
     it "exposes the version number of the content item" do
-      expect(@result.fetch(:version)).to eq(101)
+      expect(result.fetch(:version)).to eq(101)
     end
 
-    it "exposes the publication state of the content item" do
-      expect(@result.fetch(:publication_state)).to eq("draft")
+    context "with no published version" do
+      it "shows the publication state of the content item as draft" do
+        expect(result.fetch(:publication_state)).to eq("draft")
+      end
+
+      it "does not include live_version" do
+        expect(result).not_to have_key(:live_version)
+      end
+    end
+
+    context "with a published version and no subsequent draft" do
+      let(:live_content_item) { FactoryGirl.create(:live_content_item, content_id: content_id, draft_content_item: content_item) }
+
+      before do
+        FactoryGirl.create(:version, target: live_content_item, number: 101)
+      end
+
+      it "shows the publication state of the content item as live" do
+        expect(result.fetch(:publication_state)).to eq("live")
+      end
+
+      it "exposes the live version number" do
+        expect(result.fetch(:live_version)).to eq(101)
+      end
+    end
+
+    context "with a published version and a subsequent draft" do
+      let(:live_content_item) { FactoryGirl.create(:live_content_item, content_id: content_id, draft_content_item: content_item) }
+
+      before do
+        FactoryGirl.create(:version, target: live_content_item, number: 100)
+      end
+
+      it "shows the publication state of the content item as redrafted" do
+        expect(result.fetch(:publication_state)).to eq("redrafted")
+      end
+
+      it "exposes the live version number" do
+        expect(result.fetch(:live_version)).to eq(100)
+      end
     end
   end
 end

--- a/spec/queries/get_content_collection_spec.rb
+++ b/spec/queries/get_content_collection_spec.rb
@@ -2,9 +2,9 @@ require "rails_helper"
 
 RSpec.describe Queries::GetContentCollection do
   it "returns the content items of the given format" do
-    create(:draft_content_item, base_path: '/a', format: 'topic')
-    create(:draft_content_item, base_path: '/b',  format: 'topic')
-    create(:draft_content_item, base_path: '/c',  format: 'mainstream_browse_page')
+    create(:draft_content_item, :with_version, base_path: '/a', format: 'topic')
+    create(:draft_content_item, :with_version, base_path: '/b',  format: 'topic')
+    create(:draft_content_item, :with_version, base_path: '/c',  format: 'mainstream_browse_page')
 
     expect(Queries::GetContentCollection.new(
       content_format: 'topic',
@@ -16,8 +16,8 @@ RSpec.describe Queries::GetContentCollection do
   end
 
   it "returns the content items of the given format, and placeholder_format" do
-    create(:draft_content_item, base_path: '/a', format: 'topic')
-    create(:draft_content_item, base_path: '/b', format: 'placeholder_topic')
+    create(:draft_content_item, :with_version, base_path: '/a', format: 'topic')
+    create(:draft_content_item, :with_version, base_path: '/b', format: 'placeholder_topic')
 
     expect(Queries::GetContentCollection.new(
       content_format: 'topic',
@@ -29,8 +29,8 @@ RSpec.describe Queries::GetContentCollection do
   end
 
   it "includes the publishing state of the item" do
-    create(:draft_content_item, base_path: '/draft', format: 'topic')
-    item = create(:live_content_item, base_path: '/live',  format: 'topic')
+    create(:draft_content_item, :with_version, base_path: '/draft', format: 'topic')
+    create(:live_content_item, :with_version, :with_draft_version, base_path: '/live',  format: 'topic')
 
     expect(Queries::GetContentCollection.new(
       content_format: 'topic',
@@ -63,9 +63,9 @@ RSpec.describe Queries::GetContentCollection do
 
   context "filtering by publishing_app" do
     before do
-      create(:draft_content_item, base_path: '/a', format: 'topic', publishing_app: 'publisher')
-      create(:draft_content_item, base_path: '/b',  format: 'topic', publishing_app: 'publisher')
-      create(:draft_content_item, base_path: '/c',  format: 'topic', publishing_app: 'whitehall')
+      create(:draft_content_item, :with_version, base_path: '/a', format: 'topic', publishing_app: 'publisher')
+      create(:draft_content_item, :with_version, base_path: '/b',  format: 'topic', publishing_app: 'publisher')
+      create(:draft_content_item, :with_version, base_path: '/c',  format: 'topic', publishing_app: 'whitehall')
     end
 
     it "returns items corresponding to the publishing_app parameter if present" do

--- a/spec/queries/get_linked_spec.rb
+++ b/spec/queries/get_linked_spec.rb
@@ -63,11 +63,11 @@ RSpec.describe Queries::GetLinked do
 
       context "content items link to the wanted content item" do
         before do
-          create(:live_content_item, :with_draft, content_id: content_id, title: "VAT and VATy things")
+          create(:live_content_item, :with_version, :with_draft_version, content_id: content_id, title: "VAT and VATy things")
           link_set = create(:link_set, content_id: content_id)
           create(:link, link_set: link_set, link_type: "organisations", target_content_id: target_content_id)
 
-          content_item = create(:live_content_item, :with_draft, base_path: '/vatty', content_id: SecureRandom.uuid, title: "Another VATTY thing")
+          content_item = create(:live_content_item, :with_version, :with_draft_version, base_path: '/vatty', content_id: SecureRandom.uuid, title: "Another VATTY thing")
           link_set = create(:link_set, content_id: content_item.content_id)
           create(:link, link_set: link_set, link_type: "organisations", target_content_id: target_content_id)
 
@@ -100,11 +100,11 @@ RSpec.describe Queries::GetLinked do
         before do
           create(:live_content_item, :with_draft, content_id: another_target_content_id, base_path: "/send-now")
 
-          create(:draft_content_item, content_id: content_id, title: "HMRC documents")
+          create(:draft_content_item, :with_version, content_id: content_id, title: "HMRC documents")
           link_set = create(:link_set, content_id: content_id)
           create(:link, link_set: link_set, link_type: "organisations", target_content_id: another_target_content_id)
 
-          content_item = create(:draft_content_item, base_path: '/other-hmrc-document', content_id: SecureRandom.uuid, title: "Another HMRC document")
+          content_item = create(:draft_content_item, :with_version, base_path: '/other-hmrc-document', content_id: SecureRandom.uuid, title: "Another HMRC document")
           link_set = create(:link_set, content_id: content_item.content_id)
           create(:link, link_set: link_set, link_type: "organisations", target_content_id: another_target_content_id)
 


### PR DESCRIPTION
If an item has been published then subsequently edited - ie it has a live
version number less than the draft version number - then publication_state is
reported as "redrafted".

Also expose live_version attribute if the item has been published.