### PR TITLE
Update docs: post refactor changes & new endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,21 @@
 # Publishing API
 
-This is a Rails application that proxies requests to multiple content-stores. Our
-use case for this is to keep two copies of the frontend of GOV.UK running: one
-which the public sees and another which is only used by people working on
-content to review work in progress.
+The Publishing API is a Rails application that aims to provide "workflow as a
+service" so that common publishing features can be written once and used by all
+publishing apps across government.
 
-Publishing apps will talk to the publishing-api rather than the content-store.
-Normal publishing requests are forwarded to both the live and draft
-content-stores, whereas draft documents would only be forwarded to the draft
-content-store.
+The Publishing API allows publishing apps to store and retrieve content as well
+as manage the state of content as it transitions to being published on GOV.UK.
+The canonical way for a publishing app to communicate with the Publishing API is
+via the [gds-api-adapters](https://github.com/alphagov/gds-api-adapters).
 
-Decisions about the design of the publishing api are recorded as [architecture
-decision records](http://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions)
+The Publishing API mediates over two content stores, which serve frontend
+applications as well as a message queue, which is used to build search indexes
+and trigger the delivery of email notifications to users. One of the content
+stores is for viewing draft content before it goes live.
+
+Decisions about the design of the publishing api are recorded as
+[architecture decision records](http://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions)
 in the [`doc/arch`](doc/arch) folder.
 
 ### Dependencies

--- a/doc/publishing-api-syntactic-usage.md
+++ b/doc/publishing-api-syntactic-usage.md
@@ -167,3 +167,13 @@ No downstream requests will be sent if the content item doesn't exist yet.
 
 ### Required request params:
   - `document_type` the type of content item to return
+
+## `POST /lookup-by-base-path`
+
+ [Request/Response detail](https://pact-broker.dev.publishing.service.gov.uk/pacts/provider/Publishing%20API/consumer/GDS%20API%20Adapters/latest#a_/lookup-by-base-path-request_given_there_are_live_content_items_with_base_paths_/foo_and_/bar)
+
+  - Retrieves published content items for a given collection of base paths.
+  - Returns a mapping of `base_path` to `content_id`.
+
+### Required request params:
+  - `base_paths` is a collection of base paths to query by (appears in the POST request body)

--- a/doc/publishing-api-syntactic-usage.md
+++ b/doc/publishing-api-syntactic-usage.md
@@ -140,3 +140,18 @@ No downstream requests will be sent if the content item doesn't exist yet.
   - `content_id` the primary identifier for the content associated with the requested link set.
   - `link_type` the type of link between the documents
   - `fields[]` an array of fields that are validated against `ContentItem` column fields. Any invalid requested field will raise a `400`.
+
+## `GET /v2/content`
+
+ [Request/Response detail](https://pact-broker.dev.publishing.service.gov.uk/pacts/provider/Publishing%20API/consumer/GDS%20API%20Adapters/latest#a_get_entries_request_given_a_content_item_exists_in_multiple_locales_with_content_id:_bed722e6-db68-43e5-9079-063f623335a7)
+
+  - Retrieves all content items for a given `document_type` and optional `locale`.
+  - Returns only the content item's fields that have been requested with the query.
+  - Restricts the content items returned by the `publishing_app` of the current user.
+  - Can optionally return content items in all locales by specifying a `locale` of 'all'
+  - Can return the `publication_state` of the content item by including it in the `fields[]`
+
+### Required request params:
+  - `document_type` the type of content item to return
+  - `locale` (optional) is used to restrict returned content items to a given locale (defaults to 'en')
+  - `fields[]` an array of fields that are validated against `ContentItem` column fields. Any invalid requested field will raise a `400`.

--- a/doc/publishing-api-syntactic-usage.md
+++ b/doc/publishing-api-syntactic-usage.md
@@ -12,19 +12,17 @@ PUT and POST endpoints take an optional integer field `previous_version` in the 
  - Creates or updates a draft content item with the following steps:
  - Validates that the incoming request is attempting to update the correct internal lock version of the content item. Responds with 409 when lock version validation fails.
  - Instantiates a new content item or retrieves an existing item matching the content_id and locale passed in the request.
- - Validates the content item prior to saving. There are multiple validations for draft content items, the main concerns are path integrity, identity uniqueness and lock version consistency. Validation failures in these cases respond with 422.
+ - Validates the content item prior to saving. There are multiple validations for draft content items, the main concerns are path integrity, uniqueness of locale / base_path and lock version consistency. Validation failures in these cases respond with 422.
  - Increments the lock version number of the content item.
- - Prepares and sends the draft content item payload downstream to the content store. The payload is modified to include a payload_version to validate message ordering.
+ - Prepares and sends the draft content item payload downstream to the draft content store. The payload is modified to include a payload_version to validate message ordering.
  - Sends the draft content item payload to the message queue.
 
 ### Required request params:
  - `content_id` the primary identifier for the content being created or updated.
 Requests to create a new draft content item:
- - `base_path` must be a valid path
-format
+ - `base_path` must be a valid path format
  - `publishing_app`
  - `title` required unless format is redirect or gone
- - `public_updated_at` required unless format is redirect or gone
  - `phase` must be one of alpha, beta, live
 
 ### Optional request params:
@@ -36,7 +34,8 @@ Requests to update an existing draft content item:
 
 [Request/Response detail](https://pact-broker.dev.publishing.service.gov.uk/pacts/provider/Publishing%20API/consumer/GDS%20API%20Adapters/latest#a_request_to_return_the_content_item_given_a_content_item_exists_with_content_id:_bed722e6-db68-43e5-9079-063f623335a7)
 
- - Retrieves a draft content item by content_id and optional locale parameter.
+ - Retrieves a content item by content_id and optional locale parameter.
+ - If the content item exists in both a draft and published state, the draft is returned.
  - Exposes the content lock version in the response.
  - Responds with 404 if no content exists for the given content_id and locale.
 
@@ -50,17 +49,22 @@ Requests to update an existing draft content item:
 
 [Request/Response detail](https://pact-broker.dev.publishing.service.gov.uk/pacts/provider/Publishing%20API/consumer/GDS%20API%20Adapters/latest#a_publish_request_for_version_3_given_the_content_item_bed722e6-db68-43e5-9079-063f623335a7_is_at_version_3)
 
- - Validates that update_type is present and optionally that the correct lock version is being published. Responds with 422 for update_type validation failures and 409 for content lock version validation failures.
- - Retrieves the draft content item with the matching content_id and locale and creates a live content item based on a subset of the draft attributes.
- - Sends the live content item payload to the content store with a transmission timestamp to validate message ordering.
- - Sends the live content item payload to the message queue.
+ - Validates the previous_version matches that of the content item if one is provided in the payload and raises a 409 otherwise.
+ - Validates that update_type is present. If one is not provided, it will try to use the update_type previously set on the content item from the PUT request.
+ - Validates that update_type is one of `major`, `minor`, `republish` or `links` and raises a 422 otherwise.
+ - Retrieves the draft content item with the matching content_id and locale and changes its state to `published`.
+ - Sets the `public_updated_at` on a major update, assuming one hasn't been set through the PUT endpoint.
+ - Retains the `public_updated_at` from the previously published item on a minor update, assuming one hasn't been set through the PUT endpoint.
+ - Supersedes any previously published content items.
+ - Sends the published content item to the live content store.
+ - Sends the published content item to the message queue.
  - Returns 200 along with the content_id of the newly published item.
 
 ### Required request params:
  - `content_id` the primary identifier for the content to publish.
- - `update_type` must be one of major, minor, republish, links
 
 ### Optional request params:
+ - `update_type` (optional) must be one of major, minor, republish, links.
  - `locale` (optional) specifies the locale of the content item to be published.
  - `previous_version` (optional but advised) is used to ensure the request is publishing the latest lock version of this draft. ie. optimistic locking.
 
@@ -90,16 +94,20 @@ Requests to update an existing draft content item:
  - Sends the live content payload to the message queue.
  - Returns created or updated link set links in the response.
 
+Note that link sets can be created before or after the PUT requests for the content item.
+No downstream requests will be sent if the content item doesn't exist yet.
+
 ### Required request parameters:
  - `content_id` the primary identifier for the content associated with the link set to be created or updated.
-links a JSON Object containing arrays of links keyed by link type eg.
-  ```
-    "links": {
-      "organisations": [
-        "591436ab-c2ae-416f-a3c5-1901d633fbfb"
-      ]
-    }
-  ```
+ - `links` a JSON Object containing arrays of links keyed by link type eg.
+
+```javascript
+  "links": {
+    "organisations": [
+      "591436ab-c2ae-416f-a3c5-1901d633fbfb"
+    ]
+  }
+```
 
 ### Optional request params:
  - `previous_version` (optional but advised) is used to ensure the request is updating the latest lock version of this link set.
@@ -108,11 +116,11 @@ links a JSON Object containing arrays of links keyed by link type eg.
 
 [Request/Response detail](https://pact-broker.dev.publishing.service.gov.uk/pacts/provider/Publishing%20API/consumer/GDS%20API%20Adapters/latest#a_request_to_discard_draft_content_given_a_content_item_exists_with_content_id:_bed722e6-db68-43e5-9079-063f623335a7)
 
- - Deletes the draft content item
- - Creates a new draft from the live item if one exists
- - Validates that the incoming request is attempting to discard the correct internal lock version of the content item. Responds with 409 when lock version validation fails
- - Sends the draft content item payload to the content store with a transmission timestamp to validate message ordering
- - By default, the request will discard the draft content item with a locale of 'en'
+ - Deletes the draft content item.
+ - Re-sends the published content item to the draft content store, if one exists.
+ - Validates that the incoming request is attempting to discard the correct internal lock version of the content item. Responds with 409 when lock version validation fails.
+ - By default, the request will discard the draft content item with a locale of 'en'.
+ - Does not affect the link set for the content item.
 
 ### Required request parameters:
  - `content_id` the primary identifier for the draft content item to be discarded
@@ -125,8 +133,8 @@ links a JSON Object containing arrays of links keyed by link type eg.
 
  [Request/Response detail](https://pact-broker.dev.publishing.service.gov.uk/pacts/provider/Publishing%20API/consumer/GDS%20API%20Adapters/latest#a_request_to_return_the_items_linked_to_it_given_no_content_exists)
 
-  - Retrieves all content items with a link of the specified link_type to the content item with given content_id
-  - Returns only the content items' fields that have been requested with the query
+  - Retrieves all content items that link to the given content_id for some link_type
+  - Returns only the content item's fields that have been requested with the query
 
 ### Required request params:
   - `content_id` the primary identifier for the content associated with the requested link set.

--- a/doc/publishing-api-syntactic-usage.md
+++ b/doc/publishing-api-syntactic-usage.md
@@ -155,3 +155,15 @@ No downstream requests will be sent if the content item doesn't exist yet.
   - `document_type` the type of content item to return
   - `locale` (optional) is used to restrict returned content items to a given locale (defaults to 'en')
   - `fields[]` an array of fields that are validated against `ContentItem` column fields. Any invalid requested field will raise a `400`.
+
+## `GET /v2/linkables`
+
+ [Request/Response detail](https://pact-broker.dev.publishing.service.gov.uk/pacts/provider/Publishing%20API/consumer/GDS%20API%20Adapters/latest#a_get_linkables_request_given_there_is_content_with_format_'topic')
+
+  - Retrieves specific fields of content items for a given `document_type`.
+  - Returns `title`, `content_id`, `publication_state`, `base_path` and `internal_name`.
+  - Does not restrict the content items by `publishing_app`
+  - Does not paginate the results
+
+### Required request params:
+  - `document_type` the type of content item to return


### PR DESCRIPTION
I've updated the existing endpoint documentation in *syntactic usage* and have added the three(!) new endpoints we've added recently. I also updated the README app introduction to be a bit more high-level and focus on the problem that the Publishing API is trying to solve.

I had a look through the *semantics* documentation and I don't really think it's changed as the semantics of the fields has remained the same, as far as I am aware.