### PR TITLE
Assert creating a link set without a content item returns success

### DIFF
--- a/spec/requests/content_item_requests/endpoint_behaviour_spec.rb
+++ b/spec/requests/content_item_requests/endpoint_behaviour_spec.rb
@@ -332,4 +332,16 @@ RSpec.describe "Endpoint behaviour", type: :request do
       end
     end
   end
+
+  context "/links" do
+    context "PATCH /v2/links/:content_id" do
+      context "when creating a link set for a content item to be added later" do
+        it "responds with 200" do
+          patch "/v2/links/#{SecureRandom.uuid}", { links: {} }.to_json
+
+          expect(response.status).to eq(200)
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
Tuzz has explained why this works the way it does. This test is just supporting existing behaviour. I couldn't find it when trying to work out if this was indeed intended behaviour. It may/probably does already exist somewhere.

Please feel free to close if it already exists or isn't suitable!