### PR TITLE
Add request id to Event...

### DIFF
--- a/app/event_logger.rb
+++ b/app/event_logger.rb
@@ -8,7 +8,8 @@ module EventLogger
         event = Event.create!(
           action: action(command_class),
           payload: payload,
-          user_uid: GdsApi::GovukHeaders.headers[:x_govuk_authenticated_user]
+          user_uid: GdsApi::GovukHeaders.headers[:x_govuk_authenticated_user],
+          request_id: GdsApi::GovukHeaders.headers[:govuk_request_id]
         )
 
         response = yield(event) if block_given?

--- a/db/migrate/20160418144039_add_request_id_to_events.rb
+++ b/db/migrate/20160418144039_add_request_id_to_events.rb
@@ -1,0 +1,5 @@
+class AddRequestIdToEvents < ActiveRecord::Migration
+  def change
+    add_column :events, :request_id, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160407121458) do
+ActiveRecord::Schema.define(version: 20160418144039) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -57,6 +57,7 @@ ActiveRecord::Schema.define(version: 20160407121458) do
     t.string   "user_uid"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.string   "request_id"
   end
 
   create_table "link_sets", force: :cascade do |t|

--- a/spec/event_logger_spec.rb
+++ b/spec/event_logger_spec.rb
@@ -4,11 +4,17 @@ RSpec.describe EventLogger do
   let(:command_class) { Commands::PutPublishIntent }
   let(:payload) { { stuff: "1234" } }
 
+  before do
+    allow(GdsApi::GovukHeaders).to receive(:headers)
+      .and_return(govuk_request_id: "09876-54321")
+  end
+
   it "records an event, given the name and payload" do
     EventLogger.log_command(command_class, payload)
     expect(Event.count).to eq(1)
     expect(Event.first.action).to eq("PutPublishIntent")
     expect(Event.first.payload).to eq(payload)
+    expect(Event.first.request_id).to eq("09876-54321")
   end
 
   it "returns the return value of the block" do


### PR DESCRIPTION
Part of this https://trello.com/c/Io2JYTFv/27-ensure-request-id-is-available-to-multipage-frontend-and-frontend-apps and this https://trello.com/c/mfOWQkE0/350-instrumenting-admin-apps

In order to trace publishing flow from the publishing application,
through the publishing-api and into the content store we should
also add the request id to the Event records for consistency and
completeness.