### PR TITLE
Allow coming soon items to be overwritten

### DIFF
--- a/app/substitution_helper.rb
+++ b/app/substitution_helper.rb
@@ -36,7 +36,7 @@ module SubstitutionHelper
     end
 
     def substitute?(content_item)
-      %w(gone redirect unpublishing).include?(content_item.format)
+      %w(coming_soon gone redirect unpublishing).include?(content_item.format)
     end
   end
 end

--- a/spec/factories/live_content_item.rb
+++ b/spec/factories/live_content_item.rb
@@ -63,4 +63,10 @@ FactoryGirl.define do
     sequence(:base_path) {|n| "/dodo-sanctuary-#{n}" }
     format "gone"
   end
+
+  factory :coming_soon_live_content_item, parent: :live_content_item do
+    format "coming_soon"
+    title "Coming soon"
+    description "This item will be published soon"
+  end
 end

--- a/spec/helpers/substitution_helper_spec.rb
+++ b/spec/helpers/substitution_helper_spec.rb
@@ -1,0 +1,116 @@
+require 'rails_helper'
+
+RSpec.describe SubstitutionHelper do
+  before do
+    stub_request(:put, %r{.*content-store.*/content/.*})
+  end
+
+  let(:content_id) { SecureRandom.uuid }
+  let(:base_path) { '/vat-rates' }
+  let(:payload) {
+    FactoryGirl.build(:live_content_item,
+        content_id: content_id,
+        title: 'The title',
+        base_path: base_path
+      )
+  }
+
+  context "when there's an existing gone on the path already" do
+    before do
+      create(:gone_live_content_item, base_path: base_path)
+    end
+
+    it "removes the existing content" do
+      described_class.clear_live!(payload)
+      expect(LiveContentItem.exists?(base_path: base_path)).to eq(false)
+    end
+  end
+
+  context "when there's an existing redirect on the path already" do
+    before do
+      create(:redirect_live_content_item, base_path: base_path)
+    end
+
+    it "removes the existing content" do
+      described_class.clear_live!(payload)
+      expect(LiveContentItem.exists?(base_path: base_path)).to eq(false)
+    end
+  end
+
+  context "when there's an existing unpublishing on the path already" do
+    before do
+      create(:live_content_item, base_path: base_path, format: "unpublishing")
+    end
+
+    it "removes the existing content" do
+      described_class.clear_live!(payload)
+      expect(LiveContentItem.exists?(base_path: base_path)).to eq(false)
+    end
+  end
+
+  context "when a gone item wants to replace a content item" do
+    before do
+      create(:live_content_item, base_path: base_path)
+    end
+
+    let(:payload) {
+      FactoryGirl.build(:gone_live_content_item,
+        content_id: content_id,
+        base_path: base_path
+      )
+    }
+
+    it "removes the existing content" do
+      described_class.clear_live!(payload)
+      expect(LiveContentItem.exists?(base_path: base_path)).to eq(false)
+    end
+  end
+
+  context "when a redirect item wants to replace a content item" do
+    before do
+      create(:live_content_item, base_path: base_path)
+    end
+
+    let(:payload) {
+      FactoryGirl.build(:redirect_live_content_item,
+        content_id: content_id,
+        base_path: base_path
+      )
+    }
+
+    it "removes the existing content" do
+      described_class.clear_live!(payload)
+      expect(LiveContentItem.exists?(base_path: base_path)).to eq(false)
+    end
+  end
+
+  context "when an unpublishing item wants to replace a content item" do
+    before do
+      create(:live_content_item, base_path: base_path)
+    end
+
+    let(:payload) {
+      FactoryGirl.build(:live_content_item,
+        format: "unpublishing",
+        content_id: content_id,
+        base_path: base_path
+      )
+    }
+
+    it "removes the existing content" do
+      described_class.clear_live!(payload)
+      expect(LiveContentItem.exists?(base_path: base_path)).to eq(false)
+    end
+  end
+
+  context "when a content item wants to replace a content item" do
+    before do
+      create(:live_content_item, base_path: base_path)
+    end
+
+    it "does not remove the existing content" do
+      described_class.clear_live!(payload)
+      expect(LiveContentItem.exists?(base_path: base_path)).to eq(true)
+    end
+  end
+end

--- a/spec/helpers/substitution_helper_spec.rb
+++ b/spec/helpers/substitution_helper_spec.rb
@@ -103,6 +103,17 @@ RSpec.describe SubstitutionHelper do
     end
   end
 
+  context "when a content item wants to replace a Coming Soon item" do
+    before do
+      create(:coming_soon_live_content_item, base_path: base_path)
+    end
+
+    it "removes the existing content" do
+      described_class.clear_live!(payload)
+      expect(LiveContentItem.exists?(base_path: base_path)).to eq(false)
+    end
+  end
+
   context "when a content item wants to replace a content item" do
     before do
       create(:live_content_item, base_path: base_path)


### PR DESCRIPTION
Coming Soon pages are displayed at base_paths that will soon have the actual
content. Whitehall sends the coming soon with a different content-id to the
item that will be published, so until now, publishing-api has been rejecting
the request that tries to publish the actual document.

An alternative might be to change Whitehall to use the same content-id, but
this would mean we'd have to reconcile the existing data in a fairly manual
way.

Once deployed, I think it would be appropriate to republish all documents in
Whitehall that have been rejected by this issue.

/cc @elliotcm 