### PR TITLE
Deduplicate access limits...

### DIFF
--- a/db/migrate/20160301120422_deduplicate_access_limits.rb
+++ b/db/migrate/20160301120422_deduplicate_access_limits.rb
@@ -1,0 +1,5 @@
+class DeduplicateAccessLimits < ActiveRecord::Migration
+  def change
+    DataHygiene::AccessLimitsCleaner.cleanup
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160229133026) do
+ActiveRecord::Schema.define(version: 20160301120422) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/lib/data_hygiene/access_limits_cleaner.rb
+++ b/lib/data_hygiene/access_limits_cleaner.rb
@@ -1,0 +1,33 @@
+module DataHygiene
+  class AccessLimitsCleaner
+    def self.cleanup(log: STDOUT)
+      run(cleanup: true, log: log)
+    end
+
+    def self.report(log: STDOUT)
+      run(cleanup: false, log: log)
+    end
+
+    def self.run(cleanup:, log:)
+      dupe_access_limits_by_content_item = AccessLimit
+        .joins("INNER JOIN content_items ON content_items.id = access_limits.content_item_id")
+        .group("content_items.id").having("COUNT(access_limits.id) > 1").count
+
+      dupe_access_limits_by_content_item.each do |count|
+        content_item_id, access_limit_count = count
+        dupe_access_limits = AccessLimit.where(content_item_id: content_item_id).limit(access_limit_count - 1).order(updated_at: :asc)
+        log.puts "destroying AccessLimits: #{dupe_access_limits.map(&:id)} for content_item_id: #{content_item_id}"
+        dupe_access_limits.destroy_all if cleanup
+      end
+
+      published_access_limits = AccessLimit
+        .joins("INNER JOIN content_items ON content_items.id = access_limits.content_item_id")
+        .joins("INNER JOIN states ON states.content_item_id = content_items.id")
+        .where("states.name = 'published'")
+
+      log.puts "destroying #{published_access_limits.count} AccessLimits for published content."
+      log.puts published_access_limits.map(&:id)
+      published_access_limits.destroy_all if cleanup
+    end
+  end
+end

--- a/spec/lib/data_hygiene/access_limits_cleaner_spec.rb
+++ b/spec/lib/data_hygiene/access_limits_cleaner_spec.rb
@@ -1,0 +1,37 @@
+require "rails_helper"
+
+RSpec.describe DataHygiene::AccessLimitsCleaner, :cleanup do
+  let!(:unrelated_access_limit) { FactoryGirl.create(:access_limit) }
+  let(:draft_content_item) { FactoryGirl.create(:draft_content_item) }
+  let(:another_draft_content_item) { FactoryGirl.create(:draft_content_item) }
+  let!(:dupe_access_limit) { FactoryGirl.create(:access_limit, content_item: draft_content_item) }
+  let!(:another_dupe_access_limit) { FactoryGirl.create(:access_limit, content_item: draft_content_item) }
+  let!(:access_limit) { FactoryGirl.create(:access_limit, content_item: draft_content_item) }
+
+  let(:live_content_item) { FactoryGirl.create(:live_content_item) }
+  let!(:published_access_limit) { FactoryGirl.create(:access_limit, content_item: live_content_item) }
+
+  let(:log) { double(:log) }
+
+  before do
+    allow(log).to receive(:puts)
+  end
+
+  it "cleans up duplicate AccessLimits" do
+    expect {
+      described_class.cleanup(log: log)
+    }.to change(AccessLimit, :count).by(-3)
+    # verify the latest record was retained
+    expect(AccessLimit.all).to match_array([access_limit, unrelated_access_limit])
+  end
+
+  it "cleans up AccessLimits associated with published content" do
+    expect {
+      described_class.cleanup(log: log)
+    }.to change(AccessLimit, :count).by(-3)
+    # verify the live content access limit was destroyed
+    expect {
+      AccessLimit.find(published_access_limit.id)
+    }.to raise_error ActiveRecord::RecordNotFound
+  end
+end


### PR DESCRIPTION
AccessLimit records have been unintentionally duplicated for some time in the
publishing-api, there should only be one access limit record per
draft content item and published content items should not have an
access limit associated with them.