### PR TITLE
Add delay to `ContentStoreWorker` enqueuing

### DIFF
--- a/app/commands/v2/discard_draft.rb
+++ b/app/commands/v2/discard_draft.rb
@@ -34,7 +34,8 @@ module Commands
         draft.update_attributes(live.attributes.except("id", "draft_content_item_id"))
 
         if downstream
-          ContentStoreWorker.perform_async(
+          ContentStoreWorker.perform_in(
+            1.second,
             content_store: Adapters::DraftContentStore,
             live_content_item_id: live.id,
           )
@@ -45,7 +46,8 @@ module Commands
         draft.destroy
 
         if downstream
-          ContentStoreWorker.perform_async(
+          ContentStoreWorker.perform_in(
+            1.second,
             content_store: Adapters::DraftContentStore,
             base_path: draft.base_path,
             delete: true,

--- a/app/commands/v2/publish.rb
+++ b/app/commands/v2/publish.rb
@@ -77,7 +77,8 @@ module Commands
         end
 
         if downstream
-          ContentStoreWorker.perform_async(
+          ContentStoreWorker.perform_in(
+            1.second,
             content_store: Adapters::ContentStore,
             live_content_item_id: live_content_item.id,
           )

--- a/app/commands/v2/put_content.rb
+++ b/app/commands/v2/put_content.rb
@@ -9,7 +9,8 @@ module Commands
         PathReservation.reserve_base_path!(base_path, content_item[:publishing_app])
 
         if downstream
-          ContentStoreWorker.perform_async(
+          ContentStoreWorker.perform_in(
+            1.second,
             content_store: Adapters::DraftContentStore,
             draft_content_item_id: content_item.id,
           )
@@ -70,7 +71,8 @@ module Commands
               locale: content_item.locale,
             )
           else
-            ContentStoreWorker.perform_async(
+            ContentStoreWorker.perform_in(
+              1.second,
               content_store: Adapters::DraftContentStore,
               base_path: path_change[0],
               delete: true,

--- a/app/commands/v2/put_link_set.rb
+++ b/app/commands/v2/put_link_set.rb
@@ -30,14 +30,16 @@ module Commands
 
         if downstream
           if (draft_content_item = DraftContentItem.find_by(content_id: link_params.fetch(:content_id)))
-            ContentStoreWorker.perform_async(
+            ContentStoreWorker.perform_in(
+              1.second,
               content_store: Adapters::DraftContentStore,
               draft_content_item_id: draft_content_item.id,
             )
           end
 
           if (live_content_item = LiveContentItem.find_by(content_id: link_params.fetch(:content_id)))
-            ContentStoreWorker.perform_async(
+            ContentStoreWorker.perform_in(
+              1.second,
               content_store: Adapters::ContentStore,
               live_content_item_id: live_content_item.id,
             )

--- a/spec/commands/v2/publish_spec.rb
+++ b/spec/commands/v2/publish_spec.rb
@@ -143,8 +143,8 @@ RSpec.describe Commands::V2::Publish do
           .and_return(presentation)
 
         expect(ContentStoreWorker)
-          .to receive(:perform_async)
-          .with(hash_including(content_store: Adapters::ContentStore))
+          .to receive(:perform_in)
+          .with(1.second, hash_including(content_store: Adapters::ContentStore))
 
         described_class.call(payload)
       end


### PR DESCRIPTION
We are currently experiencing a fair number of `ActiveRecord::RecordNotFound` errors from the `ContentStoreWorker`. These are successfully retried so don't impact functionality as such but
do cause a lot of error 'noise'. This commit enqueues the jobs to be run in `1.second` as a temporary measure to reduce error noise. This is not meant as a permanent fix. Once the new object model is implemented and deployed we can revisit if this is still a problem so I don't think this needs to be merged into that branch.

I discussed this yesterday and it was mentioned that delaying scheduled publishings might be an issue but I don't feel that 1 second is a problem as there is no guarantee that they'd have been 'worked' from the queue within 1 second anyway.

I've run this branch on integration and so far have not seen any errors so it appears to have 'fixed' the problem for now.