### PR TITLE
Search content items by title and base_path

### DIFF
--- a/app/controllers/v2/content_items_controller.rb
+++ b/app/controllers/v2/content_items_controller.rb
@@ -8,7 +8,8 @@ module V2
         document_type: doc_type,
         fields: query_params[:fields],
         filters: filters,
-        pagination: pagination
+        pagination: pagination,
+        search_query: query_params.fetch("q", "")
       )
 
       render json: Presenters::ResultsPresenter.new(results, pagination, request.original_url).present

--- a/doc/publishing-api-syntactic-usage.md
+++ b/doc/publishing-api-syntactic-usage.md
@@ -150,11 +150,13 @@ No downstream requests will be sent if the content item doesn't exist yet.
   - Restricts the content items returned by the `publishing_app` of the current user.
   - Can optionally return content items in all locales by specifying a `locale` of 'all'
   - Can return the `publication_state` of the content item by including it in the `fields[]`
+  - Can search for queries against `base_path` or `title`
 
 ### Required request params:
   - `document_type` the type of content item to return
   - `locale` (optional) is used to restrict returned content items to a given locale (defaults to 'en')
   - `fields[]` an array of fields that are validated against `ContentItem` column fields. Any invalid requested field will raise a `400`.
+  - `q` (optional) the search term to match against `base_path` or `title`
 
 ## `GET /v2/linkables`
 

--- a/spec/queries/get_content_collection_spec.rb
+++ b/spec/queries/get_content_collection_spec.rb
@@ -256,6 +256,32 @@ RSpec.describe Queries::GetContentCollection do
     end
   end
 
+  describe "search_fields" do
+    let!(:content_item_foo) { create(:live_content_item, base_path: '/bar/foo', format: 'topic', title: "Baz") }
+    let!(:content_item_zip) { create(:live_content_item, base_path: '/baz', format: 'topic', title: 'zip') }
+    subject do
+      Queries::GetContentCollection.new(
+        document_type: 'topic',
+        fields: ['base_path'],
+        search_query: search_query
+      )
+    end
+
+    context "base_path and title" do
+      let(:search_query) { "baz" }
+      it "finds the content item" do
+        expect(subject.call.map(&:to_hash)).to eq([{ "base_path" => "/bar/foo" }, { "base_path" => "/baz" }])
+      end
+    end
+
+    context "title" do
+      let(:search_query) { "zip" }
+      it "finds the content item" do
+        expect(subject.call.map(&:to_hash)).to eq([{ "base_path" => "/baz" }])
+      end
+    end
+  end
+
   describe "pagination" do
     context "with multiple content items" do
       before do


### PR DESCRIPTION
If searching for a field that is not supported, that field is ignored
and it doesn't change the behaviour of the rest of the query

https://trello.com/c/9rpo1V2u/683-search-functionality-on-get-content-collection-endpoint-searching-documents-by-slug-and-title-in-sp