### PR TITLE
[DISCUSS] Present content items with nil base_path downstream

### DIFF
--- a/app/null_location.rb
+++ b/app/null_location.rb
@@ -1,0 +1,3 @@
+class NullLocation
+  attr_reader :base_path
+end

--- a/app/presenters/downstream_presenter.rb
+++ b/app/presenters/downstream_presenter.rb
@@ -59,7 +59,8 @@ module Presenters
     end
 
     def location
-      @location ||= Location.find_by!(content_item: content_item)
+      @location ||=
+        Location.find_by(content_item: content_item) || NullLocation.new
     end
 
     def translation

--- a/spec/requests/content_item_requests/downstream_requests_spec.rb
+++ b/spec/requests/content_item_requests/downstream_requests_spec.rb
@@ -111,6 +111,32 @@ RSpec.describe "Downstream requests", type: :request do
         expect(response).to be_ok, response.body
       end
     end
+
+    context "with a nil base_path" do
+      let(:content_item_payload) {
+        v2_content_item
+          .except(:format)
+          .merge(base_path: nil, schema_name: "government")
+      }
+      let(:content_item_for_draft_content_store) {
+        content_item_payload
+          .except(:update_type)
+          .merge(links: {}, format: "government")
+      }
+
+      it "sends to the draft content store" do
+        expect(PublishingAPI.service(:draft_content_store)).to receive(:put_content_item)
+          .with(
+            base_path: nil,
+            content_item: content_item_for_draft_content_store
+              .merge(payload_version: anything)
+          )
+
+        put "/v2/content/#{content_id}", content_item_payload.to_json
+
+        expect(response).to be_ok, response.body
+      end
+    end
   end
 
   context "/v2/links" do


### PR DESCRIPTION
Following on from https://trello.com/c/DuueB1rh/686-prevent-substitution-of-content-for-put-content-requests-with-nil-base-path

It should be possible to put content with a nil base_path, these requests are persisted in the publishing-api so they should also be presentable to the content-store.
This change amends the `DownstreamPresenter` to allow this.

I'm not 100% on what the functionality should be for content with no base path going into the content store, so please comment away.
This work came from attempting to put content into the publishing api with a nil base_path, this is no longer destructive as of https://github.com/alphagov/publishing-api/pull/266, but still not fully working.