### PR TITLE
Migration to rename Put/PatchLinks in Event log

### DIFF
--- a/db/migrate/20160203142246_rename_put_links_to_patch_links.rb
+++ b/db/migrate/20160203142246_rename_put_links_to_patch_links.rb
@@ -1,0 +1,8 @@
+class RenamePutLinksToPatchLinks < ActiveRecord::Migration
+  class Event < ActiveRecord::Base
+  end
+
+  def change
+    Event.where(action: 'PutLinkSet').update_all(action: 'PatchLinkSet')
+  end
+end


### PR DESCRIPTION
This keeps our events table internally consistent and less likely to catch
future people out.

To be merged once the [rename of the code](https://github.com/alphagov/publishing-api/pull/198) has been deployed and fully restarted.