### PR TITLE
Store published_at in content store for V2 content items

### DIFF
--- a/app/commands/v2/patch_link_set.rb
+++ b/app/commands/v2/patch_link_set.rb
@@ -85,9 +85,14 @@ module Commands
         end
 
         if live_content_item
+          set_last_published_at(live_content_item)
           send_to_content_store(live_content_item, Adapters::ContentStore)
           send_to_message_queue(live_content_item)
         end
+      end
+
+      def set_last_published_at(content_item)
+        content_item.update_attributes!(last_published_at: Time.zone.now)
       end
 
       def send_to_content_store(content_item, content_store)

--- a/app/commands/v2/publish.rb
+++ b/app/commands/v2/publish.rb
@@ -41,6 +41,8 @@ module Commands
 
         clear_published_items_of_same_locale_and_base_path(content_item, translation, location)
 
+        set_last_published_at(content_item)
+
         set_public_updated_at(content_item, previously_published_item, update_type)
         State.publish(content_item)
 
@@ -87,6 +89,10 @@ module Commands
           new_item_content_id: content_item.content_id,
           state: "published", locale: translation.locale, base_path: location.base_path
         )
+      end
+
+      def set_last_published_at(content_item)
+        content_item.update_attributes!(last_published_at: Time.zone.now)
       end
 
       def set_public_updated_at(content_item, previously_published_item, update_type)

--- a/app/presenters/downstream_presenter.rb
+++ b/app/presenters/downstream_presenter.rb
@@ -15,6 +15,7 @@ module Presenters
       symbolized_attributes
         .slice(*content_item.class::TOP_LEVEL_FIELDS)
         .merge(public_updated_at)
+        .merge(last_published_at)
         .merge(links)
         .merge(access_limited)
         .merge(content_store_payload_version)
@@ -69,6 +70,14 @@ module Presenters
     def public_updated_at
       if content_item.public_updated_at.present?
         { public_updated_at: content_item.public_updated_at.iso8601 }
+      else
+        {}
+      end
+    end
+
+    def last_published_at
+      if content_item.last_published_at.present?
+        { last_published_at: content_item.last_published_at.iso8601 }
       else
         {}
       end

--- a/db/migrate/20160307113843_add_last_published_at_to_content_items.rb
+++ b/db/migrate/20160307113843_add_last_published_at_to_content_items.rb
@@ -1,0 +1,5 @@
+class AddLastPublishedAtToContentItems < ActiveRecord::Migration
+  def change
+    add_column :content_items, :last_published_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -42,6 +42,7 @@ ActiveRecord::Schema.define(version: 20160309155913) do
     t.datetime "updated_at",                                    null: false
     t.string   "document_type"
     t.string   "schema_name"
+    t.datetime "last_published_at"
   end
 
   add_index "content_items", ["content_id"], name: "index_content_items_on_content_id", using: :btree

--- a/spec/factories/content_item_requests.rb
+++ b/spec/factories/content_item_requests.rb
@@ -7,6 +7,7 @@ FactoryGirl.define do
     format 'answer'
     need_ids []
     public_updated_at { Time.zone.now.iso8601 }
+    last_published_at { Time.zone.now.iso8601 }
     publishing_app "publisher"
     rendering_app "frontend"
     locale "en"

--- a/spec/factories/live_content_item.rb
+++ b/spec/factories/live_content_item.rb
@@ -22,6 +22,10 @@ FactoryGirl.define do
     trait :with_draft_version do
       with_draft
     end
+
+    trait :with_last_published_at do
+      last_published_at "2014-08-14T13:00:07Z"
+    end
   end
 
   factory :redirect_live_content_item, parent: :live_content_item do

--- a/spec/presenters/downstream_presenter_spec.rb
+++ b/spec/presenters/downstream_presenter_spec.rb
@@ -5,7 +5,9 @@ RSpec.describe Presenters::DownstreamPresenter do
 
   describe "V2" do
     context "for a live content item" do
-      let!(:content_item) { create(:live_content_item) }
+      let!(:content_item) do
+        create(:live_content_item, :with_last_published_at)
+      end
       let!(:link_set) { create(:link_set, content_id: content_item.content_id) }
 
       it "presents the object graph for the content store" do
@@ -24,6 +26,7 @@ RSpec.describe Presenters::DownstreamPresenter do
           need_ids: %w(100123 100124),
           phase: "beta",
           public_updated_at: "2014-05-14T13:00:06Z",
+          last_published_at: "2014-08-14T13:00:07Z",
           publishing_app: "publisher",
           redirects: [],
           rendering_app: "frontend",

--- a/spec/requests/content_item_requests/downstream_requests_spec.rb
+++ b/spec/requests/content_item_requests/downstream_requests_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe "Downstream requests", type: :request do
     let(:request_method) { :put }
 
     sends_to_draft_content_store
-    sends_to_live_content_store
+    sends_to_live_content_store_with_last_published_at
   end
 
   context "/draft-content" do
@@ -104,7 +104,7 @@ RSpec.describe "Downstream requests", type: :request do
       end
 
       does_not_send_to_draft_content_store
-      sends_to_live_content_store
+      sends_to_live_content_store_with_last_published_at
     end
 
     context "when draft and live content items exists for the link set" do
@@ -121,10 +121,16 @@ RSpec.describe "Downstream requests", type: :request do
         FactoryGirl.create(:live_content_item,
           content_id: content_id,
         )
+
+        Timecop.freeze
+      end
+
+      after do
+        Timecop.return
       end
 
       sends_to_draft_content_store
-      sends_to_live_content_store
+      sends_to_live_content_store_with_last_published_at
     end
 
     context "when a content item does not exist for the link set" do
@@ -189,6 +195,6 @@ RSpec.describe "Downstream requests", type: :request do
         )
     }
 
-    sends_to_live_content_store
+    sends_to_live_content_store_with_last_published_at
   end
 end

--- a/spec/support/request_helpers/downstream_requests.rb
+++ b/spec/support/request_helpers/downstream_requests.rb
@@ -17,6 +17,24 @@ module RequestHelpers
       end
     end
 
+    def sends_to_live_content_store_with_last_published_at
+      it "sends to live content store with last_published_at" do
+        allow(PublishingAPI.service(:live_content_store)).to receive(:put_content_item).with(anything)
+
+        expect(PublishingAPI.service(:live_content_store)).to receive(:put_content_item)
+          .with(
+            base_path: base_path,
+            content_item: content_item_for_live_content_store
+              .merge(payload_version: anything)
+              .merge(last_published_at: Time.zone.now.iso8601)
+          )
+
+        do_request
+
+        expect(response).to be_ok, response.body
+      end
+    end
+
     def sends_to_live_content_store
       it "sends to live content store" do
         allow(PublishingAPI.service(:live_content_store)).to receive(:put_content_item).with(anything)


### PR DESCRIPTION
This is really just a hack to get the functionality we needed, and should probably
have some more tests. Just want to confirm that this is the correct approach.