### PR TITLE
Fix a bug with nil descriptions

### DIFF
--- a/app/models/description_overrides.rb
+++ b/app/models/description_overrides.rb
@@ -1,0 +1,33 @@
+# Postgres's JSON columns have problems storing literal strings, so these
+# getters/setters wrap the description in a JSON object.
+
+module DescriptionOverrides
+  extend ActiveSupport::Concern
+
+  included do
+    def description=(value)
+      super(value: value)
+    end
+
+    def description
+      super.fetch(:value)
+    end
+
+    def attributes
+      attributes = super
+      description = attributes.delete("description")
+
+      if description
+        attributes.merge("description" => description.fetch("value"))
+      else
+        attributes
+      end
+    end
+  end
+
+  class_methods do
+    def column_defaults
+      super.merge("description" => nil)
+    end
+  end
+end

--- a/app/models/draft_content_item.rb
+++ b/app/models/draft_content_item.rb
@@ -4,6 +4,7 @@ class DraftContentItem < ActiveRecord::Base
   include Replaceable
   include DefaultAttributes
   include SymbolizeJSON
+  include DescriptionOverrides
 
   TOP_LEVEL_FIELDS = LiveContentItem::TOP_LEVEL_FIELDS
 
@@ -35,31 +36,6 @@ class DraftContentItem < ActiveRecord::Base
 
   validates :description, well_formed_content_types: { must_include: "text/html" }
   validates :details, well_formed_content_types: { must_include: "text/html" }
-
-  # Postgres's JSON columns have problems storing literal strings, so these
-  # getter/setter wrap the description in a JSON object.
-  def description=(value)
-    super(value: value)
-  end
-
-  def description
-    super.fetch(:value)
-  end
-
-  def attributes
-    attributes = super
-    description = attributes.delete("description")
-
-    if description
-      attributes.merge("description" => description.fetch("value"))
-    else
-      attributes
-    end
-  end
-
-  def self.column_defaults
-    super.merge("description" => nil)
-  end
 
   def published?
     live_content_item.present?

--- a/app/models/draft_content_item.rb
+++ b/app/models/draft_content_item.rb
@@ -57,6 +57,10 @@ class DraftContentItem < ActiveRecord::Base
     end
   end
 
+  def self.column_defaults
+    super.merge("description" => nil)
+  end
+
   def published?
     live_content_item.present?
   end

--- a/app/models/live_content_item.rb
+++ b/app/models/live_content_item.rb
@@ -2,6 +2,7 @@ class LiveContentItem < ActiveRecord::Base
   include Replaceable
   include DefaultAttributes
   include SymbolizeJSON
+  include DescriptionOverrides
 
   TOP_LEVEL_FIELDS = [
     :base_path,
@@ -50,31 +51,6 @@ class LiveContentItem < ActiveRecord::Base
 
   def published?
     true
-  end
-
-  # Postgres's JSON columns have problems storing literal strings, so these
-  # getter/setter wrap the description in a JSON object.
-  def description=(value)
-    super(value: value)
-  end
-
-  def description
-    super.fetch(:value)
-  end
-
-  def attributes
-    attributes = super
-    description = attributes.delete("description")
-
-    if description
-      attributes.merge("description" => description.fetch("value"))
-    else
-      attributes
-    end
-  end
-
-  def self.column_defaults
-    super.merge("description" => nil)
   end
 
 private

--- a/app/models/live_content_item.rb
+++ b/app/models/live_content_item.rb
@@ -73,6 +73,10 @@ class LiveContentItem < ActiveRecord::Base
     end
   end
 
+  def self.column_defaults
+    super.merge("description" => nil)
+  end
+
 private
   def self.query_keys
     [:content_id, :locale]

--- a/db/migrate/20160111093455_fix_nil_descriptions.rb
+++ b/db/migrate/20160111093455_fix_nil_descriptions.rb
@@ -1,0 +1,21 @@
+# https://trello.com/c/DHVC2pH1/488-bug-investigate-why-description-encapsulation-has-been-bypassed
+class FixNilDescriptions < ActiveRecord::Migration
+  def up
+    models = [DraftContentItem, LiveContentItem]
+
+    models.each do |m|
+      m.find_each do |item|
+        description = item.description
+
+        if description.is_a?(Hash)
+          item.description = description.fetch(:value)
+          item.save!(validate: false)
+        end
+      end
+    end
+  end
+
+  def down
+    # noop
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151231125222) do
+ActiveRecord::Schema.define(version: 20160111093455) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/spec/models/draft_content_item_spec.rb
+++ b/spec/models/draft_content_item_spec.rb
@@ -225,4 +225,5 @@ RSpec.describe DraftContentItem do
   it_behaves_like DefaultAttributes
   it_behaves_like RoutesAndRedirectsValidator
   it_behaves_like WellFormedContentTypesValidator
+  it_behaves_like DescriptionOverrides
 end

--- a/spec/models/live_content_item_spec.rb
+++ b/spec/models/live_content_item_spec.rb
@@ -231,4 +231,5 @@ RSpec.describe LiveContentItem do
   it_behaves_like DefaultAttributes
   it_behaves_like RoutesAndRedirectsValidator
   it_behaves_like WellFormedContentTypesValidator
+  it_behaves_like DescriptionOverrides
 end

--- a/spec/support/default_attributes.rb
+++ b/spec/support/default_attributes.rb
@@ -21,4 +21,12 @@ RSpec.shared_examples DefaultAttributes do
     subject.assign_attributes_with_defaults(attributes)
     expect(subject.title).to eq("New title")
   end
+
+  it "assigns the description attributes correctly" do
+    subject.assign_attributes_with_defaults({})
+    expect(subject.description).to eq(nil)
+
+    subject.assign_attributes_with_defaults(description: "foo")
+    expect(subject.description).to eq("foo")
+  end
 end

--- a/spec/support/description_overrides.rb
+++ b/spec/support/description_overrides.rb
@@ -1,0 +1,34 @@
+RSpec.shared_examples DescriptionOverrides do
+  it "persists descriptions of different types" do
+    subject.description = nil
+    subject.save!
+    expect(subject.reload.description).to eq(nil)
+
+    subject.description = "string"
+    subject.save!
+    expect(subject.reload.description).to eq("string")
+
+    subject.description = ["array"]
+    subject.save!
+    expect(subject.reload.description).to eq ["array"]
+  end
+
+  it "returns the correct #attributes" do
+    subject.description = nil
+    description = subject.attributes["description"]
+    expect(description).to eq(nil)
+
+    subject.description = "string"
+    description = subject.attributes["description"]
+    expect(description).to eq("string")
+
+    subject.description = ["array"]
+    description = subject.attributes["description"]
+    expect(description).to eq ["array"]
+  end
+
+  it "returns the correct .column_defaults" do
+    defaults = described_class.column_defaults
+    expect(defaults["description"]).to eq(nil)
+  end
+end


### PR DESCRIPTION
@jamiecobbett noticed a problem with `nil` descriptions appearing as a JSON object in the content store.

e.g. https://www.gov.uk/api/content/government/organisations/hm-revenue-customs

The above link has a description of: `{ value: nil }` rather than just `nil`

This fixes that.

I've also extracted the description overrides into a concern to keep it all in one place and to DRY up the models.

Note: This fixes the problem in Publishing API. For changes to be reflected in ContentStore, we'd need to republish these content items (~800).