### PR TITLE
Get content-store to know all the links of specialist-publisher owned documents

### DIFF
--- a/app/commands/put_content_with_links.rb
+++ b/app/commands/put_content_with_links.rb
@@ -51,6 +51,8 @@ module Commands
     end
 
     def delete_existing_links
+      return if protected_apps.include?(payload[:publishing_app])
+
       link_set = LinkSet.find_by(content_id: payload[:content_id])
       return unless link_set
 
@@ -60,6 +62,17 @@ module Commands
 
     def protected_link_types
       ["alpha_taxons"]
+    end
+
+    def protected_apps
+      # specialist-publisher is being converted to a "standard" Rails app
+      # that will use the publishing-api V2 endpoints.
+      # We don't know when conversion will be completed and we need
+      # specialist-publisher documents link data in content-store ASAP, hence
+      # this quick hack.
+      # Remove this exception once specialist-publisher is fully migrated to use
+      # the publishing-api V2 endpoints.
+      ["specialist-publisher"]
     end
   end
 end

--- a/app/commands/put_draft_content_with_links.rb
+++ b/app/commands/put_draft_content_with_links.rb
@@ -57,6 +57,8 @@ module Commands
     end
 
     def delete_existing_links
+      return if protected_apps.include?(payload[:publishing_app])
+
       link_set = LinkSet.find_by(content_id: payload[:content_id])
       return unless link_set
 
@@ -66,6 +68,17 @@ module Commands
 
     def protected_link_types
       ["alpha_taxons"]
+    end
+
+    def protected_apps
+      # specialist-publisher is being converted to a "standard" Rails app
+      # that will use the publishing-api V2 endpoints.
+      # We don't know when conversion will be completed and we need
+      # specialist-publisher documents link data in content-store ASAP, hence
+      # this quick hack.
+      # Remove this exception once specialist-publisher is fully migrated to use
+      # the publishing-api V2 endpoints.
+      ["specialist-publisher"]
     end
   end
 end

--- a/spec/commands/put_content_with_links_spec.rb
+++ b/spec/commands/put_content_with_links_spec.rb
@@ -83,6 +83,33 @@ RSpec.describe Commands::PutContentWithLinks do
     expect { protected_link.reload }.not_to raise_error
   end
 
+  it "protects links of certains apps from being overwritten" do
+    stub_request(:put, "http://draft-content-store.dev.gov.uk/content/foo")
+    stub_request(:put, "http://content-store.dev.gov.uk/content/foo")
+
+    link_set = create(:link_set, content_id: 'dc3643c0-ac02-43b8-a1c2-b93513878685')
+    link_1 = create(:link, link_set: link_set, link_type: 'organisations')
+    link_2 = create(:link, link_set: link_set, link_type: 'topics')
+
+    create(:lock_version, target: link_set)
+
+    described_class.call(
+      title: 'Test Title',
+      format: 'placeholder',
+      content_id: 'dc3643c0-ac02-43b8-a1c2-b93513878685',
+      base_path: '/foo',
+      publishing_app: 'specialist-publisher',
+      rendering_app: 'finder-frontend',
+      public_updated_at: Time.now,
+      routes: [{ path: '/foo', type: "exact" }],
+      update_type: "minor",
+      links: {},
+    )
+
+    expect { link_1.reload }.not_to raise_error
+    expect { link_2.reload }.not_to raise_error
+  end
+
   context "when the downstream flag is set to false" do
     it "does not send any downstream requests" do
       expect(Adapters::DraftContentStore).not_to receive(:put_content_item)

--- a/spec/commands/put_content_with_links_spec.rb
+++ b/spec/commands/put_content_with_links_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe Commands::PutContentWithLinks do
       public_updated_at: Time.now,
       routes: [{ path: '/foo', type: "exact" }],
       update_type: "minor",
-      links: { topics: [] },
+      links: {},
     )
 
     expect { normal_link.reload }.to raise_error(ActiveRecord::RecordNotFound)

--- a/spec/commands/put_draft_content_with_links_spec.rb
+++ b/spec/commands/put_draft_content_with_links_spec.rb
@@ -83,6 +83,33 @@ RSpec.describe Commands::PutDraftContentWithLinks do
     expect { protected_link.reload }.not_to raise_error
   end
 
+  it "protects links of certains apps from being overwritten" do
+    stub_request(:put, "http://draft-content-store.dev.gov.uk/content/foo")
+    stub_request(:put, "http://content-store.dev.gov.uk/content/foo")
+
+    link_set = create(:link_set, content_id: 'dc3643c0-ac02-43b8-a1c2-b93513878685')
+    link_1 = create(:link, link_set: link_set, link_type: 'organisations')
+    link_2 = create(:link, link_set: link_set, link_type: 'topics')
+
+    create(:lock_version, target: link_set)
+
+    described_class.call(
+      title: 'Test Title',
+      format: 'placeholder',
+      content_id: 'dc3643c0-ac02-43b8-a1c2-b93513878685',
+      base_path: '/foo',
+      publishing_app: 'specialist-publisher',
+      rendering_app: 'finder-frontend',
+      public_updated_at: Time.now,
+      routes: [{ path: '/foo', type: "exact" }],
+      update_type: "minor",
+      links: {},
+    )
+
+    expect { link_1.reload }.not_to raise_error
+    expect { link_2.reload }.not_to raise_error
+  end
+
   context "when the downstream flag is set to false" do
     it "does not send any downstream requests" do
       expect(Adapters::DraftContentStore).not_to receive(:put_content_item)

--- a/spec/commands/put_draft_content_with_links_spec.rb
+++ b/spec/commands/put_draft_content_with_links_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe Commands::PutDraftContentWithLinks do
       public_updated_at: Time.now,
       routes: [{ path: '/foo', type: "exact" }],
       update_type: "minor",
-      links: { topics: [] },
+      links: {},
     )
 
     expect { normal_link.reload }.to raise_error(ActiveRecord::RecordNotFound)

--- a/spec/queries/get_content_collection_spec.rb
+++ b/spec/queries/get_content_collection_spec.rb
@@ -270,7 +270,7 @@ RSpec.describe Queries::GetContentCollection do
     context "base_path and title" do
       let(:search_query) { "baz" }
       it "finds the content item" do
-        expect(subject.call.map(&:to_hash)).to eq([{ "base_path" => "/bar/foo" }, { "base_path" => "/baz" }])
+        expect(subject.call.map(&:to_hash)).to match_array([{ "base_path" => "/bar/foo" }, { "base_path" => "/baz" }])
       end
     end
 


### PR DESCRIPTION
specialist-publisher is being converted to a "standard" Rails app that uses the publishing-api V2 endpoints. We don't know when the conversion completed and we want all the links of specialist-publisher owned documents to be in the Content Store ASAP. We decided to introduce this quick-hack over having to migrate the "non-standard" Rails version of specialist-publisher.