### PR TITLE
Present content item based on top level fields...

### DIFF
--- a/app/presenters/queries/content_item_presenter.rb
+++ b/app/presenters/queries/content_item_presenter.rb
@@ -16,9 +16,10 @@ module Presenters
       def present
         content_item.as_json
           .symbolize_keys
+          .slice(*content_item.class::TOP_LEVEL_FIELDS)
           .merge(
             publication_state: publication_state,
-          ).tap do |h| 
+          ).tap do |h|
             h[:live_version] = live_version.number if live_version.present?
             h[:version] = version.number if version.present?
           end

--- a/spec/presenters/queries/content_item_presenter_spec.rb
+++ b/spec/presenters/queries/content_item_presenter_spec.rb
@@ -8,7 +8,29 @@ RSpec.describe Presenters::Queries::ContentItemPresenter do
     let(:result) { Presenters::Queries::ContentItemPresenter.present(content_item) }
 
     it "presents content item attributes as a hash" do
-      expect(result.fetch(:content_id)).to eq(content_id)
+      expected = {
+        content_id: content_id,
+        locale: "en",
+        base_path: "/vat-rates",
+        title: "VAT rates",
+        format: "guide",
+        public_updated_at: DateTime.parse("2014-05-14 13:00:06.000000000 +0000").in_time_zone,
+        details: {
+          body: "<p>Something about VAT</p>\n"
+        },
+        routes: [{path: "/vat-rates", type: "exact"}],
+        redirects: [],
+        publishing_app: "publisher",
+        rendering_app: "frontend",
+        need_ids: ["100123", "100124"],
+        update_type: "minor",
+        phase: "beta",
+        analytics_identifier: "GDS01",
+        description: "VAT rates for goods and services",
+        publication_state: "draft",
+        version: 101
+      }
+      expect(result).to eq(expected)
     end
 
     it "exposes the version number of the content item" do


### PR DESCRIPTION
https://trello.com/c/nrjQDfwo/494-content-item-presenter-exposes-primary-key-for-v2-get-content

The content item presentation should be filtered to include only top
level fields and not attrs like id and old_description.
The change also makes the initial attribute test in the presenter spec a
lot more specific.