### PR TITLE
Pre-filter by draft/published state...

### DIFF
--- a/app/presenters/queries/content_item_presenter.rb
+++ b/app/presenters/queries/content_item_presenter.rb
@@ -13,6 +13,7 @@ module Presenters
       end
 
       def self.present_many(content_item_scope, fields: nil, order: { public_updated_at: :desc }, offset: 0, limit: nil, locale: nil)
+        content_item_scope = State.filter(content_item_scope, name: %w(draft published))
         presenter = new(content_item_scope, fields: fields, order: order, limit: limit, offset: offset, locale: locale)
         presenter.present
       end


### PR DESCRIPTION
This query takes about ~~2 seconds~~ 1 second for 08d48cdd-6b50-43ff-a53b-beab47f4aab0.
After adding this restriction, it takes about 100ms. I'm not sure if this
is the right thing to do as it looks like it would affect the total count,
but all of the tests are passing with this line in.

Here is the query with/without the additional restriction:

```sql
SELECT json_agg(json_rows) FROM (
  SELECT row_to_json(item) json_item FROM (
    SELECT
    "content_items"."content_id",
    "content_items"."description",
    "content_items"."details",
    "content_items"."format",
    "content_items"."document_type",
    "content_items"."schema_name",
    "content_items"."public_updated_at",
    "content_items"."publishing_app",
    "content_items"."redirects",
    "content_items"."rendering_app",
    "content_items"."routes",
    "content_items"."title",
    "content_items"."analytics_identifier",
    "content_items"."phase",
    "content_items"."update_type",
    "content_items"."need_ids",
    "content_items"."content_id",
    states.name as state_name,
    lock_versions.number as lock_version,
    translations.locale,
    locations.base_path,
    "content_items"."public_updated_at"

    FROM "content_items"
    INNER JOIN translations ON translations.content_item_id = content_items.id
    INNER JOIN states ON states.content_item_id = content_items.id
    INNER JOIN locations ON locations.content_item_id = content_items.id
    INNER JOIN user_facing_versions ON user_facing_versions.content_item_id = content_items.id
    INNER JOIN lock_versions ON
      lock_versions.target_id = content_items.id AND
      lock_versions.target_type = 'ContentItem'
    WHERE
      "content_items"."content_id" = '08d48cdd-6b50-43ff-a53b-beab47f4aab0' AND
      "translations"."locale" = 'en'
      AND "states"."name" IN ('draft', 'published') ---      <--- restriction
    ORDER BY "content_items"."public_updated_at" DESC
  ) item
) json_rows

GROUP BY json_item->>'content_id', json_item->>'locale'
ORDER BY MAX(json_item->>'public_updated_at') desc
OFFSET 0
```