### PR TITLE
Remove `transmitted_at` from V2 Content Store calls

### DIFF
--- a/app/presenters/downstream_presenter.rb
+++ b/app/presenters/downstream_presenter.rb
@@ -16,7 +16,6 @@ module Presenters
         .merge(public_updated_at)
         .merge(links)
         .merge(access_limited)
-        .merge(transmitted_at)
     end
 
   private
@@ -62,14 +61,10 @@ module Presenters
       end
     end
 
-    def transmitted_at
-      { transmitted_at: DateTime.now.to_s(:nanoseconds) }
-    end
-
     class V1
       def self.present(attributes, update_type: true, transmitted_at: true)
         attributes = attributes.except(:update_type) unless update_type
-        attributes = attributes.merge(transmitted_at: DateTime.now.to_s(:nanoseconds)) if transmitted_at
+        attributes = attributes.merge(transmitted_at: Time.now.to_s(:nanoseconds)) if transmitted_at
 
         attributes
       end

--- a/doc/publishing-api-syntactic-usage.md
+++ b/doc/publishing-api-syntactic-usage.md
@@ -14,7 +14,7 @@ PUT and POST endpoints take an optional integer field `previous_version` in the 
  - Instantiates a new content item or retrieves an existing item matching the content_id and locale passed in the request.
  - Validates the content item prior to saving. There are multiple validations for draft content items, the main concerns are path integrity, identity uniqueness and version consistency. Validation failures in these cases respond with 422.
  - Increments the version number of the content item.
- - Prepares and sends the draft content item payload downstream to the content store. The payload is modified to include a transmitted_at timestamp to validate message ordering.
+ - Prepares and sends the draft content item payload downstream to the content store.
  - Sends the draft content item payload to the message queue.
 
 ### Required request params:

--- a/spec/commands/v2/publish_spec.rb
+++ b/spec/commands/v2/publish_spec.rb
@@ -134,7 +134,6 @@ RSpec.describe Commands::V2::Publish do
       it "sends a payload downstream asynchronously" do
         presentation = {
           content_id: content_id,
-          transmitted_at: Time.now.to_s(:nanoseconds),
           title: "Something something"
         }.to_json
 

--- a/spec/pacts/content_store/put_endpoint_spec.rb
+++ b/spec/pacts/content_store/put_endpoint_spec.rb
@@ -9,16 +9,11 @@ RSpec.describe "PUT endpoint pact with the Content Store", pact: true do
 
   let(:client) { ContentStoreWriter.new("http://localhost:3093") }
   let(:body) { Presenters::ContentStorePresenter.present(content_item) }
-  let(:request_time) { Time.at(2000000000) }
 
-  around do |example|
-    Timecop.freeze(request_time) { example.run }
-  end
-
-  context "when a content item exists that has an older transmitted_at than the request" do
+  context "a content item exists" do
     before do
       content_store
-        .given("a content item exists with base_path /vat-rates and transmitted_at 1000000000000000000")
+        .given("a content item exists with base_path /vat-rates")
         .upon_receiving("a request to create a content item")
         .with(
           method: :put,
@@ -37,104 +32,9 @@ RSpec.describe "PUT endpoint pact with the Content Store", pact: true do
         )
     end
 
-    it "accepts in-order messages to the content store" do
+    it "accepts the messages to the content store" do
       response = client.put_content_item(base_path: "/vat-rates", content_item: body)
       expect(response.code).to eq(200)
-    end
-  end
-
-  context "when a content item exists that has a newer transmitted_at than the request" do
-    before do
-      content_store
-        .given("a content item exists with base_path /vat-rates and transmitted_at 3000000000000000000")
-        .upon_receiving("a request to create a content item")
-        .with(
-          method: :put,
-          path: "/content/vat-rates",
-          body: body,
-          headers: {
-            "Content-Type" => "application/json"
-          },
-        )
-        .will_respond_with(
-          status: 409,
-          body: {},
-          headers: {
-            "Content-Type" => "application/json; charset=utf-8"
-          },
-        )
-    end
-
-    it "rejects out-of-order messages to the content store" do
-      expect {
-        client.put_content_item(base_path: "/vat-rates", content_item: body)
-      }.to raise_error(GdsApi::HTTPConflict)
-    end
-  end
-
-  describe "V1" do
-    let(:attributes) { content_item_params }
-    let(:body) do
-      Presenters::DownstreamPresenter::V1.present(
-        attributes, update_type: false
-      )
-    end
-
-    context "when a content item exists that has an older transmitted_at than the request" do
-      before do
-        content_store
-          .given("a content item exists with base_path /vat-rates and transmitted_at 1000000000000000000")
-          .upon_receiving("a request to create a content item originating from v1 endpoint")
-          .with(
-            method: :put,
-            path: "/content/vat-rates",
-            body: body,
-            headers: {
-              "Content-Type" => "application/json"
-            },
-          )
-          .will_respond_with(
-            status: 200,
-            body: {},
-            headers: {
-              "Content-Type" => "application/json; charset=utf-8"
-            },
-          )
-      end
-
-      it "accepts in-order messages to the content store" do
-        response = client.put_content_item(base_path: "/vat-rates", content_item: body)
-        expect(response.code).to eq(200)
-      end
-    end
-
-    context "when a content item exists that has a newer transmitted_at than the request" do
-      before do
-        content_store
-          .given("a content item exists with base_path /vat-rates and transmitted_at 3000000000000000000")
-          .upon_receiving("a request to create a content item originating from v1 endpoint")
-          .with(
-            method: :put,
-            path: "/content/vat-rates",
-            body: body,
-            headers: {
-              "Content-Type" => "application/json"
-            },
-          )
-          .will_respond_with(
-            status: 409,
-            body: {},
-            headers: {
-              "Content-Type" => "application/json; charset=utf-8"
-            },
-          )
-      end
-
-      it "rejects out-of-order messages to the content store" do
-        expect {
-          client.put_content_item(base_path: "/vat-rates", content_item: body)
-        }.to raise_error(GdsApi::HTTPConflict)
-      end
     end
   end
 end

--- a/spec/presenters/downstream_presenter_spec.rb
+++ b/spec/presenters/downstream_presenter_spec.rb
@@ -29,7 +29,6 @@ RSpec.describe Presenters::DownstreamPresenter do
         rendering_app: "frontend",
         routes: [{ path: "/vat-rates", type: "exact" }],
         title: "VAT rates",
-        transmitted_at: DateTime.now.to_s(:nanoseconds),
         update_type: "minor",
       )
     end
@@ -59,7 +58,6 @@ RSpec.describe Presenters::DownstreamPresenter do
         rendering_app: "frontend",
         routes: [{ path: "/vat-rates", type: "exact" }],
         title: "VAT rates",
-        transmitted_at: DateTime.now.to_s(:nanoseconds),
         update_type: "minor",
       )
     end
@@ -90,15 +88,6 @@ RSpec.describe Presenters::DownstreamPresenter do
     end
   end
 
-  describe "presented transmitted_at datetime format" do
-    it "returns a string formatted as nanoseconds" do
-      datetime = DateTime.now
-      nanoseconds = datetime.to_s(:nanoseconds)
-
-      expect(nanoseconds).to eq(datetime.strftime("%s%9N"))
-    end
-  end
-
   describe described_class::V1 do
     let(:attributes) do
       {
@@ -119,7 +108,7 @@ RSpec.describe Presenters::DownstreamPresenter do
         content_id: "content_id",
         access_limited: "access_limited",
         update_type: "update_type",
-        transmitted_at: DateTime.now.to_s(:nanoseconds),
+        transmitted_at: Time.now.to_s(:nanoseconds),
       )
     end
 
@@ -129,7 +118,7 @@ RSpec.describe Presenters::DownstreamPresenter do
       expect(result).to eq(
         content_id: "content_id",
         access_limited: "access_limited",
-        transmitted_at: DateTime.now.to_s(:nanoseconds),
+        transmitted_at: Time.now.to_s(:nanoseconds),
       )
     end
 

--- a/spec/requests/content_item_requests/message_bus_spec.rb
+++ b/spec/requests/content_item_requests/message_bus_spec.rb
@@ -120,7 +120,6 @@ RSpec.describe "Message bus", type: :request do
           expected_payload = v2_content_item.except(:access_limited).merge(
             links: links_attributes.fetch(:links),
             update_type: "links",
-            transmitted_at: DateTime.now.to_s(:nanoseconds),
           ).to_json
 
           delivery_info, _, payload = wait_for_message_on(@queue)
@@ -164,7 +163,6 @@ RSpec.describe "Message bus", type: :request do
 
         expected_payload = v2_content_item.except(:access_limited).merge(
           update_type: "major",
-          transmitted_at: DateTime.now.to_s(:nanoseconds),
           public_updated_at: DateTime.now,
         ).to_json
 

--- a/spec/requests/publish_requests_spec.rb
+++ b/spec/requests/publish_requests_spec.rb
@@ -122,8 +122,7 @@ RSpec.describe "POST /v2/publish", type: :request do
         .with(
           base_path: draft_content_item.base_path,
           content_item: expected_live_content_item_hash
-            .merge(transmitted_at: DateTime.now.to_s(:nanoseconds),
-                   public_updated_at: DateTime.now.in_time_zone.iso8601)
+            .merge(public_updated_at: DateTime.now.in_time_zone.iso8601)
         )
         do_request
       end
@@ -142,7 +141,6 @@ RSpec.describe "POST /v2/publish", type: :request do
 
           expected_live_content_item_hash.merge!(
             update_type: payload[:update_type],
-            transmitted_at: DateTime.now.to_s(:nanoseconds),
             public_updated_at: DateTime.now.in_time_zone.iso8601
           )
           expect(message).to eq(expected_live_content_item_hash.as_json)

--- a/spec/support/request_helpers/downstream_requests.rb
+++ b/spec/support/request_helpers/downstream_requests.rb
@@ -2,35 +2,29 @@ module RequestHelpers
   module DownstreamRequests
     def sends_to_draft_content_store
       it "sends to draft content store" do
-        Timecop.freeze do
-          expect(PublishingAPI.service(:draft_content_store)).to receive(:put_content_item)
-            .with(
-              base_path: base_path,
-              content_item: content_item_for_draft_content_store
-                .merge(transmitted_at: DateTime.now.to_s(:nanoseconds))
-            )
+        expect(PublishingAPI.service(:draft_content_store)).to receive(:put_content_item)
+          .with(
+            base_path: base_path,
+            content_item: content_item_for_draft_content_store,
+          )
 
-          do_request
+        do_request
 
-          expect(response.status).to eq(200), response.body
-        end
+        expect(response.status).to eq(200), response.body
       end
     end
 
     def sends_to_live_content_store
       it "sends to live content store" do
-        Timecop.freeze do
-          expect(PublishingAPI.service(:live_content_store)).to receive(:put_content_item)
-            .with(
-              base_path: base_path,
-              content_item: content_item_for_live_content_store
-                .merge(transmitted_at: DateTime.now.to_s(:nanoseconds))
-            )
+        expect(PublishingAPI.service(:live_content_store)).to receive(:put_content_item)
+          .with(
+            base_path: base_path,
+            content_item: content_item_for_live_content_store,
+          )
 
-          do_request
+        do_request
 
-          expect(response.status).to eq(200), response.body
-        end
+        expect(response.status).to eq(200), response.body
       end
     end
 


### PR DESCRIPTION
This commit removes `transmitted_at` from the V2 Content Store calls and
related tests. This supports PR https://github.com/alphagov/content-store/pull/189

Some tests have been updated to allow V1 to still support
`transmitted_at`