### PR TITLE
Allow empty links to be sent

### DIFF
--- a/app/commands/v2/put_link_set.rb
+++ b/app/commands/v2/put_link_set.rb
@@ -11,6 +11,8 @@ module Commands
 
           links_hash = link_params.fetch(:links)
 
+          link_set.links.delete_all if links_hash.empty?
+
           links_hash.each do |link_type, target_content_ids|
             if target_content_ids.empty?
               link_set.links.where(link_type: link_type).delete_all
@@ -74,7 +76,7 @@ module Commands
               }
             }
           }
-        ) unless link_params[:links].present?
+        ) unless link_params.has_key?(:links)
       end
 
       def validate_version_lock!

--- a/spec/commands/v2/put_link_set_spec.rb
+++ b/spec/commands/v2/put_link_set_spec.rb
@@ -10,6 +10,17 @@ RSpec.describe Commands::V2::PutLinkSet do
       }.to raise_error(CommandError, "Links are required")
     end
 
+    it "doesn't barf on an empty links hash" do
+      link_set = create(:link_set, links: [create(:link)])
+
+      put_link_set(
+        content_id: link_set.content_id,
+        links: {}
+      )
+
+      expect(link_set.links.count).to eql(0)
+    end
+
     it "creates one links" do
       link_set = create(:link_set)
       link_content_id = SecureRandom.uuid


### PR DESCRIPTION
We were sending an empty links hash for pieces of content which have no links
of any kind. This should make it so that those requests don't get rejected.

Additionally, it seems that if the list of links is empty, then all the
existing links should be removed. How else would you remove them?

This is breaking Whitehall in Integration right now following some work to change how it sends data to publishing-api.