### PR TITLE
Filter by the given link type

### DIFF
--- a/app/queries/get_linked.rb
+++ b/app/queries/get_linked.rb
@@ -14,6 +14,7 @@ module Queries
 
       content_ids = Link
         .where(target_content_id: target_content_id)
+        .where(link_type: link_type)
         .joins(:link_set)
         .pluck(:content_id)
 

--- a/spec/queries/get_linked_spec.rb
+++ b/spec/queries/get_linked_spec.rb
@@ -103,7 +103,7 @@ RSpec.describe Queries::GetLinked do
               FactoryGirl.create(
                 :link,
                 link_type: "related_links",
-                target_content_id: SecureRandom.uuid
+                target_content_id: target_content_id
               )
             ]
           )
@@ -130,6 +130,20 @@ RSpec.describe Queries::GetLinked do
                 "base_path" => "/vat-rates",
                 "locale" => "en",
               }
+            ])
+          end
+        end
+
+        context "when a link_type is specified" do
+          it "filters the links by the specified link_type" do
+            expect(
+              Queries::GetLinked.new(
+                content_id: target_content_id,
+                link_type: "related_links",
+                fields: %w(base_path))
+              .call
+            ).to match_array([
+              { "base_path" => "/vatty" }
             ])
           end
         end


### PR DESCRIPTION
We were missing a restriction on `link_type`. It was being plumbed through but wasn't influencing the query.