### PR TITLE
Temporarily ignore conflicting transmitted_at timestamp errors

### DIFF
--- a/app/errors/command_error.rb
+++ b/app/errors/command_error.rb
@@ -9,6 +9,11 @@ class CommandError < StandardError
   rescue GdsApi::HTTPClientError => e
     return if e.code == 404 && ignore_404s
 
+    # Temporarily ignore errors relating to conflicting transmitted_at timestamps.
+    # This mechanism throws up false positives and is being replaced with a per-item counter.
+    # Until this happens, we should not log these errors to errbit as they are very noisy.
+    return if e.code == 409 && e.message =~ /transmitted_at/
+
     fields = if e.error_details.present?
       e.error_details.fetch('errors', {})
     else


### PR DESCRIPTION
This mechanism throws up false positives and is being replaced with a per-item counter.
Until this happens, we should not log these errors to errbit as they are very noisy.

Examples: https://errbit.publishing.service.gov.uk/apps/552f95820da11577b4000032