### PR TITLE
Filter GET index results by organisation

### DIFF
--- a/app/controllers/v2/content_items_controller.rb
+++ b/app/controllers/v2/content_items_controller.rb
@@ -7,8 +7,7 @@ module V2
       results = Queries::GetContentCollection.new(
         document_type: doc_type,
         fields: query_params.fetch(:fields),
-        publishing_app: publishing_app,
-        locale: query_params[:locale],
+        filters: filters,
         pagination: pagination
       )
 
@@ -59,6 +58,22 @@ module V2
     def publishing_app
       unless current_user.has_permission?('view_all')
         current_user.app_name
+      end
+    end
+
+    def filters
+      {
+        publishing_app: publishing_app,
+        locale: query_params[:locale],
+        links: link_filters,
+      }
+    end
+
+    def link_filters
+      {}.tap do |hash|
+        query_params.each do |k, v|
+          hash[k[5..-1]] = v if k.start_with?("link_")
+        end
       end
     end
   end

--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -19,6 +19,22 @@ class Link < ActiveRecord::Base
     end
   end
 
+  def self.filter_content_items(scope, filters)
+    join_sql = <<-SQL.strip_heredoc
+      INNER JOIN link_sets ON link_sets.content_id = content_items.content_id
+      INNER JOIN links ON links.link_set_id = link_sets.id
+    SQL
+
+    scope = scope.joins(join_sql)
+
+    filters.each do |link_type, target_content_id|
+      scope = scope.where("links.link_type": link_type,
+                          "links.target_content_id": target_content_id)
+    end
+
+    scope
+  end
+
 private
 
   def link_type_is_valid

--- a/spec/controllers/v2/content_items_controller_spec.rb
+++ b/spec/controllers/v2/content_items_controller_spec.rb
@@ -152,6 +152,25 @@ RSpec.describe V2::ContentItemsController do
         expect(parsed_response_body.first.fetch("content_id")).to eq("#{content_id}")
       end
     end
+
+    context "with link filtering params" do
+      before do
+        org_content_id = SecureRandom.uuid
+        link_set = FactoryGirl.create(:link_set, content_id: content_id)
+        FactoryGirl.create(:link, link_set: link_set, target_content_id: org_content_id)
+
+        get :index, content_format: "topic", fields: ["content_id"], link_organisations: org_content_id.to_s
+      end
+
+      it "is successful" do
+        expect(response.status).to eq(200)
+      end
+
+      it "responds with the content items for the given organistion as json" do
+        parsed_response_body = JSON.parse(response.body)["results"]
+        expect(parsed_response_body.first.fetch("content_id")).to eq("#{content_id}")
+      end
+    end
   end
 
   describe "show" do

--- a/spec/models/link_spec.rb
+++ b/spec/models/link_spec.rb
@@ -40,4 +40,16 @@ RSpec.describe Link do
       expect(link.errors[:link]).to eq(["target_content_id must be a valid UUID"])
     end
   end
+
+  describe ".filter_content_items" do
+    let(:scope) { double(:scope) }
+
+    it "modifies a scope to filter linked content items" do
+      expect(scope).to receive(:joins).with(anything).and_return(scope)
+      expect(scope).to receive(:where)
+        .with("links.link_type": "organisations", "links.target_content_id": "12345")
+
+      described_class.filter_content_items(scope, "organisations" => "12345")
+    end
+  end
 end


### PR DESCRIPTION
https://trello.com/c/5n27561D/449-allow-the-get-index-endpoint-to-be-filtered-by-organisation

Makes the index endpoint for content items `/v2/content/` support an `organisation` parameter. This should be an organisation's content id. This will filter results to content items linked to the specified organisation.
The organisation is already associated with a content item via the `Link` and `LinkSet` models where `Link#link_type` is _organisations_.