### PR TITLE
Fix a problem when reinstating content items

### DIFF
--- a/app/commands/v2/put_content.rb
+++ b/app/commands/v2/put_content.rb
@@ -116,7 +116,7 @@ module Commands
       def previously_published_item
         @previously_published_item ||= (
           filter = ContentItemFilter.new(scope: ContentItem.where(content_id: content_id))
-          filter.filter(state: "published", locale: locale).first
+          filter.filter(state: %w(published withdrawn), locale: locale).first
         )
       end
 

--- a/app/commands/v2/put_content.rb
+++ b/app/commands/v2/put_content.rb
@@ -116,7 +116,8 @@ module Commands
       def previously_published_item
         @previously_published_item ||= (
           filter = ContentItemFilter.new(scope: ContentItem.where(content_id: content_id))
-          filter.filter(state: %w(published withdrawn), locale: locale).first
+          content_items = filter.filter(state: %w(published withdrawn), locale: locale)
+          UserFacingVersion.latest(content_items)
         )
       end
 

--- a/spec/integration/reinstating_content_items_spec.rb
+++ b/spec/integration/reinstating_content_items_spec.rb
@@ -1,12 +1,11 @@
 require "rails_helper"
 
-RSpec.describe "Reinstating Content Items" do
+RSpec.describe "Reinstating Content Items that were previously withdrawn" do
   let(:put_content_command) { Commands::V2::PutContent }
   let(:publish_command) { Commands::V2::Publish }
 
-  it "does not raise an error that a duplicate superseded content item has been detected " \
-    "when republishing a content item after a redirect withdrew the original" do
-    guide_draft_payload = {
+  let(:guide_draft_payload) do
+    {
       content_id: SecureRandom.uuid,
       base_path: '/vat-rates',
       title: "Guide Title",
@@ -18,12 +17,17 @@ RSpec.describe "Reinstating Content Items" do
       redirects: [],
       phase: "beta",
     }
-    guide_publish_payload = {
-      content_id: guide_draft_payload[:content_id],
+  end
+
+  let(:guide_publish_payload) do
+    {
+      content_id: guide_draft_payload.fetch(:content_id),
       update_type: "major",
     }
+  end
 
-    redirect_draft_payload = {
+  let(:redirect_draft_payload) do
+    {
       content_id: SecureRandom.uuid,
       base_path: '/vat-rates',
       destination: "/somewhere",
@@ -36,30 +40,126 @@ RSpec.describe "Reinstating Content Items" do
       redirects: [{ path: "/vat-rates", type: "exact", destination: "/somewhere" }],
       phase: "beta",
     }
-    redirect_publish_payload = {
-      content_id: redirect_draft_payload[:content_id],
+  end
+
+  let(:redirect_publish_payload) do
+    {
+      content_id: redirect_draft_payload.fetch(:content_id),
       update_type: "major",
     }
+  end
 
-    # Save and publish a guide twice to create a superseded content item
-    2.times do
-      put_content_command.call(guide_draft_payload)
-      publish_command.call(guide_publish_payload)
+  describe "after the content item is withdrawn" do
+    before do
+      2.times do
+        put_content_command.call(guide_draft_payload)
+        publish_command.call(guide_publish_payload)
+      end
+
+      put_content_command.call(redirect_draft_payload)
+      publish_command.call(redirect_publish_payload)
     end
 
-    # Save and publish a redirect for the same base path
-    put_content_command.call(redirect_draft_payload)
-    publish_command.call(redirect_publish_payload)
+    it "puts the content items into the correct states and versions" do
+      expect(ContentItem.count).to eq(3)
 
-    # Save and publish the guide again to withdraw the redirect
-    put_content_command.call(guide_draft_payload)
-    publish_command.call(guide_publish_payload)
+      superseded_item = ContentItem.first
+      withdrawn_item = ContentItem.second
+      published_item = ContentItem.third
 
-    # Save and publish the guide a final time to supersede the previous
-    # content item
-    expect {
-      put_content_command.call(guide_draft_payload)
-      publish_command.call(guide_publish_payload)
-    }.not_to raise_error
+      superseded = State.find_by!(content_item: superseded_item)
+      withdrawn = State.find_by!(content_item: withdrawn_item)
+      published = State.find_by!(content_item: published_item)
+
+      expect(superseded.name).to eq("superseded")
+      expect(withdrawn.name).to eq("withdrawn")
+      expect(published.name).to eq("published")
+
+      superseded_version = UserFacingVersion.find_by!(content_item: superseded_item)
+      withdrawn_version = UserFacingVersion.find_by!(content_item: withdrawn_item)
+      published_version = UserFacingVersion.find_by!(content_item: published_item)
+
+      expect(superseded_version.number).to eq(1)
+      expect(withdrawn_version.number).to eq(2)
+      expect(published_version.number).to eq(1),
+        "The redirect should be regarded as a new piece of content"
+    end
+
+    describe "after the original content item has been reinstated" do
+      before do
+        put_content_command.call(guide_draft_payload)
+        publish_command.call(guide_publish_payload)
+      end
+
+      it "puts the content items into the correct states and versions" do
+        expect(ContentItem.count).to eq(4)
+
+        superseded_item = ContentItem.first
+        withdrawn1_item = ContentItem.second
+        withdrawn2_item = ContentItem.third
+        published_item = ContentItem.fourth
+
+        superseded = State.find_by!(content_item: superseded_item)
+        withdrawn1 = State.find_by!(content_item: withdrawn1_item)
+        withdrawn2 = State.find_by!(content_item: withdrawn2_item)
+        published = State.find_by!(content_item: published_item)
+
+        expect(superseded.name).to eq("superseded")
+        expect(withdrawn1.name).to eq("withdrawn")
+        expect(withdrawn2.name).to eq("withdrawn")
+        expect(published.name).to eq("published")
+
+        superseded_version = UserFacingVersion.find_by!(content_item: superseded_item)
+        withdrawn1_version = UserFacingVersion.find_by!(content_item: withdrawn1_item)
+        withdrawn2_version = UserFacingVersion.find_by!(content_item: withdrawn2_item)
+        published_version = UserFacingVersion.find_by!(content_item: published_item)
+
+        expect(superseded_version.number).to eq(1)
+        expect(withdrawn1_version.number).to eq(2)
+        expect(withdrawn2_version.number).to eq(1)
+        expect(published_version.number).to eq(3)
+      end
+
+      describe "after the original content item has been superseded (again)" do
+        before do
+          put_content_command.call(guide_draft_payload)
+          publish_command.call(guide_publish_payload)
+        end
+
+        it "puts the content items into the correct states and versions" do
+          expect(ContentItem.count).to eq(5)
+
+          superseded1_item = ContentItem.first
+          withdrawn1_item = ContentItem.second
+          withdrawn2_item = ContentItem.third
+          superseded2_item = ContentItem.fourth
+          published_item = ContentItem.fifth
+
+          superseded1 = State.find_by!(content_item: superseded1_item)
+          withdrawn1 = State.find_by!(content_item: withdrawn1_item)
+          withdrawn2 = State.find_by!(content_item: withdrawn2_item)
+          superseded2 = State.find_by!(content_item: superseded2_item)
+          published = State.find_by!(content_item: published_item)
+
+          expect(superseded1.name).to eq("superseded")
+          expect(withdrawn1.name).to eq("withdrawn")
+          expect(withdrawn2.name).to eq("withdrawn")
+          expect(superseded2.name).to eq("superseded")
+          expect(published.name).to eq("published")
+
+          superseded1_version = UserFacingVersion.find_by!(content_item: superseded1_item)
+          withdrawn1_version = UserFacingVersion.find_by!(content_item: withdrawn1_item)
+          withdrawn2_version = UserFacingVersion.find_by!(content_item: withdrawn2_item)
+          superseded2_version = UserFacingVersion.find_by!(content_item: superseded2_item)
+          published_version = UserFacingVersion.find_by!(content_item: published_item)
+
+          expect(superseded1_version.number).to eq(1)
+          expect(withdrawn1_version.number).to eq(2)
+          expect(withdrawn2_version.number).to eq(1)
+          expect(superseded2_version.number).to eq(3)
+          expect(published_version.number).to eq(4)
+        end
+      end
+    end
   end
 end

--- a/spec/integration/reinstating_content_items_spec.rb
+++ b/spec/integration/reinstating_content_items_spec.rb
@@ -1,0 +1,65 @@
+require "rails_helper"
+
+RSpec.describe "Reinstating Content Items" do
+  let(:put_content_command) { Commands::V2::PutContent }
+  let(:publish_command) { Commands::V2::Publish }
+
+  it "does not raise an error that a duplicate superseded content item has been detected " \
+    "when republishing a content item after a redirect withdrew the original" do
+    guide_draft_payload = {
+      content_id: SecureRandom.uuid,
+      base_path: '/vat-rates',
+      title: "Guide Title",
+      publishing_app: "publisher",
+      rendering_app: "frontend",
+      format: "guide",
+      locale: "en",
+      routes: [{ path: "/vat-rates", type: "exact" }],
+      redirects: [],
+      phase: "beta",
+    }
+    guide_publish_payload = {
+      content_id: guide_draft_payload[:content_id],
+      update_type: "major",
+    }
+
+    redirect_draft_payload = {
+      content_id: SecureRandom.uuid,
+      base_path: '/vat-rates',
+      destination: "/somewhere",
+      title: "Redirect Title",
+      publishing_app: "publisher",
+      rendering_app: "frontend",
+      format: "redirect",
+      locale: "en",
+      routes: [],
+      redirects: [{ path: "/vat-rates", type: "exact", destination: "/somewhere" }],
+      phase: "beta",
+    }
+    redirect_publish_payload = {
+      content_id: redirect_draft_payload[:content_id],
+      update_type: "major",
+    }
+
+    # Save and publish a guide twice to create a superseded content item
+    2.times do
+      put_content_command.call(guide_draft_payload)
+      publish_command.call(guide_publish_payload)
+    end
+
+    # Save and publish a redirect for the same base path
+    put_content_command.call(redirect_draft_payload)
+    publish_command.call(redirect_publish_payload)
+
+    # Save and publish the guide again to withdraw the redirect
+    put_content_command.call(guide_draft_payload)
+    publish_command.call(guide_publish_payload)
+
+    # Save and publish the guide a final time to supersede the previous
+    # content item
+    expect {
+      put_content_command.call(guide_draft_payload)
+      publish_command.call(guide_publish_payload)
+    }.not_to raise_error
+  end
+end


### PR DESCRIPTION
This is more for discussion rather than something I want merged.

We have a problem with a content item. It was once published, a redirect was published for the same base path and eventually the original item was republished. It has now become impossible to publish this content item because the user facing version counter has been reset by the redirect, it is attempting to reuse the same range, and the uniqueness validator is triggering. (More precisely - the counter resets itself,rather than the redirect resetting it, when it cannot find any previously published items upon which to increment the count from.)

Here is a dry run of sorts for the content item in question.

```
# base path, content_id, format, user facing version
["/service-manual/the-team", "7735fb0d-c1a5-440e-869a-f4d1f213657b", "service_manual_topic", "superseded", 1],
["/service-manual/the-team", "7735fb0d-c1a5-440e-869a-f4d1f213657b", "service_manual_topic", "superseded", 2],
["/service-manual/the-team", "7735fb0d-c1a5-440e-869a-f4d1f213657b", "service_manual_topic", "superseded", 3],
["/service-manual/the-team", "7735fb0d-c1a5-440e-869a-f4d1f213657b", "service_manual_topic", "superseded", 4],
["/service-manual/the-team", "7735fb0d-c1a5-440e-869a-f4d1f213657b", "service_manual_topic", "superseded", 5],
["/service-manual/the-team", "7735fb0d-c1a5-440e-869a-f4d1f213657b", "service_manual_topic", "superseded", 6],
["/service-manual/the-team", "7735fb0d-c1a5-440e-869a-f4d1f213657b", "service_manual_topic", "superseded", 7],
["/service-manual/the-team", "7735fb0d-c1a5-440e-869a-f4d1f213657b", "service_manual_topic", "superseded", 8],
["/service-manual/the-team", "7735fb0d-c1a5-440e-869a-f4d1f213657b", "service_manual_topic", "superseded", 9],
["/service-manual/the-team", "7735fb0d-c1a5-440e-869a-f4d1f213657b", "service_manual_topic", "superseded", 10],
["/service-manual/the-team", "7735fb0d-c1a5-440e-869a-f4d1f213657b", "service_manual_topic", "superseded", 11],
["/service-manual/the-team", "7735fb0d-c1a5-440e-869a-f4d1f213657b", "service_manual_topic", "superseded", 12],
["/service-manual/the-team", "7735fb0d-c1a5-440e-869a-f4d1f213657b", "service_manual_topic", "superseded", 13],
["/service-manual/the-team", "7735fb0d-c1a5-440e-869a-f4d1f213657b", "service_manual_topic", "superseded", 14],
["/service-manual/the-team", "7735fb0d-c1a5-440e-869a-f4d1f213657b", "service_manual_topic", "superseded", 15],
["/service-manual/the-team", "7735fb0d-c1a5-440e-869a-f4d1f213657b", "service_manual_topic", "superseded", 16],
["/service-manual/the-team", "7735fb0d-c1a5-440e-869a-f4d1f213657b", "service_manual_topic", "superseded", 17],
["/service-manual/the-team", "7735fb0d-c1a5-440e-869a-f4d1f213657b", "service_manual_topic", "superseded", 18],
["/service-manual/the-team", "7735fb0d-c1a5-440e-869a-f4d1f213657b", "service_manual_topic", "superseded", 19],
["/service-manual/the-team", "7735fb0d-c1a5-440e-869a-f4d1f213657b", "service_manual_topic", "withdrawn", 20],
["/service-manual/the-team", "9c413199-1999-4b10-9394-89856d273f88", "redirect", "withdrawn", 1],
["/service-manual/the-team", "7735fb0d-c1a5-440e-869a-f4d1f213657b", "service_manual_topic", "published", 1],
["/service-manual/the-team", "7735fb0d-c1a5-440e-869a-f4d1f213657b", "service_manual_topic", "draft", 2]
```

The error seen when trying to publish the final item is that a duplicate superseded version 1 is detected.

The first commit of this branch is a failing test so you can see it happening in the flesh.

The second commit is a potential solution (with an explanation of why it works it in the commit message) but I'm keen to hear opinions. For example, perhaps bringing the old content item back to life should be impossible?