### PR TITLE
Update pact tests to no longer expect 409 responses

### DIFF
--- a/spec/pacts/content_store/put_endpoint_spec.rb
+++ b/spec/pacts/content_store/put_endpoint_spec.rb
@@ -62,18 +62,12 @@ RSpec.describe "PUT endpoint pact with the Content Store", pact: true do
           },
         )
         .will_respond_with(
-          status: 409,
+          status: 200,
           body: {},
           headers: {
             "Content-Type" => "application/json; charset=utf-8"
           },
         )
-    end
-
-    it "rejects out-of-order messages to the content store" do
-      expect {
-        client.put_content_item(base_path: "/vat-rates", content_item: body)
-      }.to raise_error(GdsApi::HTTPConflict)
     end
   end
 
@@ -130,18 +124,12 @@ RSpec.describe "PUT endpoint pact with the Content Store", pact: true do
             },
           )
           .will_respond_with(
-            status: 409,
+            status: 200,
             body: {},
             headers: {
               "Content-Type" => "application/json; charset=utf-8"
             },
           )
-      end
-
-      it "rejects out-of-order messages to the content store" do
-        expect {
-          client.put_content_item(base_path: "/vat-rates", content_item: body)
-        }.to raise_error(GdsApi::HTTPConflict)
       end
     end
   end


### PR DESCRIPTION
We are going to stop returning 409 for `payload_version`/`transmitted_at` conflicts in Content Store so this update is required to get the pacts passing.