### PR TITLE
Make content store push on discard draft more obvious

### DIFF
--- a/app/commands/v2/discard_draft.rb
+++ b/app/commands/v2/discard_draft.rb
@@ -36,7 +36,7 @@ module Commands
         if downstream
           ContentStoreWorker.perform_async(
             content_store: Adapters::DraftContentStore,
-            live_content_item_id: live.id,
+            draft_content_item_id: draft.id,
           )
         end
       end


### PR DESCRIPTION
This change doesn't functionally change anything, because at the point
when the publishing action is called, the live and draft content items
are exactly the same.

However, this change makes the code slightly clearer because it no longer breaks
the pattern "live items go to the live store, draft items to the draft store".