### PR TITLE
Fix an order-dependent test

### DIFF
--- a/spec/queries/get_content_collection_spec.rb
+++ b/spec/queries/get_content_collection_spec.rb
@@ -220,7 +220,8 @@ RSpec.describe Queries::GetContentCollection do
           pagination: Pagination.new(start: 1, page_size: 2)
         ).call
 
-        expect(content_items.first['base_path']).to eq('/b')
+        base_paths = content_items.map { |item| item.fetch("base_path") }
+        expect(base_paths).to match_array ["/b", "/c"]
       end
 
       it "when page_size is higher than results we only receive remaining content items" do


### PR DESCRIPTION
Both of these content item have the same `public_updated_at` and so it's not specified which order they'd come back in. We could set a `public_updated_at` to break the tie, but that's not really what this scenario is testing, so this seems more reasonable.