### PR TITLE
Remove access_limited from draft_content_items

### DIFF
--- a/app/models/draft_content_item.rb
+++ b/app/models/draft_content_item.rb
@@ -10,8 +10,6 @@ class DraftContentItem < ActiveRecord::Base
 
   NON_RENDERABLE_FORMATS = %w(redirect gone)
 
-  deprecated_columns :access_limited
-
   has_one :live_content_item
 
   scope :renderable_content, -> { where.not(format: NON_RENDERABLE_FORMATS) }

--- a/db/migrate/20160111103706_remove_access_limited_column.rb
+++ b/db/migrate/20160111103706_remove_access_limited_column.rb
@@ -1,0 +1,5 @@
+class RemoveAccessLimitedColumn < ActiveRecord::Migration
+  def change
+    remove_column :draft_content_items, :access_limited, :json, default: {}
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160111093455) do
+ActiveRecord::Schema.define(version: 20160111103706) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -34,7 +34,6 @@ ActiveRecord::Schema.define(version: 20160111093455) do
     t.string   "old_description"
     t.string   "format"
     t.datetime "public_updated_at"
-    t.json     "access_limited",       default: {}
     t.json     "details",              default: {}
     t.json     "routes",               default: []
     t.json     "redirects",            default: []

--- a/spec/lib/tasks/data_sanitizer_spec.rb
+++ b/spec/lib/tasks/data_sanitizer_spec.rb
@@ -40,6 +40,6 @@ RSpec.describe Tasks::DataSanitizer do
     limited_draft.reload
 
     expect(limited_draft.title).to eq("A live content item")
-    expect(limited_draft.access_limited).to eq({})
+    expect(AccessLimit.count).to be_zero
   end
 end

--- a/spec/requests/content_item_requests/derived_representations_spec.rb
+++ b/spec/requests/content_item_requests/derived_representations_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe "Derived representations", type: :request do
   context "/content" do
-    let(:request_body) { content_item_params.to_json }
+    let(:request_body) { content_item_params.merge(access_limited: access_limit_params).to_json }
     let(:request_path) { "/content#{base_path}" }
     let(:request_method) { :put }
 
@@ -12,7 +12,7 @@ RSpec.describe "Derived representations", type: :request do
   end
 
   context "/draft-content" do
-    let(:request_body) { content_item_params.to_json }
+    let(:request_body) { content_item_params.merge(access_limited: access_limit_params).to_json }
     let(:request_path) { "/draft-content#{base_path}" }
     let(:request_method) { :put }
 
@@ -22,7 +22,7 @@ RSpec.describe "Derived representations", type: :request do
   end
 
   context "/v2/content" do
-    let(:request_body) { v2_content_item.to_json }
+    let(:request_body) { v2_content_item.merge(access_limited: access_limit_params).to_json }
     let(:request_path) { "/v2/content/#{content_id}" }
     let(:request_method) { :put }
 

--- a/spec/requests/content_item_requests/downstream_requests_spec.rb
+++ b/spec/requests/content_item_requests/downstream_requests_spec.rb
@@ -67,6 +67,7 @@ RSpec.describe "Downstream requests", type: :request do
     let(:content_item_for_draft_content_store) {
       content_item
         .except(:update_type)
+        .merge(access_limited: access_limit_params)
     }
     let(:content_item_for_live_content_store) {
       content_item
@@ -80,7 +81,7 @@ RSpec.describe "Downstream requests", type: :request do
       before do
         draft = FactoryGirl.create(:draft_content_item, v2_content_item.slice(*DraftContentItem::TOP_LEVEL_FIELDS))
         FactoryGirl.create(:version, target: draft, number: 1)
-        FactoryGirl.create(:access_limit, target: draft, users: content_item.fetch(:access_limited).fetch(:users))
+        FactoryGirl.create(:access_limit, target: draft, users: access_limit_params.fetch(:users))
       end
 
       sends_to_draft_content_store
@@ -106,7 +107,7 @@ RSpec.describe "Downstream requests", type: :request do
         )
 
         draft = live.draft_content_item
-        FactoryGirl.create(:access_limit, target: draft, users: content_item.fetch(:access_limited).fetch(:users))
+        FactoryGirl.create(:access_limit, target: draft, users: access_limit_params.fetch(:users))
 
         FactoryGirl.create(:version, target: draft, number: 1)
         FactoryGirl.create(:version, target: live, number: 1)

--- a/spec/requests/content_item_requests/downstream_timeouts_spec.rb
+++ b/spec/requests/content_item_requests/downstream_timeouts_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe "Downstream timeouts", type: :request do
 
       FactoryGirl.create(:access_limit,
         target: draft,
-        users: v2_content_item.fetch(:access_limited).fetch(:users)
+        users: access_limit_params.fetch(:users),
       )
 
       FactoryGirl.create(:version, target: draft, number: 1)

--- a/spec/support/request_helpers/mocks.rb
+++ b/spec/support/request_helpers/mocks.rb
@@ -33,14 +33,17 @@ module RequestHelpers
         ],
         redirects: [],
         update_type: "major",
-        access_limited: {
-          users: [
-            "bf3e4b4f-f02d-4658-95a7-df7c74cd0f50",
-            "74c7d700-5b4a-0131-7a8e-005056030037",
-          ],
-        },
         analytics_identifier: "GDS01",
       }.merge(links_attributes)
+    end
+
+    def access_limit_params
+      {
+        users: [
+          "bf3e4b4f-f02d-4658-95a7-df7c74cd0f50",
+          "74c7d700-5b4a-0131-7a8e-005056030037",
+        ],
+      }
     end
 
     def links_attributes


### PR DESCRIPTION
Please could @elliotcm have a look before merging as he completed the work to extract AccessLimit.

> This was made more complicated by the fact that
we’re using the mocks for both POSTing requests to
the API and also for asserting that the right
things are sent downstream to the content store.

> It made sense to break the access_limit_params out
of the content items mocks so that they can be
merged in only when POSTing. However, I’d
recommend we go a step further and avoid using 
these mocks as assertions.

https://trello.com/c/iej9ZE6x/470-refactor-remove-old-access-limited-field-from-draft-content-items