### PR TITLE
Add an index on document_type

### DIFF
--- a/db/migrate/20160315070023_add_content_items_index_on_document_type.rb
+++ b/db/migrate/20160315070023_add_content_items_index_on_document_type.rb
@@ -1,0 +1,5 @@
+class AddContentItemsIndexOnDocumentType < ActiveRecord::Migration
+  def change
+    add_index :content_items, :document_type
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160309155913) do
+ActiveRecord::Schema.define(version: 20160315070023) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -45,6 +45,7 @@ ActiveRecord::Schema.define(version: 20160309155913) do
   end
 
   add_index "content_items", ["content_id"], name: "index_content_items_on_content_id", using: :btree
+  add_index "content_items", ["document_type"], name: "index_content_items_on_document_type", using: :btree
   add_index "content_items", ["format"], name: "index_content_items_on_format", using: :btree
   add_index "content_items", ["public_updated_at"], name: "index_content_items_on_public_updated_at", using: :btree
   add_index "content_items", ["publishing_app"], name: "index_content_items_on_publishing_app", using: :btree


### PR DESCRIPTION
The `format` column had an index, but it hasn’t been created for the
new `document_type` index. This is being filtered on by the linkables
endpoint now used by Whitehall, but is slow to query for policies.

Explain before: http://explain.depesz.com/s/HVYa
Explain after: http://explain.depesz.com/s/9XY