### PR TITLE
Content item index endpoint pagination

### DIFF
--- a/app/controllers/v2/content_items_controller.rb
+++ b/app/controllers/v2/content_items_controller.rb
@@ -7,7 +7,7 @@ module V2
       render json: Queries::GetContentCollection.new(content_format: content_format,
                                                     fields: fields,
                                                     publishing_app: publishing_app,
-                                                    pagination: pagination_params).call
+                                                    pagination: Pagination.new(params)).call
     end
 
     def show
@@ -41,13 +41,6 @@ module V2
   private
     def content_item
       payload.merge(content_id: params[:content_id])
-    end
-
-    def pagination_params
-      {
-        start: params.fetch(:start, 0).to_i,
-        count: params.fetch(:count, 50).to_i,
-      }
     end
   end
 end

--- a/app/controllers/v2/content_items_controller.rb
+++ b/app/controllers/v2/content_items_controller.rb
@@ -4,7 +4,10 @@ module V2
       content_format = params.fetch(:content_format)
       fields = params.fetch(:fields)
       publishing_app = params[:publishing_app]  # can be blank
-      render json: Queries::GetContentCollection.new(content_format: content_format, fields: fields, publishing_app: publishing_app).call
+      render json: Queries::GetContentCollection.new(content_format: content_format,
+                                                    fields: fields,
+                                                    publishing_app: publishing_app,
+                                                    pagination: pagination_params).call
     end
 
     def show
@@ -38,6 +41,13 @@ module V2
   private
     def content_item
       payload.merge(content_id: params[:content_id])
+    end
+
+    def pagination_params
+      {
+        start: params.fetch(:start, 0).to_i,
+        count: params.fetch(:count, 50).to_i,
+      }
     end
   end
 end

--- a/app/pagination.rb
+++ b/app/pagination.rb
@@ -1,0 +1,8 @@
+class Pagination
+  attr_reader :start, :count
+
+  def initialize(options = {})
+    @start = options[:start] ? options[:start].to_i : 0
+    @count = options[:count] ? options[:count].to_i : 50
+  end
+end

--- a/app/queries/get_content_collection.rb
+++ b/app/queries/get_content_collection.rb
@@ -2,10 +2,11 @@ module Queries
   class GetContentCollection
     attr_reader :content_format, :fields
 
-    def initialize(content_format:, fields:, publishing_app: nil)
+    def initialize(content_format:, fields:, publishing_app: nil, pagination: { start: 0, count: 50 })
       @content_format = content_format
       @fields = fields
       @publishing_app = publishing_app
+      @pagination = pagination
     end
 
     def call
@@ -23,20 +24,28 @@ module Queries
 
   private
 
-    attr_reader :live_versions, :draft_versions
+    attr_reader :live_versions, :draft_versions, :pagination
 
     def content_items
+      count = pagination[:count]
+      start = pagination[:start]
+
       draft_items = DraftContentItem
         .includes(:live_content_item)
         .where(format: [content_format, "placeholder_#{content_format}"])
         .select(*fields + %i[id content_id])
+        .limit(count).offset(start)
 
       draft_items = draft_items.where(publishing_app: @publishing_app) if @publishing_app.present?
+
+      live_limit = count - draft_items.length
+      live_start = draft_items.any? ? 0 : start
 
       live_items = LiveContentItem
         .where.not(content_id: draft_items.map(&:content_id))
         .where(format: [content_format, "placeholder_#{content_format}"])
         .select(*fields + %i[id])
+        .limit(live_limit).offset(live_start)
 
       live_items = live_items.where(publishing_app: @publishing_app) if @publishing_app.present?
 

--- a/spec/controllers/v2/content_items_controller_spec.rb
+++ b/spec/controllers/v2/content_items_controller_spec.rb
@@ -5,8 +5,35 @@ RSpec.describe V2::ContentItemsController do
 
   before do
     stub_request(:any, /content-store/)
-    @draft = FactoryGirl.create(:draft_content_item, content_id: content_id)
+    @draft = FactoryGirl.create(:draft_content_item, content_id: content_id, format: "topic")
     FactoryGirl.create(:version, target: @draft, number: 2)
+  end
+
+  describe "index" do
+    context "with pagination params" do
+      before do
+        get :index, content_format: 'topic', fields: ['content_id'], start: "0", count: "20"
+      end
+      it "is successful" do
+        expect(response.status).to eq(200)
+      end
+      it "responds with the content item as json" do
+        parsed_response_body = JSON.parse(response.body)
+        expect(parsed_response_body.first.fetch("content_id")).to eq("#{content_id}")
+      end
+    end
+    context "without pagination params" do
+      before do
+        get :index, content_format: 'topic', fields: ['content_id']
+      end
+      it "is successful" do
+        expect(response.status).to eq(200)
+      end
+      it "responds with the content item as json" do
+        parsed_response_body = JSON.parse(response.body)
+        expect(parsed_response_body.first.fetch("content_id")).to eq("#{content_id}")
+      end
+    end
   end
 
   describe "show" do

--- a/spec/pagination_spec.rb
+++ b/spec/pagination_spec.rb
@@ -1,0 +1,48 @@
+require 'rails_helper'
+
+RSpec.describe Pagination do
+  describe "initialize" do
+    context "without pagination params" do
+      subject { described_class.new }
+
+      it "returns the default start value" do
+        expect(subject.start).to eq(0)
+      end
+    end
+
+    context "with a start param" do
+      subject { described_class.new(start: "5") }
+
+      it "parses the start param as an integer" do
+        expect(subject.start).to eq(5)
+      end
+      it "returns the default count" do
+        expect(subject.count).to eq(50)
+      end
+    end
+
+
+    context "with a count param" do
+      subject { described_class.new(count: "20") }
+
+      it "parses the count param as an integer" do
+        expect(subject.count).to eq(20)
+      end
+      it "returns the default start" do
+        expect(subject.start).to eq(0)
+      end
+    end
+
+
+    context "with pagination params" do
+      subject { described_class.new(start: "5", count: "20") }
+
+      it "parses the start param as an integer" do
+        expect(subject.start).to eq(5)
+      end
+      it "parses the count param as an integer" do
+        expect(subject.count).to eq(20)
+      end
+    end
+  end
+end

--- a/spec/queries/get_content_collection_spec.rb
+++ b/spec/queries/get_content_collection_spec.rb
@@ -90,4 +90,88 @@ RSpec.describe Queries::GetContentCollection do
       ])
     end
   end
+
+  describe "pagination" do
+    context "with multiple content items" do
+      before do
+        create(:draft_content_item, :with_version, base_path: '/a', format: 'topic')
+        create(:draft_content_item, :with_version, base_path: '/b', format: 'topic')
+        create(:draft_content_item, :with_version, base_path: '/c', format: 'topic')
+        create(:draft_content_item, :with_version, base_path: '/d', format: 'topic')
+        create(:live_content_item, :with_version, base_path: '/live1',  format: 'topic')
+        create(:live_content_item, :with_version, base_path: '/live2',  format: 'topic')
+      end
+
+      it "limits the results returned" do
+        content_items = Queries::GetContentCollection.new(
+          content_format: 'topic',
+          fields: ['publishing_app'],
+          pagination: {
+            start: 0,
+            count: 3,
+          }
+        ).call
+
+        expect(content_items.size).to eq(3)
+      end
+
+      it "fetches results from a specified index" do
+        content_items = Queries::GetContentCollection.new(
+          content_format: 'topic',
+          fields: ['base_path'],
+          pagination: {
+            start: 1,
+            count: 2,
+          }
+        ).call
+
+        expect(content_items.first['base_path']).to eq('/b')
+      end
+
+      it "when count is higher than results we only receieve remaining content items" do
+        content_items = Queries::GetContentCollection.new(
+          content_format: 'topic',
+          fields: ['base_path'],
+          pagination: {
+            start: 3,
+            count: 8,
+          }
+        ).call
+
+        expect(content_items.first['base_path']).to eq('/d')
+        expect(content_items.last['base_path']).to eq('/live2')
+      end
+
+      it "returns both content item types up to the limit" do
+        content_items = Queries::GetContentCollection.new(
+          content_format: 'topic',
+          fields: ['base_path'],
+          pagination: {
+            start: 0,
+            count: 5,
+          }
+        ).call
+
+        expect(content_items.first['base_path']).to eq('/a')
+        expect(content_items.last['base_path']).to eq('/live1')
+      end
+    end
+    context "with only live items" do
+      before do
+        create(:live_content_item, :with_version, base_path: '/live1',  format: 'topic')
+        create(:live_content_item, :with_version, base_path: '/live2',  format: 'topic')
+      end
+      it "returns expected number of live items" do
+        content_items = Queries::GetContentCollection.new(
+          content_format: 'topic',
+          fields: ['base_path'],
+          pagination: {
+            start: 2,
+            count: 8,
+          }
+        ).call
+        expect(content_items).to be_empty
+      end
+    end
+  end
 end

--- a/spec/queries/get_content_collection_spec.rb
+++ b/spec/queries/get_content_collection_spec.rb
@@ -106,10 +106,10 @@ RSpec.describe Queries::GetContentCollection do
         content_items = Queries::GetContentCollection.new(
           content_format: 'topic',
           fields: ['publishing_app'],
-          pagination: {
+          pagination: Pagination.new({
             start: 0,
             count: 3,
-          }
+          })
         ).call
 
         expect(content_items.size).to eq(3)
@@ -119,10 +119,10 @@ RSpec.describe Queries::GetContentCollection do
         content_items = Queries::GetContentCollection.new(
           content_format: 'topic',
           fields: ['base_path'],
-          pagination: {
+          pagination: Pagination.new({
             start: 1,
             count: 2,
-          }
+          })
         ).call
 
         expect(content_items.first['base_path']).to eq('/b')
@@ -132,10 +132,10 @@ RSpec.describe Queries::GetContentCollection do
         content_items = Queries::GetContentCollection.new(
           content_format: 'topic',
           fields: ['base_path'],
-          pagination: {
+          pagination: Pagination.new({
             start: 3,
             count: 8,
-          }
+          })
         ).call
 
         expect(content_items.first['base_path']).to eq('/d')
@@ -146,10 +146,10 @@ RSpec.describe Queries::GetContentCollection do
         content_items = Queries::GetContentCollection.new(
           content_format: 'topic',
           fields: ['base_path'],
-          pagination: {
+          pagination: Pagination.new({
             start: 0,
             count: 5,
-          }
+          })
         ).call
 
         expect(content_items.first['base_path']).to eq('/a')
@@ -165,10 +165,10 @@ RSpec.describe Queries::GetContentCollection do
         content_items = Queries::GetContentCollection.new(
           content_format: 'topic',
           fields: ['base_path'],
-          pagination: {
+          pagination: Pagination.new({
             start: 2,
             count: 8,
-          }
+          })
         ).call
         expect(content_items).to be_empty
       end


### PR DESCRIPTION
https://trello.com/c/OZF9rKeX/487-linked-items-endpoint-should-support-pagination

Added pagination so that content items can be retrieved in batches by publishing apps. 