### PR TITLE
`ContentStoreWorker` accepts content item `id`

### DIFF
--- a/app/commands/v2/discard_draft.rb
+++ b/app/commands/v2/discard_draft.rb
@@ -36,8 +36,7 @@ module Commands
         if downstream
           ContentStoreWorker.perform_async(
             content_store: Adapters::DraftContentStore,
-            base_path: draft.base_path,
-            payload: Presenters::ContentStorePresenter.present(live),
+            live_content_item_id: live.id,
           )
         end
       end

--- a/app/commands/v2/publish.rb
+++ b/app/commands/v2/publish.rb
@@ -77,11 +77,9 @@ module Commands
         end
 
         if downstream
-          live_payload = Presenters::ContentStorePresenter.present(live_content_item)
           ContentStoreWorker.perform_async(
             content_store: Adapters::ContentStore,
-            base_path: live_content_item.base_path,
-            payload: live_payload,
+            live_content_item_id: live_content_item.id,
           )
 
           queue_payload = Presenters::MessageQueuePresenter.present(live_content_item, update_type: update_type)

--- a/app/commands/v2/put_content.rb
+++ b/app/commands/v2/put_content.rb
@@ -9,11 +9,9 @@ module Commands
         PathReservation.reserve_base_path!(base_path, content_item[:publishing_app])
 
         if downstream
-          draft_payload = Presenters::ContentStorePresenter.present(content_item)
           ContentStoreWorker.perform_async(
             content_store: Adapters::DraftContentStore,
-            base_path: base_path,
-            payload: draft_payload,
+            draft_content_item_id: content_item.id,
           )
         end
 

--- a/app/commands/v2/put_link_set.rb
+++ b/app/commands/v2/put_link_set.rb
@@ -30,20 +30,16 @@ module Commands
 
         if downstream
           if (draft_content_item = DraftContentItem.find_by(content_id: link_params.fetch(:content_id)))
-            draft_payload = Presenters::ContentStorePresenter.present(draft_content_item)
             ContentStoreWorker.perform_async(
               content_store: Adapters::DraftContentStore,
-              base_path: draft_content_item.base_path,
-              payload: draft_payload,
+              draft_content_item_id: draft_content_item.id,
             )
           end
 
           if (live_content_item = LiveContentItem.find_by(content_id: link_params.fetch(:content_id)))
-            live_payload = Presenters::ContentStorePresenter.present(live_content_item)
             ContentStoreWorker.perform_async(
               content_store: Adapters::ContentStore,
-              base_path: live_content_item.base_path,
-              payload: live_payload,
+              live_content_item_id: live_content_item.id,
             )
 
             queue_payload = Presenters::MessageQueuePresenter.present(live_content_item, update_type: "links")

--- a/app/workers/content_store_worker.rb
+++ b/app/workers/content_store_worker.rb
@@ -5,14 +5,13 @@ class ContentStoreWorker
     args = args.deep_symbolize_keys
 
     content_store = args.fetch(:content_store).constantize
-    content_item = load_content_item_from(args)
-    base_path = content_item.base_path
 
     if args[:delete]
-      content_store.delete_content_item(base_path)
+      content_store.delete_content_item(args.fetch(:base_path))
     else
+      content_item = load_content_item_from(args)
       payload = Presenters::ContentStorePresenter.present(content_item)
-      content_store.put_content_item(base_path, payload)
+      content_store.put_content_item(content_item.base_path, payload)
     end
 
   rescue => e

--- a/app/workers/content_store_worker.rb
+++ b/app/workers/content_store_worker.rb
@@ -5,12 +5,13 @@ class ContentStoreWorker
     args = args.deep_symbolize_keys
 
     content_store = args.fetch(:content_store).constantize
-    base_path = args.fetch(:base_path)
+    content_item = load_content_item_from(args)
+    base_path = content_item.base_path
 
     if args[:delete]
       content_store.delete_content_item(base_path)
     else
-      payload = args.fetch(:payload)
+      payload = Presenters::ContentStorePresenter.present(content_item)
       content_store.put_content_item(base_path, payload)
     end
 
@@ -19,6 +20,17 @@ class ContentStoreWorker
   end
 
 private
+
+  def load_content_item_from(args)
+    case
+    when args[:draft_content_item_id]
+      DraftContentItem.find(args[:draft_content_item_id])
+    when args[:live_content_item_id]
+      LiveContentItem.find(args[:live_content_item_id])
+    else
+      raise "a live or a draft content item is needed"
+    end
+  end
 
   def handle_error(error)
     if !error.is_a?(CommandError)

--- a/app/workers/content_store_worker.rb
+++ b/app/workers/content_store_worker.rb
@@ -1,6 +1,8 @@
 class ContentStoreWorker
   include Sidekiq::Worker
 
+  sidekiq_options queue: :content_store
+
   def perform(args = {})
     args = args.deep_symbolize_keys
 

--- a/app/workers/deprecated_content_store_worker.rb
+++ b/app/workers/deprecated_content_store_worker.rb
@@ -1,0 +1,36 @@
+class DeprecatedContentStoreWorker
+  include Sidekiq::Worker
+
+  sidekiq_options queue: :default
+
+  def perform(args = {})
+    args = args.deep_symbolize_keys
+
+    content_store = args.fetch(:content_store).constantize
+    base_path = args.fetch(:base_path)
+
+    if args[:delete]
+      content_store.delete_content_item(base_path)
+    else
+      payload = args.fetch(:payload)
+      content_store.put_content_item(base_path, payload)
+    end
+
+  rescue => e
+    handle_error(e)
+  end
+
+private
+
+  def handle_error(error)
+    if !error.is_a?(CommandError)
+      raise error
+    elsif error.code >= 500
+      raise error
+    else
+      explanation = "The message is a duplicate and does not need to be retried"
+      Airbrake.notify_or_ignore(error, parameters: { explanation: explanation })
+    end
+  end
+end
+

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -4,3 +4,4 @@
 :logfile: ./log/sidekiq.json.log
 :queues:
   - default
+  - content_store

--- a/spec/commands/v2/publish_spec.rb
+++ b/spec/commands/v2/publish_spec.rb
@@ -144,9 +144,7 @@ RSpec.describe Commands::V2::Publish do
 
         expect(ContentStoreWorker)
           .to receive(:perform_async)
-          .with(content_store: Adapters::ContentStore,
-               base_path: "/vat-rates",
-               payload: presentation)
+          .with(hash_including(content_store: Adapters::ContentStore))
 
         described_class.call(payload)
       end

--- a/spec/workers/content_store_worker_spec.rb
+++ b/spec/workers/content_store_worker_spec.rb
@@ -1,19 +1,6 @@
 require "rails_helper"
 
 RSpec.describe ContentStoreWorker do
-  before do
-    stub_request(:put, "http://content-store.dev.gov.uk/content/foo").
-      to_return(status: status, body: {}.to_json)
-  end
-
-  def do_request
-    subject.perform(
-      content_store: "Adapters::ContentStore",
-      base_path: "/foo",
-      payload: { some: "payload" }
-    )
-  end
-
   expectations = {
     200 => { raises_error: false, logs_to_airbrake: false },
     202 => { raises_error: false, logs_to_airbrake: false },
@@ -24,7 +11,20 @@ RSpec.describe ContentStoreWorker do
 
   expectations.each do |status, expectation|
     context "when the content store responds with a #{status}" do
+      before do
+        stub_request(:put, "http://content-store.dev.gov.uk/content/foo").
+          to_return(status: status, body: {}.to_json)
+      end
+
+      def do_request
+        subject.perform(
+          content_store: "Adapters::ContentStore",
+          live_content_item_id: LiveContentItem.last.id,
+        )
+      end
+
       let(:status) { status }
+      let!(:content_item) { create(:live_content_item, base_path: '/foo') }
 
       if expectation.fetch(:raises_error)
         it "raises an error" do
@@ -47,6 +47,36 @@ RSpec.describe ContentStoreWorker do
           do_request rescue CommandError
         end
       end
+    end
+  end
+
+  context "when a draft item is enqueued" do
+    let!(:draft_content_item)  { create(:draft_content_item, base_path: '/foo') }
+
+    it "publishes a presented draft content item to the draft Content Store" do
+      api_call = stub_request(:put, "http://draft-content-store.dev.gov.uk/content/foo")
+
+      subject.perform(
+        content_store: 'Adapters::DraftContentStore',
+        draft_content_item_id: draft_content_item.id,
+      )
+
+      expect(api_call).to have_been_made
+    end
+  end
+
+  context "when a live item is enqueued" do
+    let!(:live_content_item)  { create(:live_content_item, base_path: '/foo') }
+
+    it "publishes a presented live content item to the live Content Store" do
+      api_call = stub_request(:put, "http://content-store.dev.gov.uk/content/foo")
+
+      subject.perform(
+        content_store: 'Adapters::ContentStore',
+        live_content_item_id: live_content_item.id,
+      )
+
+      expect(api_call).to have_been_made
     end
   end
 end

--- a/spec/workers/content_store_worker_spec.rb
+++ b/spec/workers/content_store_worker_spec.rb
@@ -79,4 +79,18 @@ RSpec.describe ContentStoreWorker do
       expect(api_call).to have_been_made
     end
   end
+
+  context "when a deletion is enqueued" do
+    it "deletes the content item" do
+      api_call = stub_request(:delete, "http://draft-content-store.dev.gov.uk/content/abc")
+
+      subject.perform(
+        content_store: 'Adapters::DraftContentStore',
+        base_path: "/abc",
+        delete: true,
+      )
+
+      expect(api_call).to have_been_made
+    end
+  end
 end

--- a/spec/workers/deprecated_content_store_worker_spec.rb
+++ b/spec/workers/deprecated_content_store_worker_spec.rb
@@ -1,0 +1,52 @@
+require "rails_helper"
+
+RSpec.describe DeprecatedContentStoreWorker do
+  before do
+    stub_request(:put, "http://content-store.dev.gov.uk/content/foo").
+      to_return(status: status, body: {}.to_json)
+  end
+
+  def do_request
+    subject.perform(
+      content_store: "Adapters::ContentStore",
+      base_path: "/foo",
+      payload: { some: "payload" }
+    )
+  end
+
+  expectations = {
+    200 => { raises_error: false, logs_to_airbrake: false },
+    202 => { raises_error: false, logs_to_airbrake: false },
+    400 => { raises_error: false, logs_to_airbrake: true },
+    409 => { raises_error: false, logs_to_airbrake: true },
+    500 => { raises_error: true, logs_to_airbrake: false },
+  }
+
+  expectations.each do |status, expectation|
+    context "when the content store responds with a #{status}" do
+      let(:status) { status }
+
+      if expectation.fetch(:raises_error)
+        it "raises an error" do
+          expect { do_request }.to raise_error(CommandError)
+        end
+      else
+        it "does not raise an error" do
+          expect { do_request }.to_not raise_error
+        end
+      end
+
+      if expectation.fetch(:logs_to_airbrake)
+        it "logs the response to airbrake" do
+          expect(Airbrake).to receive(:notify_or_ignore)
+          do_request rescue CommandError
+        end
+      else
+        it "does not log the response to airbrake" do
+          expect(Airbrake).to_not receive(:notify_or_ignore)
+          do_request rescue CommandError
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
To avoid the potential race when links and content are sent to the Publishing API almost simultaneously by Whitehall we have moved the presentation of the item into the worker. This will ensure that even if a newer version of the item is received by Publishing API it will not cause `transmitted_at` conflict on the Content Store.

[Trello](https://trello.com/c/a7qp3eOx)

There is a refactor going on of Publishing API so please don't merge until we've had a 👍from the Publishing Platform team.

cc: @danielroseman @tuzz

In response to @jamiecobbett comment -

Where the publishing API receives two requests in quick succession (as it does when Whitehall publishes content and links). With the existing approach request one gets a `transmitted_at` timestamp of 100 (for simplicity) and the subsequent request gets `transmitted_at` timestamp of 110. These are both queued on an async queue. If request two gets processed before one then content store will return and error when one is processed. Admittedly it 'should' have the latest representation at this point anyway but the amount of errors when doing a 'bulk' republish could be masking other errors.

With this PR when request two is 'worked' it is sent to the content store no problem. Request one is then processed and retrieves the latest representation from the Publishing API database (which was stored when request two was sent to the Publishing API). So... it gets the latest version and that is sent to the content store. 

This does ultimately cause two identical requests to be sent to the content store but that is preferable to the error and could be fixed in an optimisation in the future should it cause any performance issues (which is unlikely).

This does beg the question as to whether `transmitted_at` is required any longer? I'm happy to remove it but would appreciate some feedback.