### PR TITLE
Add `receipt_order` to `DraftContentItem` and `LiveContentItem`

### DIFF
--- a/app/commands/v2/discard_draft.rb
+++ b/app/commands/v2/discard_draft.rb
@@ -33,6 +33,8 @@ module Commands
       def update_draft_from_live
         draft.update_attributes(live.attributes.except("id", "draft_content_item_id"))
 
+        draft.increment_receipt_order
+
         if downstream
           ContentStoreWorker.perform_in(
             1.second,

--- a/app/commands/v2/publish.rb
+++ b/app/commands/v2/publish.rb
@@ -76,6 +76,8 @@ module Commands
           end
         end
 
+        live_content_item.increment_receipt_order
+
         if downstream
           ContentStoreWorker.perform_in(
             1.second,

--- a/app/commands/v2/put_content.rb
+++ b/app/commands/v2/put_content.rb
@@ -8,6 +8,8 @@ module Commands
 
         PathReservation.reserve_base_path!(base_path, content_item[:publishing_app])
 
+        content_item.increment_receipt_order
+
         if downstream
           ContentStoreWorker.perform_in(
             1.second,

--- a/app/commands/v2/put_link_set.rb
+++ b/app/commands/v2/put_link_set.rb
@@ -30,6 +30,9 @@ module Commands
 
         if downstream
           if (draft_content_item = DraftContentItem.find_by(content_id: link_params.fetch(:content_id)))
+
+            draft_content_item.increment_receipt_order
+
             ContentStoreWorker.perform_in(
               1.second,
               content_store: Adapters::DraftContentStore,
@@ -38,6 +41,9 @@ module Commands
           end
 
           if (live_content_item = LiveContentItem.find_by(content_id: link_params.fetch(:content_id)))
+
+            live_content_item.increment_receipt_order
+
             ContentStoreWorker.perform_in(
               1.second,
               content_store: Adapters::ContentStore,

--- a/app/models/draft_content_item.rb
+++ b/app/models/draft_content_item.rb
@@ -10,20 +10,7 @@ class DraftContentItem < ActiveRecord::Base
 
   NON_RENDERABLE_FORMATS = %w(redirect gone)
 
-  after_save :increment_receipt_order
-  after_touch :increment_receipt_order
-  def increment_receipt_order
-    sql = <<-SQL
-        UPDATE draft_content_items
-        SET receipt_order = COALESCE(receipt_order, 0) + 1
-        WHERE id = #{self.id}
-        RETURNING receipt_order;
-      SQL
-    self.receipt_order = DraftContentItem.connection
-      .execute(sql)
-      .first["receipt_order"]
-    clear_changes_information
-  end
+  include ReceiptOrderable
 
   has_one :live_content_item
 

--- a/app/models/live_content_item.rb
+++ b/app/models/live_content_item.rb
@@ -3,6 +3,7 @@ class LiveContentItem < ActiveRecord::Base
   include DefaultAttributes
   include SymbolizeJSON
   include DescriptionOverrides
+  include ReceiptOrderable
 
   TOP_LEVEL_FIELDS = [
     :base_path,

--- a/app/models/receipt_orderable.rb
+++ b/app/models/receipt_orderable.rb
@@ -1,0 +1,21 @@
+module ReceiptOrderable
+  extend ActiveSupport::Concern
+
+  included do
+    after_save :increment_receipt_order
+    after_touch :increment_receipt_order
+  end
+
+  def increment_receipt_order
+    klass = self.class
+    sql = <<-SQL
+        UPDATE #{ klass.table_name}
+        SET receipt_order = COALESCE(receipt_order, 0) + 1
+        WHERE id = #{ self.id }
+        RETURNING receipt_order;
+      SQL
+    self.receipt_order = DraftContentItem.connection
+      .execute(sql)
+      .first["receipt_order"]
+  end
+end

--- a/app/models/receipt_orderable.rb
+++ b/app/models/receipt_orderable.rb
@@ -1,11 +1,6 @@
 module ReceiptOrderable
   extend ActiveSupport::Concern
 
-  included do
-    after_save :increment_receipt_order
-    after_touch :increment_receipt_order
-  end
-
   def increment_receipt_order
     klass = self.class
     sql = <<-SQL

--- a/db/migrate/20160218145245_add_receipt_order_to_draft_content_items.rb
+++ b/db/migrate/20160218145245_add_receipt_order_to_draft_content_items.rb
@@ -1,0 +1,5 @@
+class AddReceiptOrderToDraftContentItems < ActiveRecord::Migration
+  def change
+    add_column :draft_content_items, :receipt_order, :integer
+  end
+end

--- a/db/migrate/20160218154519_add_receipt_order_to_live_content_items.rb
+++ b/db/migrate/20160218154519_add_receipt_order_to_live_content_items.rb
@@ -1,0 +1,5 @@
+class AddReceiptOrderToLiveContentItems < ActiveRecord::Migration
+  def change
+    add_column :live_content_items, :receipt_order, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160218145245) do
+ActiveRecord::Schema.define(version: 20160218154519) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -97,6 +97,7 @@ ActiveRecord::Schema.define(version: 20160218145245) do
     t.string   "phase",                 default: "live"
     t.string   "analytics_identifier"
     t.json     "description",           default: {"value"=>nil}
+    t.integer  "receipt_order"
   end
 
   add_index "live_content_items", ["base_path"], name: "index_live_content_items_on_base_path", unique: true, using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160204120652) do
+ActiveRecord::Schema.define(version: 20160218145245) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -44,6 +44,7 @@ ActiveRecord::Schema.define(version: 20160204120652) do
     t.string   "phase",                default: "live"
     t.string   "analytics_identifier"
     t.json     "description",          default: {"value"=>nil}
+    t.integer  "receipt_order"
   end
 
   add_index "draft_content_items", ["base_path"], name: "index_draft_content_items_on_base_path", unique: true, using: :btree

--- a/spec/commands/v2/publish_spec.rb
+++ b/spec/commands/v2/publish_spec.rb
@@ -49,19 +49,22 @@ RSpec.describe Commands::V2::Publish do
     end
 
     context "with a valid payload" do
-      it "creates or replaces a live content item" do
+      before do
         stub_request(:put, %r{.*content-store.*/content/.*})
+      end
 
+      it "creates or replaces a live content item" do
         expect {
           described_class.call(payload)
         }.to change(LiveContentItem, :count).by(1)
       end
 
-      context "with no public_updated_at in the payload" do
-        before do
-          stub_request(:put, %r{.*content-store.*/content/.*})
-        end
+      it "increments the receipt_order on the live content item" do
+        described_class.call(payload)
+        expect(LiveContentItem.last.receipt_order).to eq(1)
+      end
 
+      context "with no public_updated_at in the payload" do
         context "for a major update" do
           it "updates the public_updated_at time" do
             described_class.call(payload)

--- a/spec/commands/v2/put_content_spec.rb
+++ b/spec/commands/v2/put_content_spec.rb
@@ -20,6 +20,13 @@ RSpec.describe Commands::V2::PutContent do
         )
     }
 
+    describe "#call" do
+      it "increments receipt_order on the content item" do
+        described_class.call(payload)
+        expect(DraftContentItem.last.receipt_order).to eq(1)
+      end
+    end
+
     describe "validation" do
       before do
         create(:path_reservation, publishing_app: payload[:publishing_app], base_path: base_path)

--- a/spec/commands/v2/put_link_set_spec.rb
+++ b/spec/commands/v2/put_link_set_spec.rb
@@ -92,6 +92,42 @@ RSpec.describe Commands::V2::PutLinkSet do
       expect(link_set.links.map(&:target_content_id)).to eql([link_to_keep.target_content_id])
     end
 
+    context "with a DraftContentItem" do
+      let(:draft_content_item){ create(:draft_content_item) }
+      let(:link_set){ create(:link_set, content_id: draft_content_item.content_id) }
+
+      before do
+        stub_request(:put, "http://draft-content-store.dev.gov.uk/content/vat-rates")
+      end
+
+      it "increments receipt_order on the item" do
+        put_link_set(
+          content_id: link_set.content_id,
+          links: {
+          }
+        )
+        expect(draft_content_item.reload.receipt_order).to eq(1)
+      end
+    end
+
+    context "with a LiveContentItem" do
+      let(:live_content_item){ create(:live_content_item) }
+      let(:link_set){ create(:link_set, content_id: live_content_item.content_id) }
+
+      before do
+        stub_request(:put, "http://content-store.dev.gov.uk/content/vat-rates")
+      end
+
+      it "increments receipt_order on the item" do
+        put_link_set(
+          content_id: link_set.content_id,
+          links: {
+          }
+        )
+        expect(live_content_item.reload.receipt_order).to eq(1)
+      end
+    end
+
     def put_link_set(links)
       Commands::V2::PutLinkSet.call(links)
     end

--- a/spec/models/draft_content_item_spec.rb
+++ b/spec/models/draft_content_item_spec.rb
@@ -194,6 +194,35 @@ RSpec.describe DraftContentItem do
     end
   end
 
+  describe "receipt_order" do
+    context "on save" do
+      let(:content_item){ build(:draft_content_item) }
+
+      before do
+        content_item.save
+      end
+
+      it "is incremented" do
+        expect(content_item.receipt_order).to eq(1)
+        content_item.save
+        expect(content_item.receipt_order).to eq(2)
+      end
+
+      it "doesn't mark the item dirty" do
+        expect(content_item).not_to be_changed
+      end
+    end
+
+    context "on touch" do
+      it "is incremented" do
+        content_item = create(:draft_content_item)
+        original_receipt_order = content_item.receipt_order
+        content_item.touch
+        expect(content_item.receipt_order).to eq(original_receipt_order + 1)
+      end
+    end
+  end
+
   context "replaceable" do
     let!(:existing) { FactoryGirl.create(:draft_content_item) }
 

--- a/spec/models/draft_content_item_spec.rb
+++ b/spec/models/draft_content_item_spec.rb
@@ -194,35 +194,6 @@ RSpec.describe DraftContentItem do
     end
   end
 
-  describe "receipt_order" do
-    context "on save" do
-      let(:content_item){ build(:draft_content_item) }
-
-      before do
-        content_item.save
-      end
-
-      it "is incremented" do
-        expect(content_item.receipt_order).to eq(1)
-        content_item.save
-        expect(content_item.receipt_order).to eq(2)
-      end
-
-      it "doesn't mark the item dirty" do
-        expect(content_item).not_to be_changed
-      end
-    end
-
-    context "on touch" do
-      it "is incremented" do
-        content_item = create(:draft_content_item)
-        original_receipt_order = content_item.receipt_order
-        content_item.touch
-        expect(content_item.receipt_order).to eq(original_receipt_order + 1)
-      end
-    end
-  end
-
   context "replaceable" do
     let!(:existing) { FactoryGirl.create(:draft_content_item) }
 
@@ -255,4 +226,5 @@ RSpec.describe DraftContentItem do
   it_behaves_like RoutesAndRedirectsValidator
   it_behaves_like WellFormedContentTypesValidator
   it_behaves_like DescriptionOverrides
+  it_behaves_like ReceiptOrderable
 end

--- a/spec/models/live_content_item_spec.rb
+++ b/spec/models/live_content_item_spec.rb
@@ -232,4 +232,5 @@ RSpec.describe LiveContentItem do
   it_behaves_like RoutesAndRedirectsValidator
   it_behaves_like WellFormedContentTypesValidator
   it_behaves_like DescriptionOverrides
+  it_behaves_like ReceiptOrderable
 end

--- a/spec/requests/content_item_requests/downstream_requests_spec.rb
+++ b/spec/requests/content_item_requests/downstream_requests_spec.rb
@@ -162,7 +162,7 @@ RSpec.describe "Downstream requests", type: :request do
     let(:content_item_for_live_content_store) {
       draft.attributes.deep_symbolize_keys
         .merge(public_updated_at: Time.zone.now.iso8601)
-        .except(:id, :access_limited, :update_type, :metadata, :version, :old_description)
+        .except(:id, :access_limited, :update_type, :metadata, :version, :old_description, :receipt_order)
     }
 
     sends_to_live_content_store

--- a/spec/requests/discard_draft_request_spec.rb
+++ b/spec/requests/discard_draft_request_spec.rb
@@ -105,6 +105,11 @@ RSpec.describe "Discard draft requests", type: :request do
         end
 
         sends_to_draft_content_store
+
+        it "increments the receipt_order" do
+          do_request
+          expect(DraftContentItem.last.receipt_order).to eq(1)
+        end
       end
     end
 

--- a/spec/requests/publish_requests_spec.rb
+++ b/spec/requests/publish_requests_spec.rb
@@ -81,6 +81,11 @@ RSpec.describe "POST /v2/publish", type: :request do
 
       expect(live_version.number).to eq(draft_version.number)
     end
+
+    it "increments the receipt order" do
+      do_request
+      expect(LiveContentItem.last.receipt_order).to eq(1)
+    end
   end
 
   context "a draft exists with version 2, a live exists with version 1" do
@@ -127,6 +132,11 @@ RSpec.describe "POST /v2/publish", type: :request do
         )
         do_request
       end
+    end
+
+    it "increments the receipt order" do
+      do_request
+      expect(LiveContentItem.last.receipt_order).to eq(1)
     end
 
     describe "message queue integration" do
@@ -216,6 +226,11 @@ RSpec.describe "POST /v2/publish", type: :request do
 
         expect(live_item.locale).to eq("fr")
         expect(live_item.draft_content_item).to eq(french_draft)
+      end
+
+      it "increments the receipt_order" do
+        do_request
+        expect(LiveContentItem.last.receipt_order).to eq(1)
       end
     end
 

--- a/spec/requests/publish_requests_spec.rb
+++ b/spec/requests/publish_requests_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe "POST /v2/publish", type: :request do
       .merge(
         links: Presenters::Queries::LinkSetPresenter.new(link_set).links,
       )
-      .except(:update_type)
+      .except(:update_type, :receipt_order)
   }
 
   let(:content_id) { draft_content_item.content_id }

--- a/spec/support/receipt_orderable.rb
+++ b/spec/support/receipt_orderable.rb
@@ -1,0 +1,27 @@
+RSpec.shared_examples ReceiptOrderable do
+  describe "receipt_order" do
+    before do
+      subject.save
+    end
+
+    context "after_save" do
+      it "is incremented" do
+        expect(subject.receipt_order).to eq(1)
+        subject.save
+        expect(subject.receipt_order).to eq(2)
+      end
+
+      it "doesn't mark the item dirty" do
+        expect(subject).not_to be_changed
+      end
+    end
+
+    context "on touch" do
+      it "is incremented" do
+        original_receipt_order = subject.receipt_order
+        subject.touch
+        expect(subject.receipt_order).to eq(original_receipt_order + 1)
+      end
+    end
+  end
+end

--- a/spec/support/receipt_orderable.rb
+++ b/spec/support/receipt_orderable.rb
@@ -1,26 +1,10 @@
 RSpec.shared_examples ReceiptOrderable do
-  describe "receipt_order" do
-    before do
+  describe "#increment_receipt_order" do
+    it "increments the receipt order" do
       subject.save
-    end
-
-    context "after_save" do
-      it "is incremented" do
-        expect(subject.receipt_order).to eq(1)
-        subject.save
-        expect(subject.receipt_order).to eq(2)
-      end
-
-      it "doesn't mark the item dirty" do
-        expect(subject).not_to be_changed
-      end
-    end
-
-    context "on touch" do
-      it "is incremented" do
-        original_receipt_order = subject.receipt_order
-        subject.touch
-        expect(subject.receipt_order).to eq(original_receipt_order + 1)
+      5.times do |count|
+        subject.increment_receipt_order
+        expect(subject.receipt_order).to eq(count + 1)
       end
     end
   end


### PR DESCRIPTION
This PR adds an integer field `receipt_order` to each of `DraftContentItem` and `LiveContentItem` that is incremented at the database to avoid the risk of incorrect ordering caused by race conditions or the time based ordering that we currently employ.

In this PR the content items are stamped with the `receipt_order` field within each command on their way to the content store. The field is not currently 'presented` to the content store though. There will be subsequent PRs to add support for both the `transmitted_at` and `receipt_order` fields concurrently on content store following which we'll be able to go back and start sending `receipt_order` before removing `transmitted_at` altogether.

[Trello](https://trello.com/c/dBmI96gI/304-change-locking-criteria-on-content-store)