### PR TITLE
Log with request uuid

### DIFF
--- a/app/commands/base_command.rb
+++ b/app/commands/base_command.rb
@@ -1,6 +1,8 @@
 module Commands
   class BaseCommand
     def self.call(payload, downstream: true)
+      logger.debug "#{self} called with payload:\n#{payload}"
+
       EventLogger.log_command(self, payload) do |event|
         new(payload, event: event, downstream: downstream).call
       end

--- a/app/commands/v2/discard_draft.rb
+++ b/app/commands/v2/discard_draft.rb
@@ -40,6 +40,7 @@ module Commands
           content_store: Adapters::DraftContentStore,
           base_path: draft_path,
           delete: true,
+          request_uuid: GdsApi::GovukHeaders.headers[:x_govuk_request_uuid],
         )
       end
 
@@ -47,6 +48,7 @@ module Commands
         PresentedContentStoreWorker.perform_async(
           content_store: Adapters::DraftContentStore,
           payload: Presenters::ContentStorePresenter.present(live, event),
+          request_uuid: GdsApi::GovukHeaders.headers[:x_govuk_request_uuid],
         )
       end
 

--- a/app/commands/v2/patch_link_set.rb
+++ b/app/commands/v2/patch_link_set.rb
@@ -94,6 +94,7 @@ module Commands
         PresentedContentStoreWorker.perform_async(
           content_store: content_store,
           payload: Presenters::ContentStorePresenter.present(content_item, event),
+          request_uuid: GdsApi::GovukHeaders.headers[:x_govuk_request_uuid],
         )
       end
 

--- a/app/commands/v2/publish.rb
+++ b/app/commands/v2/publish.rb
@@ -133,6 +133,7 @@ module Commands
           content_item,
           event,
           update_type: update_type
+          request_uuid: GdsApi::GovukHeaders.headers[:x_govuk_request_uuid],
         )
 
         PublishingAPI.service(:queue_publisher).send_message(queue_payload)

--- a/app/commands/v2/publish.rb
+++ b/app/commands/v2/publish.rb
@@ -127,13 +127,13 @@ module Commands
             content_item,
             event
           ),
+          request_uuid: GdsApi::GovukHeaders.headers[:x_govuk_request_uuid]
         )
 
         queue_payload = Presenters::MessageQueuePresenter.present(
           content_item,
           event,
           update_type: update_type
-          request_uuid: GdsApi::GovukHeaders.headers[:x_govuk_request_uuid],
         )
 
         PublishingAPI.service(:queue_publisher).send_message(queue_payload)

--- a/app/commands/v2/put_content.rb
+++ b/app/commands/v2/put_content.rb
@@ -167,9 +167,14 @@ module Commands
       def send_downstream(content_item)
         return unless downstream
 
+        message = "Enqueuing ContentStoreWorker job with "
+        message += "{ content_store: Adapters::DraftContentStore, content_item_id: #{content_item.id} }"
+        logger.info message
+
         PresentedContentStoreWorker.perform_async(
           content_store: Adapters::DraftContentStore,
           payload: Presenters::ContentStorePresenter.present(content_item, event),
+          request_uuid: GdsApi::GovukHeaders.headers[:x_govuk_request_uuid],
         )
       end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -16,6 +16,7 @@ class ApplicationController < ActionController::Base
   end
 
   before_action :require_signin_permission!
+  before_action :add_govuk_request_uuid_header
 
   Warden::Manager.after_authentication do |user, _, _|
     user.set_app_name!
@@ -58,5 +59,9 @@ private
 
   def path_params
     @post_params ||= ActionController::Parameters.new(request.path_parameters)
+  end
+
+  def add_govuk_request_uuid_header
+    GdsApi::GovukHeaders.set_header(:x_govuk_request_uuid, request.uuid)
   end
 end

--- a/app/workers/content_store_worker.rb
+++ b/app/workers/content_store_worker.rb
@@ -29,7 +29,7 @@ class ContentStoreWorker
 
   def self.perform_with_defaults(opts)
     keys = [:content_store, :content_item_id, :base_path, :delete]
-    opts = opts.select { |k,v| keys.include?(k) }
+    opts = opts.select { |k, _| keys.include?(k) }
 
     opts[:content_store] = opts[:content_store] || Adapters::DraftContentStore
     opts[:request_uuid] = GdsApi::GovukHeaders.headers[:x_govuk_request_uuid]

--- a/app/workers/content_store_worker.rb
+++ b/app/workers/content_store_worker.rb
@@ -27,16 +27,6 @@ class ContentStoreWorker
     handle_error(e)
   end
 
-  def self.perform_with_defaults(opts)
-    keys = [:content_store, :content_item_id, :base_path, :delete]
-    opts = opts.select { |k, _| keys.include?(k) }
-
-    opts[:content_store] = opts[:content_store] || Adapters::DraftContentStore
-    opts[:request_uuid] = GdsApi::GovukHeaders.headers[:x_govuk_request_uuid]
-
-    perform_in(2.seconds, opts)
-  end
-
 private
 
   # Previously, the content_store_payload_id was sourced from a separate table.

--- a/app/workers/content_store_worker.rb
+++ b/app/workers/content_store_worker.rb
@@ -6,6 +6,8 @@ class ContentStoreWorker
   def perform(args = {})
     args = args.deep_symbolize_keys
 
+    logger.debug "[#{args[:request_uuid]}] ContentStoreWorker#perform with #{args}"
+
     content_store = args.fetch(:content_store).constantize
 
     if args[:delete]

--- a/app/workers/content_store_worker.rb
+++ b/app/workers/content_store_worker.rb
@@ -27,6 +27,16 @@ class ContentStoreWorker
     handle_error(e)
   end
 
+  def self.perform_with_defaults(opts)
+    keys = [:content_store, :content_item_id, :base_path, :delete]
+    opts = opts.select { |k,v| keys.include?(k) }
+
+    opts[:content_store] = opts[:content_store] || Adapters::DraftContentStore
+    opts[:request_uuid] = GdsApi::GovukHeaders.headers[:x_govuk_request_uuid]
+
+    perform_in(2.seconds, opts)
+  end
+
 private
 
   # Previously, the content_store_payload_id was sourced from a separate table.

--- a/app/workers/presented_content_store_worker.rb
+++ b/app/workers/presented_content_store_worker.rb
@@ -6,6 +6,8 @@ class PresentedContentStoreWorker
   def perform(args = {})
     args = args.deep_symbolize_keys
 
+    logger.debug "[#{args[:request_uuid]}] ContentStoreWorker#perform with #{args}"
+
     content_store = args.fetch(:content_store).constantize
 
     if args[:delete]

--- a/config/application.rb
+++ b/config/application.rb
@@ -37,6 +37,6 @@ module PublishingAPI
       :tk, :tr, :uk, :ur, :uz, :vi, :zh, :'zh-hk', :'zh-tw'
     ]
 
-    config.log_tags = [ lambda { |r| r.uuid } ]
+    config.log_tags = [lambda { |r| r.uuid }]
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -36,5 +36,7 @@ module PublishingAPI
       :lv, :ms, :pl, :ps, :pt, :ro, :ru, :si, :sk, :so, :sq, :sr, :sw, :ta, :th,
       :tk, :tr, :uk, :ur, :uz, :vi, :zh, :'zh-hk', :'zh-tw'
     ]
+
+    config.log_tags = [ lambda { |r| r.uuid } ]
   end
 end

--- a/spec/commands/v2/discard_draft_spec.rb
+++ b/spec/commands/v2/discard_draft_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe Commands::V2::DiscardDraft do
     before do
       stub_request(:delete, %r{.*content-store.*/content/.*})
       stub_request(:put, %r{.*content-store.*/content/.*})
+      GdsApi::GovukHeaders.set_header(:x_govuk_request_uuid, "12345-67890")
     end
 
     let(:expected_content_store_payload) { { base_path: "/vat-rates" } }
@@ -58,6 +59,7 @@ RSpec.describe Commands::V2::DiscardDraft do
             content_store: Adapters::DraftContentStore,
             base_path: base_path,
             delete: true,
+            request_uuid: "12345-67890",
           )
 
         described_class.call(payload)
@@ -120,6 +122,7 @@ RSpec.describe Commands::V2::DiscardDraft do
               content_store: Adapters::DraftContentStore,
               base_path: base_path,
               delete: true,
+              request_uuid: "12345-67890",
             )
 
           described_class.call(payload)
@@ -136,6 +139,7 @@ RSpec.describe Commands::V2::DiscardDraft do
             .with(
               content_store: Adapters::DraftContentStore,
               payload: expected_content_store_payload,
+              request_uuid: "12345-67890",
             )
 
           described_class.call(payload)

--- a/spec/commands/v2/discard_draft_spec.rb
+++ b/spec/commands/v2/discard_draft_spec.rb
@@ -5,7 +5,6 @@ RSpec.describe Commands::V2::DiscardDraft do
     before do
       stub_request(:delete, %r{.*content-store.*/content/.*})
       stub_request(:put, %r{.*content-store.*/content/.*})
-      GdsApi::GovukHeaders.set_header(:x_govuk_request_uuid, "12345-67890")
     end
 
     let(:expected_content_store_payload) { { base_path: "/vat-rates" } }
@@ -59,7 +58,6 @@ RSpec.describe Commands::V2::DiscardDraft do
             content_store: Adapters::DraftContentStore,
             base_path: base_path,
             delete: true,
-            request_uuid: "12345-67890",
           )
 
         described_class.call(payload)
@@ -67,7 +65,6 @@ RSpec.describe Commands::V2::DiscardDraft do
 
       it "does not send any request to the live content store" do
         expect(PresentedContentStoreWorker).not_to receive(:perform_async)
-          .with(hash_including(content_store: Adapters::ContentStore))
 
         described_class.call(payload)
       end
@@ -122,7 +119,6 @@ RSpec.describe Commands::V2::DiscardDraft do
               content_store: Adapters::DraftContentStore,
               base_path: base_path,
               delete: true,
-              request_uuid: "12345-67890",
             )
 
           described_class.call(payload)

--- a/spec/commands/v2/discard_draft_spec.rb
+++ b/spec/commands/v2/discard_draft_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe Commands::V2::DiscardDraft do
     before do
       stub_request(:delete, %r{.*content-store.*/content/.*})
       stub_request(:put, %r{.*content-store.*/content/.*})
+      GdsApi::GovukHeaders.set_header(:x_govuk_request_uuid, "12345-67890")
     end
 
     let(:expected_content_store_payload) { { base_path: "/vat-rates" } }
@@ -58,6 +59,7 @@ RSpec.describe Commands::V2::DiscardDraft do
             content_store: Adapters::DraftContentStore,
             base_path: base_path,
             delete: true,
+            request_uuid: "12345-67890"
           )
 
         described_class.call(payload)
@@ -65,6 +67,7 @@ RSpec.describe Commands::V2::DiscardDraft do
 
       it "does not send any request to the live content store" do
         expect(PresentedContentStoreWorker).not_to receive(:perform_async)
+          .with(content_store: Adapters::ContentStore)
 
         described_class.call(payload)
       end
@@ -119,6 +122,7 @@ RSpec.describe Commands::V2::DiscardDraft do
               content_store: Adapters::DraftContentStore,
               base_path: base_path,
               delete: true,
+              request_uuid: "12345-67890",
             )
 
           described_class.call(payload)

--- a/spec/commands/v2/patch_link_set_spec.rb
+++ b/spec/commands/v2/patch_link_set_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe Commands::V2::PatchLinkSet do
 
     allow(Presenters::ContentStorePresenter).to receive(:present)
       .and_return(expected_content_store_payload)
+    GdsApi::GovukHeaders.set_header(:x_govuk_request_uuid, "12345-67890")
   end
 
   context "when no link set exists" do
@@ -205,6 +206,7 @@ RSpec.describe Commands::V2::PatchLinkSet do
         .with(
           content_store: Adapters::DraftContentStore,
           payload: expected_content_store_payload,
+          request_uuid: "12345-67890",
         )
 
       described_class.call(payload)
@@ -241,6 +243,7 @@ RSpec.describe Commands::V2::PatchLinkSet do
             .with(
               content_store: Adapters::DraftContentStore,
               payload: expected_content_store_payload,
+              request_uuid: "12345-67890",
             )
 
           described_class.call(payload)
@@ -285,6 +288,7 @@ RSpec.describe Commands::V2::PatchLinkSet do
         .with(
           content_store: Adapters::ContentStore,
           payload: expected_content_store_payload,
+          request_uuid: "12345-67890",
         )
 
       described_class.call(payload)
@@ -331,6 +335,7 @@ RSpec.describe Commands::V2::PatchLinkSet do
             .with(
               content_store: Adapters::ContentStore,
               payload: expected_content_store_payload,
+              request_uuid: "12345-67890",
             )
 
           expect(PublishingAPI.service(:queue_publisher)).to receive(:send_message)

--- a/spec/commands/v2/publish_spec.rb
+++ b/spec/commands/v2/publish_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe Commands::V2::Publish do
 
       allow(Presenters::ContentStorePresenter).to receive(:present)
         .and_return(expected_content_store_payload)
+      GdsApi::GovukHeaders.set_header(:x_govuk_request_uuid, "12345-67890")
     end
 
     around do |example|
@@ -156,6 +157,7 @@ RSpec.describe Commands::V2::Publish do
           .with(
             content_store: Adapters::ContentStore,
             payload: expected_content_store_payload,
+            request_uuid: "12345-67890",
           )
 
         described_class.call(payload)
@@ -228,6 +230,7 @@ RSpec.describe Commands::V2::Publish do
               .with(
                 content_store: Adapters::ContentStore,
                 payload: expected_content_store_payload,
+                request_uuid: "12345-67890",
               )
 
             described_class.call(payload)
@@ -250,6 +253,7 @@ RSpec.describe Commands::V2::Publish do
               .with(
                 content_store: Adapters::ContentStore,
                 payload: expected_content_store_payload,
+                request_uuid: "12345-67890",
               )
 
             described_class.call(payload)

--- a/spec/commands/v2/put_content_spec.rb
+++ b/spec/commands/v2/put_content_spec.rb
@@ -4,7 +4,6 @@ RSpec.describe Commands::V2::PutContent do
   describe "call" do
     before do
       stub_request(:put, %r{.*content-store.*/content/.*})
-      GdsApi::GovukHeaders.set_header(:x_govuk_request_uuid, "12345-67890")
     end
 
     let(:expected_content_store_payload) { { base_path: "/vat-rates" } }
@@ -61,7 +60,6 @@ RSpec.describe Commands::V2::PutContent do
     context "when the 'downstream' parameter is false" do
       it "does not send any requests to any content store" do
         expect(PresentedContentStoreWorker).not_to receive(:perform_async)
-        described_class.call(payload, downstream: false)
       end
     end
 

--- a/spec/commands/v2/put_content_spec.rb
+++ b/spec/commands/v2/put_content_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe Commands::V2::PutContent do
   describe "call" do
     before do
       stub_request(:put, %r{.*content-store.*/content/.*})
+      GdsApi::GovukHeaders.set_header(:x_govuk_request_uuid, "12345-67890")
     end
 
     let(:expected_content_store_payload) { { base_path: "/vat-rates" } }
@@ -36,6 +37,7 @@ RSpec.describe Commands::V2::PutContent do
         .with(
           content_store: Adapters::DraftContentStore,
           payload: expected_content_store_payload,
+          request_uuid: "12345-67890",
         )
 
       described_class.call(payload)
@@ -293,6 +295,7 @@ RSpec.describe Commands::V2::PutContent do
             .with(
               content_store: Adapters::DraftContentStore,
               payload: expected_content_store_payload,
+              request_uuid: "12345-67890",
             ).twice
 
           described_class.call(payload)

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -11,6 +11,8 @@ abort("The Rails environment is running in production mode!") if Rails.env.produ
 require 'spec_helper'
 require 'rspec/rails'
 # Add additional requires below this line. Rails is not loaded until this point!
+require 'sidekiq/testing'
+Sidekiq::Logging.logger = nil
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are

--- a/spec/requests/logging_requests_spec.rb
+++ b/spec/requests/logging_requests_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe "Logging requests", type: :request do
 
     expect(ContentStoreWorker).to receive(:perform_in)
       .with(
-        1.second,
+        2.second,
         content_store: Adapters::DraftContentStore,
         content_item_id: anything,
         request_uuid: "12345-67890",

--- a/spec/requests/logging_requests_spec.rb
+++ b/spec/requests/logging_requests_spec.rb
@@ -1,0 +1,26 @@
+require "rails_helper"
+
+RSpec.describe "Logging requests", type: :request do
+  let(:content_id) { SecureRandom.uuid }
+  let(:draft_content_item_params) { content_item_params.except(:links) }
+
+  it "adds a govuk request uuid header" do
+    put "/v2/content/#{content_id}", draft_content_item_params.to_json
+    expect(GdsApi::GovukHeaders.headers).to include(:x_govuk_request_uuid)
+  end
+
+  it "adds a request uuid to the content store worker job" do
+    allow_any_instance_of(ActionDispatch::Request)
+      .to receive(:uuid).and_return("12345-67890")
+
+    expect(ContentStoreWorker).to receive(:perform_in)
+      .with(
+        1.second,
+        content_store: Adapters::DraftContentStore,
+        content_item_id: anything,
+        request_uuid: "12345-67890",
+      )
+
+    put "/v2/content/#{content_id}", draft_content_item_params.to_json
+  end
+end

--- a/spec/requests/logging_requests_spec.rb
+++ b/spec/requests/logging_requests_spec.rb
@@ -13,11 +13,10 @@ RSpec.describe "Logging requests", type: :request do
     allow_any_instance_of(ActionDispatch::Request)
       .to receive(:uuid).and_return("12345-67890")
 
-    expect(ContentStoreWorker).to receive(:perform_in)
+    expect(PresentedContentStoreWorker).to receive(:perform_async)
       .with(
-        2.second,
         content_store: Adapters::DraftContentStore,
-        content_item_id: anything,
+        payload: anything,
         request_uuid: "12345-67890",
       )
 

--- a/spec/workers/content_store_worker_spec.rb
+++ b/spec/workers/content_store_worker_spec.rb
@@ -162,23 +162,4 @@ RSpec.describe ContentStoreWorker do
       )
     end
   end
-
-
-  describe ".perform_with_defaults" do
-    let(:draft_content_item) { create(:draft_content_item, base_path: '/foo') }
-
-    it "calls .perform_in with common defaults" do
-      GdsApi::GovukHeaders.set_header(:x_govuk_request_uuid, "12345-67890")
-
-      expect(described_class).to receive(:perform_in)
-        .with(
-          2.seconds,
-          content_item_id: draft_content_item.id,
-          content_store: Adapters::DraftContentStore,
-          request_uuid: "12345-67890",
-        )
-
-      described_class.perform_with_defaults(content_item_id: draft_content_item.id)
-    end
-  end
 end

--- a/spec/workers/content_store_worker_spec.rb
+++ b/spec/workers/content_store_worker_spec.rb
@@ -162,4 +162,23 @@ RSpec.describe ContentStoreWorker do
       )
     end
   end
+
+
+  describe ".perform_with_defaults" do
+    let(:draft_content_item) { create(:draft_content_item, base_path: '/foo') }
+
+    it "calls .perform_in with common defaults" do
+      GdsApi::GovukHeaders.set_header(:x_govuk_request_uuid, "12345-67890")
+
+      expect(described_class).to receive(:perform_in)
+        .with(
+          2.seconds,
+          content_item_id: draft_content_item.id,
+          content_store: Adapters::DraftContentStore,
+          request_uuid: "12345-67890",
+        )
+
+      described_class.perform_with_defaults(content_item_id: draft_content_item.id)
+    end
+  end
 end


### PR DESCRIPTION
This PR adds a basic request identifier to logging output which can be used in worker processes.
The `GdsApi::GovukHeaders.headers[:x_govuk_request_uuid]` header is populated with an `ActionDispatch::Request#uuid` and this is passed on to the `ContentStoreWorker` as an argument.

eg. in the application log:
![screenshot from 2016-03-02 15 52 31](https://cloud.githubusercontent.com/assets/93511/13465743/d9797d92-e08e-11e5-9b71-950a6da5443d.png)

in the sidekiq log:
![screenshot from 2016-03-02 15 57 12](https://cloud.githubusercontent.com/assets/93511/13465892/7f9827fa-e08f-11e5-8222-199e0f21d240.png)


I've assumed `GdsApi::GovukHeaders` is thread safe because https://github.com/alphagov/gds-api-adapters/blob/master/lib/gds_api/govuk_headers.rb#L15, this might not be the best mechanism for storing an internal identifier in the publishing-api.

I've also [logged the payload here](https://github.com/alphagov/publishing-api/commit/9471eacaf4436684ad98930c3faa0be1c8fc3a62#diff-e78d7903df6b6db2ce1780d8f618ca26R4), this might be too verbose, perhaps this could be a default to be overridden for noisier commands like `V2::PutContent`.

