### PR TITLE
Optimise accessing content by format

### DIFF
--- a/app/queries/get_content_collection.rb
+++ b/app/queries/get_content_collection.rb
@@ -34,7 +34,7 @@ module Queries
       draft_items = draft_items.where(publishing_app: @publishing_app) if @publishing_app.present?
 
       live_items = LiveContentItem
-        .where.not(content_id: draft_items.map(&:content_id))
+        .where("draft_content_item_id IS NULL")
         .where(format: [content_format, "placeholder_#{content_format}"])
         .select(*fields + %i[id])
 

--- a/db/migrate/20160115162121_add_indexes_for_content_collection_access.rb
+++ b/db/migrate/20160115162121_add_indexes_for_content_collection_access.rb
@@ -1,0 +1,7 @@
+class AddIndexesForContentCollectionAccess < ActiveRecord::Migration
+  def change
+      add_index :draft_content_items, :format
+      add_index :live_content_items, :format
+      add_index :versions, :target_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160111103706) do
+ActiveRecord::Schema.define(version: 20160115162121) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -48,6 +48,7 @@ ActiveRecord::Schema.define(version: 20160111103706) do
 
   add_index "draft_content_items", ["base_path"], name: "index_draft_content_items_on_base_path", unique: true, using: :btree
   add_index "draft_content_items", ["content_id", "locale"], name: "index_draft_content_items_on_content_id_and_locale", unique: true, using: :btree
+  add_index "draft_content_items", ["format"], name: "index_draft_content_items_on_format", using: :btree
 
   create_table "events", force: :cascade do |t|
     t.string   "action",                  null: false
@@ -99,6 +100,7 @@ ActiveRecord::Schema.define(version: 20160111103706) do
   add_index "live_content_items", ["base_path"], name: "index_live_content_items_on_base_path", unique: true, using: :btree
   add_index "live_content_items", ["content_id", "locale"], name: "index_live_content_items_on_content_id_and_locale", unique: true, using: :btree
   add_index "live_content_items", ["draft_content_item_id"], name: "index_live_content_items_on_draft_content_item_id", using: :btree
+  add_index "live_content_items", ["format"], name: "index_live_content_items_on_format", using: :btree
 
   create_table "path_reservations", force: :cascade do |t|
     t.string   "base_path",      null: false
@@ -116,6 +118,8 @@ ActiveRecord::Schema.define(version: 20160111103706) do
     t.datetime "created_at",              null: false
     t.datetime "updated_at",              null: false
   end
+
+  add_index "versions", ["target_id"], name: "index_versions_on_target_id", using: :btree
 
   add_foreign_key "links", "link_sets"
 end

--- a/lib/query_benchmarks.rb
+++ b/lib/query_benchmarks.rb
@@ -1,0 +1,31 @@
+require 'benchmark'
+include Benchmark
+
+module QueryBenchmarks
+    LABEL_WIDTH = 7
+    ITERATIONS = 10
+
+    class ContentCollectionBenchmark
+        CONTENT_FORMAT = "organisation"
+        FIELDS = %w(content_id format title base_path)
+        PUBLISHING_APP = ""
+
+        def self.organisations!
+            Queries::GetContentCollection.new(content_format: CONTENT_FORMAT, fields: FIELDS, publishing_app: PUBLISHING_APP).call
+        end
+
+        def self.run!(name, &block)
+            Benchmark.benchmark(CAPTION, LABEL_WIDTH, FORMAT, "total: ", "avg: ") do |bm|
+                sum = Benchmark::Tms.new
+                ITERATIONS.times do
+                    sum += bm.report(name, &block)
+                end
+                [sum, sum/ITERATIONS.to_f]
+            end
+        end
+
+        def self.run_organisations!
+            run!("organisations") {self.organisations!}
+        end
+    end
+end


### PR DESCRIPTION
I've been looking at performance of the /v2/content?content_format endpoint for policy-publisher (trello ticket: https://trello.com/c/BQDQ824W/468-use-publishing-api-v2-for-policy-publisher)

We use this endpoint in policy-publisher to populate select boxes for people,
organisations, and working groups when we are creating/editing a policy.

I'm going to continue taking a look at this but I'd like to get this first set of changes reviewed independently as this is a blocker for that work, and the current master of policy-publisher is undeployable because calls to this endpoint time out. It's still slower than I'd like but this version resolves that issue.

The main change is to add indexes for format on the content tables and target_id on the
versions table.

I've added a simple benchmark to time this part of the call, which I can either keep or remove depending on if it's useful to anyone else. I've also been looking at query times logged out by active record when using the policy publisher and doing some profiling of the publisher api calls.

Some of the queries for the content index endpoint were taking hundreds or
thousands of milliseconds to complete without the indexes, particularly
when the versions were loaded.

I found that rewriting the live content items query made a measurable improvement to the overall time as well. The previous version of the query could
generate very large NOT IN clauses and the execution time was slower than
the other queries. As far as I can tell the new version should be equivalent - draft_items vs live_items are non overlapping sets, with draft_items containing those items that have both live/draft records.

## Timings
This is the benchmark applied to the organisations list. It's slower for people, faster for working groups (due to more/less records respectively).

### Before
```
              user     system      total        real
organisations  0.420000   0.070000   0.490000 (  3.870851)
organisations  0.330000   0.010000   0.340000 (  3.580921)
organisations  0.310000   0.030000   0.340000 (  3.538710)
organisations  0.270000   0.020000   0.290000 (  3.553315)
organisations  0.270000   0.010000   0.280000 (  3.479635)
organisations  0.270000   0.020000   0.290000 (  3.515088)
organisations  0.320000   0.010000   0.330000 (  3.663402)
organisations  0.260000   0.020000   0.280000 (  3.641198)
organisations  0.300000   0.020000   0.320000 (  3.665974)
organisations  0.320000   0.020000   0.340000 (  3.625141)
total:    3.070000   0.230000   3.300000 ( 36.134233)
avg:      0.307000   0.023000   0.330000 (  3.613423)
```

### After
```
              user     system      total        real
organisations  0.450000   0.060000   0.510000 (  0.603195)
organisations  0.420000   0.050000   0.470000 (  0.485523)
organisations  0.270000   0.020000   0.290000 (  0.333716)
organisations  0.260000   0.030000   0.290000 (  0.338112)
organisations  0.300000   0.030000   0.330000 (  0.364923)
organisations  0.290000   0.020000   0.310000 (  0.358848)
organisations  0.290000   0.020000   0.310000 (  0.341321)
organisations  0.290000   0.020000   0.310000 (  0.331396)
organisations  0.320000   0.020000   0.340000 (  0.358104)
organisations  0.310000   0.010000   0.320000 (  0.343731)
total:    3.200000   0.280000   3.480000 (  3.858870)
avg:      0.320000   0.028000   0.348000 (  0.385887)
```