### PR TITLE
Add rake task for sanitizing access limited drafts.

### DIFF
--- a/app/commands/v2/discard_draft.rb
+++ b/app/commands/v2/discard_draft.rb
@@ -29,7 +29,12 @@ module Commands
       end
 
       def update_draft_from_live
-        draft.update_attributes(live.attributes.except("id", "draft_content_item_id"))
+        live_attributes = live.attributes.except("id", "draft_content_item_id")
+        safe_attributes = live_attributes.merge(
+          "access_limited" => {}
+        )
+
+        draft.update_attributes(safe_attributes)
 
         if downstream
           ContentStoreWorker.perform_async(

--- a/lib/tasks/data_sanitizer.rb
+++ b/lib/tasks/data_sanitizer.rb
@@ -1,0 +1,11 @@
+module Tasks
+  class DataSanitizer
+    def self.delete_access_limited(stdout)
+      DraftContentItem.where("access_limited::text <> '{}'::text").each do |limited_draft|
+        stdout.puts "Discarding access limited draft content item '#{limited_draft.content_id}'"
+        simulated_payload = limited_draft.as_json.symbolize_keys
+        Commands::V2::DiscardDraft.call(simulated_payload, downstream: true)
+      end
+    end
+  end
+end

--- a/lib/tasks/sanitize_data.rake
+++ b/lib/tasks/sanitize_data.rake
@@ -1,0 +1,4 @@
+desc "Sanitize access limited data"
+task sanitize_data: :environment do
+  Tasks::DataSanitizer.delete_access_limited(STDOUT)
+end

--- a/spec/lib/tasks/data_sanitizer_spec.rb
+++ b/spec/lib/tasks/data_sanitizer_spec.rb
@@ -1,0 +1,45 @@
+require "rails_helper"
+
+RSpec.describe Tasks::DataSanitizer do
+  let!(:non_limited_draft) { FactoryGirl.create(:draft_content_item) }
+  let!(:limited_draft) { FactoryGirl.create(:access_limited_draft_content_item) }
+  let!(:live_content_item) { FactoryGirl.create(:live_content_item) }
+  let(:stdout) { double(:stdout, puts: nil)}
+
+  before do
+    stub_request(:any, %r{.*draft-content-store.*/content/.*})
+  end
+
+  it "deletes all access limited drafts" do
+    Tasks::DataSanitizer.delete_access_limited(stdout)
+
+    expect(DraftContentItem.exists?(limited_draft.id)).to eq(false)
+    expect(DraftContentItem.exists?(non_limited_draft.id)).to eq(true)
+    expect(LiveContentItem.exists?(live_content_item.id)).to eq(true)
+  end
+
+  it "deletes access limited drafts from the draft content store" do
+    expect(PublishingAPI.service(:draft_content_store)).to receive(:delete_content_item)
+      .with(limited_draft.base_path)
+
+    Tasks::DataSanitizer.delete_access_limited(stdout)
+  end
+
+  it "resets drafts to live if available, wiping access limiting" do
+    FactoryGirl.create(:live_content_item,
+      base_path: limited_draft.base_path,
+      content_id: limited_draft.content_id,
+      draft_content_item: limited_draft,
+      title: "A live content item",
+    )
+
+    Tasks::DataSanitizer.delete_access_limited(stdout)
+
+    expect(DraftContentItem.exists?(limited_draft.id)).to eq(true)
+
+    limited_draft.reload
+
+    expect(limited_draft.title).to eq("A live content item")
+    expect(limited_draft.access_limited).to eq({})
+  end
+end


### PR DESCRIPTION
Changes the draft discard code so access limiting is also reset.  @danielroseman I remember us having a conversation about this but not the conclusion.  Did we say we needed to keep these access limits around after a reset?