### PR TITLE
Return an error message for linting errors...

### DIFF
--- a/jenkins.sh
+++ b/jenkins.sh
@@ -41,7 +41,7 @@ bundle install --path "${HOME}/bundles/${JOB_NAME}" --deployment --without devel
 bundle exec govuk-lint-ruby \
   --format html --out rubocop-${GIT_COMMIT}.html \
   --format clang \
-  app config Gemfile lib spec
+  app config Gemfile lib spec || echo "Linting errors detected"
 
 bundle exec rake db:drop db:create db:schema:load
 


### PR DESCRIPTION
https://trello.com/c/HseMC05U/630-modify-jenkins-to-go-unstable-on-linting-errors-rather-than-failing

This doesn't prevent the rest of the jenkins build script from running.
Tests and pacts will be checked and the build will be flagged unstable.

See [this branch built successfully](https://ci.dev.publishing.service.gov.uk/job/govuk_publishing-api_branches/1329/console) and [this unstable branch with linting errors](https://ci.dev.publishing.service.gov.uk/job/govuk_publishing-api_branches/1328/)