### PR TITLE
Improve handling of content store 404 errors

### DIFF
--- a/app/adapters/draft_content_store.rb
+++ b/app/adapters/draft_content_store.rb
@@ -10,7 +10,7 @@ module Adapters
     end
 
     def self.delete_content_item(base_path)
-      CommandError.with_error_handling do
+      CommandError.with_error_handling(ignore_404s: true) do
         PublishingAPI.service(:draft_content_store).delete_content_item(base_path)
       end
     end

--- a/app/errors/command_error.rb
+++ b/app/errors/command_error.rb
@@ -7,11 +7,16 @@ class CommandError < StandardError
     should_suppress = (PublishingAPI.swallow_connection_errors && e.code == 502)
     raise CommandError.new(code: e.code, message: e.message) unless should_suppress
   rescue GdsApi::HTTPClientError => e
+    fields = if e.error_details.present?
+      e.error_details.fetch('errors', {})
+    else
+      {}
+    end
     raise CommandError.new(code: e.code, error_details: {
       error: {
         code: e.code,
         message: e.message,
-        fields: e.error_details.fetch('errors', {})
+        fields: fields,
       }
     })
   rescue GdsApi::BaseError => e

--- a/spec/requests/content_item_requests/invalid_requests_spec.rb
+++ b/spec/requests/content_item_requests/invalid_requests_spec.rb
@@ -1,23 +1,41 @@
 require "rails_helper"
 
 RSpec.describe "Invalid content requests", type: :request do
-  let(:error_details) { { errors: { update_type: "invalid" } } }
+  context "when the response has a JSON body and therefore 'error_details'" do
+    let(:error_details) { { errors: { update_type: "invalid" } } }
 
-  before do
-    stub_request(:put, /publish-intent/)
-      .to_return(
-        status: 422,
-        body: error_details.to_json,
-        headers: {"Content-type" => "application/json"}
-      )
+    before do
+      stub_request(:put, /publish-intent/)
+        .to_return(
+          status: 422,
+          body: error_details.to_json,
+          headers: {"Content-type" => "application/json"}
+        )
+    end
+
+    context "/publish-intent" do
+      let(:request_body) { content_item_params.to_json }
+      let(:request_path) { "/publish-intent/#{base_path}" }
+      let(:request_method) { :put }
+
+      does_not_log_event
+      creates_no_derived_representations
+    end
   end
 
-  context "/publish-intent" do
-    let(:request_body) { content_item_params.to_json }
-    let(:request_path) { "/publish-intent/#{base_path}" }
-    let(:request_method) { :put }
+  context "when the response has no JSON body and therefore no 'error_details'" do
+    before do
+      stub_request(:put, /publish-intent/)
+        .to_return(status: 404)
+    end
 
-    does_not_log_event
-    creates_no_derived_representations
+    context "/publish-intent" do
+      let(:request_body) { content_item_params.to_json }
+      let(:request_path) { "/publish-intent/#{base_path}" }
+      let(:request_method) { :put }
+
+      does_not_log_event
+      creates_no_derived_representations
+    end
   end
 end

--- a/spec/workers/content_store_worker_spec.rb
+++ b/spec/workers/content_store_worker_spec.rb
@@ -93,4 +93,21 @@ RSpec.describe ContentStoreWorker do
       expect(api_call).to have_been_made
     end
   end
+
+  context "when a deletion is enqueued, but content-store doesn't have the item" do
+    it "swallows the returned 404" do
+      api_call = stub_request(:delete, "http://draft-content-store.dev.gov.uk/content/abc")
+                             .to_return(status: 404)
+
+      expect(Airbrake).not_to receive(:notify_or_ignore)
+
+      subject.perform(
+        content_store: 'Adapters::DraftContentStore',
+        base_path: "/abc",
+        delete: true,
+      )
+
+      expect(api_call).to have_been_made
+    end
+  end
 end


### PR DESCRIPTION
These changes:
* mean we don't [throw a secondary masking error when a 404 occurs](https://errbit.integration.publishing.service.gov.uk/apps/552637940da1157bfa000399/problems/56bd7c816578630691290000)
* swallow 404s when deleting, instead of reporting them to Errbit