### PR TITLE
Scope items by locale

### DIFF
--- a/app/controllers/v2/content_items_controller.rb
+++ b/app/controllers/v2/content_items_controller.rb
@@ -4,7 +4,12 @@ module V2
       content_format = params.fetch(:content_format)
       fields = params.fetch(:fields)
       publishing_app = params[:publishing_app]  # can be blank
-      render json: Queries::GetContentCollection.new(content_format: content_format, fields: fields, publishing_app: publishing_app).call
+      locale = params[:locale]
+      render json: Queries::GetContentCollection.new(
+        content_format: content_format,
+        fields: fields,
+        publishing_app: publishing_app,
+        locale: locale).call
     end
 
     def show

--- a/app/queries/get_content_collection.rb
+++ b/app/queries/get_content_collection.rb
@@ -1,11 +1,12 @@
 module Queries
   class GetContentCollection
-    attr_reader :content_format, :fields
+    attr_reader :content_format, :fields, :locale
 
-    def initialize(content_format:, fields:, publishing_app: nil)
+    def initialize(content_format:, fields:, publishing_app: nil, locale: nil)
       @content_format = content_format
       @fields = fields
       @publishing_app = publishing_app
+      @locale = locale || "en"
     end
 
     def call
@@ -32,6 +33,7 @@ module Queries
         .select(*fields + %i[id content_id])
 
       draft_items = draft_items.where(publishing_app: @publishing_app) if @publishing_app.present?
+      draft_items = draft_items.where(locale: locale) unless @locale == 'all'
 
       live_items = LiveContentItem
         .where("draft_content_item_id IS NULL")
@@ -39,6 +41,7 @@ module Queries
         .select(*fields + %i[id])
 
       live_items = live_items.where(publishing_app: @publishing_app) if @publishing_app.present?
+      live_items = live_items.where(locale: locale) unless @locale == 'all'
 
       @draft_versions = Version.in_bulk(draft_items, DraftContentItem)
       @live_versions = Version.in_bulk(

--- a/app/queries/get_content_collection.rb
+++ b/app/queries/get_content_collection.rb
@@ -33,7 +33,7 @@ module Queries
         .select(*fields + %i[id content_id])
 
       draft_items = draft_items.where(publishing_app: @publishing_app) if @publishing_app.present?
-      draft_items = draft_items.where(locale: locale) unless @locale == 'all'
+      draft_items = draft_items.where(locale: locale) unless locale == 'all'
 
       live_items = LiveContentItem
         .where("draft_content_item_id IS NULL")
@@ -41,7 +41,7 @@ module Queries
         .select(*fields + %i[id])
 
       live_items = live_items.where(publishing_app: @publishing_app) if @publishing_app.present?
-      live_items = live_items.where(locale: locale) unless @locale == 'all'
+      live_items = live_items.where(locale: locale) unless locale == 'all'
 
       @draft_versions = Version.in_bulk(draft_items, DraftContentItem)
       @live_versions = Version.in_bulk(

--- a/spec/controllers/v2/content_items_controller_spec.rb
+++ b/spec/controllers/v2/content_items_controller_spec.rb
@@ -5,17 +5,16 @@ RSpec.describe V2::ContentItemsController do
 
   before do
     stub_request(:any, /content-store/)
-    @draft = FactoryGirl.create(:draft_content_item, content_id: content_id)
+    @draft = FactoryGirl.create(:draft_content_item,
+        content_id: content_id, locale: "en",
+        base_path: "/content.en",
+        format: "topic")
     FactoryGirl.create(:version, target: @draft, number: 2)
   end
 
   describe "index" do
     before do
-      @en_draft_content = FactoryGirl.create(:draft_content_item,
-        content_id: content_id,
-        locale: "en",
-        base_path: "/content.en",
-        format: "topic")
+      @en_draft_content = @draft
       @ar_draft_content = FactoryGirl.create(:draft_content_item,
         content_id: content_id,
         locale: "ar",
@@ -39,7 +38,7 @@ RSpec.describe V2::ContentItemsController do
 
     context "without providing a locale parameter" do
       before do
-        get :index, content_format: "topic", fields: ["locale","content_id","base_path","publication_state"]
+        get :index, content_format: "topic", fields: ["locale","content_id","base_path"]
       end
 
       it "is successful" do

--- a/spec/controllers/v2/content_items_controller_spec.rb
+++ b/spec/controllers/v2/content_items_controller_spec.rb
@@ -49,10 +49,12 @@ RSpec.describe V2::ContentItemsController do
       it "responds with the english content item as json" do
         parsed_response_body = JSON.parse(response.body)
         expect(parsed_response_body.length == 2)
-        expect(parsed_response_body.first.fetch("base_path")).to eq("/content.en")
-        expect(parsed_response_body.first.fetch("publication_state")).to eq("draft")
-        expect(parsed_response_body.second.fetch("base_path")).to eq("/content.en")
-        expect(parsed_response_body.second.fetch("publication_state")).to eq("live")
+
+        base_paths = parsed_response_body.map { |item| item.fetch("base_path") }
+        expect(base_paths). to eq ["/content.en", "/content.en"]
+
+        publication_states = parsed_response_body.map { |item| item.fetch("publication_state") }
+        expect(publication_states). to eq ["draft", "live"]
       end
     end
 
@@ -68,10 +70,12 @@ RSpec.describe V2::ContentItemsController do
       it "responds with the specific locale content item as json" do
         parsed_response_body = JSON.parse(response.body)
         expect(parsed_response_body.length == 2)
-        expect(parsed_response_body.first.fetch("base_path")).to eq("/content.ar")
-        expect(parsed_response_body.first.fetch("publication_state")).to eq("draft")
-        expect(parsed_response_body.second.fetch("base_path")).to eq("/content.ar")
-        expect(parsed_response_body.second.fetch("publication_state")).to eq("live")
+
+        base_paths = parsed_response_body.map { |item| item.fetch("base_path") }
+        expect(base_paths). to eq ["/content.ar", "/content.ar"]
+
+        base_paths = parsed_response_body.map { |item| item.fetch("publication_state") }
+        expect(base_paths). to eq ["draft", "live"]
       end
     end
 
@@ -87,17 +91,12 @@ RSpec.describe V2::ContentItemsController do
       it "responds with all the localised content items as json" do
         parsed_response_body = JSON.parse(response.body)
         expect(parsed_response_body.length == 4)
-        expect(parsed_response_body[0].fetch("base_path")).to eq("/content.en")
-        expect(parsed_response_body[0].fetch("publication_state")).to eq("draft")
 
-        expect(parsed_response_body[1].fetch("base_path")).to eq("/content.ar")
-        expect(parsed_response_body[1].fetch("publication_state")).to eq("draft")
+        base_paths = parsed_response_body.map { |item| item.fetch("base_path") }
+        expect(base_paths). to eq ["/content.en", "/content.ar", "/content.ar", "/content.en"]
 
-        expect(parsed_response_body[2].fetch("base_path")).to eq("/content.ar")
-        expect(parsed_response_body[2].fetch("publication_state")).to eq("live")
-
-        expect(parsed_response_body[3].fetch("base_path")).to eq("/content.en")
-        expect(parsed_response_body[3].fetch("publication_state")).to eq("live")
+        publication_states = parsed_response_body.map { |item| item.fetch("publication_state") }
+        expect(publication_states). to eq ["draft", "draft", "live", "live"]
       end
     end
   end

--- a/spec/controllers/v2/content_items_controller_spec.rb
+++ b/spec/controllers/v2/content_items_controller_spec.rb
@@ -10,29 +10,24 @@ RSpec.describe V2::ContentItemsController do
   end
 
   describe "index" do
-    let(:en_draft_content_id) { SecureRandom.uuid }
-    let(:ar_draft_content_id) { SecureRandom.uuid }
-    let(:en_live_content_id) { SecureRandom.uuid }
-    let(:ar_live_content_id) { SecureRandom.uuid }
-
     before do
       @en_draft_content = FactoryGirl.create(:draft_content_item,
-        content_id: en_draft_content_id,
+        content_id: content_id,
         locale: "en",
         base_path: "/content.en",
         format: "topic")
       @ar_draft_content = FactoryGirl.create(:draft_content_item,
-        content_id: ar_draft_content_id,
+        content_id: content_id,
         locale: "ar",
         base_path: "/content.ar",
         format: "topic")
       @en_live_content = FactoryGirl.create(:live_content_item,
-        content_id: en_live_content_id,
+        content_id: content_id,
         locale: "en",
         base_path: "/content.en",
         format: "topic")
       @ar_live_content = FactoryGirl.create(:live_content_item,
-        content_id: ar_live_content_id,
+        content_id: content_id,
         locale: "ar",
         base_path: "/content.ar",
         format: "topic")
@@ -44,7 +39,7 @@ RSpec.describe V2::ContentItemsController do
 
     context "without providing a locale parameter" do
       before do
-        get :index, content_format: "topic", fields: ["locale","content_id","base_path"]
+        get :index, content_format: "topic", fields: ["locale","content_id","base_path","publication_state"]
       end
 
       it "is successful" do
@@ -54,8 +49,10 @@ RSpec.describe V2::ContentItemsController do
       it "responds with the english content item as json" do
         parsed_response_body = JSON.parse(response.body)
         expect(parsed_response_body.length == 2)
-        expect(parsed_response_body.first.fetch("content_id")).to eq("#{en_draft_content_id}")
-        expect(parsed_response_body.second.fetch("content_id")).to eq("#{en_live_content_id}")
+        expect(parsed_response_body.first.fetch("base_path")).to eq("/content.en")
+        expect(parsed_response_body.first.fetch("publication_state")).to eq("draft")
+        expect(parsed_response_body.second.fetch("base_path")).to eq("/content.en")
+        expect(parsed_response_body.second.fetch("publication_state")).to eq("live")
       end
     end
 
@@ -71,8 +68,10 @@ RSpec.describe V2::ContentItemsController do
       it "responds with the specific locale content item as json" do
         parsed_response_body = JSON.parse(response.body)
         expect(parsed_response_body.length == 2)
-        expect(parsed_response_body.first.fetch("content_id")).to eq("#{ar_draft_content_id}")
-        expect(parsed_response_body.second.fetch("content_id")).to eq("#{ar_live_content_id}")
+        expect(parsed_response_body.first.fetch("base_path")).to eq("/content.ar")
+        expect(parsed_response_body.first.fetch("publication_state")).to eq("draft")
+        expect(parsed_response_body.second.fetch("base_path")).to eq("/content.ar")
+        expect(parsed_response_body.second.fetch("publication_state")).to eq("live")
       end
     end
 
@@ -88,10 +87,17 @@ RSpec.describe V2::ContentItemsController do
       it "responds with all the localised content items as json" do
         parsed_response_body = JSON.parse(response.body)
         expect(parsed_response_body.length == 4)
-        expect(parsed_response_body[0].fetch("content_id")).to eq("#{en_draft_content_id}")
-        expect(parsed_response_body[1].fetch("content_id")).to eq("#{ar_draft_content_id}")
-        expect(parsed_response_body[2].fetch("content_id")).to eq("#{ar_live_content_id}")
-        expect(parsed_response_body[3].fetch("content_id")).to eq("#{en_live_content_id}")
+        expect(parsed_response_body[0].fetch("base_path")).to eq("/content.en")
+        expect(parsed_response_body[0].fetch("publication_state")).to eq("draft")
+
+        expect(parsed_response_body[1].fetch("base_path")).to eq("/content.ar")
+        expect(parsed_response_body[1].fetch("publication_state")).to eq("draft")
+
+        expect(parsed_response_body[2].fetch("base_path")).to eq("/content.ar")
+        expect(parsed_response_body[2].fetch("publication_state")).to eq("live")
+
+        expect(parsed_response_body[3].fetch("base_path")).to eq("/content.en")
+        expect(parsed_response_body[3].fetch("publication_state")).to eq("live")
       end
     end
   end

--- a/spec/queries/get_content_collection_spec.rb
+++ b/spec/queries/get_content_collection_spec.rb
@@ -90,4 +90,48 @@ RSpec.describe Queries::GetContentCollection do
       ])
     end
   end
+
+  describe "the locale filter parameter" do
+    before do
+      create(:draft_content_item, :with_version, base_path: '/content.en', format: 'topic', locale: 'en')
+      create(:draft_content_item, :with_version, base_path: '/content.ar', format: 'topic', locale: 'ar')
+      create(:live_content_item, :with_version, base_path: '/content.en', format: 'topic', locale: 'en')
+      create(:live_content_item, :with_version, base_path: '/content.ar', format: 'topic', locale: 'ar')
+    end
+
+    it "returns the content items filtered by 'en' locale by default" do
+      expect(Queries::GetContentCollection.new(
+        content_format: 'topic',
+        fields: ['base_path'],
+      ).call).to eq([
+        { "base_path" => "/content.en", "publication_state" => "draft" },
+        { "base_path" => "/content.en", "publication_state" => "live" },
+      ])
+    end
+
+    it "returns the content items filtered by locale parameter" do
+      expect(Queries::GetContentCollection.new(
+        content_format: 'topic',
+        fields: ['base_path'],
+        locale: 'ar',
+      ).call).to eq([
+        { "base_path" => "/content.ar", "publication_state" => "draft" },
+        { "base_path" => "/content.ar", "publication_state" => "live" },
+      ])
+    end
+
+    it "returns all content items if the locale parameter is 'all'" do
+      expect(Queries::GetContentCollection.new(
+        content_format: 'topic',
+        fields: ['base_path'],
+        locale: 'all',
+      ).call).to eq([
+        { "base_path" => "/content.en", "publication_state" => "draft" },
+        { "base_path" => "/content.ar", "publication_state" => "draft" },
+        { "base_path" => "/content.ar", "publication_state" => "live" },
+        { "base_path" => "/content.en", "publication_state" => "live" },
+      ])
+    end
+  end
+
 end

--- a/spec/service_consumers/pact_helper.rb
+++ b/spec/service_consumers/pact_helper.rb
@@ -159,9 +159,9 @@ Pact.provider_states_for "GDS API Adapters" do
 
   provider_state "a content item exists in multiple locales with content_id: bed722e6-db68-43e5-9079-063f623335a7" do
     set_up do
-      english_draft = FactoryGirl.create(:draft_content_item, content_id: "bed722e6-db68-43e5-9079-063f623335a7", locale: "en")
-      french_draft = FactoryGirl.create(:draft_content_item, content_id: "bed722e6-db68-43e5-9079-063f623335a7", locale: "fr")
-      arabic_draft = FactoryGirl.create(:draft_content_item, content_id: "bed722e6-db68-43e5-9079-063f623335a7", locale: "ar")
+      english_draft = FactoryGirl.create(:draft_content_item, content_id: "bed722e6-db68-43e5-9079-063f623335a7", locale: "en", format: 'topic')
+      french_draft = FactoryGirl.create(:draft_content_item, content_id: "bed722e6-db68-43e5-9079-063f623335a7", locale: "fr", format: 'topic')
+      arabic_draft = FactoryGirl.create(:draft_content_item, content_id: "bed722e6-db68-43e5-9079-063f623335a7", locale: "ar", format: 'topic')
 
       FactoryGirl.create(:version, target: english_draft, number: 1)
       FactoryGirl.create(:version, target: french_draft, number: 1)


### PR DESCRIPTION
Add a new `locale` parameter to the contents index path `/v2/content`, in order to:
* filter by the provided `locale` value
* filter by `locale == 'en'` if no `locale` parameter is provided
* do not filter if `locale == 'all'` parameter is provided (this was the previous behaviour)

https://trello.com/c/xAitVd24/505-scope-content-items-index-results-by-locale