### PR TITLE
Prevent content substitution for nil base path

### DIFF
--- a/app/commands/v2/put_content.rb
+++ b/app/commands/v2/put_content.rb
@@ -23,7 +23,7 @@ module Commands
     private
 
       def create_new_content_item(content_item)
-        clear_draft_items_of_same_locale_and_base_path(content_item, locale, base_path)
+        clear_draft_items_of_same_locale_and_base_path(content_item, locale, base_path) unless base_path.nil?
 
         create_supporting_objects(content_item)
         ensure_link_set_exists(content_item)

--- a/app/substitution_helper.rb
+++ b/app/substitution_helper.rb
@@ -1,6 +1,8 @@
 module SubstitutionHelper
   class << self
     def clear!(new_item_format:, new_item_content_id:, base_path:, locale:, state:)
+      raise NilBasePathError if base_path.nil?
+
       blocking_items = ContentItemFilter.filter(base_path: base_path, locale: locale, state: state)
 
       blocking_items.each do |blocking_item|
@@ -19,4 +21,6 @@ module SubstitutionHelper
       %w(coming_soon gone redirect unpublishing).include?(format)
     end
   end
+
+  class NilBasePathError < StandardError; end
 end

--- a/spec/substitution_helper_spec.rb
+++ b/spec/substitution_helper_spec.rb
@@ -33,63 +33,79 @@ RSpec.describe SubstitutionHelper do
   }
 
 
-  before do
-    subject.clear!(
-      new_item_format: new_format,
-      new_item_content_id: new_content_id,
-      base_path: existing_base_path,
-      locale: "en",
-      state: "draft",
-    )
-  end
-
-  context "when the content_id is the same as the existing item" do
-    let(:new_content_id) { existing_item.content_id }
-
-    it "does not withdraw the existing item" do
-      state = State.find_by!(content_item: existing_item)
-      expect(state.name).not_to eq("withdrawn")
-    end
-  end
-
-  context "when the content_id differs from the existing item" do
-    let(:new_content_id) { SecureRandom.uuid }
-
-    context "when the existing item has a format that is substitutable" do
-      let(:existing_format) { "gone" }
-
-      it "withdraws the existing item" do
-        state = State.find_by!(content_item: existing_item)
-        expect(state.name).to eq("withdrawn")
-      end
-
-      it "doesn't withdraw any other items" do
-        expect(State.find_by!(content_item: live_item).name).not_to eq("withdrawn")
-        expect(State.find_by!(content_item: french_item).name).not_to eq("withdrawn")
-        expect(State.find_by!(content_item: item_elsewhere).name).not_to eq("withdrawn")
-      end
+  context "given a base_path" do
+    before do
+      subject.clear!(
+        new_item_format: new_format,
+        new_item_content_id: new_content_id,
+        base_path: existing_base_path,
+        locale: "en",
+        state: "draft",
+      )
     end
 
-    context "when the new item has a format that is substitutable" do
-      let(:new_format) { "gone" }
+    context "when the content_id is the same as the existing item" do
+      let(:new_content_id) { existing_item.content_id }
 
-      it "withdraws the existing item" do
-        state = State.find_by!(content_item: existing_item)
-        expect(state.name).to eq("withdrawn")
-      end
-
-      it "doesn't withdraw any other items" do
-        expect(State.find_by!(content_item: live_item).name).not_to eq("withdrawn")
-        expect(State.find_by!(content_item: french_item).name).not_to eq("withdrawn")
-        expect(State.find_by!(content_item: item_elsewhere).name).not_to eq("withdrawn")
-      end
-    end
-
-    context "when neither item has a format that is substitutable" do
       it "does not withdraw the existing item" do
         state = State.find_by!(content_item: existing_item)
         expect(state.name).not_to eq("withdrawn")
       end
+    end
+
+    context "when the content_id differs from the existing item" do
+      let(:new_content_id) { SecureRandom.uuid }
+
+      context "when the existing item has a format that is substitutable" do
+        let(:existing_format) { "gone" }
+
+        it "withdraws the existing item" do
+          state = State.find_by!(content_item: existing_item)
+          expect(state.name).to eq("withdrawn")
+        end
+
+        it "doesn't withdraw any other items" do
+          expect(State.find_by!(content_item: live_item).name).not_to eq("withdrawn")
+          expect(State.find_by!(content_item: french_item).name).not_to eq("withdrawn")
+          expect(State.find_by!(content_item: item_elsewhere).name).not_to eq("withdrawn")
+        end
+      end
+
+      context "when the new item has a format that is substitutable" do
+        let(:new_format) { "gone" }
+
+        it "withdraws the existing item" do
+          state = State.find_by!(content_item: existing_item)
+          expect(state.name).to eq("withdrawn")
+        end
+
+        it "doesn't withdraw any other items" do
+          expect(State.find_by!(content_item: live_item).name).not_to eq("withdrawn")
+          expect(State.find_by!(content_item: french_item).name).not_to eq("withdrawn")
+          expect(State.find_by!(content_item: item_elsewhere).name).not_to eq("withdrawn")
+        end
+      end
+
+      context "when neither item has a format that is substitutable" do
+        it "does not withdraw the existing item" do
+          state = State.find_by!(content_item: existing_item)
+          expect(state.name).not_to eq("withdrawn")
+        end
+      end
+    end
+  end
+
+  context "when base_path is nil" do
+    it "raises an exception" do
+      expect {
+        subject.clear!(
+          new_item_format: "government",
+          new_item_content_id: SecureRandom.uuid,
+          base_path: nil,
+          locale: "en",
+          state: "draft",
+        )
+      }.to raise_error(SubstitutionHelper::NilBasePathError)
     end
   end
 end


### PR DESCRIPTION
https://trello.com/c/DuueB1rh/686-prevent-substitution-of-content-for-put-content-requests-with-nil-base-path

- Raise an error when attempting to clear content without a given base path.
- Don't attempt to clear content for a PUT content request with a nil base path.

/cc @tijmenb @elliotcm @tuzz 