### PR TITLE
Set GitHub build status to 'error' on linting errors

### DIFF
--- a/jenkins.sh
+++ b/jenkins.sh
@@ -41,7 +41,7 @@ bundle install --path "${HOME}/bundles/${JOB_NAME}" --deployment --without devel
 bundle exec govuk-lint-ruby \
   --format html --out rubocop-${GIT_COMMIT}.html \
   --format clang \
-  app config Gemfile lib spec || echo "Linting errors detected"
+  app config Gemfile lib spec || linting_error=1
 
 bundle exec rake db:drop db:create db:schema:load
 
@@ -50,7 +50,12 @@ if bundle exec rake ${TEST_TASK:-"default"}; then
     bundle exec rake pact:publish:branch
   fi
 
-  github_status success "succeeded on Jenkins"
+  if [ "$linting_error" = 1 ]; then
+    echo "Linting errors detected"
+    github_status error "linting errors detected on Jenkins"
+  else
+    github_status success "succeeded on Jenkins"
+  fi
 else
   github_status failure "failed on Jenkins"
   exit 1


### PR DESCRIPTION
![screenshot from 2016-03-22 15 24 54](https://cloud.githubusercontent.com/assets/93511/13956870/4346b51a-f042-11e5-9473-83d697ebfa49.png)

Since marking builds with linting errors as unstable, the github status from jenkins will still show a confusing `success` status. Github build API doesn't support 'unstable' as a status so set the Github build status to `error` and provide a suitable message for linting errors but continue the test suite run.