### PR TITLE
Clone content register

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,6 @@
 class ApplicationController < ActionController::Base
+  rescue_from ActionController::ParameterMissing, with: :parameter_missing_error
+
   include GDS::SSO::ControllerMethods
 
   class BadRequest < StandardError; end
@@ -21,6 +23,17 @@ class ApplicationController < ActionController::Base
 
 private
 
+  def parameter_missing_error(e)
+    error = CommandError.new(code: 422, error_details: {
+      error: {
+        code: 422,
+        message: e.message
+      }
+    })
+
+    respond_with_command_error(error)
+  end
+
   def respond_with_command_error(error)
     render status: error.code, json: error
   end
@@ -33,5 +46,17 @@ private
     @payload ||= JSON.parse(request.body.read).deep_symbolize_keys
   rescue JSON::ParserError
     raise BadRequest
+  end
+
+  def query_params
+    @query_params ||= ActionController::Parameters.new(request.query_parameters)
+  end
+
+  def post_params
+    @post_params ||= ActionController::Parameters.new(request.request_parameters)
+  end
+
+  def path_params
+    @post_params ||= ActionController::Parameters.new(request.path_parameters)
   end
 end

--- a/app/controllers/v2/content_items_controller.rb
+++ b/app/controllers/v2/content_items_controller.rb
@@ -21,6 +21,7 @@ module V2
           content_id
           publication_state
           base_path
+          internal_name
         ),
       ).call
     end

--- a/app/controllers/v2/link_sets_controller.rb
+++ b/app/controllers/v2/link_sets_controller.rb
@@ -1,7 +1,5 @@
 module V2
   class LinkSetsController < ApplicationController
-    rescue_from ActionController::ParameterMissing, with: :parameter_missing_error
-
     def get_links
       render json: Queries::GetLinkSet.call(content_id)
     end
@@ -27,17 +25,6 @@ module V2
 
     def content_id
       params.fetch(:content_id)
-    end
-
-    def parameter_missing_error(e)
-      error = CommandError.new(code: 422, error_details: {
-        error: {
-          code: 422,
-          message: e.message
-        }
-      })
-
-      respond_with_command_error(error)
     end
   end
 end

--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -38,27 +38,6 @@ class ContentItem < ActiveRecord::Base
   validates :description, well_formed_content_types: { must_include: "text/html" }
   validates :details, well_formed_content_types: { must_include: "text/html" }
 
-  # Postgres's JSON columns have problems storing literal strings, so these
-  # getter/setter wrap the description in a JSON object.
-  def description=(value)
-    super(value: value)
-  end
-
-  def description
-    super.fetch(:value)
-  end
-
-  def attributes
-    attributes = super
-    description = attributes.delete("description")
-
-    if description
-      attributes.merge("description" => description.fetch("value"))
-    else
-      attributes
-    end
-  end
-
 private
 
   def renderable_content?

--- a/app/presenters/queries/content_item_presenter.rb
+++ b/app/presenters/queries/content_item_presenter.rb
@@ -33,14 +33,19 @@ module Presenters
           most_recent_item = draft || live
           next unless most_recent_item
 
+          parse_json_fields!(most_recent_item)
+
+          if output_fields.include?("internal_name")
+            details = most_recent_item.fetch("details")
+            most_recent_item["internal_name"] = details["internal_name"] || most_recent_item.fetch("title")
+          end
+
           most_recent_item["publication_state"] = publication_state(draft, live)
           most_recent_item["lock_version"] = most_recent_item.fetch("lock_version").to_i
 
           if live
             most_recent_item["live_version"] = live.fetch("lock_version").to_i
           end
-
-          parse_json_fields!(most_recent_item)
 
           most_recent_item.slice(*output_fields)
         end

--- a/app/presenters/queries/content_item_presenter.rb
+++ b/app/presenters/queries/content_item_presenter.rb
@@ -68,7 +68,7 @@ module Presenters
 
       def select_fields(scope)
         scope.select(
-          *(ContentItem::TOP_LEVEL_FIELDS - ["publication_state"]),
+          *ContentItem::TOP_LEVEL_FIELDS,
           "content_id",
           "states.name as state_name",
           "lock_versions.number as lock_version",

--- a/app/queries/get_content_collection.rb
+++ b/app/queries/get_content_collection.rb
@@ -51,7 +51,7 @@ module Queries
     end
 
     def permitted_fields
-      ContentItem.column_names + %w(base_path locale publication_state)
+      ContentItem.column_names + %w(base_path locale publication_state internal_name)
     end
 
     def select_output_fields_only(presenter)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,6 +21,8 @@ Rails.application.routes.draw do
       # put is provided for backwards compatibility.
       put "/links/:content_id", to: "link_sets#patch_links"
       get "/linked/:content_id", to: "link_sets#get_linked"
+
+      get "/linkables", to: "content_items#linkables"
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
-  scope format: false do |_r|
+  scope format: false do
     put "/draft-content(/*base_path)", to: "content_items#put_draft_content_item"
     put "/content(/*base_path)", to: "content_items#put_live_content_item"
 

--- a/spec/presenters/queries/content_item_presenter_spec.rb
+++ b/spec/presenters/queries/content_item_presenter_spec.rb
@@ -171,5 +171,46 @@ RSpec.describe Presenters::Queries::ContentItemPresenter do
         expect(results.first.keys).to match_array(%w(title phase publication_state))
       end
     end
+
+    context "when internal_name is requested" do
+      let(:fields) { %w(internal_name) }
+
+      context "and an internal_name is present" do
+        before do
+          details = content_item.details
+          details[:internal_name] = "An internal name"
+
+          content_item.update_attributes(
+            details: details,
+          )
+        end
+
+        it "returns the internal_name" do
+          content_items = ContentItem.where(content_id: content_id)
+
+          results = described_class.present_many(content_items, fields: fields)
+          expect(results.first["internal_name"]).to eq("An internal name")
+        end
+      end
+
+      context "but an internal_name is not present" do
+        before do
+          details = content_item.details
+          details.delete(:internal_name)
+
+          content_item.update_attributes(
+            details: details,
+            title: "A normal title",
+          )
+        end
+
+        it "falls back to the title" do
+          content_items = ContentItem.where(content_id: content_id)
+
+          results = described_class.present_many(content_items, fields: fields)
+          expect(results.first["internal_name"]).to eq("A normal title")
+        end
+      end
+    end
   end
 end

--- a/spec/requests/index_spec.rb
+++ b/spec/requests/index_spec.rb
@@ -1,0 +1,45 @@
+require "rails_helper"
+
+RSpec.describe "GET /v2/content", type: :request do
+  let!(:policy_1) {
+    FactoryGirl.create(:content_item,
+      state: "draft",
+      format: "policy",
+      title: "Policy 1",
+      base_path: "/cat-rates",
+    )
+  }
+
+  let!(:policy_2) {
+    FactoryGirl.create(:content_item,
+      state: "published",
+      format: "policy",
+      title: "Policy 2",
+    )
+  }
+
+  it "accepts either 'content_format' or 'format'" do
+    expected_result = [
+      {
+        title: "Policy 1",
+      },
+      {
+        title: "Policy 2",
+      },
+    ]
+
+    get "/v2/content", format: "policy", fields: ["title"]
+    expect(JSON.parse(response.body, symbolize_names: true)).to match_array(expected_result)
+
+    get "/v2/content", content_format: "policy", fields: ["title"]
+    expect(JSON.parse(response.body, symbolize_names: true)).to match_array(expected_result)
+  end
+
+  context "without a format" do
+    it "422s" do
+      get "/v2/content", fields: ["title"]
+
+      expect(response.status).to eq(422)
+    end
+  end
+end

--- a/spec/requests/linkables_spec.rb
+++ b/spec/requests/linkables_spec.rb
@@ -1,0 +1,47 @@
+require "rails_helper"
+
+RSpec.describe "GET /v2/linkables", type: :request do
+  let!(:policy_1) {
+    FactoryGirl.create(:content_item,
+      state: "draft",
+      format: "policy",
+      title: "Policy 1",
+      base_path: "/cat-rates",
+    )
+  }
+
+  let!(:policy_2) {
+    FactoryGirl.create(:content_item,
+      state: "published",
+      format: "policy",
+      title: "Policy 2",
+    )
+  }
+
+  it "returns the title, content ID, state, and base path for all content items of a given format" do
+    get "/v2/linkables", format: "policy"
+
+    expect(JSON.parse(response.body, symbolize_names: true)).to match_array([
+      {
+        content_id: policy_1.content_id,
+        title: "Policy 1",
+        publication_state: "draft",
+        base_path: "/cat-rates",
+      },
+      {
+        content_id: policy_2.content_id,
+        title: "Policy 2",
+        publication_state: "live",
+        base_path: "/vat-rates",
+      },
+    ])
+  end
+
+  context "without a format" do
+    it "422s" do
+      get "/v2/linkables"
+
+      expect(response.status).to eq(422)
+    end
+  end
+end

--- a/spec/requests/linkables_spec.rb
+++ b/spec/requests/linkables_spec.rb
@@ -7,6 +7,9 @@ RSpec.describe "GET /v2/linkables", type: :request do
       format: "policy",
       title: "Policy 1",
       base_path: "/cat-rates",
+      details: {
+        internal_name: "Cat rates (do not use for actual cats)"
+      }
     )
   }
 
@@ -18,7 +21,7 @@ RSpec.describe "GET /v2/linkables", type: :request do
     )
   }
 
-  it "returns the title, content ID, state, and base path for all content items of a given format" do
+  it "returns the title, content ID, state, internal name and base path for all content items of a given format" do
     get "/v2/linkables", format: "policy"
 
     expect(JSON.parse(response.body, symbolize_names: true)).to match_array([
@@ -27,12 +30,14 @@ RSpec.describe "GET /v2/linkables", type: :request do
         title: "Policy 1",
         publication_state: "draft",
         base_path: "/cat-rates",
+        internal_name: "Cat rates (do not use for actual cats)",
       },
       {
         content_id: policy_2.content_id,
         title: "Policy 2",
         publication_state: "live",
         base_path: "/vat-rates",
+        internal_name: "Policy 2"
       },
     ])
   end

--- a/spec/service_consumers/pact_helper.rb
+++ b/spec/service_consumers/pact_helper.rb
@@ -218,21 +218,22 @@ Pact.provider_states_for "GDS API Adapters" do
 
   provider_state "there is content with format 'topic'" do
     set_up do
-      content_item = FactoryGirl.create(
-        :draft_content_item,
+      FactoryGirl.create(:draft_content_item,
         title: 'Content Item A',
+        content_id: 'aaaaaaaa-aaaa-1aaa-aaaa-aaaaaaaaaaaa',
         base_path: '/a-base-path',
         format: 'topic',
+        details: {
+          internal_name: "an internal name",
+        },
       )
-      FactoryGirl.create(:lock_version, target: content_item, number: 1)
 
-      content_item = FactoryGirl.create(
-        :draft_content_item,
+      FactoryGirl.create(:live_content_item,
         title: 'Content Item B',
+        content_id: 'bbbbbbbb-bbbb-2bbb-bbbb-bbbbbbbbbbbb',
         base_path: '/another-base-path',
         format: 'topic',
       )
-      FactoryGirl.create(:lock_version, target: content_item, number: 1)
     end
   end
 


### PR DESCRIPTION
This endpoint is to serve as a replacement for the current content register endpoint, namely for populating dropdowns in publishing applications.

Although we're making use of the same code as the index endpoint, they serve different purposes.

To my understanding the purpose of the index endpoint is to provide all the information required to render an index page in a publishing application.  This requires some fields that the dropdowns do not, and vice versa.  The index endpoint also has authentication, and soon ordering, filtering and pagination, none of which the dropdowns need.

I believe the eventual intent is for the publishing API to also provide an endpoint which gives all the information required to render an edit page for a given format, at which point this dropdowns endpoint will become redundant and can be removed.

I've named the endpoint `linkables` because the content register used "entries" which needs more context in an app with multiple endpoints.  It provides lists of things which can be linked to your content item, hence the name.

There are possibly further performance improvements that could be made to the underlying code and I'd love to hear them, but I don't feel that they should block this code going out as testing seems to show it to be Fast Enough™.

https://trello.com/c/jzI3JlLH/515-remove-content-register