### PR TITLE
Allow passing link hashes through to content store

### DIFF
--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -1,8 +1,23 @@
 class Link < ActiveRecord::Base
+  include SymbolizeJSON
+
   belongs_to :link_set
 
   validate :link_type_is_valid
   validate :content_id_is_valid
+
+  def target_content_id
+    passthrough_hash || super
+  end
+
+  def target_content_id=(string_or_hash)
+    case string_or_hash
+    when String
+      super
+    when Hash
+      self.passthrough_hash = string_or_hash
+    end
+  end
 
 private
 
@@ -13,7 +28,7 @@ private
   end
 
   def content_id_is_valid
-    unless UuidValidator.valid?(target_content_id)
+    unless target_content_id.is_a?(Hash) || UuidValidator.valid?(target_content_id)
       errors[:link] = "target_content_id must be a valid UUID"
     end
   end

--- a/db/migrate/20160125143518_add_passthrough_field_to_link.rb
+++ b/db/migrate/20160125143518_add_passthrough_field_to_link.rb
@@ -1,0 +1,6 @@
+class AddPassthroughFieldToLink < ActiveRecord::Migration
+  def change
+    add_column :links, :passthrough_hash, :json
+    change_column_null :links, :target_content_id, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160115162121) do
+ActiveRecord::Schema.define(version: 20160125143518) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -67,10 +67,11 @@ ActiveRecord::Schema.define(version: 20160115162121) do
 
   create_table "links", force: :cascade do |t|
     t.integer  "link_set_id"
-    t.string   "target_content_id", null: false
+    t.string   "target_content_id"
     t.string   "link_type",         null: false
     t.datetime "created_at",        null: false
     t.datetime "updated_at",        null: false
+    t.json     "passthrough_hash"
   end
 
   add_index "links", ["link_set_id", "target_content_id"], name: "index_links_on_link_set_id_and_target_content_id", using: :btree

--- a/spec/requests/content_item_requests/downstream_requests_spec.rb
+++ b/spec/requests/content_item_requests/downstream_requests_spec.rb
@@ -121,6 +121,30 @@ RSpec.describe "Downstream requests", type: :request do
       does_not_send_to_draft_content_store
       does_not_send_to_live_content_store
     end
+
+    context "when sending passthrough links" do
+      def links_attributes
+        {
+          content_id: content_id,
+          links: {
+            organisations: [
+              {
+                content_id: "a-passthrough-content-id",
+                title: "Some passthrough content",
+              }
+            ]
+          }
+        }
+      end
+
+      before do
+        draft = FactoryGirl.create(:draft_content_item, v2_content_item.slice(*DraftContentItem::TOP_LEVEL_FIELDS))
+        FactoryGirl.create(:version, target: draft, number: 1)
+        FactoryGirl.create(:access_limit, target: draft, users: access_limit_params.fetch(:users))
+      end
+
+      sends_to_draft_content_store
+    end
   end
 
   context "/v2/publish" do


### PR DESCRIPTION
This works with https://github.com/alphagov/content-store/pull/182 to
allow publishing applications to “hardcode” link expansion for content
not yet in the publishing API (such as governments for history mode).