### PR TITLE
Paginate get content collection

### DIFF
--- a/app/controllers/v2/content_items_controller.rb
+++ b/app/controllers/v2/content_items_controller.rb
@@ -23,6 +23,8 @@ module V2
           base_path
           internal_name
         ),
+        locale: locale,
+        pagination: Pagination.new(params)
       ).call
     end
 

--- a/app/controllers/v2/content_items_controller.rb
+++ b/app/controllers/v2/content_items_controller.rb
@@ -8,6 +8,7 @@ module V2
         fields: query_params.fetch(:fields),
         publishing_app: publishing_app,
         locale: query_params[:locale],
+        pagination: Pagination.new(query_params)
       ).call
     end
 
@@ -22,9 +23,7 @@ module V2
           publication_state
           base_path
           internal_name
-        ),
-        locale: locale,
-        pagination: Pagination.new(params)
+        )
       ).call
     end
 

--- a/app/pagination.rb
+++ b/app/pagination.rb
@@ -1,16 +1,25 @@
 class Pagination
-  attr_reader :start, :page_size, :all_items
+  attr_reader :start, :page_size, :all_items, :order
 
-  def initialize(options={})
+  def initialize(options = {})
+    @order = options[:order] || { public_updated_at: :desc }
+
     if options[:start] || options[:page_size]
-      @start = options[:start] ? options[:start].to_i : 0
-      @page_size = options[:page_size] ? options[:page_size].to_i : 50
+      @start = Integer(options.fetch(:start, 0))
+      @page_size = Integer(options.fetch(:page_size, 50))
     else
       @all_items = true
     end
   end
 
   def paginate(items)
-    items.limit(page_size).offset(start)
+    unless all_items
+      items = items.limit(page_size).offset(start)
+    end
+    items
+  end
+
+  def order_fields
+    order.keys.map(&:to_s)
   end
 end

--- a/app/pagination.rb
+++ b/app/pagination.rb
@@ -1,0 +1,16 @@
+class Pagination
+  attr_reader :start, :page_size, :all_items
+
+  def initialize(options={})
+    if options[:start] || options[:page_size]
+      @start = options[:start] ? options[:start].to_i : 0
+      @page_size = options[:page_size] ? options[:page_size].to_i : 50
+    else
+      @all_items = true
+    end
+  end
+
+  def paginate(items)
+    items.limit(page_size).offset(start)
+  end
+end

--- a/app/pagination.rb
+++ b/app/pagination.rb
@@ -2,7 +2,7 @@ class Pagination
   attr_reader :start, :page_size, :all_items, :order
 
   def initialize(options = {})
-    @order = options[:order] || { public_updated_at: :desc }
+    @order = { public_updated_at: :desc }
 
     if options[:start] || options[:page_size]
       @start = Integer(options.fetch(:start, 0))

--- a/db/migrate/20160307112043_index_content_items_public_updated_at.rb
+++ b/db/migrate/20160307112043_index_content_items_public_updated_at.rb
@@ -1,0 +1,5 @@
+class IndexContentItemsPublicUpdatedAt < ActiveRecord::Migration
+  def change
+    add_index :content_items, :public_updated_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160303101053) do
+ActiveRecord::Schema.define(version: 20160307112043) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -53,6 +53,7 @@ ActiveRecord::Schema.define(version: 20160303101053) do
 
   add_index "content_items", ["content_id"], name: "index_content_items_on_content_id", using: :btree
   add_index "content_items", ["format"], name: "index_content_items_on_format", using: :btree
+  add_index "content_items", ["public_updated_at"], name: "index_content_items_on_public_updated_at", using: :btree
   add_index "content_items", ["publishing_app"], name: "index_content_items_on_publishing_app", using: :btree
   add_index "content_items", ["rendering_app"], name: "index_content_items_on_rendering_app", using: :btree
 

--- a/spec/controllers/v2/content_items_controller_spec.rb
+++ b/spec/controllers/v2/content_items_controller_spec.rb
@@ -112,6 +112,7 @@ RSpec.describe V2::ContentItemsController do
       before do
         get :index, content_format: "topic", fields: ["content_id"], start: "0", page_size: "20"
       end
+
       it "is successful" do
         expect(response.status).to eq(200)
       end

--- a/spec/controllers/v2/content_items_controller_spec.rb
+++ b/spec/controllers/v2/content_items_controller_spec.rb
@@ -107,6 +107,45 @@ RSpec.describe V2::ContentItemsController do
         expect(publication_states). to eq %w(live live)
       end
     end
+
+    context "with pagination params" do
+      before do
+        get :index, content_format: "topic", fields: ["content_id"], start: "0", page_size: "20"
+      end
+      it "is successful" do
+        expect(response.status).to eq(200)
+      end
+      it "responds with the content item as json" do
+        parsed_response_body = JSON.parse(response.body)
+        expect(parsed_response_body.first.fetch("content_id")).to eq("#{content_id}")
+      end
+    end
+
+    context "without pagination params" do
+      before do
+        get :index, content_format: 'topic', fields: ['content_id']
+      end
+      it "is successful" do
+        expect(response.status).to eq(200)
+      end
+      it "responds with the content item as json" do
+        parsed_response_body = JSON.parse(response.body)
+        expect(parsed_response_body.first.fetch("content_id")).to eq("#{content_id}")
+      end
+    end
+
+    context "with all_items param" do
+      before do
+        get :index, content_format: "topic", fields: ["content_id"], all_items: "true"
+      end
+      it "is successful" do
+        expect(response.status).to eq(200)
+      end
+      it "responds with the content item as json" do
+        parsed_response_body = JSON.parse(response.body)
+        expect(parsed_response_body.first.fetch("content_id")).to eq("#{content_id}")
+      end
+    end
   end
 
   describe "show" do

--- a/spec/integration/paging_content_items_spec.rb
+++ b/spec/integration/paging_content_items_spec.rb
@@ -1,0 +1,52 @@
+require "rails_helper"
+
+RSpec.describe "Paging through content items" do
+  before do
+    5.times do |n|
+      FactoryGirl.create(
+        :draft_content_item,
+        base_path: "/content-#{n}",
+        format: "guide",
+        public_updated_at: n.minutes.ago
+      )
+    end
+  end
+
+  context "when no pagination params are supplied" do
+    before do
+      get "/v2/content", content_format: "guide", fields: %w(base_path publishing_app)
+    end
+
+    it "responds successfully" do
+      expect(response).to be_successful
+    end
+
+    it "responds with content items in the correct order" do
+      parsed_response_body = JSON.parse(response.body)
+      expect(parsed_response_body.size).to eq(5)
+      expect(parsed_response_body.first["base_path"]).to eq("/content-0")
+      expect(parsed_response_body.last["base_path"]).to eq("/content-4")
+    end
+  end
+
+  context "when pagination params are supplied" do
+    before do
+      get "/v2/content",
+        content_format: "guide",
+        fields: %w(base_path publishing_app),
+        start: "3",
+        page_size: "2"
+    end
+
+    it "responds successfully" do
+      expect(response).to be_successful
+    end
+
+    it "responds with content items limited by page_size" do
+      parsed_response_body = JSON.parse(response.body)
+      expect(parsed_response_body.size).to eq(2)
+      expect(parsed_response_body.first["base_path"]).to eq("/content-3")
+      expect(parsed_response_body.last["base_path"]).to eq("/content-4")
+    end
+  end
+end

--- a/spec/pagination_spec.rb
+++ b/spec/pagination_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe Pagination do
   describe 'initialize' do
     context "without pagination params" do
-      subject { described_class.new}
+      subject { described_class.new }
 
       it "returns all items" do
         expect(subject.all_items).to be(true)
@@ -16,31 +16,89 @@ RSpec.describe Pagination do
       it "parses the start param as an integer" do
         expect(subject.start).to eq(5)
       end
+
       it "returns the default page_size" do
         expect(subject.page_size).to eq(50)
       end
     end
 
-  context "with a page_size param" do
-    subject { described_class.new(page_size: "20")}
+    context "with a page_size param" do
+      subject { described_class.new(page_size: "20") }
 
       it "parses the page_size param as an integer" do
         expect(subject.page_size).to eq(20)
       end
+
       it "returns the default start" do
         expect(subject.start).to eq(0)
       end
     end
+
+    context "with pagination params" do
+      subject { described_class.new(start: "5", page_size: "20") }
+
+      it "parses the start param as an integer" do
+        expect(subject.start).to eq(5)
+      end
+
+      it "parses the page_size param as an integer" do
+        expect(subject.page_size).to eq(20)
+      end
+    end
+
+    context "without order param" do
+      subject { described_class.new }
+
+      it "uses the default order" do
+        expect(subject.order).to eq(public_updated_at: :desc)
+      end
+    end
+
+    context "with order param" do
+      subject { described_class.new(order: { title: :asc }) }
+
+      it "uses the order params supplied" do
+        expect(subject.order).to eq(title: :asc)
+      end
+    end
   end
 
-  context "with pagination params" do
-    subject { described_class.new(start: "5", page_size: "20")}
+  describe "paginate" do
+    let(:items) { double(:items) }
+    let(:scope) { double(:scope) }
 
-    it "parses the start param as an integer" do
-      expect(subject.start).to eq(5)
+    context "when all items are requested" do
+      it "doesn't apply limiting or offset to the scope" do
+        expect(items).not_to receive(:limit)
+        expect(described_class.new.paginate(items)).to eq(items)
+      end
     end
-    it "parses the page_size param as an integer" do
-      expect(subject.page_size).to eq(20)
+
+    context "using default pagination page size" do
+      it "applies a default limit and offset to the scope" do
+        expect(scope).to receive(:offset).with(33)
+        expect(items).to receive(:limit).with(50).and_return(scope)
+
+        described_class.new(start: "33").paginate(items)
+      end
+    end
+
+    context "using default pagination offset" do
+      it "applies a default offset to the scope" do
+        expect(scope).to receive(:offset).with(0)
+        expect(items).to receive(:limit).with(40).and_return(scope)
+
+        described_class.new(page_size: "40").paginate(items)
+      end
+    end
+
+    context "using pagination offset and page size" do
+      it "applies offset and page size to the scope" do
+        expect(scope).to receive(:offset).with(20)
+        expect(items).to receive(:limit).with(40).and_return(scope)
+
+        described_class.new(start: "20", page_size: "40").paginate(items)
+      end
     end
   end
 end

--- a/spec/pagination_spec.rb
+++ b/spec/pagination_spec.rb
@@ -46,19 +46,11 @@ RSpec.describe Pagination do
       end
     end
 
-    context "without order param" do
+    context "default order param" do
       subject { described_class.new }
 
       it "uses the default order" do
         expect(subject.order).to eq(public_updated_at: :desc)
-      end
-    end
-
-    context "with order param" do
-      subject { described_class.new(order: { title: :asc }) }
-
-      it "uses the order params supplied" do
-        expect(subject.order).to eq(title: :asc)
       end
     end
   end

--- a/spec/pagination_spec.rb
+++ b/spec/pagination_spec.rb
@@ -1,0 +1,46 @@
+require 'rails_helper'
+
+RSpec.describe Pagination do
+  describe 'initialize' do
+    context "without pagination params" do
+      subject { described_class.new}
+
+      it "returns all items" do
+        expect(subject.all_items).to be(true)
+      end
+    end
+
+    context "with a start param" do
+      subject { described_class.new(start: "5") }
+
+      it "parses the start param as an integer" do
+        expect(subject.start).to eq(5)
+      end
+      it "returns the default page_size" do
+        expect(subject.page_size).to eq(50)
+      end
+    end
+
+  context "with a page_size param" do
+    subject { described_class.new(page_size: "20")}
+
+      it "parses the page_size param as an integer" do
+        expect(subject.page_size).to eq(20)
+      end
+      it "returns the default start" do
+        expect(subject.start).to eq(0)
+      end
+    end
+  end
+
+  context "with pagination params" do
+    subject { described_class.new(start: "5", page_size: "20")}
+
+    it "parses the start param as an integer" do
+      expect(subject.start).to eq(5)
+    end
+    it "parses the page_size param as an integer" do
+      expect(subject.page_size).to eq(20)
+    end
+  end
+end

--- a/spec/queries/get_content_collection_spec.rb
+++ b/spec/queries/get_content_collection_spec.rb
@@ -274,46 +274,5 @@ RSpec.describe Queries::GetContentCollection do
       expect(content_items.first['public_updated_at']).to eq('2014-06-14 00:00:00')
       expect(content_items.last['public_updated_at']).to eq('2014-06-13 00:00:00')
     end
-
-    it "returns content items in the specified order" do
-      content_items = Queries::GetContentCollection.new(
-        document_type: 'guide',
-        fields: %w(public_updated_at),
-        pagination: Pagination.new(order: { title: :asc })
-      ).call
-
-      expect(content_items.size).to eq(4)
-      expect(content_items.first['title']).to eq('A')
-      expect(content_items.last['title']).to eq('D')
-    end
-
-    it "returns paginated content items in the specified order" do
-      content_items = Queries::GetContentCollection.new(
-        document_type: 'guide',
-        fields: %w(public_updated_at),
-        pagination: Pagination.new(
-          start: 2,
-          page_size: 4,
-          order: { title: :asc }
-        ),
-      ).call
-
-      expect(content_items.first['title']).to eq('C')
-      expect(content_items.last['title']).to eq('D')
-    end
-
-    it "does not order by supporting objects" do
-      expect {
-        Queries::GetContentCollection.new(
-          document_type: 'guide',
-          fields: %w(public_updated_at),
-          pagination: Pagination.new(
-            start: 2,
-            page_size: 4,
-            order: { "states.name": :asc }
-          ),
-        ).call
-      }.to raise_error(CommandError, /Invalid column name/)
-    end
   end
 end

--- a/spec/requests/index_spec.rb
+++ b/spec/requests/index_spec.rb
@@ -20,12 +20,8 @@ RSpec.describe "GET /v2/content", type: :request do
 
   it "accepts either 'content_format' or 'document_type'" do
     expected_result = [
-      {
-        title: "Policy 1",
-      },
-      {
-        title: "Policy 2",
-      },
+      hash_including(title: "Policy 1"),
+      hash_including(title: "Policy 2"),
     ]
 
     get "/v2/content", document_type: "policy", fields: ["title"]

--- a/spec/requests/linkables_spec.rb
+++ b/spec/requests/linkables_spec.rb
@@ -25,20 +25,20 @@ RSpec.describe "GET /v2/linkables", type: :request do
     get "/v2/linkables", document_type: "policy"
 
     expect(JSON.parse(response.body, symbolize_names: true)).to match_array([
-      {
+      hash_including(
         content_id: policy_1.content_id,
         title: "Policy 1",
         publication_state: "draft",
         base_path: "/cat-rates",
         internal_name: "Cat rates (do not use for actual cats)",
-      },
-      {
+      ),
+      hash_including(
         content_id: policy_2.content_id,
         title: "Policy 2",
         publication_state: "live",
         base_path: "/vat-rates",
         internal_name: "Policy 2"
-      },
+      ),
     ])
   end
 


### PR DESCRIPTION
https://trello.com/c/OZF9rKeX/487-index-endpoint-should-support-pagination

Support pagination and add default ordering of content items index `/v2/content` endpoint.

Original PR here: https://github.com/alphagov/publishing-api/pull/211
It was easier, in light of the large refactor to the Publishing-API, to cherry-pick relevant commits to new branch. Paired with @Rosa-Fox on this story.