### PR TITLE
Add lint task with similar params to CI

### DIFF
--- a/lib/tasks/lint.rake
+++ b/lib/tasks/lint.rake
@@ -1,0 +1,4 @@
+desc "Run govuk-lint with similar params to CI"
+task "lint" do
+  sh "bundle exec govuk-lint-ruby --format clang app config Gemfile lib spec"
+end


### PR DESCRIPTION
Adds a task to lint as per CI (omitting html output).
`bundle exec rake lint`
This could be added to our default task, but that's open for discussion.
