### PR TITLE
Remove redundant order clause...

### DIFF
--- a/app/presenters/queries/content_item_presenter.rb
+++ b/app/presenters/queries/content_item_presenter.rb
@@ -50,7 +50,7 @@ module Presenters
 
       def scope
         scope = join_supporting_objects(content_item_scope)
-        select_fields(scope).order(order)
+        select_fields(scope)
       end
 
       def aggregated_sql(sql)


### PR DESCRIPTION
The main query to retrieve and order content items consists of Postgres JSON functions wrapping a sub query.
Ordering is attempted in the sub query which has no effect on the result
yet appears in the explain plan as a significant sort.

```
"              ->  Sort  (cost=23.04..23.05 rows=3 width=588)"
"                    Sort Key: content_items.public_updated_at"
```

See before and after explain plans for more detail.

[explain-plan-before.txt](https://github.com/alphagov/publishing-api/files/213127/explain-plan-before.txt)
[explain-plan-after.txt](https://github.com/alphagov/publishing-api/files/213128/explain-plan-after.txt)