### PR TITLE
Don't reject an empty links hash in put_links (Mk2)

### DIFF
--- a/app/commands/v2/put_link_set.rb
+++ b/app/commands/v2/put_link_set.rb
@@ -74,7 +74,7 @@ module Commands
               }
             }
           }
-        ) unless link_params[:links].present?
+        ) unless link_params.has_key?(:links)
       end
 
       def validate_version_lock!

--- a/spec/commands/v2/put_link_set_spec.rb
+++ b/spec/commands/v2/put_link_set_spec.rb
@@ -10,6 +10,17 @@ RSpec.describe Commands::V2::PutLinkSet do
       }.to raise_error(CommandError, "Links are required")
     end
 
+    it "doesn't reject an empty links hash, but doesn't delete links either" do
+      link_set = create(:link_set, links: [create(:link)])
+
+      put_link_set(
+        content_id: link_set.content_id,
+        links: {}
+      )
+
+      expect(link_set.links.count).to eql(1)
+    end
+
     it "creates one links" do
       link_set = create(:link_set)
       link_content_id = SecureRandom.uuid


### PR DESCRIPTION
We were sending an empty links hash for some types of content which have no
links of any kind. This should be allowed. It doesn't/shouldn't delete any
links because the behaviour of put_links is HTTP PATCH - ie only update keys
supplied.

This is breaking Whitehall in Integration right now following some work to change how it sends data to publishing-api.