### PR TITLE
Spike on computing an edge-restricted transitive closure in Postgres

### DIFF
--- a/app/queries/get_dependents.rb
+++ b/app/queries/get_dependents.rb
@@ -1,0 +1,31 @@
+module Queries
+  module GetDependents
+    # Finds all content_ids that depend on the given content_id. This query is
+    # recursive and will also return content_ids that aren't direct neighbours
+    # to the given content_id. This is called a 'transitive closure'.
+    #
+    # If the optional link_type is given, only links that have that link_type
+    # will be followed when computing dependencies.
+    def self.call(content_id, link_type = nil)
+      results = ActiveRecord::Base.connection.execute(
+        <<-SQL
+          WITH RECURSIVE dependents(content_id, link_type) AS (
+            SELECT '#{content_id}'::TEXT, '#{link_type}'
+          UNION
+              SELECT DISTINCT link_sets.content_id, dependents.link_type
+              FROM dependents
+              JOIN links
+                ON links.target_content_id = dependents.content_id
+            #{'AND links.link_type = dependents.link_type' if link_type}
+              JOIN link_sets
+                ON link_sets.id = links.link_set_id
+          )
+          SELECT DISTINCT content_id FROM dependents
+          WHERE content_id != '#{content_id}'
+        SQL
+      )
+
+      results.map { |r| r.fetch("content_id") }
+    end
+  end
+end

--- a/db/migrate/20160315123002_add_index_to_links_target.rb
+++ b/db/migrate/20160315123002_add_index_to_links_target.rb
@@ -1,0 +1,6 @@
+class AddIndexToLinksTarget < ActiveRecord::Migration
+  def change
+    add_index :links, :target_content_id
+    add_index :links, [:target_content_id, :link_type]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160315070023) do
+ActiveRecord::Schema.define(version: 20160315123002) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -80,6 +80,8 @@ ActiveRecord::Schema.define(version: 20160315070023) do
   add_index "links", ["link_set_id", "target_content_id"], name: "index_links_on_link_set_id_and_target_content_id", using: :btree
   add_index "links", ["link_set_id"], name: "index_links_on_link_set_id", using: :btree
   add_index "links", ["link_type"], name: "index_links_on_link_type", using: :btree
+  add_index "links", ["target_content_id", "link_type"], name: "index_links_on_target_content_id_and_link_type", using: :btree
+  add_index "links", ["target_content_id"], name: "index_links_on_target_content_id", using: :btree
 
   create_table "locations", force: :cascade do |t|
     t.integer  "content_item_id", null: false

--- a/spec/queries/get_dependents_spec.rb
+++ b/spec/queries/get_dependents_spec.rb
@@ -1,0 +1,193 @@
+require "rails_helper"
+
+RSpec.describe Queries::GetDependents do
+  def create_node
+    link_set = FactoryGirl.create(:link_set, content_id: SecureRandom.uuid)
+    link_set.content_id
+  end
+
+  def create_edge(from, to, link_type)
+    link_set = LinkSet.find_by(content_id: from)
+
+    FactoryGirl.create(
+      :link,
+      link_set: link_set,
+      target_content_id: to,
+      link_type: link_type
+    )
+  end
+
+  it "finds nodes that depend on the given node" do
+    a = create_node
+    b = create_node
+    c = create_node
+
+    create_edge(a, c, "parent")
+    create_edge(b, c, "parent")
+
+    results = described_class.call(c, "parent")
+    expect(results).to match_array [a, b]
+  end
+
+  it "does not find nodes that do not depend on the given node" do
+    a = create_node
+    b = create_node
+    c = create_node
+
+    create_edge(a, c, "parent")
+
+    results = described_class.call(c, "parent")
+    expect(results).not_to include(b)
+  end
+
+  it "does not find nodes that are connected with a different link_type" do
+    a = create_node
+    b = create_node
+    c = create_node
+
+    create_edge(a, c, "parent")
+    create_edge(b, c, "something_else")
+
+    results = described_class.call(c, "parent")
+    expect(results).not_to include(b)
+  end
+
+  it "can optionally omit link_type to return all dependent nodes" do
+    a = create_node
+    b = create_node
+    c = create_node
+
+    create_edge(a, c, "parent")
+    create_edge(b, c, "something_else")
+
+    results = described_class.call(c)
+    expect(results).to match_array [a, b]
+  end
+
+  it "returns an empty array if no nodes depend on the given node" do
+    a = create_node
+
+    results = described_class.call(a, "parent")
+    expect(results).to be_empty
+  end
+
+  it "finds nodes that transitively depend on the given node" do
+    a = create_node
+    b = create_node
+    c = create_node
+
+    create_edge(a, b, "parent")
+    create_edge(b, c, "parent")
+
+    results = described_class.call(c, "parent")
+    expect(results).to match_array [a, b]
+  end
+
+  it "does not find nodes where the outbound edge is the wrong link_type" do
+    a = create_node
+    b = create_node
+    c = create_node
+
+    create_edge(a, b, "something_else")
+    create_edge(b, c, "parent")
+
+    results = described_class.call(c, "parent")
+    expect(results).to eq [b]
+  end
+
+  it "does not find nodes where an intermediate edge is the wrong link_type" do
+    a = create_node
+    b = create_node
+    c = create_node
+    d = create_node
+
+    create_edge(a, b, "parent")
+    create_edge(b, c, "something_else")
+    create_edge(c, d, "parent")
+
+    results = described_class.call(d, "parent")
+    expect(results).to eq [c]
+  end
+
+  it "can optionally omit link_type to return all transitively dependent nodes" do
+    a = create_node
+    b = create_node
+    c = create_node
+    d = create_node
+
+    create_edge(a, b, "parent")
+    create_edge(b, c, "something_else")
+    create_edge(c, d, "parent")
+
+    results = described_class.call(d)
+    expect(results).to match_array [a, b, c]
+  end
+
+  it "terminates when the graph has cycles" do
+    a = create_node
+    b = create_node
+
+    create_edge(a, b, "related")
+    create_edge(b, a, "related")
+
+    results = described_class.call(b)
+    expect(results).to eq [a]
+  end
+
+  it "runs performantly for a relatively large dependency graph" do
+    content_id = create_node
+
+    inserts = []
+
+    # Builds a four-level tree that fans out ten nodes at a time.
+    1.upto(10) do |i|
+      i_id = SecureRandom.uuid
+      inserts << dependency_sql(from: i_id, to: content_id)
+
+      1.upto(10) do |j|
+        j_id = SecureRandom.uuid
+        inserts << dependency_sql(from: j_id, to: i_id)
+
+        1.upto(10) do |k|
+          k_id = SecureRandom.uuid
+          inserts << dependency_sql(from: k_id, to: j_id)
+
+          1.upto(10) do |l|
+            l_id = SecureRandom.uuid
+            inserts << dependency_sql(from: l_id, to: k_id)
+          end
+        end
+      end
+    end
+
+    ActiveRecord::Base.connection.execute(inserts.join(";"))
+
+    results = nil
+    time_taken = Benchmark.realtime do
+      results = described_class.call(content_id)
+    end
+
+    expect(results.size).to eq(10 + 100 + 1000 + 10000)
+    expect(time_taken).to be < 0.25
+  end
+
+  def dependency_sql(from:, to:)
+    @id ||= 100
+    @id += 1
+
+    <<-SQL
+      INSERT INTO link_sets (id, content_id)
+      VALUES (#{@id}, '#{from}');
+
+      INSERT INTO links (
+        id,
+        link_set_id,
+        target_content_id,
+        link_type,
+        created_at,
+        updated_at
+      )
+      VALUES (#{@id}, #{@id}, '#{to}', 'parent', now(), now())
+    SQL
+  end
+end


### PR DESCRIPTION
I've opened a pull request so that we can review the approach. This code shouldn't be merged.


```ruby
require 'benchmark';

hash = LinkSet.all.offset(200000).each.with_object({}) do |link_set, hash|
  results = nil;
  time_taken = Benchmark.realtime do
    results = Queries::GetDependents.call(link_set.content_id)
  end
  next if results.size.zero?
  hash[link_set.content_id] = [time_taken, results.size]
  puts "#{link_set.content_id} : #{results.size} results : query took #{time_taken.round(4)} seconds"
end; nil
```