### PR TITLE
Fix a race condition in PutContent

### DIFF
--- a/app/commands/v2/put_content.rb
+++ b/app/commands/v2/put_content.rb
@@ -57,7 +57,7 @@ module Commands
       end
 
       def find_previously_drafted_content_item
-        filter = ContentItemFilter.new(scope: ContentItem.where(content_id: content_id))
+        filter = ContentItemFilter.new(scope: pessimistic_content_item_scope)
         filter.filter(locale: locale, state: "draft").first
       end
 
@@ -115,10 +115,14 @@ module Commands
 
       def previously_published_item
         @previously_published_item ||= (
-          filter = ContentItemFilter.new(scope: ContentItem.where(content_id: content_id))
+          filter = ContentItemFilter.new(scope: pessimistic_content_item_scope)
           content_items = filter.filter(state: %w(published withdrawn), locale: locale)
           UserFacingVersion.latest(content_items)
         )
+      end
+
+      def pessimistic_content_item_scope
+        ContentItem.where(content_id: content_id).lock
       end
 
       def path_has_changed?(location)

--- a/spec/commands/v2/put_content_spec.rb
+++ b/spec/commands/v2/put_content_spec.rb
@@ -117,6 +117,26 @@ RSpec.describe Commands::V2::PutContent do
         expect(State.find_by!(content_item: content_item).name).to eq("draft")
         expect(UserFacingVersion.find_by!(content_item: content_item).number).to eq(6)
       end
+
+      describe "race condtitions", skip_cleaning: true do
+        after do
+          DatabaseCleaner.clean_with :truncation
+        end
+
+        it "copes with race conditions" do
+          described_class.call(payload)
+          Commands::V2::Publish.call(content_id: content_id, update_type: "minor")
+
+          expect {
+            thread1 = Thread.new { described_class.call(payload) }
+            thread2 = Thread.new { described_class.call(payload) }
+            thread1.join
+            thread2.join
+          }.to raise_error(CommandError, /conflicts with a duplicate/)
+
+          expect(State.all.pluck(:name)).to eq %w(superseded published draft)
+        end
+      end
     end
 
     context "when creating a draft for a previously withdrawn content item" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -55,8 +55,10 @@ RSpec.configure do |config|
   end
 
   config.around(:each) do |example|
-    DatabaseCleaner.cleaning do
+    if example.metadata[:skip_cleaning]
       example.run
+    else
+      DatabaseCleaner.cleaning { example.run }
     end
   end
 


### PR DESCRIPTION
Someone had double clicked on the ‘Save & Publish’
button in travel advice publisher. This sent two
requests simultaneously to the Publishing API
which raced against each other.

This change uses row-level pessimistic locking,
which causes the second request to wait for a
mutex before it can proceed. This has the effect
that the second request is processed after the
first completes and we maintain data integrity.

The tests for this change use the truncation
strategy to clean the database instead of the
default transaction strategy. This is because the
threads use separate connections from the
connection pool which cannot be collectively
wrapped in a single transaction.