### PR TITLE
Ensure link set exists

### DIFF
--- a/app/commands/v2/put_content.rb
+++ b/app/commands/v2/put_content.rb
@@ -33,6 +33,7 @@ module Commands
           clear_draft_items_of_same_locale_and_base_path(content_item, locale, base_path)
 
           supporting_objects = create_supporting_objects(content_item)
+          ensure_link_set_exists(content_item)
 
           if payload[:access_limited] && (users = payload[:access_limited][:users])
             AccessLimit.create!(content_item: content_item, users: users)
@@ -84,6 +85,14 @@ module Commands
         Translation.create!(content_item: content_item, locale: locale)
         UserFacingVersion.create!(content_item: content_item, number: user_facing_version_number_for_new_draft)
         LockVersion.create!(target: content_item, number: lock_version_number_for_new_draft)
+      end
+
+      def ensure_link_set_exists(content_item)
+        existing_link_set = LinkSet.find_by(content_id: content_item.content_id)
+        return if existing_link_set
+
+        link_set = LinkSet.create!(content_id: content_item.content_id)
+        LockVersion.create!(target: link_set, number: 1)
       end
 
       def lock_version_number_for_new_draft

--- a/db/migrate/20160229133026_create_missing_link_sets.rb
+++ b/db/migrate/20160229133026_create_missing_link_sets.rb
@@ -1,0 +1,20 @@
+class CreateMissingLinkSets < ActiveRecord::Migration
+  def up
+    content_ids_without_link_sets = ContentItem
+      .joins("LEFT JOIN link_sets on link_sets.content_id = content_items.content_id")
+      .where("link_sets.id IS NULL")
+      .pluck(:content_id)
+      .uniq
+
+    content_ids_without_link_sets.each do |content_id|
+      puts "Creating empty LinkSet for content_id #{content_id}"
+      link_set = LinkSet.create!(content_id: content_id)
+      LockVersion.create!(target: link_set, number: 1)
+    end
+
+    puts "\n>>> Created #{content_ids_without_link_sets.size} link sets"
+  end
+
+  def down
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160229110645) do
+ActiveRecord::Schema.define(version: 20160229133026) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/spec/commands/v2/put_content_spec.rb
+++ b/spec/commands/v2/put_content_spec.rb
@@ -413,6 +413,31 @@ RSpec.describe Commands::V2::PutContent do
       end
     end
 
+    context "when a link set does not exist for the content id" do
+      it "creates an empty link set" do
+        expect {
+          described_class.call(payload)
+        }.to change(LinkSet, :count).by(1)
+
+        link_set = LinkSet.last
+
+        expect(link_set.content_id).to eq(content_id)
+        expect(link_set.links).to be_empty
+      end
+
+      it "creates a lock version for the link set" do
+        expect {
+          described_class.call(payload)
+        }.to change(LinkSet, :count).by(1)
+
+        link_set = LinkSet.last
+        lock_version = LockVersion.find_by(target: link_set)
+
+        expect(lock_version).to be_present
+        expect(lock_version.number).to eq(1)
+      end
+    end
+
     context "when a link set exists for the content id" do
       let(:link_target) { SecureRandom.uuid }
 

--- a/spec/requests/content_item_requests/downstream_requests_spec.rb
+++ b/spec/requests/content_item_requests/downstream_requests_spec.rb
@@ -34,6 +34,7 @@ RSpec.describe "Downstream requests", type: :request do
     let(:content_item_for_draft_content_store) {
       v2_content_item
         .except(:update_type)
+        .merge(links: {})
     }
     let(:request_body) { v2_content_item.to_json }
     let(:request_path) { "/v2/content/#{content_id}" }


### PR DESCRIPTION
This was the behaviour before the refactor and we don’t have
a good reason to change this.