### PR TITLE
Extracts access limiting into its own model.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,7 @@ gem 'whenever', '0.9.4', :require => false
 gem "sidekiq", "3.5.1"
 gem "sidekiq-logging-json", "0.0.14"
 gem "sidekiq-statsd", "0.1.5"
+gem "deprecated_columns"
 
 group :development do
   # Access an IRB console on exception pages or by using <%= console %> in views

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -76,6 +76,8 @@ GEM
       safe_yaml (~> 1.0.0)
     database_cleaner (1.3.0)
     debug_inspector (0.0.2)
+    deprecated_columns (0.1.0)
+      rails (>= 4.0)
     diff-lcs (1.2.5)
     docile (1.1.5)
     domain_name (0.5.24)
@@ -313,6 +315,7 @@ DEPENDENCIES
   airbrake (~> 4.2.1)
   bunny (= 2.0.0)
   database_cleaner
+  deprecated_columns
   factory_girl_rails (= 4.5.0)
   gds-api-adapters (= 25.1.0)
   govuk-client-url_arbiter (= 0.0.3)

--- a/app/adapters/content_store.rb
+++ b/app/adapters/content_store.rb
@@ -6,7 +6,7 @@ module Adapters
       CommandError.with_error_handling do
         PublishingAPI.service(:live_content_store).put_content_item(
           base_path: base_path,
-          content_item: content_item.except(:access_limited),
+          content_item: content_item,
         )
       end
     end

--- a/app/commands/put_content_with_links.rb
+++ b/app/commands/put_content_with_links.rb
@@ -11,8 +11,7 @@ module Commands
 
       if downstream
         content_store_payload = Presenters::DownstreamPresenter::V1.present(
-          content_item,
-          access_limited: false,
+          content_item.except(:access_limited),
           update_type: false
         )
 
@@ -21,7 +20,6 @@ module Commands
 
         message_bus_payload = Presenters::DownstreamPresenter::V1.present(
           payload,
-          access_limited: false,
         )
         PublishingAPI.service(:queue_publisher).send_message(message_bus_payload)
       end

--- a/app/commands/v2/discard_draft.rb
+++ b/app/commands/v2/discard_draft.rb
@@ -11,6 +11,8 @@ module Commands
           delete_draft
         end
 
+        delete_access_limit
+
         Success.new(content_id: content_id)
       end
 
@@ -29,12 +31,7 @@ module Commands
       end
 
       def update_draft_from_live
-        live_attributes = live.attributes.except("id", "draft_content_item_id")
-        safe_attributes = live_attributes.merge(
-          "access_limited" => {}
-        )
-
-        draft.update_attributes(safe_attributes)
+        draft.update_attributes(live.attributes.except("id", "draft_content_item_id"))
 
         if downstream
           ContentStoreWorker.perform_async(
@@ -55,6 +52,10 @@ module Commands
             delete: true,
           )
         end
+      end
+
+      def delete_access_limit
+        AccessLimit.find_by(target: draft).try(:destroy)
       end
 
       def draft

--- a/app/commands/v2/discard_draft.rb
+++ b/app/commands/v2/discard_draft.rb
@@ -5,13 +5,13 @@ module Commands
         validate_version_lock!
         raise_error_if_missing_draft!
 
+        delete_access_limit
+
         if live
           update_draft_from_live
         else
           delete_draft
         end
-
-        delete_access_limit
 
         Success.new(content_id: content_id)
       end

--- a/app/commands/v2/publish.rb
+++ b/app/commands/v2/publish.rb
@@ -93,7 +93,6 @@ module Commands
       def build_live_attributes(draft_content_item)
         attributes = draft_content_item
           .attributes
-          .except("version")
           .merge(draft_content_item: draft_content_item)
 
         unless attributes[:public_updated_at] || update_type != "major"

--- a/app/commands/v2/publish.rb
+++ b/app/commands/v2/publish.rb
@@ -93,7 +93,7 @@ module Commands
       def build_live_attributes(draft_content_item)
         attributes = draft_content_item
           .attributes
-          .except("access_limited", "version")
+          .except("version")
           .merge(draft_content_item: draft_content_item)
 
         unless attributes[:public_updated_at] || update_type != "major"

--- a/app/models/access_limit.rb
+++ b/app/models/access_limit.rb
@@ -1,0 +1,21 @@
+class AccessLimit < ActiveRecord::Base
+  belongs_to :target, polymorphic: true
+
+  validate :user_uids_are_strings
+
+  def self.viewable?(target, user_uid: nil)
+    if (access_limit = self.find_by(target: target))
+      user_uid.present? && access_limit.users.include?(user_uid)
+    else
+      true
+    end
+  end
+
+private
+
+  def user_uids_are_strings
+    unless users.all? { |id| id.is_a?(String) }
+      errors.set(:users, ["contains non-string user UIDs"])
+    end
+  end
+end

--- a/app/models/draft_content_item.rb
+++ b/app/models/draft_content_item.rb
@@ -9,6 +9,8 @@ class DraftContentItem < ActiveRecord::Base
 
   NON_RENDERABLE_FORMATS = %w(redirect gone)
 
+  deprecated_columns :access_limited
+
   has_one :live_content_item
 
   scope :renderable_content, -> { where.not(format: NON_RENDERABLE_FORMATS) }

--- a/app/models/draft_content_item.rb
+++ b/app/models/draft_content_item.rb
@@ -5,9 +5,7 @@ class DraftContentItem < ActiveRecord::Base
   include DefaultAttributes
   include SymbolizeJSON
 
-  TOP_LEVEL_FIELDS = (LiveContentItem::TOP_LEVEL_FIELDS + [
-    :access_limited,
-  ]).freeze
+  TOP_LEVEL_FIELDS = LiveContentItem::TOP_LEVEL_FIELDS
 
   NON_RENDERABLE_FORMATS = %w(redirect gone)
 
@@ -23,7 +21,6 @@ class DraftContentItem < ActiveRecord::Base
   validates :title, presence: true, if: :renderable_content?
   validates :rendering_app, presence: true, dns_hostname: true, if: :renderable_content?
   validates :public_updated_at, presence: true, if: :renderable_content?
-  validate :access_limited_is_valid
   validates :locale, inclusion: {
     in: I18n.available_locales.map(&:to_s),
     message: 'must be a supported locale'
@@ -58,10 +55,6 @@ class DraftContentItem < ActiveRecord::Base
     end
   end
 
-  def viewable_by?(user_uid)
-    !access_limited? || authorised_user_uids.include?(user_uid)
-  end
-
   def published?
     live_content_item.present?
   end
@@ -79,23 +72,5 @@ private
 
   def renderable_content?
     NON_RENDERABLE_FORMATS.exclude?(format)
-  end
-
-  def access_limited_is_valid
-    if access_limited? && (!access_limited_keys_valid? || !access_limited_values_valid?)
-      errors.set(:access_limited, ['is not valid'])
-    end
-  end
-
-  def access_limited_keys_valid?
-    access_limited.keys == [:users]
-  end
-
-  def access_limited_values_valid?
-    authorised_user_uids.is_a?(Array) && authorised_user_uids.all? { |id| id.is_a?(String) }
-  end
-
-  def authorised_user_uids
-    access_limited[:users]
   end
 end

--- a/app/models/replaceable.rb
+++ b/app/models/replaceable.rb
@@ -14,7 +14,7 @@ module Replaceable
       end
 
       retry_strategy.call do
-        item.assign_attributes(payload.except(:id, :version))
+        item.assign_attributes(payload.except(:id, :version, :access_limited))
 
         if block_given?
           yield(item)

--- a/app/models/replaceable.rb
+++ b/app/models/replaceable.rb
@@ -14,7 +14,7 @@ module Replaceable
       end
 
       retry_strategy.call do
-        item.assign_attributes(payload.except(:id, :version, :access_limited))
+        item.assign_attributes(payload.except(:id, :access_limited))
 
         if block_given?
           yield(item)

--- a/app/presenters/downstream_presenter.rb
+++ b/app/presenters/downstream_presenter.rb
@@ -15,6 +15,7 @@ module Presenters
         .slice(*content_item.class::TOP_LEVEL_FIELDS)
         .merge(public_updated_at)
         .merge(links)
+        .merge(access_limited)
         .merge(transmitted_at)
     end
 
@@ -33,8 +34,24 @@ module Presenters
       end
     end
 
+    def access_limited
+      if access_limit
+        {
+          access_limited: {
+            users: access_limit.users
+          }
+        }
+      else
+        {}
+      end
+    end
+
     def link_set_presenter
       Presenters::Queries::LinkSetPresenter.new(link_set)
+    end
+
+    def access_limit
+      @access_limit ||= AccessLimit.find_by(target: content_item)
     end
 
     def public_updated_at
@@ -50,8 +67,7 @@ module Presenters
     end
 
     class V1
-      def self.present(attributes, access_limited: true, update_type: true, transmitted_at: true)
-        attributes = attributes.except(:access_limited) unless access_limited
+      def self.present(attributes, update_type: true, transmitted_at: true)
         attributes = attributes.except(:update_type) unless update_type
         attributes = attributes.merge(transmitted_at: DateTime.now.to_s(:nanoseconds)) if transmitted_at
 

--- a/db/migrate/20151231125222_extract_access_limiting.rb
+++ b/db/migrate/20151231125222_extract_access_limiting.rb
@@ -1,0 +1,21 @@
+class ExtractAccessLimiting < ActiveRecord::Migration
+  def up
+    create_table :access_limits do |t|
+      t.integer :target_id, null: false
+      t.string :target_type, null: false
+      t.json :users, null: false, default: []
+      t.timestamps null: false
+    end
+
+    DraftContentItem.where("access_limited::text <> '{}'::text").each do |limited_draft|
+      AccessLimit.create(
+        target: limited_draft,
+        users: limited_draft.access_limited[:users],
+      )
+    end
+  end
+
+  def down
+    drop_table :access_limits
+  end
+end

--- a/db/migrate/20151231125222_extract_access_limiting.rb
+++ b/db/migrate/20151231125222_extract_access_limiting.rb
@@ -7,15 +7,22 @@ class ExtractAccessLimiting < ActiveRecord::Migration
       t.timestamps null: false
     end
 
+    add_index :access_limits, [:target_type, :target_id], name: "index_access_limits_on_target"
+
     DraftContentItem.where("access_limited::text <> '{}'::text").each do |limited_draft|
-      AccessLimit.create(
+      users = limited_draft.access_limited[:users]
+
+      AccessLimit.create!(
         target: limited_draft,
-        users: limited_draft.access_limited[:users],
+        users: users,
       )
+
+      puts "AccessLimit created for #{limited_draft.content_id} (#{users.size} users)"
     end
   end
 
   def down
+    remove_index :access_limits, name: "index_access_limits_on_target"
     drop_table :access_limits
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -24,6 +24,8 @@ ActiveRecord::Schema.define(version: 20151231125222) do
     t.datetime "updated_at",               null: false
   end
 
+  add_index "access_limits", ["target_type", "target_id"], name: "index_access_limits_on_target", using: :btree
+
   create_table "draft_content_items", force: :cascade do |t|
     t.string   "content_id"
     t.string   "locale",               default: "en"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,10 +11,18 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151207154727) do
+ActiveRecord::Schema.define(version: 20151231125222) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "access_limits", force: :cascade do |t|
+    t.integer  "target_id",                null: false
+    t.string   "target_type",              null: false
+    t.json     "users",       default: [], null: false
+    t.datetime "created_at",               null: false
+    t.datetime "updated_at",               null: false
+  end
 
   create_table "draft_content_items", force: :cascade do |t|
     t.string   "content_id"

--- a/lib/tasks/data_sanitizer.rb
+++ b/lib/tasks/data_sanitizer.rb
@@ -1,7 +1,8 @@
 module Tasks
   class DataSanitizer
     def self.delete_access_limited(stdout)
-      DraftContentItem.where("access_limited::text <> '{}'::text").each do |limited_draft|
+      AccessLimit.all.each do |access_limit|
+        limited_draft = access_limit.target
         stdout.puts "Discarding access limited draft content item '#{limited_draft.content_id}'"
         simulated_payload = limited_draft.as_json.symbolize_keys
         Commands::V2::DiscardDraft.call(simulated_payload, downstream: true)

--- a/spec/factories/access_limit.rb
+++ b/spec/factories/access_limit.rb
@@ -1,0 +1,5 @@
+FactoryGirl.define do
+  factory :access_limit do
+    users { [SecureRandom.uuid] }
+  end
+end

--- a/spec/factories/draft_content_item.rb
+++ b/spec/factories/draft_content_item.rb
@@ -15,7 +15,6 @@ FactoryGirl.define do
     details {
       { body: "<p>Something about VAT</p>\n", }
     }
-    access_limited { }
     need_ids ["100123", "100124"]
     phase "beta"
     update_type "minor"
@@ -30,7 +29,7 @@ FactoryGirl.define do
     }
 
     trait :with_version do
-      after(:create) do |item, evaluator|
+      after(:create) do |item, _|
         FactoryGirl.create(:version, target: item)
       end
     end
@@ -53,8 +52,9 @@ FactoryGirl.define do
 
   factory :access_limited_draft_content_item, parent: :draft_content_item do
     sequence(:base_path) {|n| "/access-limited-#{n}" }
-    access_limited {
-      { users: [SecureRandom.uuid] }
-    }
+
+    after(:create) do |item, _|
+      FactoryGirl.create(:access_limit, target: item)
+    end
   end
 end

--- a/spec/models/access_limit_spec.rb
+++ b/spec/models/access_limit_spec.rb
@@ -1,0 +1,46 @@
+require "rails_helper"
+
+RSpec.describe AccessLimit do
+  subject { FactoryGirl.build(:access_limit) }
+
+  it "validates that user UIDs are strings" do
+    subject.users << "a-string-uuid"
+    expect(subject).to be_valid
+
+    subject.users << 123
+    expect(subject).not_to be_valid
+  end
+
+  context "a content item that is not access limited" do
+    let!(:content_item) { create(:draft_content_item) }
+
+    it "is not access limited" do
+      expect(AccessLimit.viewable?(content_item)).to be(true)
+    end
+
+    it "is viewable by all" do
+      expect(AccessLimit.viewable?(content_item, user_uid: "a-user-uid")).to be(true)
+    end
+  end
+
+  context "an access-limited content item" do
+    let!(:content_item) { create(:access_limited_draft_content_item) }
+    let(:authorised_user_uid) {
+      AccessLimit.find_by(target: content_item).users.first
+    }
+    let(:unauthorised_user_uid) { "unauthorised-user-uid" }
+
+    it "is access limited" do
+      expect(AccessLimit.viewable?(content_item)).to be(false)
+    end
+
+    it "is viewable by an authorised user" do
+      expect(AccessLimit.viewable?(content_item, user_uid: authorised_user_uid)).to be(true)
+    end
+
+    it "is not viewable by an unauthorised user" do
+      expect(AccessLimit.viewable?(content_item, user_uid: authorised_user_uid)).to be(true)
+      expect(AccessLimit.viewable?(content_item, user_uid: unauthorised_user_uid)).to be(false)
+    end
+  end
+end

--- a/spec/models/draft_content_item_spec.rb
+++ b/spec/models/draft_content_item_spec.rb
@@ -151,47 +151,6 @@ RSpec.describe DraftContentItem do
       end
     end
 
-    describe 'access limiting' do
-      it "validates the format of the access_limited hash" do
-        content_item = build(:draft_content_item, access_limited: { bad_key: []})
-        expect(content_item).not_to be_valid
-
-        content_item = build(:draft_content_item, access_limited: { users: { other: 'stuff'}})
-        expect(content_item).not_to be_valid
-      end
-
-      context 'a content item that is not access limited' do
-        let!(:content_item) { create(:draft_content_item) }
-
-        it 'is not access limited' do
-          expect(content_item.access_limited?).to be(false)
-        end
-
-        it 'is viewable by all' do
-          expect(content_item.viewable_by?(nil)).to be(true)
-          expect(content_item.viewable_by?('a-user-uid')).to be(true)
-        end
-      end
-
-      context 'an access-limited content item' do
-        let!(:content_item) { create(:access_limited_draft_content_item) }
-        let(:authorised_user_uid) { content_item.access_limited[:users].first }
-
-        it 'is access limited' do
-          expect(content_item.access_limited?).to be(true)
-        end
-
-        it 'is viewable by an authorised user' do
-          expect(content_item.viewable_by?(authorised_user_uid)).to be(true)
-        end
-
-        it 'is not viewable by an unauthorised user' do
-          expect(content_item.viewable_by?('unauthorised-user')).to be(false)
-          expect(content_item.viewable_by?(nil)).to be(false)
-        end
-      end
-    end
-
     context "locale" do
       it "defaults to the default I18n locale" do
         expect(described_class.new.locale).to eq(I18n.default_locale.to_s)

--- a/spec/pacts/content_store/put_endpoint_spec.rb
+++ b/spec/pacts/content_store/put_endpoint_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe "PUT endpoint pact with the Content Store", pact: true do
     let(:attributes) { content_item_params }
     let(:body) do
       Presenters::DownstreamPresenter::V1.present(
-        attributes, access_limited: false, update_type: false
+        attributes, update_type: false
       )
     end
 

--- a/spec/presenters/downstream_presenter_spec.rb
+++ b/spec/presenters/downstream_presenter_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Presenters::DownstreamPresenter do
     let!(:content_item) { FactoryGirl.create(:live_content_item) }
     let!(:link_set) { FactoryGirl.create(:link_set, content_id: content_item.content_id) }
 
-    it "presents the object graph for the content store (excludes access_limited)" do
+    it "presents the object graph for the content store" do
       result = described_class.present(content_item)
 
       expect(result).to eq(
@@ -45,7 +45,6 @@ RSpec.describe Presenters::DownstreamPresenter do
       expect(result).to eq(
         content_id: content_item.content_id,
         base_path: "/vat-rates",
-        access_limited: nil,
         analytics_identifier: "GDS01",
         description: "VAT rates for goods and services",
         details: { body: "<p>Something about VAT</p>\n" },
@@ -119,16 +118,6 @@ RSpec.describe Presenters::DownstreamPresenter do
       expect(result).to eq(
         content_id: "content_id",
         access_limited: "access_limited",
-        update_type: "update_type",
-        transmitted_at: DateTime.now.to_s(:nanoseconds),
-      )
-    end
-
-    it "can optionally remove the access_limited attribute" do
-      result = described_class.present(attributes, access_limited: false)
-
-      expect(result).to eq(
-        content_id: "content_id",
         update_type: "update_type",
         transmitted_at: DateTime.now.to_s(:nanoseconds),
       )

--- a/spec/requests/content_item_requests/downstream_requests_spec.rb
+++ b/spec/requests/content_item_requests/downstream_requests_spec.rb
@@ -80,6 +80,7 @@ RSpec.describe "Downstream requests", type: :request do
       before do
         draft = FactoryGirl.create(:draft_content_item, v2_content_item.slice(*DraftContentItem::TOP_LEVEL_FIELDS))
         FactoryGirl.create(:version, target: draft, number: 1)
+        FactoryGirl.create(:access_limit, target: draft, users: content_item.fetch(:access_limited).fetch(:users))
       end
 
       sends_to_draft_content_store
@@ -105,8 +106,7 @@ RSpec.describe "Downstream requests", type: :request do
         )
 
         draft = live.draft_content_item
-
-        draft.update!(access_limited: v2_content_item.fetch(:access_limited))
+        FactoryGirl.create(:access_limit, target: draft, users: content_item.fetch(:access_limited).fetch(:users))
 
         FactoryGirl.create(:version, target: draft, number: 1)
         FactoryGirl.create(:version, target: live, number: 1)

--- a/spec/requests/content_item_requests/downstream_timeouts_spec.rb
+++ b/spec/requests/content_item_requests/downstream_timeouts_spec.rb
@@ -39,7 +39,10 @@ RSpec.describe "Downstream timeouts", type: :request do
       )
       draft = live.draft_content_item
 
-      draft.update!(access_limited: v2_content_item.fetch(:access_limited))
+      FactoryGirl.create(:access_limit,
+        target: draft,
+        users: v2_content_item.fetch(:access_limited).fetch(:users)
+      )
 
       FactoryGirl.create(:version, target: draft, number: 1)
       FactoryGirl.create(:version, target: live, number: 1)

--- a/spec/support/request_helpers/derived_representations.rb
+++ b/spec/support/request_helpers/derived_representations.rb
@@ -81,9 +81,8 @@ module RequestHelpers
         expect(item.analytics_identifier).to eq(expected_attributes[:analytics_identifier])
         expect(item.update_type).to eq(expected_attributes[:update_type])
 
-        if access_limited
-          expect(item.access_limited).to eq(expected_attributes[:access_limited])
-        end
+
+        expect(AccessLimit.viewable?(item)).to eq(!access_limited)
       end
 
       it "gives the first #{representation_class} a version number of 1" do


### PR DESCRIPTION
This is done in a similar manner to versioning.

Some points:
- The `access_limited` field remains and needs to
  be removed in a later ticket.
- Some references to the field exist in the tests
  and will also need removing when the column is
  gone.
- The `viewable?` method which I ported over from
  the draft content item model is not used anywhere.
  Neither was the `access_limited?` method which
  was tested but unused.
  Do we know why?

https://trello.com/c/m0TgNj9i/379-refactor-extract-accesslimitation-from-contentitems