### PR TITLE
Better base path errors

### DIFF
--- a/app/models/draft_content_item.rb
+++ b/app/models/draft_content_item.rb
@@ -17,7 +17,7 @@ class DraftContentItem < ActiveRecord::Base
 
   validates :content_id, presence: true, uuid: true
   validate :content_ids_match
-  validates :base_path, presence: true, absolute_path: true
+  validates :base_path, presence: true, absolute_path: true, uniqueness: true
   validates :format, presence: true
   validates :publishing_app, presence: true
   validates :title, presence: true, if: :renderable_content?

--- a/app/models/live_content_item.rb
+++ b/app/models/live_content_item.rb
@@ -30,7 +30,7 @@ class LiveContentItem < ActiveRecord::Base
 
   validates :content_id, presence: true, uuid: true
   validate :content_ids_match
-  validates :base_path, presence: true, absolute_path: true
+  validates :base_path, presence: true, absolute_path: true, uniqueness: true
   validates :format, presence: true
   validates :publishing_app, presence: true
   validates :title, presence: true, if: :renderable_content?

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151126135748) do
+ActiveRecord::Schema.define(version: 20151207154727) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/spec/commands/v2/reallocating_base_path_spec.rb
+++ b/spec/commands/v2/reallocating_base_path_spec.rb
@@ -31,7 +31,9 @@ RSpec.describe "Reallocating base paths of content items" do
     it "cannot be replaced by another regular content item" do
       expect {
         command.call(regular_payload)
-      }.to raise_error(CommandRetryableError)
+      }.to raise_error(CommandError) { |error|
+        expect(error.code).to eq(422)
+      }
     end
 
     it "can be replaced by a 'substitute' content item" do
@@ -50,7 +52,9 @@ RSpec.describe "Reallocating base paths of content items" do
     it "cannot be replaced by another regular content item" do
       expect {
         command.call(regular_payload)
-      }.to raise_error(CommandRetryableError)
+      }.to raise_error(CommandError) { |error|
+        expect(error.code).to eq(422)
+      }
     end
 
     it "can be replaced by a 'substitute' content item" do
@@ -132,7 +136,9 @@ RSpec.describe "Reallocating base paths of content items" do
       it "raises an error" do
         expect {
           command.call(payload)
-        }.to raise_error(CommandRetryableError)
+        }.to raise_error(CommandError) { |error|
+          expect(error.code).to eq(422)
+        }
       end
     end
 
@@ -234,7 +240,9 @@ RSpec.describe "Reallocating base paths of content items" do
         it "cannot be replaced by another regular content item" do
           expect {
             command.call(regular_payload)
-          }.to raise_error(CommandRetryableError)
+          }.to raise_error(CommandError) { |error|
+            expect(error.code).to eq(422)
+          }
         end
 
         it "can be replaced by a 'substitute' content item" do
@@ -253,7 +261,9 @@ RSpec.describe "Reallocating base paths of content items" do
         it "cannot be replaced by another regular content item" do
           expect {
             command.call(regular_payload)
-          }.to raise_error(CommandRetryableError)
+          }.to raise_error(CommandError) { |error|
+            expect(error.code).to eq(422)
+          }
         end
 
         it "replaces both the draft and live content items" do

--- a/spec/models/draft_content_item_spec.rb
+++ b/spec/models/draft_content_item_spec.rb
@@ -129,7 +129,7 @@ RSpec.describe DraftContentItem do
         subject = FactoryGirl.build(:redirect_draft_content_item, base_path: "/foo")
 
         expect {
-          subject.save!
+          subject.save(validate: false)
         }.to raise_error(ActiveRecord::RecordNotUnique)
       end
     end

--- a/spec/models/live_content_item_spec.rb
+++ b/spec/models/live_content_item_spec.rb
@@ -121,7 +121,7 @@ RSpec.describe LiveContentItem do
         subject = FactoryGirl.build(:redirect_live_content_item, base_path: "/foo")
 
         expect {
-          subject.save!
+          subject.save(validate: false)
         }.to raise_error(ActiveRecord::RecordNotUnique)
       end
     end


### PR DESCRIPTION
Adds an active record validation for base path uniqueness, as well as the existing DB-level constraint.

This provides better error messaging to upstream applications and prevent retrying when the violation is not from a race condition, leaving the DB constraint to catch the less-common race condition.

Also commits a schema version that was left out of someone's previous code.

https://trello.com/c/Mq3b2dz1/423-handle-too-many-retries-errors-more-gracefully