### PR TITLE
Rake task to validate version sequences

### DIFF
--- a/lib/tasks/validate.rake
+++ b/lib/tasks/validate.rake
@@ -3,4 +3,9 @@ namespace :db do
   task validate: :environment do
     Tasks::DatabaseRecordValidator.validate
   end
+
+  desc "Validates the version sequence for all content items in the database"
+  task validate_versions: :environment do
+    Tasks::VersionValidator.validate
+  end
 end

--- a/lib/tasks/version_validator.rb
+++ b/lib/tasks/version_validator.rb
@@ -1,0 +1,70 @@
+module Tasks
+  module VersionValidator
+    class << self
+      def validate
+        results = nil
+
+        puts "Running query..."
+        time_taken = Benchmark.realtime do
+          results = ActiveRecord::Base.connection.execute(query)
+        end
+        puts "Done. Took #{time_taken.round(1)} seconds."
+        puts
+
+        results.each do |r|
+          content_id = r.fetch("content_id")
+          locale = r.fetch("locale")
+          versions = parse(r.fetch("versions")).map(&:to_i)
+          states = parse(r.fetch("states"))
+          base_paths = parse(r.fetch("base_paths"))
+
+          items = versions.zip(states, base_paths)
+          items.sort_by!(&:first)
+
+          valid_version_sequence = true
+
+          items.each.with_index do |item, index|
+            item_version = item.first
+
+            if item_version != index + 1
+              valid_version_sequence = false
+            end
+          end
+
+          unless valid_version_sequence
+            puts "Invalid version sequence for #{content_id}, #{locale}:"
+            items.each { |i| puts i.inspect }
+            puts
+          end
+        end
+      end
+
+      def query
+        <<-SQL
+          select
+            ci.content_id,
+            t.locale,
+
+            -- select arrays of supporting attributes
+            array_agg(s.name) as states,
+            array_agg(v.number) as versions,
+            array_agg(l.base_path) as base_paths
+
+          from content_items ci
+
+          -- join supporting objects
+          join states s on s.content_item_id = ci.id
+          join user_facing_versions v on v.content_item_id = ci.id
+          join translations t on t.content_item_id = ci.id
+          join locations l on l.content_item_id = ci.id
+
+          group by ci.content_id, t.locale
+        SQL
+      end
+
+      def parse(array_string)
+        array_string[1..-2].split(",")
+      end
+    end
+  end
+end

--- a/spec/lib/tasks/version_validator_spec.rb
+++ b/spec/lib/tasks/version_validator_spec.rb
@@ -1,0 +1,73 @@
+require "rails_helper"
+
+RSpec.describe Tasks::VersionValidator do
+  let(:content_id) { SecureRandom.uuid }
+
+  before do
+    FactoryGirl.create(
+      :content_item,
+      content_id: content_id,
+      state: "superseded",
+      user_facing_version: 1,
+      locale: "en"
+    )
+
+    FactoryGirl.create(
+      :content_item,
+      content_id: content_id,
+      state: "published",
+      user_facing_version: 2,
+      locale: "en"
+    )
+  end
+
+  context "when there are no version sequence problems" do
+    it "does not output any problems" do
+      expect {
+        subject.validate
+      }.not_to output(/Invalid version sequence/).to_stdout
+    end
+  end
+
+  context "when two items of the same content_id have identical versions" do
+    before do
+      version = UserFacingVersion.last
+      version.number = 1
+      version.save!(validate: false)
+    end
+
+    it "outputs that the content item has an invalid version sequence" do
+      expect {
+        subject.validate
+      }.to output(/Invalid version sequence for #{content_id}/).to_stdout
+    end
+
+    context "but the content items have different locales" do
+      before do
+        translation = Translation.last
+        translation.locale = "fr"
+        translation.save!(validate: false)
+      end
+
+      it "does not output any problems" do
+        expect {
+          subject.validate
+        }.not_to output(/Invalid version sequence/).to_stdout
+      end
+    end
+  end
+
+  context "when the version sequence does not begin at zero" do
+    before do
+      version = UserFacingVersion.first
+      version.number = 3
+      version.save!(validate: false)
+    end
+
+    it "outputs that the content item has an invalid version sequence" do
+      expect {
+        subject.validate
+      }.to output(/Invalid version sequence for #{content_id}/).to_stdout
+    end
+  end
+end


### PR DESCRIPTION
I wrote a quick thing to validate version sequences. These are most likely remnants of the race condition bug that was fixed a while ago. I haven't written any tests, but can do if we think this is a valuable thing to repeatedly run in the future.

This should help @MatMoore and @davidslv fix the problems they were seeing yesterday afternoon. We should probably add a migration to fix records with invalid version sequences.

We could also consider extended these checks to consider whether the states are valid, too. For example, we may want to validate that there is only one published and draft item.

```
$ bundle exec rake db:validate_versions

Running query...
Done. Took 7.3 seconds.

Invalid version sequence for 37c6a708-3e88-4470-9aca-81d4ba103b0a, en:
[1, "superseded", "/guidance/tick-surveillance-scheme"]
[2, "superseded", "/guidance/tick-surveillance-scheme"]
[3, "superseded", "/guidance/tick-surveillance-scheme"]
[4, "published", "/guidance/tick-surveillance-scheme"]
[4, "superseded", "/guidance/tick-surveillance-scheme"]

Invalid version sequence for 42f57c6c-dba6-486e-b266-4224fdb858e9, en:
[1, "superseded", "/guidance/contacts-phe-health-protection-teams"]
[2, "superseded", "/guidance/contacts-phe-health-protection-teams"]
[3, "published", "/guidance/contacts-phe-health-protection-teams"]
[3, "superseded", "/guidance/contacts-phe-health-protection-teams"]
[4, "draft", "/guidance/contacts-phe-health-protection-teams"]

Invalid version sequence for 5c6c8576-3cd2-4a80-b9da-bd8271ebe079, en:
[1, "superseded", "/government/publications/veterans-world"]
[2, "superseded", "/government/publications/veterans-world"]
[3, "superseded", "/government/publications/veterans-world"]
[3, "published", "/government/publications/veterans-world"]

Invalid version sequence for 5e9f05e7-7706-11e4-a3cb-005056011aef, fa:
[1, "superseded", "/government/world/iran.fa"]
[2, "superseded", "/government/world/iran.fa"]
[2, "published", "/government/world/iran.fa"]
[3, "draft", "/government/world/iran.fa"]
[3, "draft", "/government/world/iran.fa"]

Invalid version sequence for 5f4b0a93-7631-11e4-a3cb-005056011aef, en:
[1, "superseded", "/guidance/educational-psychology-funded-training-scheme"]
[2, "superseded", "/guidance/educational-psychology-funded-training-scheme"]
[3, "draft", "/guidance/educational-psychology-funded-training-scheme"]
[3, "published", "/guidance/educational-psychology-funded-training-scheme"]

Invalid version sequence for 5f4c84d3-7631-11e4-a3cb-005056011aef, en:
[1, "superseded", "/government/collections/investment-in-the-uk-guidance-for-overseas-businesses"]
[2, "published", "/government/collections/investment-in-the-uk-guidance-for-overseas-businesses"]
[3, "draft", "/government/collections/investment-in-the-uk-guidance-for-overseas-businesses"]
[3, "draft", "/government/collections/investment-in-the-uk-guidance-for-overseas-businesses"]

Invalid version sequence for 5fa75e01-7631-11e4-a3cb-005056011aef, en:
[1, "superseded", "/guidance/pupil-premium-virtual-school-heads-responsibilities"]
[2, "superseded", "/guidance/pupil-premium-virtual-school-heads-responsibilities"]
[3, "draft", "/guidance/pupil-premium-virtual-school-heads-responsibilities"]
[3, "published", "/guidance/pupil-premium-virtual-school-heads-responsibilities"]

Invalid version sequence for 6a293b0f-ba2e-4d6a-a305-a339b2e6c60f, en:
[1, "superseded", "/government/organisations/highways-england/about/access-and-opening"]
[2, "superseded", "/government/organisations/highways-england/about/access-and-opening"]
[3, "superseded", "/government/organisations/highways-england/about/access-and-opening"]
[4, "draft", "/government/organisations/highways-england/about/access-and-opening"]
[4, "published", "/government/organisations/highways-england/about/access-and-opening"]

Invalid version sequence for 919bd03c-8c0a-4aca-9350-f8427199789e, en:
[1, "withdrawn", "/government/case-studies/stuart-scott"]
[1, "published", "/government/case-studies/intellectual-property-stuart-scott"]
```