### PR TITLE
Remove redundant curriculum policy.

### DIFF
--- a/db/migrate/20160407121458_remove_redundant_policy.rb
+++ b/db/migrate/20160407121458_remove_redundant_policy.rb
@@ -1,0 +1,16 @@
+class RemoveRedundantPolicy < ActiveRecord::Migration
+  # Remove /government/policies/schools-and-college-qualifications-and-curriculum
+  def up
+    content_items = ContentItem.where(content_id: "3c04de88-9e4a-4ebb-bdc9-ef5946db17b9")
+    Translation.where(content_item: content_items).destroy_all
+    Location.where(content_item: content_items).destroy_all
+    State.where(content_item: content_items).destroy_all
+    UserFacingVersion.where(content_item: content_items).destroy_all
+    AccessLimit.where(content_item: content_items).destroy_all
+    LockVersion.where(target: content_items).destroy_all
+    content_items.destroy_all
+
+    link_sets = LinkSet.where(content_id: "3c04de88-9e4a-4ebb-bdc9-ef5946db17b9")
+    link_sets.destroy_all
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160315123002) do
+ActiveRecord::Schema.define(version: 20160407121458) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
Removes /government/policies/schools-and-college-qualifications-and-curriculum
content_id 3c04de88-9e4a-4ebb-bdc9-ef5946db17b9.

https://govuk.zendesk.com/agent/tickets/1299583

Background:
Back in the election times we seem to have created two of these with slightly different paths, but the "wrong" one is no longer in Policy Publisher.  It should be removed from the publishing API so it stops showing up in dropdowns.

The correct one is here: https://www.gov.uk/api/content/government/policies/school-and-college-qualifications-and-curriculum