### PR TITLE
Restore links that were accidently erased

### DIFF
--- a/lib/tasks/sanitize_data.rake
+++ b/lib/tasks/sanitize_data.rake
@@ -2,3 +2,66 @@ desc "Sanitize access limited data"
 task sanitize_data: :environment do
   Tasks::DataSanitizer.delete_access_limited(STDOUT)
 end
+
+task :restore_policy_links, [:action] => [:environment] do |_, args|
+  dry_run = args["action"] != 'apply'
+  puts "Dry run" if dry_run
+
+  policy_query = Queries::GetContentCollection.new(
+    document_type: 'policy',
+    fields: %w(content_id),
+    pagination: NullPagination.new
+  )
+  policy_content_ids = policy_query.call.map { |item| item["content_id"] }
+
+  # Identify the destructive events
+  policy_wipe_events = Event
+    .where("created_at::date = '2016-03-14' and action = 'PatchLinkSet'")
+    .where(content_id: policy_content_ids)
+    .order("content_id, created_at asc")
+
+  wipe_events_by_content_id = Hash.new { |h, k| h[k] = [] }
+
+  puts "Found #{policy_wipe_events.size} destructive events"
+
+  policy_wipe_events.each do |event|
+    puts "#{event.content_id} #{event.action} #{event.created_at} #{event.payload[:links]}"
+
+    wipe_events_by_content_id[event.content_id] << event.id
+  end
+
+  puts
+
+  # Restore the links
+  policy_wipe_events.each do |wipe_event|
+    puts "Restoring #{wipe_event.content_id}..."
+
+    policy_events = Event.where(
+      content_id: wipe_event.content_id,
+      action: %w(PutContentWithLinks PatchLinkSet)
+    ).order("created_at desc")
+
+    policy_log = []
+
+    policy_events.each do |event|
+      policy_log << event
+      break if event.action == 'PutContentWithLinks'
+    end
+
+    raise "Event log error: no events found for #{wipe_event.content_id}" if policy_log.empty?
+
+    if policy_log.last.action != 'PutContentWithLinks'
+      # Policy created since Publishing API V2
+      puts "New policy #{wipe_event.content_id}"
+    end
+
+    policy_log.reverse_each do |event|
+      unless wipe_events_by_content_id[event.content_id].include?(event.id)
+        puts "Reapplying #{event.created_at} #{event.action}: #{event.payload[:links]}"
+        Commands::V2::PatchLinkSet.call(event.payload) unless dry_run
+      end
+    end
+
+    puts
+  end
+end


### PR DESCRIPTION
## The problem
On March 14th a task was run from policy publisher that unintentionally cleared all organisations, lead_organisations, people and working groups from policies.

We don't see any updates since the event that cleared the links, and the event log seems to be mostly automated tasks, for example:

```
2015-12-02 10:42:58 UTC PutContentWithLinks

# Policy publish lead organisation/supporting organisation split
2016-01-29 14:10:29 UTC PatchLinkSet

# Policy publish lead organisation/supporting organisation split
2016-02-08 15:13:04 UTC PatchLinkSet

# Policy publisher republish rake task
2016-03-14 12:04:20 UTC PutContent
2016-03-14 12:04:20 UTC Publish
2016-03-14 12:04:20 UTC PatchLinkSet
```

## How we are correcting it
To correct this, we are going to replay the event log, ignoring the commands that caused the problem.

We need to replay more than one event because we now have PatchLinks, which doesn't require the whole entity.

All except one policy had links populated by a PutContentWithLinks command
in december 2015. We can ignore anything earlier than that, since this action replaces the entire links hash.

## Policy Links after running

219 policies:

```
     link_type      | count
--------------------+-------
 alpha_taxons       |     1
 policy_areas       |     6
 organisations      |   400
 lead_organisations |   219
 working_groups     |    90
 email_alert_signup |   219
 related            |     6
 people             |   340
```

## Review

The PR is currently a long rake task specifically for this fix. I'm not sure if it would be worth factoring out some of the functionality into something more reusable, and whether there is anything else we can do test this better, or any other constraints we should enforce when we run it.

Having general purpose functionality for replaying events does seem like something that will be useful in the future.

At a first glance the data looks correct on dev, but I want to check this more thoroughly before merging.

Part of https://trello.com/c/rQL3rtOD/599-fix-taggings-of-policies