### PR TITLE
	Make base_path optional for selected schemas

### DIFF
--- a/app/commands/v2/put_content.rb
+++ b/app/commands/v2/put_content.rb
@@ -4,7 +4,7 @@ module Commands
       def call
         raise_if_links_is_provided
 
-        PathReservation.reserve_base_path!(base_path, publishing_app)
+        PathReservation.reserve_base_path!(base_path, publishing_app) if base_path_required?
 
         if (content_item = find_previously_drafted_content_item)
           clear_draft_items_of_same_locale_and_base_path(content_item, locale, base_path)
@@ -80,7 +80,7 @@ module Commands
       end
 
       def create_supporting_objects(content_item)
-        Location.create!(content_item: content_item, base_path: base_path)
+        Location.create!(content_item: content_item, base_path: base_path) if base_path_required?
         State.create!(content_item: content_item, name: "draft")
         Translation.create!(content_item: content_item, locale: locale)
         UserFacingVersion.create!(content_item: content_item, number: user_facing_version_number_for_new_draft)
@@ -134,7 +134,11 @@ module Commands
       end
 
       def base_path
-        payload.fetch(:base_path)
+        payload[:base_path]
+      end
+
+      def base_path_required?
+        !ContentItem::EMPTY_BASE_PATH_FORMATS.include?(payload[:format] || payload[:schema_name])
       end
 
       def locale

--- a/app/filters/content_item_filter.rb
+++ b/app/filters/content_item_filter.rb
@@ -7,7 +7,7 @@ class ContentItemFilter
     params = params.dup
 
     params[:locale] = translation(content_item).locale unless params.has_key?(:locale)
-    params[:base_path] = location(content_item).base_path unless params.has_key?(:base_path)
+    params[:base_path] = location(content_item).try(:base_path) unless params.has_key?(:base_path)
     params[:state] = state(content_item).name unless params.has_key?(:state)
     params[:user_version] = user_facing_version(content_item).number unless params.has_key?(:user_version)
 
@@ -34,7 +34,7 @@ class ContentItemFilter
   end
 
   def self.location(content_item)
-    Location.find_by!(content_item: content_item)
+    Location.find_by(content_item: content_item)
   end
 
   def self.state(content_item)

--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -25,6 +25,7 @@ class ContentItem < ActiveRecord::Base
   ].freeze
 
   NON_RENDERABLE_FORMATS = %w(redirect gone).freeze
+  EMPTY_BASE_PATH_FORMATS = %w(government).freeze
 
   scope :renderable_content, -> { where.not(format: NON_RENDERABLE_FORMATS) }
 

--- a/spec/commands/v2/discard_draft_spec.rb
+++ b/spec/commands/v2/discard_draft_spec.rb
@@ -5,7 +5,8 @@ RSpec.describe Commands::V2::DiscardDraft do
     before do
       stub_request(:delete, %r{.*content-store.*/content/.*})
       stub_request(:put, %r{.*content-store.*/content/.*})
-      GdsApi::GovukHeaders.set_header(:x_govuk_request_uuid, "12345-67890")
+      allow(GdsApi::GovukHeaders).to receive(:headers)
+        .and_return(x_govuk_request_uuid: "12345-67890")
     end
 
     let(:expected_content_store_payload) { { base_path: "/vat-rates" } }

--- a/spec/commands/v2/patch_link_set_spec.rb
+++ b/spec/commands/v2/patch_link_set_spec.rb
@@ -21,7 +21,8 @@ RSpec.describe Commands::V2::PatchLinkSet do
 
     allow(Presenters::ContentStorePresenter).to receive(:present)
       .and_return(expected_content_store_payload)
-    GdsApi::GovukHeaders.set_header(:x_govuk_request_uuid, "12345-67890")
+    allow(GdsApi::GovukHeaders).to receive(:headers)
+      .and_return(x_govuk_request_uuid: "12345-67890")
   end
 
   context "when no link set exists" do

--- a/spec/commands/v2/publish_spec.rb
+++ b/spec/commands/v2/publish_spec.rb
@@ -18,7 +18,8 @@ RSpec.describe Commands::V2::Publish do
 
       allow(Presenters::ContentStorePresenter).to receive(:present)
         .and_return(expected_content_store_payload)
-      GdsApi::GovukHeaders.set_header(:x_govuk_request_uuid, "12345-67890")
+      allow(GdsApi::GovukHeaders).to receive(:headers)
+        .and_return(x_govuk_request_uuid: "12345-67890")
     end
 
     around do |example|

--- a/spec/commands/v2/put_content_spec.rb
+++ b/spec/commands/v2/put_content_spec.rb
@@ -4,6 +4,8 @@ RSpec.describe Commands::V2::PutContent do
   describe "call" do
     before do
       stub_request(:put, %r{.*content-store.*/content/.*})
+      allow(GdsApi::GovukHeaders).to receive(:headers)
+        .and_return(x_govuk_request_uuid: "12345-67890")
     end
 
     let(:expected_content_store_payload) { { base_path: "/vat-rates" } }

--- a/spec/commands/v2/put_content_spec.rb
+++ b/spec/commands/v2/put_content_spec.rb
@@ -562,6 +562,38 @@ RSpec.describe Commands::V2::PutContent do
       end
     end
 
+    context "without a base_path" do
+      before do
+        payload.delete(:base_path)
+      end
+
+      context "when schema requires a base_path" do
+        it "raises an error" do
+          expect {
+            described_class.call(payload)
+          }.to raise_error(CommandError, /Base path is not a valid absolute URL path/)
+        end
+      end
+
+      context "when schema does not require a base_path" do
+        before do
+          payload.merge!(schema_name: 'government', document_type: 'government').delete(:format)
+        end
+
+        it "does not raise an error" do
+          expect {
+            described_class.call(payload)
+          }.not_to raise_error
+        end
+
+        it "does not try to reserve a path" do
+          expect {
+            described_class.call(payload)
+          }.not_to change(PathReservation, :count)
+        end
+      end
+    end
+
     it_behaves_like TransactionalCommand
   end
 end


### PR DESCRIPTION
ContentItems of some schema types - eg governments - will not be published and so will not have a base_path. These items will not register a PathReservation, do not create a Location entry and are not sent to the content_store.