### PR TITLE
PATCH /v2/links/:content_id for an absent content item returns a 404

### DIFF
--- a/app/commands/v2/patch_link_set.rb
+++ b/app/commands/v2/patch_link_set.rb
@@ -2,6 +2,7 @@ module Commands
   module V2
     class PatchLinkSet < BaseCommand
       def call
+        raise_unless_content_item_exists
         raise_unless_links_hash_is_provided
 
         link_set = LinkSet.find_by(content_id: content_id)
@@ -72,6 +73,17 @@ module Commands
               }
             }
           )
+        end
+      end
+
+      def raise_unless_content_item_exists
+        unless ContentItem.exists?(content_id: content_id)
+          raise CommandError.new(code: 404, error_details: {
+            error: {
+              code: 404,
+              message: "No item with content_id: '#{content_id}'"
+            }
+          })
         end
       end
 

--- a/spec/commands/v2/patch_link_set_spec.rb
+++ b/spec/commands/v2/patch_link_set_spec.rb
@@ -394,5 +394,18 @@ RSpec.describe Commands::V2::PatchLinkSet do
     end
   end
 
+  context "when the content item does not exist" do
+    it "raises a command error" do
+      payload_for_unknown_content_item = {
+        content_id: SecureRandom.uuid,
+        links: {}
+      }
+
+      expect {
+        described_class.call(payload_for_unknown_content_item)
+      }.to raise_error(CommandError, /No item with content_id/)
+    end
+  end
+
   it_behaves_like TransactionalCommand
 end

--- a/spec/requests/content_item_requests/endpoint_behaviour_spec.rb
+++ b/spec/requests/content_item_requests/endpoint_behaviour_spec.rb
@@ -332,4 +332,16 @@ RSpec.describe "Endpoint behaviour", type: :request do
       end
     end
   end
+
+  context "/links" do
+    context "PATCH /v2/links/:content_id" do
+      context "when the content item doesn't exist" do
+        it "responds with 404" do
+          patch "/v2/links/#{SecureRandom.uuid}", { "links" => {} }.to_json
+
+          expect(response.status).to eq(404)
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
Updating the links for a content item that doesn't exist is currently returning a 200.

Before I fix the large-ish quantity of tests this patch has broken I wanted to check that this is indeed a problem and that this is the right approach to fixing it?