### PR TITLE
Make the ContentItemPresenter much faster

### DIFF
--- a/app/controllers/v2/content_items_controller.rb
+++ b/app/controllers/v2/content_items_controller.rb
@@ -6,7 +6,7 @@ module V2
 
       results = Queries::GetContentCollection.new(
         document_type: doc_type,
-        fields: query_params.fetch(:fields),
+        fields: query_params[:fields],
         filters: filters,
         pagination: pagination
       )

--- a/app/presenters/queries/content_item_presenter.rb
+++ b/app/presenters/queries/content_item_presenter.rb
@@ -1,182 +1,149 @@
+# This presenter has been carefully written to run quickly. Please be careful
+# if editing its behaviour and make sure to compare benchmarks.
 module Presenters
   module Queries
     class ContentItemPresenter
-      attr_accessor :order, :offset, :limit
+      attr_accessor :scope, :fields, :order, :limit, :offset
+
+      DEFAULT_FIELDS = [
+        *ContentItem::TOP_LEVEL_FIELDS,
+        :publication_state,
+        :user_facing_version,
+        :base_path,
+        :locale,
+        :lock_version,
+        :internal_name,
+      ]
+
+      def self.present_many(scope, params = {})
+        new(scope, params).present_many
+      end
 
       def self.present(content_item)
         translation = Translation.find_by!(content_item: content_item)
 
-        content_items = ContentItem.where(content_id: content_item.content_id)
-        content_items = Translation.filter(content_items, locale: translation.locale)
+        scope = ContentItem.where(content_id: content_item.content_id)
+        scope = Translation.filter(scope, locale: translation.locale)
 
-        present_many(content_items).first
+        present_many(scope).first
       end
 
-      def self.present_many(content_item_scope, fields: nil, order: { public_updated_at: :desc }, offset: 0, limit: nil, locale: nil)
-        presenter = new(content_item_scope, fields: fields, order: order, limit: limit, offset: offset, locale: locale)
-        presenter.present
+      def initialize(scope, params = {})
+        self.scope = scope
+        self.fields = (params[:fields] || DEFAULT_FIELDS).map(&:to_sym)
+        self.order = params[:order]
+        self.limit = params[:limit]
+        self.offset = params[:offset]
       end
 
-      def initialize(content_item_scope, fields: nil, order: {}, limit: nil, offset: 0, locale: nil)
-        self.content_item_scope = content_item_scope
-        self.fields = fields
-        self.order = order
-        self.limit = limit
-        self.offset = offset
-        self.locale = locale
-      end
+      def present_many
+        scope = ::Queries::GetLatest.call(self.scope)
+        scope = join_supporting_objects(scope)
+        scope = order_and_paginate(scope)
 
-      def present
-        group_items(groups).compact
+        extract_fields(scope)
       end
 
       def total
-        ActiveRecord::Base.connection.execute(total_query).first["count"].to_i
+        ::Queries::GetLatest.call(self.scope).count
       end
 
     private
 
-      attr_accessor :content_item_scope, :fields, :locale
-
-      def total_query
-        sql = content_item_scope.select(:content_id)
-        sql = sql.group(:content_id) unless locale == "all"
-        "SELECT COUNT(*) FROM (#{sql.to_sql}) total"
-      end
-
-      def groups
-        ActiveRecord::Base.connection.execute(aggregated_sql(scope.to_sql))
-      end
-
-      def scope
-        scope = join_supporting_objects(content_item_scope)
-        select_fields(scope)
-      end
-
-      def aggregated_sql(sql)
-        <<-END.strip_heredoc
-          #{aggregated_query(sql)}
-          #{aggregated_order}
-          OFFSET #{offset}
-          #{aggregated_limit}
-        END
-      end
-
-      def aggregated_query(sql)
-        <<-END.strip_heredoc
-          SELECT json_agg(json_rows) FROM (
-            SELECT row_to_json(item) json_item FROM (#{sql}) item
-          ) json_rows
-          GROUP BY json_item->>'content_id', json_item->>'locale'
-        END
-      end
-
-      def aggregated_order
-        "ORDER BY MAX(json_item->>'#{order_field}') #{direction}"
-      end
-
-      def order_field
-        order.keys.first || :public_updated_at
-      end
-
-      def direction
-        order.values.first || :desc
-      end
-
-      def aggregated_limit
-        "LIMIT #{limit}" if limit
-      end
-
-      def group_items(groups)
-        groups.map do |raw_group|
-          items = JSON.parse(raw_group["json_agg"]).map { |g| g["json_item"] }
-
-          draft = detect_draft(items)
-          live = detect_live(items)
-
-          most_recent_item = draft || live
-          next unless most_recent_item
-
-          most_recent_item["description"] = most_recent_item["description"]["value"] if most_recent_item["description"]
-
-          if output_fields.include?("internal_name")
-            details = most_recent_item.fetch("details")
-            most_recent_item["internal_name"] = details["internal_name"] || most_recent_item.fetch("title")
-          end
-
-          most_recent_item["publication_state"] = publication_state(draft, live)
-          most_recent_item["lock_version"] = most_recent_item.fetch("lock_version").to_i
-
-          if live
-            most_recent_item["live_version"] = live.fetch("lock_version").to_i
-          end
-
-          most_recent_item.slice(*output_fields)
-        end
-      end
-
       def join_supporting_objects(scope)
         scope = State.join_content_items(scope)
+        scope = UserFacingVersion.join_content_items(scope)
         scope = Translation.join_content_items(scope)
         scope = Location.join_content_items(scope)
-        scope = UserFacingVersion.join_content_items(scope)
-        scope = LockVersion.join_content_items(scope)
 
+        LockVersion.join_content_items(scope)
+      end
+
+      def order_and_paginate(scope)
+        scope = scope.order(order.to_a.join(" ")) if order
+        scope = scope.limit(limit) if limit
+        scope = scope.offset(offset) if offset
         scope
       end
 
-      def select_fields(scope)
-        ordering_fields = order.keys.map(&:to_s)
-        scope.select(
-          *ContentItem::TOP_LEVEL_FIELDS,
-          "content_id",
-          "states.name as state_name",
-          "lock_versions.number as lock_version",
-          "translations.locale",
-          "locations.base_path",
-          *ordering_fields,
-        )
-      end
-
-      def output_fields
-        if fields
-          output_fields = fields
-        else
-          additional_fields = %w(
-            locale
-            base_path
-            lock_version
-            publication_state
-            live_version
-          )
-
-          output_fields = ContentItem::TOP_LEVEL_FIELDS + additional_fields
+      def extract_fields(scope)
+        fields_to_select = fields.map do |field|
+          case field
+          when :publication_state
+            "#{publication_state_sql} AS publication_state"
+          when :user_facing_version
+            "user_facing_versions.number AS user_facing_version"
+          when :lock_version
+            "lock_versions.number AS lock_version"
+          when :description
+            "description->>'value' AS description"
+          when :internal_name
+            "#{internal_name_sql} AS internal_name"
+          when :public_updated_at
+            "to_char(public_updated_at, '#{iso8601_sql}') as public_updated_at"
+          else
+            field
+          end
         end
 
-        output_fields.map(&:to_s)
+        scope = scope.select(*fields_to_select)
+        results = evaluate_query(scope)
+
+        parsing_enumerator(results)
       end
 
-      def publication_state(draft, live)
-        draft_lock_version = draft.fetch("lock_version") if draft
-        live_lock_version = live.fetch("lock_version") if live
+      def publication_state_sql
+        <<-SQL
+          CASE WHEN (user_facing_versions.number > 1 AND states.name = 'draft') THEN
+            'redrafted'
+          WHEN (states.name = 'published') THEN
+            'live'
+          ELSE
+            states.name
+          END
+        SQL
+      end
 
-        if draft_lock_version && live_lock_version && (draft_lock_version > live_lock_version)
-          "redrafted"
-        elsif live
-          "live"
-        elsif draft
-          "draft"
-        else
-          raise "Something unexpected happened"
+      def iso8601_sql
+        "YYYY-MM-DD\"T\"HH24:MI:SS\"Z\""
+      end
+
+      # This returns the internal_name from the details hash if it is present,
+      # otherwise it falls back to the content item's title.
+      def internal_name_sql
+        "COALESCE(details->>'internal_name', title) "
+      end
+
+      def parsing_enumerator(results)
+        json_columns = %w(details routes redirects need_ids)
+        int_columns = %w(user_facing_version lock_version)
+
+        Enumerator.new do |yielder|
+          results.each do |result|
+            json_columns.each { |c| parse_json_column(result, c) }
+            int_columns.each { |c| parse_int_column(result, c) }
+
+            yielder.yield result
+          end
         end
       end
 
-      def detect_draft(items)
-        items.detect { |i| i.fetch("state_name") == "draft" }
+      def parse_json_column(result, column)
+        return unless result.key?(column)
+        result[column] = JSON.parse(result[column])
       end
 
-      def detect_live(items)
-        items.detect { |i| i.fetch("state_name") == "published" }
+      def parse_int_column(result, column)
+        return unless result.key?(column)
+        result[column] = result[column].to_i
+      end
+
+      # It is substantially faster to evaluate directly against Postgres than
+      # to use: #as_json, #pluck or even ActiveRecord::Base.connection.execute
+      # The reason for this is that the results of this query don't have to go
+      # through as many abstraction layers. This is closer to the metal.
+      def evaluate_query(scope)
+        ActiveRecord::Base.connection.raw_connection.exec(scope.to_sql)
       end
     end
   end

--- a/app/queries/get_content.rb
+++ b/app/queries/get_content.rb
@@ -7,10 +7,10 @@ module Queries
       content_items = Translation.filter(content_items, locale: locale)
       content_items = State.filter(content_items, name: %w(draft published))
 
-      content_item = UserFacingVersion.latest(content_items)
+      response = Presenters::Queries::ContentItemPresenter.present_many(content_items).first
 
-      if content_item
-        Presenters::Queries::ContentItemPresenter.present(content_item)
+      if response.present?
+        response
       else
         raise_not_found(content_id)
       end

--- a/app/queries/get_latest.rb
+++ b/app/queries/get_latest.rb
@@ -1,0 +1,26 @@
+module Queries
+  module GetLatest
+    class << self
+      # Returns a new scope for the content items with the highest user-facing
+      # version number per content_id and locale of the given scope.
+      def call(content_item_scope)
+        scope = Translation.join_content_items(content_item_scope)
+        scope = UserFacingVersion.join_content_items(scope)
+        scope = scope.select(:id, :content_id, :locale, :number)
+
+        ContentItem.joins <<-SQL
+          INNER JOIN (
+            WITH scope AS (#{scope.to_sql})
+            SELECT s1.id FROM scope s1
+            LEFT OUTER JOIN scope s2 ON
+              s1.content_id = s2.content_id AND
+              s1.locale = s2.locale AND
+              s1.number < s2.number
+            WHERE s2.content_id IS NULL
+          ) AS latest_versions
+          ON latest_versions.id = content_items.id
+        SQL
+      end
+    end
+  end
+end

--- a/spec/controllers/v2/content_items_controller_spec.rb
+++ b/spec/controllers/v2/content_items_controller_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe V2::ContentItemsController do
       base_path: "/content.en",
       format: "topic",
       locale: "en",
-      lock_version: 2,
+      user_facing_version: 2,
     )
   end
 
@@ -25,7 +25,7 @@ RSpec.describe V2::ContentItemsController do
         locale: "ar",
         base_path: "/content.ar",
         format: "topic",
-        lock_version: 2,
+        user_facing_version: 2,
       )
       @en_live_content = FactoryGirl.create(
         :live_content_item,
@@ -33,7 +33,7 @@ RSpec.describe V2::ContentItemsController do
         locale: "en",
         base_path: "/content.en",
         format: "topic",
-        lock_version: 2,
+        user_facing_version: 1,
       )
       @ar_live_content = FactoryGirl.create(
         :live_content_item,
@@ -41,13 +41,13 @@ RSpec.describe V2::ContentItemsController do
         locale: "ar",
         base_path: "/content.ar",
         format: "topic",
-        lock_version: 2,
+        user_facing_version: 1,
       )
     end
 
     context "without providing a locale parameter" do
       before do
-        get :index, document_type: "topic", fields: %w(locale content_id base_path publication_state)
+        get :index, document_type: "topic", fields: %w(base_path)
       end
 
       it "is successful" do
@@ -56,19 +56,16 @@ RSpec.describe V2::ContentItemsController do
 
       it "responds with the english content item as json" do
         parsed_response_body = JSON.parse(response.body)["results"]
-        expect(parsed_response_body.length == 2)
+        expect(parsed_response_body.length).to eq(1)
 
         base_paths = parsed_response_body.map { |item| item.fetch("base_path") }
-        expect(base_paths). to eq ["/content.en"]
-
-        publication_states = parsed_response_body.map { |item| item.fetch("publication_state") }
-        expect(publication_states). to eq ["live"]
+        expect(base_paths).to eq ["/content.en"]
       end
     end
 
     context "providing a specific locale parameter" do
       before do
-        get :index, document_type: "topic", fields: %w(locale content_id base_path publication_state), locale: "ar"
+        get :index, document_type: "topic", fields: %w(base_path), locale: "ar"
       end
 
       it "is successful" do
@@ -77,19 +74,16 @@ RSpec.describe V2::ContentItemsController do
 
       it "responds with the specific locale content item as json" do
         parsed_response_body = JSON.parse(response.body)["results"]
-        expect(parsed_response_body.length == 2)
+        expect(parsed_response_body.length).to eq(1)
 
         base_paths = parsed_response_body.map { |item| item.fetch("base_path") }
         expect(base_paths). to eq ["/content.ar"]
-
-        base_paths = parsed_response_body.map { |item| item.fetch("publication_state") }
-        expect(base_paths). to eq ["live"]
       end
     end
 
     context "providing a locale parameter set to 'all'" do
       before do
-        get :index, document_type: "topic", fields: %w(locale content_id base_path publication_state), locale: "all"
+        get :index, document_type: "topic", fields: %w(base_path), locale: "all"
       end
 
       let(:parsed_response_body) { JSON.parse(response.body)["results"] }
@@ -99,17 +93,12 @@ RSpec.describe V2::ContentItemsController do
       end
 
       it "has the corrent number of items" do
-        expect(parsed_response_body.length == 4)
+        expect(parsed_response_body.length).to eq(2)
       end
 
       it "responds with all the localised content items as json" do
         base_paths = parsed_response_body.map { |item| item.fetch("base_path") }
         expect(base_paths.sort). to eq ["/content.en", "/content.ar"].sort
-      end
-
-      it "has the correct publication states" do
-        publication_states = parsed_response_body.map { |item| item.fetch("publication_state") }
-        expect(publication_states). to eq %w(live live)
       end
     end
 

--- a/spec/queries/get_content_spec.rb
+++ b/spec/queries/get_content_spec.rb
@@ -42,12 +42,14 @@ RSpec.describe Queries::GetContent do
         :draft_content_item,
         content_id: content_id,
         title: "Draft Title",
+        user_facing_version: 2,
       )
 
       FactoryGirl.create(
         :live_content_item,
         content_id: content_id,
         title: "Live Title",
+        user_facing_version: 1,
       )
     end
 
@@ -62,17 +64,17 @@ RSpec.describe Queries::GetContent do
       FactoryGirl.create(
         :content_item,
         content_id: content_id,
-        user_facing_version: 2,
-        title: "Superseded Title",
-        state: "superseded",
+        user_facing_version: 1,
+        title: "Published Title",
+        state: "published",
       )
 
       FactoryGirl.create(
         :content_item,
         content_id: content_id,
-        user_facing_version: 1,
-        title: "Published Title",
-        state: "published",
+        user_facing_version: 2,
+        title: "Submitted Title",
+        state: "submitted",
       )
     end
 

--- a/spec/queries/get_latest_spec.rb
+++ b/spec/queries/get_latest_spec.rb
@@ -1,0 +1,37 @@
+require "rails_helper"
+
+RSpec.describe Queries::GetLatest do
+  let(:a) { SecureRandom.uuid }
+  let(:b) { SecureRandom.uuid }
+  let(:c) { SecureRandom.uuid }
+
+  before do
+    FactoryGirl.create(:content_item, content_id: a, user_facing_version: 2, base_path: "/a2")
+    FactoryGirl.create(:content_item, content_id: a, user_facing_version: 1, base_path: "/a1")
+    FactoryGirl.create(:content_item, content_id: a, user_facing_version: 3, base_path: "/a3")
+
+    FactoryGirl.create(:content_item, content_id: b, user_facing_version: 1, base_path: "/b1")
+    FactoryGirl.create(:content_item, content_id: b, user_facing_version: 2, locale: "fr", base_path: "/b2")
+
+    FactoryGirl.create(:content_item, content_id: c, user_facing_version: 1, base_path: "/c1")
+    FactoryGirl.create(:content_item, content_id: c, user_facing_version: 2, base_path: "/c2")
+  end
+
+  def base_paths(result)
+    result.map { |i| Location.find_by!(content_item: i).base_path }
+  end
+
+  it "returns a scope of the latest content_items for the given scope" do
+    scope = ContentItem.all
+    result = subject.call(scope)
+    expect(base_paths(result)).to match_array(["/a3", "/b1", "/b2", "/c2"])
+
+    scope = scope.where(content_id: [a, b])
+    result = subject.call(scope)
+    expect(base_paths(result)).to match_array(["/a3", "/b1", "/b2"])
+
+    scope = Translation.filter(scope, locale: "fr")
+    result = subject.call(scope)
+    expect(base_paths(result)).to match_array(["/b2"])
+  end
+end

--- a/spec/service_consumers/pact_helper.rb
+++ b/spec/service_consumers/pact_helper.rb
@@ -112,12 +112,10 @@ Pact.provider_states_for "GDS API Adapters" do
     set_up do
       live = FactoryGirl.create(
         :live_content_item,
-        #:with_draft, # TODO is this needed?
         content_id: "bed722e6-db68-43e5-9079-063f623335a7"
       )
 
       FactoryGirl.create(:lock_version, target: live, number: 1)
-      #FactoryGirl.create(:lock_version, target: live.draft_content_item, number: 1)
     end
   end
 
@@ -159,31 +157,30 @@ Pact.provider_states_for "GDS API Adapters" do
 
   provider_state "a content item exists in multiple locales with content_id: bed722e6-db68-43e5-9079-063f623335a7" do
     set_up do
-      english_draft = FactoryGirl.create(
+      FactoryGirl.create(
         :draft_content_item,
         content_id: "bed722e6-db68-43e5-9079-063f623335a7",
         locale: "en",
         format: "topic",
         public_updated_at: '2015-01-03',
+        user_facing_version: 1,
       )
-      french_draft = FactoryGirl.create(
+      FactoryGirl.create(
         :draft_content_item,
         content_id: "bed722e6-db68-43e5-9079-063f623335a7",
         locale: "fr",
         format: "topic",
         public_updated_at: '2015-01-02',
+        user_facing_version: 1,
       )
-      arabic_draft = FactoryGirl.create(
+      FactoryGirl.create(
         :draft_content_item,
         content_id: "bed722e6-db68-43e5-9079-063f623335a7",
         locale: "ar",
         format: "topic",
         public_updated_at: '2015-01-01',
+        user_facing_version: 1,
       )
-
-      FactoryGirl.create(:lock_version, target: english_draft, number: 1)
-      FactoryGirl.create(:lock_version, target: french_draft, number: 1)
-      FactoryGirl.create(:lock_version, target: arabic_draft, number: 1)
     end
   end
 
@@ -277,28 +274,32 @@ Pact.provider_states_for "GDS API Adapters" do
       content_id2 = "08dfd5c3-d935-4e81-88fd-cfe65b78893d"
       content_id3 = "e2961462-bc37-48e9-bb98-c981ef1a2d59"
 
-      content_item = FactoryGirl.create(
+      FactoryGirl.create(
         :live_content_item,
-        :with_draft,
         content_id: content_id1,
+        user_facing_version: 1,
       )
-      FactoryGirl.create(:lock_version, target: content_item, number: 1)
+      FactoryGirl.create(
+        :draft_content_item,
+        content_id: content_id1,
+        user_facing_version: 2
+      )
 
-      content_item = FactoryGirl.create(
+      FactoryGirl.create(
         :live_content_item,
         content_id: content_id3,
         base_path: '/item-b',
         public_updated_at: '2015-01-02',
+        user_facing_version: 1,
       )
-      FactoryGirl.create(:lock_version, target: content_item, number: 1)
 
-      content_item = FactoryGirl.create(
+      FactoryGirl.create(
         :live_content_item,
         content_id: content_id2,
         base_path: '/item-a',
         public_updated_at: '2015-01-01',
+        user_facing_version: 1,
       )
-      FactoryGirl.create(:lock_version, target: content_item, number: 1)
 
       link_set1 = FactoryGirl.create(:link_set, content_id: content_id2)
       link_set2 = FactoryGirl.create(:link_set, content_id: content_id3)


### PR DESCRIPTION
https://trello.com/c/1wLclYR2/668-improve-efficiency-of-content-item-presenter

**Note:** Tests won't pass until this is merged: https://github.com/alphagov/gds-api-adapters/pull/488

Previously, the ContentItemPresenter could take a long time,
even with pagination and this was causing timeouts across a
number of projects and general instability. It was also
slowing down put content requests because the response goes
through the presenter.

This work effectively rewrites this presenter to work much
more quickly. It relies on `Queries::GetLatest` which is an
example of a "get rows with max value per group" query.
There are further improvements that could be made, perhaps
with how the count is computed, but these changes are
probably good enough for now.

The old presenter made it so that public_updated_at was
always output, regardless of whether this field was
requested or not. I have fixed this. It should now be
explicitly requested, just like any other field. In
addition to this, I made it so that the presenter defaults
to return all fields. The presenter is now quick enough to
do this and I think it serves as good documentation as to
which fields are available.

Finally, here are the results of some quick benchmarking
in development. Times are in milliseconds:

```
/v2/linkables?document_type=organisation
new: 95, 100, 96, 97, 95 (avg 97)
old: 553, 302, 535, 519, 563 (avg 494)
average: 509% as fast

/v2/linkables?document_type=policy
new: 39, 44, 37, 44, 38 (avg 40)
old: 109, 91, 92, 197, 210 (avg 140)
average: 350% as fast

/v2/content?document_type=organisation&fields[]=title&fields[]=base_path
new: 84, 87, 83, 90, 87 (avg 86)
old: 320, 361, 374, 351, 368 (avg 355)
average: 416% as fast

/v2/content?document_type=cma_case&fields[]=description&per_page=1000
new: 116, 111, 109, 114, 117 (avg 113)
old: 985, 678, 964, 953, 730 (avg 862)
average: 763% as fast

/v2/content?document_type=travel_advice&fields[]=details&per_page=3
new: 98, 99, 98, 105, 107 (avg 101)
old: 1363, 1048, 1020, 1025, 1030 (avg 1097)
average: 1086% as fast

PUT /v2/content/08d48cdd-6b50-43ff-a53b-beab47f4aab0 (travel advice index)
new: 904, 780, 804, 660, 883 (avg 806)
old: 3601, 2483, 2683, 2542, 2592 (avg 2780)
average: 345% as fast
```

Note: This last case was particularly problematic because the default
gds-api-adapters timeout is 4 seconds, which the old implementation
was close to hitting.

## Benchmarks graph

![benchmark](https://cloud.githubusercontent.com/assets/892251/14531374/fc9ee7c0-0254-11e6-817f-aec7c95c7f86.png)
