### PR TITLE
Migrate publishing app for email campaign content

### DIFF
--- a/db/migrate/20160204120652_change_publishing_app_for_email_campaign_content.rb
+++ b/db/migrate/20160204120652_change_publishing_app_for_email_campaign_content.rb
@@ -1,0 +1,26 @@
+class ChangePublishingAppForEmailCampaignContent < ActiveRecord::Migration
+  def change
+    PathReservation.where(publishing_app: "email-campaign-frontend").each do |reservation|
+      reservation.publishing_app = "share-sale-publisher"
+      reservation.save(validate: false)
+    end
+
+    DraftContentItem.where(publishing_app: "email-campaign-frontend").each do |content_item|
+      content_item.update_attributes!(publishing_app: "share-sale-publisher")
+
+      ContentStoreWorker.perform_async(
+        content_store: Adapters::DraftContentStore,
+        draft_content_item_id: content_item.id,
+      )
+    end
+
+    LiveContentItem.where(publishing_app: "email-campaign-frontend").each do |content_item|
+      content_item.update_attributes!(publishing_app: "share-sale-publisher")
+
+      ContentStoreWorker.perform_async(
+        content_store: Adapters::ContentStore,
+        live_content_item_id: content_item.id,
+      )
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160125143518) do
+ActiveRecord::Schema.define(version: 20160204120652) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
Make sure that existing email campaign content can be seen by the new publishing tool.

Not to be merged until we're ready to go live.