### PR TITLE
Fix a problem with discard draft not cleaning up properly...

### DIFF
--- a/app/commands/v2/discard_draft.rb
+++ b/app/commands/v2/discard_draft.rb
@@ -7,14 +7,14 @@ module Commands
         check_version_and_raise_if_conflicting(draft, payload[:previous_version])
 
         draft_path = Location.find_by!(content_item: draft).base_path
+
         delete_supporting_objects
+        delete_draft_from_database
+        delete_draft_from_draft_content_store(draft_path) if downstream
 
         if live
           increment_live_lock_version
           send_live_to_draft_content_store(live) if downstream
-        else
-          delete_draft_from_database
-          delete_draft_from_draft_content_store(draft_path) if downstream
         end
 
         Success.new(content_id: content_id)

--- a/spec/commands/v2/discard_draft_spec.rb
+++ b/spec/commands/v2/discard_draft_spec.rb
@@ -98,6 +98,7 @@ RSpec.describe Commands::V2::DiscardDraft do
           FactoryGirl.create(:live_content_item,
             content_id: content_id,
             lock_version: 3,
+            base_path: "/hat-rates",
           )
         }
 
@@ -109,7 +110,23 @@ RSpec.describe Commands::V2::DiscardDraft do
           }.to change { published_lock_version.reload.number }.to(4)
         end
 
+        it "deletes the draft content item from the draft content store" do
+          allow(ContentStoreWorker).to receive(:perform_in)
+
+          expect(ContentStoreWorker).to receive(:perform_in)
+            .with(
+              1.second,
+              content_store: Adapters::DraftContentStore,
+              base_path: base_path,
+              delete: true,
+            )
+
+          described_class.call(payload)
+        end
+
         it "sends the published content item to the draft content store" do
+          allow(ContentStoreWorker).to receive(:perform_in)
+
           expect(ContentStoreWorker).to receive(:perform_in)
             .with(
               1.second,
@@ -118,6 +135,30 @@ RSpec.describe Commands::V2::DiscardDraft do
             )
 
           described_class.call(payload)
+        end
+
+        it "deletes the supporting objects for the draft item" do
+          described_class.call(payload)
+
+          state = State.find_by(content_item: existing_draft_item)
+          translation = Translation.find_by(content_item: existing_draft_item)
+          location = Location.find_by(content_item: existing_draft_item)
+          access_limit = AccessLimit.find_by(content_item: existing_draft_item)
+          user_facing_version = UserFacingVersion.find_by(content_item: existing_draft_item)
+          lock_version = LockVersion.find_by(target: existing_draft_item)
+
+          expect(state).to be_nil
+          expect(translation).to be_nil
+          expect(location).to be_nil
+          expect(access_limit).to be_nil
+          expect(user_facing_version).to be_nil
+          expect(lock_version).to be_nil
+        end
+
+        it "deletes the draft" do
+          expect {
+            described_class.call(payload)
+          }.to change(ContentItem, :count).by(-1)
         end
       end
 


### PR DESCRIPTION
Following the deploy to prod, we found that discard draft
should be unconditionally deleting the draft content item.
We should also make sure that a delete request is sent to
the content store because the base path might have changed
between the draft/live content items and the live content
item might not replace the draft in the content store.