### PR TITLE
Rename PutLinkSet to PatchLinkSet

### DIFF
--- a/app/commands/put_content_with_links.rb
+++ b/app/commands/put_content_with_links.rb
@@ -5,7 +5,7 @@ module Commands
         delete_existing_links
 
         V2::PutContent.call(v2_put_content_payload, downstream: downstream)
-        V2::PutLinkSet.call(v2_put_link_set_payload, downstream: downstream)
+        V2::PatchLinkSet.call(v2_put_link_set_payload, downstream: downstream)
         V2::Publish.call(v2_publish_payload, downstream: downstream)
       else
         base_path = payload.fetch(:base_path)

--- a/app/commands/put_draft_content_with_links.rb
+++ b/app/commands/put_draft_content_with_links.rb
@@ -5,7 +5,7 @@ module Commands
         delete_existing_links
 
         V2::PutContent.call(v2_put_content_payload, downstream: downstream)
-        V2::PutLinkSet.call(v2_put_link_set_payload, downstream: downstream)
+        V2::PatchLinkSet.call(v2_put_link_set_payload, downstream: downstream)
       else
         PathReservation.reserve_base_path!(base_path, payload[:publishing_app])
 

--- a/app/commands/v2/patch_link_set.rb
+++ b/app/commands/v2/patch_link_set.rb
@@ -1,6 +1,6 @@
 module Commands
   module V2
-    class PutLinkSet < BaseCommand
+    class PatchLinkSet < BaseCommand
       def call
         raise_unless_links_hash_is_provided
 

--- a/app/controllers/v2/link_sets_controller.rb
+++ b/app/controllers/v2/link_sets_controller.rb
@@ -6,8 +6,8 @@ module V2
       render json: Queries::GetLinkSet.call(content_id)
     end
 
-    def put_links
-      response = Commands::V2::PutLinkSet.call(links_params)
+    def patch_links
+      response = Commands::V2::PatchLinkSet.call(links_params)
       render status: response.code, json: response
     end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,8 +17,9 @@ Rails.application.routes.draw do
       post "/content/:content_id/discard-draft", to: "content_items#discard_draft"
 
       get "/links/:content_id", to: "link_sets#get_links"
-      put "/links/:content_id", to: "link_sets#put_links"
-
+      patch "/links/:content_id", to: "link_sets#patch_links"
+      # put is provided for backwards compatibility.
+      put "/links/:content_id", to: "link_sets#patch_links"
       get "/linked/:content_id", to: "link_sets#get_linked"
     end
   end

--- a/doc/publishing-api-syntactic-usage.md
+++ b/doc/publishing-api-syntactic-usage.md
@@ -75,11 +75,11 @@ Requests to update an existing draft content item:
 ### Required request params:
  - `content_id` the primary identifier for the content associated with the requested link set.
 
-## `PUT /v2/links/:content_id`
+## `PATCH /v2/links/:content_id`
 
 [Request/Response detail](https://pact-broker.dev.publishing.service.gov.uk/pacts/provider/Publishing%20API/consumer/GDS%20API%20Adapters/latest#a_request_to_update_the_linkset_at_version_3_given_the_linkset_for_bed722e6-db68-43e5-9079-063f623335a7_is_at_version_3)
 
- - Creates or replaces a link set given a content_id.
+ - Creates or updates a link set given a content_id.
  - Validates the presence of the links request parameter and responds with 422 if not present.
  - Validates the link set lock version in the request and responds with 409 if the lock version is incorrect.
  - Instantiates or retrieves an existing link set.

--- a/spec/commands/v2/patch_link_set_spec.rb
+++ b/spec/commands/v2/patch_link_set_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe Commands::V2::PutLinkSet do
+RSpec.describe Commands::V2::PatchLinkSet do
   let(:content_id) { SecureRandom.uuid }
   let(:topics) { 3.times.map { SecureRandom.uuid } }
   let(:parent) { [SecureRandom.uuid] }

--- a/spec/requests/content_item_requests/downstream_requests_spec.rb
+++ b/spec/requests/content_item_requests/downstream_requests_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe "Downstream requests", type: :request do
     }
     let(:request_body) { links_attributes.to_json }
     let(:request_path) { "/v2/links/#{content_id}" }
-    let(:request_method) { :put }
+    let(:request_method) { :patch }
 
     context "when only a draft content item exists for the link set" do
       before do

--- a/spec/requests/content_item_requests/downstream_timeouts_spec.rb
+++ b/spec/requests/content_item_requests/downstream_timeouts_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe "Downstream timeouts", type: :request do
   context "/v2/links" do
     let(:request_body) { links_attributes.to_json }
     let(:request_path) { "/v2/links/#{content_id}" }
-    let(:request_method) { :put }
+    let(:request_method) { :patch }
 
     before do
       FactoryGirl.create(:live_content_item, v2_content_item.slice(*ContentItem::TOP_LEVEL_FIELDS))

--- a/spec/requests/content_item_requests/message_bus_spec.rb
+++ b/spec/requests/content_item_requests/message_bus_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe "Message bus", type: :request do
   context "/v2/links" do
     let(:request_body) { links_attributes.to_json }
     let(:request_path) { "/v2/links/#{content_id}" }
-    let(:request_method) { :put }
+    let(:request_method) { :patch }
 
     context "with a live content item" do
       let!(:live_content_item) {

--- a/spec/support/request_helpers/actions.rb
+++ b/spec/support/request_helpers/actions.rb
@@ -4,6 +4,8 @@ module RequestHelpers
       case request_method
       when :put
         put request_path, body, headers
+      when :patch
+        patch request_path, body, headers
       when :get
         get request_path, body, headers
       when :post


### PR DESCRIPTION
After speaking to @danielroseman and @rboulton we agreed that this endpoint's behaviour and the original intent was for it to be a PATCH action, not an overwrite (PUT). 

This is a stab at changing the method.

Related PRs:
* cleanup data migration: https://github.com/alphagov/publishing-api/pull/199
* update gds-api-adapters to use PATCH for links: https://github.com/alphagov/gds-api-adapters/pull/428