### PR TITLE
Add ContentStorePayloadVersion

### DIFF
--- a/app/commands/put_content_with_links.rb
+++ b/app/commands/put_content_with_links.rb
@@ -13,6 +13,7 @@ module Commands
         PathReservation.reserve_base_path!(base_path, payload[:publishing_app])
 
         if downstream
+          ContentStorePayloadVersion::V1.increment
           content_store_payload = Presenters::DownstreamPresenter::V1.present(
             payload.except(:access_limited),
             update_type: false

--- a/app/commands/put_draft_content_with_links.rb
+++ b/app/commands/put_draft_content_with_links.rb
@@ -10,6 +10,7 @@ module Commands
         PathReservation.reserve_base_path!(base_path, payload[:publishing_app])
 
         if downstream
+          ContentStorePayloadVersion::V1.increment
           content_store_payload = Presenters::DownstreamPresenter::V1.present(payload, update_type: false)
           Adapters::DraftContentStore.put_content_item(base_path, content_store_payload)
         end

--- a/app/commands/put_publish_intent.rb
+++ b/app/commands/put_publish_intent.rb
@@ -4,7 +4,7 @@ module Commands
       PathReservation.reserve_base_path!(base_path, payload[:publishing_app])
 
       if downstream
-        payload = Presenters::DownstreamPresenter::V1.present(publish_intent, transmitted_at: false)
+        payload = Presenters::DownstreamPresenter::V1.present(publish_intent, payload_version: false)
         Adapters::ContentStore.put_publish_intent(base_path, payload)
       end
 

--- a/app/commands/v2/discard_draft.rb
+++ b/app/commands/v2/discard_draft.rb
@@ -45,6 +45,7 @@ module Commands
       end
 
       def send_live_to_draft_content_store(live)
+        ContentStorePayloadVersion.increment(live.id)
         ContentStoreWorker.perform_in(
           1.second,
           content_store: Adapters::DraftContentStore,

--- a/app/commands/v2/patch_link_set.rb
+++ b/app/commands/v2/patch_link_set.rb
@@ -91,7 +91,7 @@ module Commands
       end
 
       def send_to_content_store(content_item, content_store)
-        ContentStorePayloadVersion.increment(content_item_id: content_item.id)
+        ContentStorePayloadVersion.increment(content_item.id)
         ContentStoreWorker.perform_in(
           1.second,
           content_store: content_store,

--- a/app/commands/v2/patch_link_set.rb
+++ b/app/commands/v2/patch_link_set.rb
@@ -91,6 +91,7 @@ module Commands
       end
 
       def send_to_content_store(content_item, content_store)
+        ContentStorePayloadVersion.increment(content_item_id: content_item.id)
         ContentStoreWorker.perform_in(
           1.second,
           content_store: content_store,

--- a/app/commands/v2/publish.rb
+++ b/app/commands/v2/publish.rb
@@ -121,6 +121,7 @@ module Commands
       def send_downstream(content_item, update_type)
         return unless downstream
 
+        ContentStorePayloadVersion.increment(content_item.id)
         ContentStoreWorker.perform_in(
           1.second,
           content_store: Adapters::ContentStore,

--- a/app/commands/v2/put_content.rb
+++ b/app/commands/v2/put_content.rb
@@ -167,6 +167,7 @@ module Commands
       def send_downstream(content_item)
         return unless downstream
 
+        ContentStorePayloadVersion.increment(content_item.id)
         ContentStoreWorker.perform_in(
           1.second,
           content_store: Adapters::DraftContentStore,

--- a/app/errors/command_error.rb
+++ b/app/errors/command_error.rb
@@ -9,10 +9,8 @@ class CommandError < StandardError
   rescue GdsApi::HTTPClientError => e
     return if e.code == 404 && ignore_404s
 
-    # Temporarily ignore errors relating to conflicting transmitted_at timestamps.
-    # This mechanism throws up false positives and is being replaced with a per-item counter.
-    # Until this happens, we should not log these errors to errbit as they are very noisy.
-    return if e.code == 409 && e.message =~ /transmitted_at/
+    #ignore payload_version conflicts
+    return if e.code == 409 && e.message =~ /transmitted_at|payload_version/
 
     fields = if e.error_details.present?
                e.error_details.fetch('errors', {})

--- a/app/errors/command_error.rb
+++ b/app/errors/command_error.rb
@@ -10,7 +10,10 @@ class CommandError < StandardError
     return if e.code == 404 && ignore_404s
 
     #ignore payload_version conflicts
-    return if e.code == 409 && e.message =~ /transmitted_at|payload_version/
+    if e.code == 409 && e.message =~ /transmitted_at|payload_version/
+      PublishingAPI::Application.statsd.increment("payload_version_conflicts")
+      return
+    end
 
     fields = if e.error_details.present?
                e.error_details.fetch('errors', {})

--- a/app/models/content_store_payload_version.rb
+++ b/app/models/content_store_payload_version.rb
@@ -1,0 +1,39 @@
+class ContentStorePayloadVersion < ActiveRecord::Base
+  def self.increment(content_item_id)
+    sql = <<-SQL
+        INSERT INTO content_store_payload_versions (content_item_id)
+        SELECT #{content_item_id || 'NULL'}
+        WHERE NOT EXISTS(
+        SELECT *
+        FROM content_store_payload_versions
+        WHERE content_item_id #{content_item_id_sql(content_item_id)});
+
+        UPDATE content_store_payload_versions
+        SET current = COALESCE(current, 0) + 1
+        WHERE content_item_id #{content_item_id_sql(content_item_id)}
+        RETURNING current;
+      SQL
+
+    ContentStorePayloadVersion.connection
+      .execute(sql)
+      .first["current"].to_i
+  end
+
+  def self.current_for(content_item_id)
+    ContentStorePayloadVersion.find_by(content_item_id: content_item_id).current
+  end
+
+  class V1
+    def self.current
+      ContentStorePayloadVersion.current_for(nil)
+    end
+
+    def self.increment
+      ContentStorePayloadVersion.increment(nil)
+    end
+  end
+
+  def self.content_item_id_sql(content_item_id)
+    content_item_id.nil? ? "IS NULL" : " = #{content_item_id}"
+  end
+end

--- a/app/presenters/downstream_presenter.rb
+++ b/app/presenters/downstream_presenter.rb
@@ -86,9 +86,10 @@ module Presenters
     end
 
     class V1
-      def self.present(attributes, update_type: true)
+      def self.present(attributes, update_type: true, payload_version: true)
         attributes = attributes.except(:update_type) unless update_type
-        attributes.merge(payload_version: ContentStorePayloadVersion::V1.current)
+        attributes.merge!(payload_version: ContentStorePayloadVersion::V1.current) if payload_version
+        attributes
       end
     end
   end

--- a/app/presenters/downstream_presenter.rb
+++ b/app/presenters/downstream_presenter.rb
@@ -16,7 +16,7 @@ module Presenters
         .merge(public_updated_at)
         .merge(links)
         .merge(access_limited)
-        .merge(transmitted_at)
+        .merge(content_store_payload_version)
         .merge(base_path)
         .merge(locale)
     end
@@ -81,16 +81,14 @@ module Presenters
       { locale: translation.locale }
     end
 
-    def transmitted_at
-      { transmitted_at: DateTime.now.to_s(:nanoseconds) }
+    def content_store_payload_version
+      { payload_version: ContentStorePayloadVersion.current_for(content_item.id) }
     end
 
     class V1
-      def self.present(attributes, update_type: true, transmitted_at: true)
+      def self.present(attributes, update_type: true)
         attributes = attributes.except(:update_type) unless update_type
-        attributes = attributes.merge(transmitted_at: DateTime.now.to_s(:nanoseconds)) if transmitted_at
-
-        attributes
+        attributes.merge(payload_version: ContentStorePayloadVersion::V1.current)
       end
     end
   end

--- a/config/application.rb
+++ b/config/application.rb
@@ -17,6 +17,7 @@ Bundler.require(*Rails.groups)
 
 module PublishingAPI
   class Application < Rails::Application
+    attr_accessor :statsd
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.

--- a/config/initializers/statsd.rb
+++ b/config/initializers/statsd.rb
@@ -1,0 +1,10 @@
+require "statsd"
+
+# Statsd "the process" listens on a port on the provided host for UDP
+# messages. Given that it's UDP, it's fire-and-forget and will not
+# block your application. You do not need to have a statsd process
+# running locally on your development environment.
+statsd_client = Statsd.new("localhost")
+statsd_client.namespace = "govuk.app.publishing-api"
+
+PublishingAPI::Application.statsd = statsd_client

--- a/db/migrate/20160225113309_create_content_store_payload_versions.rb
+++ b/db/migrate/20160225113309_create_content_store_payload_versions.rb
@@ -1,0 +1,10 @@
+class CreateContentStorePayloadVersions < ActiveRecord::Migration
+  def change
+    create_table :content_store_payload_versions do |t|
+      t.integer :content_item_id
+      t.integer :current, default: 0
+    end
+
+    add_index :content_store_payload_versions, :content_item_id, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -54,6 +54,13 @@ ActiveRecord::Schema.define(version: 20160229133026) do
   add_index "content_items", ["publishing_app"], name: "index_content_items_on_publishing_app", using: :btree
   add_index "content_items", ["rendering_app"], name: "index_content_items_on_rendering_app", using: :btree
 
+  create_table "content_store_payload_versions", force: :cascade do |t|
+    t.integer "content_item_id"
+    t.integer "current",         default: 0
+  end
+
+  add_index "content_store_payload_versions", ["content_item_id"], name: "index_content_store_payload_versions_on_content_item_id", unique: true, using: :btree
+
   create_table "draft_content_items", force: :cascade do |t|
     t.string   "content_id"
     t.string   "locale",               default: "en"

--- a/doc/publishing-api-syntactic-usage.md
+++ b/doc/publishing-api-syntactic-usage.md
@@ -14,7 +14,7 @@ PUT and POST endpoints take an optional integer field `previous_version` in the 
  - Instantiates a new content item or retrieves an existing item matching the content_id and locale passed in the request.
  - Validates the content item prior to saving. There are multiple validations for draft content items, the main concerns are path integrity, identity uniqueness and lock version consistency. Validation failures in these cases respond with 422.
  - Increments the lock version number of the content item.
- - Prepares and sends the draft content item payload downstream to the content store. The payload is modified to include a transmitted_at timestamp to validate message ordering.
+ - Prepares and sends the draft content item payload downstream to the content store. The payload is modified to include a payload_version to validate message ordering.
  - Sends the draft content item payload to the message queue.
 
 ### Required request params:

--- a/spec/commands/put_content_with_links_spec.rb
+++ b/spec/commands/put_content_with_links_spec.rb
@@ -27,11 +27,17 @@ RSpec.describe Commands::PutContentWithLinks do
   context "when a content_id is not provided" do
     before do
       payload[:content_id] = nil
+      create(:v1_content_store_payload_version)
     end
 
     it "responds successfully" do
       result = described_class.call(payload)
       expect(result).to be_a(Commands::Success)
+    end
+
+    it "increments the ContentStorePayloadVersion" do
+      expect(ContentStorePayloadVersion::V1).to receive(:increment)
+      described_class.call(payload)
     end
   end
 

--- a/spec/commands/put_draft_content_with_links_spec.rb
+++ b/spec/commands/put_draft_content_with_links_spec.rb
@@ -27,11 +27,18 @@ RSpec.describe Commands::PutDraftContentWithLinks do
   context "when a content_id is not provided" do
     before do
       payload[:content_id] = nil
+      create(:v1_content_store_payload_version)
     end
 
     it "responds successfully" do
       result = described_class.call(payload)
       expect(result).to be_a(Commands::Success)
+    end
+
+    it "increments ContentStorePayloadVersion" do
+      expect(ContentStorePayloadVersion)
+        .to receive(:increment)
+      described_class.call(payload)
     end
   end
 

--- a/spec/commands/v2/discard_draft_spec.rb
+++ b/spec/commands/v2/discard_draft_spec.rb
@@ -157,6 +157,15 @@ RSpec.describe Commands::V2::DiscardDraft do
             described_class.call(payload)
           }.to change(ContentItem, :count).by(-1)
         end
+
+        it "increments the ContentStorePayloadLock" do
+          ContentStorePayloadVersion.increment(published_item.id)
+          expect(ContentStorePayloadVersion)
+            .to receive(:increment)
+            .with(published_item.id)
+
+          described_class.call(payload)
+        end
       end
 
       context "when a locale is provided in the payload" do

--- a/spec/commands/v2/patch_link_set_spec.rb
+++ b/spec/commands/v2/patch_link_set_spec.rb
@@ -187,8 +187,8 @@ RSpec.describe Commands::V2::PatchLinkSet do
   end
 
   context "when a draft content item exists for the content_id" do
-    before do
-      FactoryGirl.create(
+    let!(:draft_content_item) do
+      create(
         :draft_content_item,
         content_id: content_id,
         base_path: "/some-path",
@@ -201,8 +201,20 @@ RSpec.describe Commands::V2::PatchLinkSet do
         .with(
           1.second,
           content_store: Adapters::DraftContentStore,
-          content_item_id: ContentItem.last.id,
+          content_item_id: draft_content_item.id,
         )
+
+      described_class.call(payload)
+    end
+
+    it "increments the ContentStorePayloadVersion" do
+      create(
+        :content_store_payload_version,
+        content_item_id: draft_content_item.id,
+      )
+      expect(ContentStorePayloadVersion)
+        .to receive(:increment)
+        .with(content_item_id: draft_content_item.id)
 
       described_class.call(payload)
     end
@@ -213,8 +225,8 @@ RSpec.describe Commands::V2::PatchLinkSet do
       end
 
       context "and a draft content item exists for that locale" do
-        before do
-          FactoryGirl.create(
+        let!(:draft_content_item) do
+          create(
             :draft_content_item,
             content_id: content_id,
             base_path: "/french-path",
@@ -228,8 +240,21 @@ RSpec.describe Commands::V2::PatchLinkSet do
             .with(
               1.second,
               content_store: Adapters::DraftContentStore,
-              content_item_id: ContentItem.last.id,
+              content_item_id: draft_content_item.id,
             )
+
+          described_class.call(payload)
+        end
+
+        it "increments the ContentStorePayloadVersion" do
+          create(
+            :content_store_payload_version,
+            content_item_id: draft_content_item.id,
+          )
+
+          expect(ContentStorePayloadVersion)
+            .to receive(:increment)
+            .with(content_item_id: draft_content_item.id)
 
           described_class.call(payload)
         end
@@ -259,8 +284,8 @@ RSpec.describe Commands::V2::PatchLinkSet do
   end
 
   context "when a live content item exists for the content_id" do
-    before do
-      FactoryGirl.create(
+    let!(:live_content_item) do
+      create(
         :live_content_item,
         content_id: content_id,
         base_path: "/some-path",
@@ -273,8 +298,21 @@ RSpec.describe Commands::V2::PatchLinkSet do
         .with(
           1.second,
           content_store: Adapters::ContentStore,
-          content_item_id: ContentItem.last.id,
+          content_item_id: live_content_item.id,
         )
+
+      described_class.call(payload)
+    end
+
+    it "increments the ContentStorePayloadVersion" do
+      create(
+        :content_store_payload_version,
+        content_item_id: live_content_item.id,
+      )
+
+      expect(ContentStorePayloadVersion)
+        .to receive(:increment)
+        .with(content_item_id: live_content_item.id)
 
       described_class.call(payload)
     end
@@ -298,8 +336,8 @@ RSpec.describe Commands::V2::PatchLinkSet do
       end
 
       context "and a live content item exists for that locale" do
-        before do
-          FactoryGirl.create(
+        let!(:live_content_item) do
+          create(
             :live_content_item,
             content_id: content_id,
             base_path: "/french-path",
@@ -313,11 +351,23 @@ RSpec.describe Commands::V2::PatchLinkSet do
             .with(
               1.second,
               content_store: Adapters::ContentStore,
-              content_item_id: ContentItem.last.id,
-             )
+              content_item_id: live_content_item.id,
+            )
 
           expect(PublishingAPI.service(:queue_publisher)).to receive(:send_message)
             .with(hash_including(title: "French Title"))
+
+          described_class.call(payload)
+        end
+
+        it "increments the ContentStorePayloadVersion" do
+          create(
+            :content_store_payload_version,
+            content_item_id: live_content_item.id,
+          )
+          expect(ContentStorePayloadVersion)
+            .to receive(:increment)
+            .with(content_item_id: live_content_item.id)
 
           described_class.call(payload)
         end

--- a/spec/commands/v2/patch_link_set_spec.rb
+++ b/spec/commands/v2/patch_link_set_spec.rb
@@ -214,7 +214,7 @@ RSpec.describe Commands::V2::PatchLinkSet do
       )
       expect(ContentStorePayloadVersion)
         .to receive(:increment)
-        .with(content_item_id: draft_content_item.id)
+        .with(draft_content_item.id)
 
       described_class.call(payload)
     end
@@ -254,7 +254,7 @@ RSpec.describe Commands::V2::PatchLinkSet do
 
           expect(ContentStorePayloadVersion)
             .to receive(:increment)
-            .with(content_item_id: draft_content_item.id)
+            .with(draft_content_item.id)
 
           described_class.call(payload)
         end
@@ -312,7 +312,7 @@ RSpec.describe Commands::V2::PatchLinkSet do
 
       expect(ContentStorePayloadVersion)
         .to receive(:increment)
-        .with(content_item_id: live_content_item.id)
+        .with(live_content_item.id)
 
       described_class.call(payload)
     end
@@ -367,7 +367,7 @@ RSpec.describe Commands::V2::PatchLinkSet do
           )
           expect(ContentStorePayloadVersion)
             .to receive(:increment)
-            .with(content_item_id: live_content_item.id)
+            .with(live_content_item.id)
 
           described_class.call(payload)
         end

--- a/spec/commands/v2/publish_spec.rb
+++ b/spec/commands/v2/publish_spec.rb
@@ -12,6 +12,13 @@ RSpec.describe Commands::V2::Publish do
 
     let(:content_id) { SecureRandom.uuid }
 
+    let!(:content_store_payload_version) do
+      create(
+        :content_store_payload_version,
+        content_item_id: draft_item.id,
+      )
+    end
+
     before do
       stub_request(:put, %r{.*content-store.*/content/.*})
     end
@@ -164,6 +171,14 @@ RSpec.describe Commands::V2::Publish do
             content_store: Adapters::ContentStore,
             content_item_id: draft_item.id,
           )
+
+        described_class.call(payload)
+      end
+
+      it "increments the ContentStorePayloadVersion" do
+        expect(ContentStorePayloadVersion)
+          .to receive(:increment)
+          .with(draft_item.id)
 
         described_class.call(payload)
       end

--- a/spec/commands/v2/publish_spec.rb
+++ b/spec/commands/v2/publish_spec.rb
@@ -156,7 +156,7 @@ RSpec.describe Commands::V2::Publish do
       it "sends a payload downstream asynchronously" do
         presentation = {
           content_id: content_id,
-          transmitted_at: Time.now.to_s(:nanoseconds),
+          payload_version: 1,
           title: "Something something"
         }.to_json
 

--- a/spec/commands/v2/put_content_spec.rb
+++ b/spec/commands/v2/put_content_spec.rb
@@ -36,6 +36,14 @@ RSpec.describe Commands::V2::PutContent do
       described_class.call(payload)
     end
 
+    it "increments ContentStorePayloadVersion" do
+      described_class.call(payload)
+      payload_version = ContentStorePayloadVersion.last
+      expect(payload_version.content_item_id)
+        .to eq(ContentItem.last.id)
+      expect(payload_version.current).to eq(1)
+    end
+
     it "does not send the content item on the message queue" do
       expect(PublishingAPI.service(:queue_publisher)).not_to receive(:send_message)
       described_class.call(payload)

--- a/spec/factories/content_store_payload_version.rb
+++ b/spec/factories/content_store_payload_version.rb
@@ -2,4 +2,8 @@ FactoryGirl.define do
   factory :content_store_payload_version do
     content_item_id 1
   end
+
+  factory :v1_content_store_payload_version, parent: :content_store_payload_version do
+    content_item_id nil
+  end
 end

--- a/spec/factories/content_store_payload_version.rb
+++ b/spec/factories/content_store_payload_version.rb
@@ -1,0 +1,5 @@
+FactoryGirl.define do
+  factory :content_store_payload_version do
+    content_item_id 1
+  end
+end

--- a/spec/models/content_store_payload_version_spec.rb
+++ b/spec/models/content_store_payload_version_spec.rb
@@ -1,0 +1,89 @@
+require "rails_helper"
+
+RSpec.describe ContentStorePayloadVersion do
+  let(:content_item_id) { 10 }
+  describe ".current_for" do
+    it "returns the current value for the supplied content_item_id" do
+      described_class.increment(content_item_id)
+      expect(described_class.current_for(content_item_id)).to eq(1)
+    end
+  end
+
+  describe ".increment" do
+    context "when there is no record" do
+      it "creates one" do
+        described_class.increment(content_item_id)
+        expect(described_class.count).to eq(1)
+      end
+
+      it "initializes current to 1" do
+        described_class.increment(content_item_id)
+        expect(described_class.last.current).to eq(1)
+      end
+
+      it "sets the content_item_id" do
+        described_class.increment(content_item_id)
+        expect(described_class.last.content_item_id).to eq(content_item_id)
+      end
+
+      it "returns the current value" do
+        expect(described_class.increment(content_item_id)).to eq(1)
+      end
+    end
+
+    context "when a record already exists" do
+      let!(:content_store_payload_version) do
+        described_class.create(
+          content_item_id: content_item_id,
+          current: 10
+        )
+      end
+
+      it "increments the current value before returning it" do
+        expect(described_class.increment(content_item_id))
+          .to eq(11)
+      end
+    end
+  end
+
+  describe ContentStorePayloadVersion::V1 do
+    describe ".current" do
+      it "returns the current value from the nil content_item_id record" do
+        described_class.increment
+        expect(described_class.current).to eq(1)
+      end
+    end
+
+    describe ".increment" do
+      context "when there is no record" do
+        it "creates one" do
+          described_class.increment
+          expect(ContentStorePayloadVersion.count).to eq(1)
+        end
+
+        it "sets content_item_id to null" do
+          described_class.increment
+          expect(ContentStorePayloadVersion.last.content_item_id).to be_nil
+        end
+
+        it "returns current value of 1" do
+          expect(described_class.increment).to eq(1)
+        end
+      end
+
+      context "when a record already exists" do
+        let!(:content_store_payload_version) do
+          ContentStorePayloadVersion.create(
+            content_item_id: nil,
+            current: 10
+          )
+        end
+
+        it "increments the current value before returning it" do
+          expect(described_class.increment)
+            .to eq(11)
+        end
+      end
+    end
+  end
+end

--- a/spec/pacts/content_store/put_endpoint_spec.rb
+++ b/spec/pacts/content_store/put_endpoint_spec.rb
@@ -10,20 +10,20 @@ RSpec.describe "PUT endpoint pact with the Content Store", pact: true do
       content_id: content_id
     )
   end
+
+  let!(:content_store_payload_version) do
+    create(:content_store_payload_version, content_item_id: content_item.id)
+  end
+
   let!(:link_set) { FactoryGirl.create(:link_set, content_id: content_id) }
 
   let(:client) { ContentStoreWriter.new("http://localhost:3093") }
   let(:body) { Presenters::ContentStorePresenter.present(content_item) }
-  let(:request_time) { Time.at(2000000000) }
 
-  around do |example|
-    Timecop.freeze(request_time) { example.run }
-  end
-
-  context "when a content item exists that has an older transmitted_at than the request" do
+  context "when a content item exists that has an older payload_version than the request" do
     before do
       content_store
-        .given("a content item exists with base_path /vat-rates and transmitted_at 1000000000000000000")
+        .given("a content item exists with base_path /vat-rates and version 0")
         .upon_receiving("a request to create a content item")
         .with(
           method: :put,
@@ -48,10 +48,10 @@ RSpec.describe "PUT endpoint pact with the Content Store", pact: true do
     end
   end
 
-  context "when a content item exists that has a newer transmitted_at than the request" do
+  context "when a content item exists that has a higher payload_version than the request" do
     before do
       content_store
-        .given("a content item exists with base_path /vat-rates and transmitted_at 3000000000000000000")
+        .given("a content item exists with base_path /vat-rates and payload_version 10")
         .upon_receiving("a request to create a content item")
         .with(
           method: :put,
@@ -84,11 +84,14 @@ RSpec.describe "PUT endpoint pact with the Content Store", pact: true do
         attributes, update_type: false
       )
     end
+    let!(:content_store_payload_version) do
+      create(:v1_content_store_payload_version)
+    end
 
-    context "when a content item exists that has an older transmitted_at than the request" do
+    context "when a content item exists that has an lower payload_version than the request" do
       before do
         content_store
-          .given("a content item exists with base_path /vat-rates and transmitted_at 1000000000000000000")
+          .given("a content item exists with base_path /vat-rates and payload_version 0")
           .upon_receiving("a request to create a content item originating from v1 endpoint")
           .with(
             method: :put,
@@ -113,10 +116,10 @@ RSpec.describe "PUT endpoint pact with the Content Store", pact: true do
       end
     end
 
-    context "when a content item exists that has a newer transmitted_at than the request" do
+    context "when a content item exists that has a higher payload_version than the request" do
       before do
         content_store
-          .given("a content item exists with base_path /vat-rates and transmitted_at 3000000000000000000")
+          .given("a content item exists with base_path /vat-rates and payload_version 10")
           .upon_receiving("a request to create a content item originating from v1 endpoint")
           .with(
             method: :put,

--- a/spec/presenters/content_store_presenter_spec.rb
+++ b/spec/presenters/content_store_presenter_spec.rb
@@ -1,7 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe Presenters::ContentStorePresenter do
-  let(:content_item) { FactoryGirl.create(:live_content_item) }
+  let(:content_item) { create(:live_content_item) }
+  let!(:content_store_payload_version) do
+    create(:content_store_payload_version, content_item_id: content_item.id)
+  end
 
   it "excludes the update_type from the presentation" do
     presentation = described_class.present(content_item)

--- a/spec/presenters/downstream_presenter_spec.rb
+++ b/spec/presenters/downstream_presenter_spec.rb
@@ -129,5 +129,15 @@ RSpec.describe Presenters::DownstreamPresenter do
         payload_version: 1,
       )
     end
+
+    it "can optionally remove the payload_version attribute" do
+      result = described_class.present(attributes, payload_version: false)
+
+      expect(result).to eq(
+        content_id: "content_id",
+        access_limited: "access_limited",
+        update_type: "update_type",
+      )
+    end
   end
 end

--- a/spec/presenters/downstream_presenter_spec.rb
+++ b/spec/presenters/downstream_presenter_spec.rb
@@ -1,101 +1,94 @@
 require 'rails_helper'
 
 RSpec.describe Presenters::DownstreamPresenter do
-  around do |example|
-    Timecop.freeze { example.run }
-  end
-
-  context "for a live content item" do
-    let!(:content_item) { FactoryGirl.create(:live_content_item) }
-    let!(:link_set) { FactoryGirl.create(:link_set, content_id: content_item.content_id) }
-
-    it "presents the object graph for the content store" do
-      result = described_class.present(content_item)
-
-      expect(result).to eq(
-        content_id: content_item.content_id,
-        base_path: "/vat-rates",
-        analytics_identifier: "GDS01",
-        description: "VAT rates for goods and services",
-        details: { body: "<p>Something about VAT</p>\n" },
-        format: "guide",
-        links: Presenters::Queries::LinkSetPresenter.new(link_set).links,
-        locale: "en",
-        need_ids: %w(100123 100124),
-        phase: "beta",
-        public_updated_at: "2014-05-14T13:00:06Z",
-        publishing_app: "publisher",
-        redirects: [],
-        rendering_app: "frontend",
-        routes: [{ path: "/vat-rates", type: "exact" }],
-        title: "VAT rates",
-        transmitted_at: DateTime.now.to_s(:nanoseconds),
-        update_type: "minor",
-      )
+  describe "V2" do
+    before do
+      ContentStorePayloadVersion.increment(content_item.id)
     end
-  end
 
-  context "for a draft content item" do
-    let!(:content_item) { FactoryGirl.create(:draft_content_item) }
-    let!(:link_set) { FactoryGirl.create(:link_set, content_id: content_item.content_id) }
+    context "for a live content item" do
+      let!(:content_item) { create(:live_content_item) }
+      let!(:link_set) { create(:link_set, content_id: content_item.content_id) }
 
-    it "presents the object graph for the content store" do
-      result = described_class.present(content_item)
+      it "presents the object graph for the content store" do
+        result = described_class.present(content_item)
 
-      expect(result).to eq(
-        content_id: content_item.content_id,
-        base_path: "/vat-rates",
-        analytics_identifier: "GDS01",
-        description: "VAT rates for goods and services",
-        details: { body: "<p>Something about VAT</p>\n" },
-        format: "guide",
-        links: Presenters::Queries::LinkSetPresenter.new(link_set).links,
-        locale: "en",
-        need_ids: %w(100123 100124),
-        phase: "beta",
-        public_updated_at: "2014-05-14T13:00:06Z",
-        publishing_app: "publisher",
-        redirects: [],
-        rendering_app: "frontend",
-        routes: [{ path: "/vat-rates", type: "exact" }],
-        title: "VAT rates",
-        transmitted_at: DateTime.now.to_s(:nanoseconds),
-        update_type: "minor",
-      )
-    end
-  end
-
-  describe "conditional attributes" do
-    let!(:content_item) { FactoryGirl.create(:live_content_item) }
-    let!(:link_set) { FactoryGirl.create(:link_set, content_id: content_item.content_id) }
-
-    context "when the link_set is not present" do
-      before { link_set.destroy }
-
-      it "does not raise an error" do
-        expect {
-          described_class.present(content_item)
-        }.to_not raise_error
+        expect(result).to eq(
+          content_id: content_item.content_id,
+          base_path: "/vat-rates",
+          analytics_identifier: "GDS01",
+          description: "VAT rates for goods and services",
+          details: { body: "<p>Something about VAT</p>\n" },
+          format: "guide",
+          links: Presenters::Queries::LinkSetPresenter.new(link_set).links,
+          locale: "en",
+          need_ids: %w(100123 100124),
+          phase: "beta",
+          public_updated_at: "2014-05-14T13:00:06Z",
+          publishing_app: "publisher",
+          redirects: [],
+          rendering_app: "frontend",
+          routes: [{ path: "/vat-rates", type: "exact" }],
+          title: "VAT rates",
+          payload_version: 1,
+          update_type: "minor",
+        )
       end
     end
 
-    context "when the public_updated_at is not present" do
-      let!(:content_item) { FactoryGirl.create(:gone_draft_content_item) }
+    context "for a draft content item" do
+      let!(:content_item) { create(:draft_content_item) }
+      let!(:link_set) { create(:link_set, content_id: content_item.content_id) }
 
-      it "does not raise an error" do
-        expect {
-          described_class.present(content_item)
-        }.to_not raise_error
+      it "presents the object graph for the content store" do
+        result = described_class.present(content_item)
+
+        expect(result).to eq(
+          content_id: content_item.content_id,
+          base_path: "/vat-rates",
+          analytics_identifier: "GDS01",
+          description: "VAT rates for goods and services",
+          details: { body: "<p>Something about VAT</p>\n" },
+          format: "guide",
+          links: Presenters::Queries::LinkSetPresenter.new(link_set).links,
+          locale: "en",
+          need_ids: %w(100123 100124),
+          phase: "beta",
+          public_updated_at: "2014-05-14T13:00:06Z",
+          publishing_app: "publisher",
+          redirects: [],
+          rendering_app: "frontend",
+          routes: [{ path: "/vat-rates", type: "exact" }],
+          title: "VAT rates",
+          payload_version: 1,
+          update_type: "minor",
+        )
       end
     end
-  end
 
-  describe "presented transmitted_at datetime format" do
-    it "returns a string formatted as nanoseconds" do
-      datetime = DateTime.now
-      nanoseconds = datetime.to_s(:nanoseconds)
+    describe "conditional attributes" do
+      let!(:content_item) { create(:live_content_item) }
+      let!(:link_set) { create(:link_set, content_id: content_item.content_id) }
 
-      expect(nanoseconds).to eq(datetime.strftime("%s%9N"))
+      context "when the link_set is not present" do
+        before { link_set.destroy }
+
+        it "does not raise an error" do
+          expect {
+            described_class.present(content_item)
+          }.to_not raise_error
+        end
+      end
+
+      context "when the public_updated_at is not present" do
+        let!(:content_item) { create(:gone_draft_content_item) }
+
+        it "does not raise an error" do
+          expect {
+            described_class.present(content_item)
+          }.to_not raise_error
+        end
+      end
     end
   end
 
@@ -112,14 +105,18 @@ RSpec.describe Presenters::DownstreamPresenter do
       Timecop.freeze { example.run }
     end
 
-    it "presents all attributes by default and mixes in transmitted_at" do
+    before do
+      ContentStorePayloadVersion::V1.increment
+    end
+
+    it "presents all attributes by default" do
       result = described_class.present(attributes)
 
       expect(result).to eq(
         content_id: "content_id",
         access_limited: "access_limited",
         update_type: "update_type",
-        transmitted_at: DateTime.now.to_s(:nanoseconds),
+        payload_version: 1,
       )
     end
 
@@ -129,17 +126,7 @@ RSpec.describe Presenters::DownstreamPresenter do
       expect(result).to eq(
         content_id: "content_id",
         access_limited: "access_limited",
-        transmitted_at: DateTime.now.to_s(:nanoseconds),
-      )
-    end
-
-    it "can optionally omit the transmitted_at" do
-      result = described_class.present(attributes, transmitted_at: false)
-
-      expect(result).to eq(
-        content_id: "content_id",
-        access_limited: "access_limited",
-        update_type: "update_type",
+        payload_version: 1,
       )
     end
   end

--- a/spec/support/request_helpers/downstream_requests.rb
+++ b/spec/support/request_helpers/downstream_requests.rb
@@ -4,18 +4,16 @@ module RequestHelpers
       it "sends to draft content store" do
         allow(PublishingAPI.service(:draft_content_store)).to receive(:put_content_item).with(anything)
 
-        Timecop.freeze do
-          expect(PublishingAPI.service(:draft_content_store)).to receive(:put_content_item)
-            .with(
-              base_path: base_path,
-              content_item: content_item_for_draft_content_store
-                .merge(transmitted_at: DateTime.now.to_s(:nanoseconds))
-            )
+        expect(PublishingAPI.service(:draft_content_store)).to receive(:put_content_item)
+          .with(
+            base_path: base_path,
+            content_item: content_item_for_draft_content_store
+              .merge(payload_version: anything)
+          )
 
-          do_request
+        do_request
 
-          expect(response.status).to eq(200), response.body
-        end
+        expect(response).to be_ok, response.body
       end
     end
 
@@ -23,18 +21,16 @@ module RequestHelpers
       it "sends to live content store" do
         allow(PublishingAPI.service(:live_content_store)).to receive(:put_content_item).with(anything)
 
-        Timecop.freeze do
-          expect(PublishingAPI.service(:live_content_store)).to receive(:put_content_item)
-            .with(
-              base_path: base_path,
-              content_item: content_item_for_live_content_store
-                .merge(transmitted_at: DateTime.now.to_s(:nanoseconds))
-            )
+        expect(PublishingAPI.service(:live_content_store)).to receive(:put_content_item)
+          .with(
+            base_path: base_path,
+            content_item: content_item_for_live_content_store
+              .merge(payload_version: anything)
+          )
 
-          do_request
+        do_request
 
-          expect(response.status).to eq(200), response.body
-        end
+        expect(response).to be_ok, response.body
       end
     end
 

--- a/spec/workers/content_store_worker_spec.rb
+++ b/spec/workers/content_store_worker_spec.rb
@@ -25,6 +25,12 @@ RSpec.describe ContentStoreWorker do
 
       let(:status) { status }
       let!(:content_item) { create(:live_content_item, base_path: '/foo') }
+      let!(:content_store_payload_version) do
+        create(
+          :content_store_payload_version,
+          content_item_id: content_item.id
+        )
+      end
 
       if expectation.fetch(:raises_error)
         it "raises an error" do
@@ -52,6 +58,12 @@ RSpec.describe ContentStoreWorker do
 
   context "when a draft item is enqueued" do
     let!(:draft_content_item) { create(:draft_content_item, base_path: '/foo') }
+    let!(:content_store_payload_version) do
+      create(
+        :content_store_payload_version,
+        content_item_id: draft_content_item.id
+      )
+    end
 
     it "publishes a presented draft content item to the draft Content Store" do
       api_call = stub_request(:put, "http://draft-content-store.dev.gov.uk/content/foo")
@@ -66,7 +78,13 @@ RSpec.describe ContentStoreWorker do
   end
 
   context "when a live item is enqueued" do
-    let!(:live_content_item)  { create(:live_content_item, base_path: '/foo') }
+    let!(:live_content_item) { create(:live_content_item, base_path: '/foo') }
+    let!(:content_store_payload_version) do
+      create(
+        :content_store_payload_version,
+        content_item_id: live_content_item.id
+      )
+    end
 
     it "publishes a presented live content item to the live Content Store" do
       api_call = stub_request(:put, "http://content-store.dev.gov.uk/content/foo")


### PR DESCRIPTION
This PR replaces `transmitted_at` with an incrementing integer `payload_version`. Since we started 'presenting' the content items at the time the Sidekiq worker actually runs we should now be able to safely ignore payloads that have a lower or equal `payload_version`. Using an integer, incremented atomically at the DB should protect us from race conditions and negate the time variance we have between machines that was causing issues with the time based `transmitted_at`.

[This PR](https://github.com/alphagov/content-store/pull/193) on Content Store added support at the 'other end'

[Trello](https://trello.com/c/dBmI96gI/304-change-locking-criteria-on-content-store)