### PR TITLE
Add /lookup-by-base-path endpoint

### DIFF
--- a/app/controllers/lookups_controller.rb
+++ b/app/controllers/lookups_controller.rb
@@ -1,0 +1,11 @@
+class LookupsController < ApplicationController
+  def by_base_path
+    base_paths_and_content_ids = ContentItemFilter
+      .filter(state: "published", base_path: params.fetch(:base_paths))
+      .pluck(:base_path, :content_id)
+      .uniq
+
+    response = Hash[base_paths_and_content_ids]
+    render json: response
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,8 @@ Rails.application.routes.draw do
 
     put "/paths(/*base_path)", to: "path_reservations#reserve_path"
 
+    post '/lookup-by-base-path', to: 'lookups#by_base_path'
+
     namespace :v2 do
       get "/content", to: "content_items#index"
       put "/content/:content_id", to: "content_items#put_content"

--- a/spec/requests/lookups_spec.rb
+++ b/spec/requests/lookups_spec.rb
@@ -1,0 +1,24 @@
+require "rails_helper"
+
+RSpec.describe "POST /lookup-by-base-path", type: :request do
+  it "returns content_ids for base_paths" do
+    create(:content_item, state: "published", base_path: "/my-page", content_id: "b9b2da0a-ec50-4b0e-b29c-b7cbc8195307")
+    create(:content_item, state: "draft", base_path: "/my-page", content_id: "f7cdb359-c8ab-4d6d-b1f0-5c5640b24c09")
+    create(:content_item, state: "published", base_path: "/other-page", content_id: "b879bcdb-6160-4bfd-b758-f546bbb408c4")
+
+    post "/lookup-by-base-path", base_paths: ["/my-page", "/other-page", "/does-not-exist"]
+
+    expect(JSON.parse(response.body)).to eql(
+      "/my-page" => "b9b2da0a-ec50-4b0e-b29c-b7cbc8195307",
+      "/other-page" => "b879bcdb-6160-4bfd-b758-f546bbb408c4",
+    )
+  end
+
+  it "requires a base_paths param" do
+    post "/lookup-by-base-path"
+
+    expect(JSON.parse(response.body)).to eql(
+      "error" => { "code" => 422, "message" => "param is missing or the value is empty: base_paths" }
+    )
+  end
+end


### PR DESCRIPTION
This endpoint can be used by clients to fetch the `content_id` of one or more URLs on GOV.UK.

I've thought about making a `/content/?base_path=/foo` endpoint with the same result as `/content/:id`, but that seemed contrary to the spirit of referring to everything by `content_id`.

It will be used by:

- [content-tagger](https://github.com/alphagov/content-tagger/blob/2267c396e5c854aa8e398ce9be311e68b953fc63/app/forms/content_lookup_form.rb) to look up the content_id of a URL the user wants to tag.
- [content-tagger](https://github.com/alphagov/content-tagger/blob/4ccb14faf1bbcbfb1d7f3df1d227732b3b0169ac/lib/alpha_taxonomy/taxon_linker.rb#L76) to look up the `content_id` of items from a bulk-tagging spreadsheet.
- publisher during migration to fetch the `content_id` of tagged [topics](https://github.com/alphagov/publisher/blob/master/app/presenters/published_edition_presenter.rb#L24-L28) to send to the publishing-api.
- whitehall during migration to look up tags (see https://github.com/alphagov/whitehall/pull/2494/files#r55371472)

Also, I'm pretty sure this code is wrong, since it will return the `content_id` for all content-items that have existed at a certain `base_path`.

WDYT @danielroseman @elliotcm @tuzz?
