### PR TITLE
Handle race condition in path_reservations

### DIFF
--- a/app/models/path_reservation.rb
+++ b/app/models/path_reservation.rb
@@ -7,5 +7,11 @@ class PathReservation < ActiveRecord::Base
     record = find_or_initialize_by(base_path: base_path)
     record.publishing_app = publishing_app
     record.save!
+  rescue ActiveRecord::RecordNotUnique, PG::UniqueViolation
+    # If a path is already reserved by the same publishing app, ignore the error
+    record = find_by(base_path: base_path)
+    raise unless record.publishing_app == publishing_app
+
+    record
   end
 end


### PR DESCRIPTION
Path reservations might be attempted to be created concurrently due to
publish intents being added for Stats Announcements. Postgres raises an
error for this, we should swallow the error if the other reservation is
the same as the one this request is trying to create.

/cc @gpeng @tuzz @steventux 