### PR TITLE
Change withdrawn to unpublished

### DIFF
--- a/app/commands/v2/put_content.rb
+++ b/app/commands/v2/put_content.rb
@@ -147,7 +147,7 @@ module Commands
       def previously_published_item
         @previously_published_item ||= (
           filter = ContentItemFilter.new(scope: pessimistic_content_item_scope)
-          content_items = filter.filter(state: %w(published withdrawn), locale: locale)
+          content_items = filter.filter(state: %w(published unpublished), locale: locale)
           UserFacingVersion.latest(content_items)
         )
       end

--- a/app/models/state.rb
+++ b/app/models/state.rb
@@ -22,8 +22,8 @@ class State < ActiveRecord::Base
     change_state(content_item, name: "published")
   end
 
-  def self.withdraw(content_item)
-    change_state(content_item, name: "withdrawn")
+  def self.unpublish(content_item)
+    change_state(content_item, name: "unpublished")
   end
 
   def self.change_state(content_item, name:)

--- a/app/models/state.rb
+++ b/app/models/state.rb
@@ -24,6 +24,12 @@ class State < ActiveRecord::Base
 
   def self.unpublish(content_item)
     change_state(content_item, name: "unpublished")
+
+    Unpublishing.create!(
+      content_item: content_item,
+      type: "substitute",
+      explanation: "Automatically unpublished to make way for another content item",
+    )
   end
 
   def self.change_state(content_item, name:)

--- a/app/models/unpublishing.rb
+++ b/app/models/unpublishing.rb
@@ -1,0 +1,18 @@
+class Unpublishing < ActiveRecord::Base
+  self.inheritance_column = nil
+
+  belongs_to :content_item
+
+  validates :content_item, presence: true, uniqueness: true
+  validates :type, presence: true
+  validates :explanation, presence: true, if: :withdrawal?
+  validates :alternative_url, presence: true, if: :redirect?
+
+  def withdrawal?
+    type == "withdrawal"
+  end
+
+  def redirect?
+    type == "redirect"
+  end
+end

--- a/app/substitution_helper.rb
+++ b/app/substitution_helper.rb
@@ -10,7 +10,7 @@ module SubstitutionHelper
         allowed_to_substitute = (substitute?(new_item_format) || substitute?(blocking_item.format))
 
         if mismatch && allowed_to_substitute
-          State.withdraw(blocking_item)
+          State.unpublish(blocking_item)
         end
       end
     end

--- a/app/validators/content_item_uniqueness_validator.rb
+++ b/app/validators/content_item_uniqueness_validator.rb
@@ -15,14 +15,14 @@ class ContentItemUniquenessValidator < ActiveModel::Validator
     return unless state && translation && location && user_facing_version
 
     # For now, we have agreed to relax the validator so that you can have
-    # duplicates with a state of withdrawn. The reason for doing this is because
+    # duplicates with a state of unpublished. The reason for doing this is because
     # we think that the 'gone' and 'redirect' mechanisms are modelled incorrect
     # and need to be revisited.
     #
     # As it stands right now, when these content items are sent to the
-    # Publishing API, they have the side-effect of withdrawing other content
+    # Publishing API, they have the side-effect of unpublishing other content
     # items. We think think that this should change in the future.
-    return if state.name == "withdrawn"
+    return if state.name == "unpublished"
 
     state_name = state.name
     locale = translation.locale

--- a/db/migrate/20160429095656_change_withdrawn_to_unpublished.rb
+++ b/db/migrate/20160429095656_change_withdrawn_to_unpublished.rb
@@ -1,0 +1,40 @@
+class ChangeWithdrawnToUnpublished < ActiveRecord::Migration
+  def up
+    create_table :unpublishings do |t|
+      t.references :content_item, null: false
+      t.string :type, null: false
+      t.string :explanation
+      t.string :alternative_url
+      t.timestamps
+    end
+
+    add_index :unpublishings, :content_item_id
+    add_index :unpublishings, [:content_item_id, :type]
+
+    withdrawn_content_items = ContentItemFilter.filter(state: "withdrawn")
+
+    puts "Updating #{withdrawn_content_items.count} withdrawn content items"
+
+    withdrawn_content_items.find_each do |withdrawn_ci|
+      user_facing_version = UserFacingVersion.find_by(content_item: withdrawn_ci)
+      location = Location.find_by(content_item: withdrawn_ci)
+      translation = Translation.find_by(content_item: withdrawn_ci)
+
+      puts "Creating unpublishing for [ #{user_facing_version.number} | withdrawn | #{location.base_path} | #{translation.locale} ]"
+
+      Unpublishing.create!(
+        content_item: withdrawn_ci,
+        type: "substitute",
+        explanation: "Automatically unpublished to make way for another content item",
+      )
+    end
+
+    puts "Renaming 'withdrawn' to 'unpublished'"
+    State.where(name: "withdrawn").update_all(name: "unpublished")
+  end
+
+  def down
+    drop_table :unpublishings
+    State.where(name: "unpublished").update_all(name: "withdrawn")
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160429092127) do
+ActiveRecord::Schema.define(version: 20160429095656) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -133,6 +133,18 @@ ActiveRecord::Schema.define(version: 20160429092127) do
   end
 
   add_index "translations", ["content_item_id", "locale"], name: "index_translations_on_content_item_id_and_locale", using: :btree
+
+  create_table "unpublishings", force: :cascade do |t|
+    t.integer  "content_item_id", null: false
+    t.string   "type",            null: false
+    t.string   "explanation"
+    t.string   "alternative_url"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  add_index "unpublishings", ["content_item_id", "type"], name: "index_unpublishings_on_content_item_id_and_type", using: :btree
+  add_index "unpublishings", ["content_item_id"], name: "index_unpublishings_on_content_item_id", using: :btree
 
   create_table "user_facing_versions", force: :cascade do |t|
     t.integer  "content_item_id",             null: false

--- a/doc/object-model-explanation/workflow.dot
+++ b/doc/object-model-explanation/workflow.dot
@@ -12,7 +12,7 @@ digraph G {
   discarded_3[label="(deleted)", group="3", fontcolor="red"]
   draft_4[label="3 | draft", group="4"]
   published_4[label="3 | published", group="4"]
-  withdrawn_4[label="3 | withdrawn", group="4"]
+  unpublished_4[label="3 | unpublished", group="4"]
 
   draft_1 -> published_1[label="  publish"]
   published_1 -> superseded_1
@@ -24,7 +24,7 @@ digraph G {
   draft_3b -> discarded_3[label="  discard"]
   published_2:e -> draft_4[label="  redraft (again)"]
   draft_4 -> published_4[label="  publish"]
-  published_4 -> withdrawn_4[label="  withdraw"]
+  published_4 -> unpublished_4[label="  unpublish"]
 
 
   { rank=same; superseded_1; published_2 }

--- a/doc/publishing-application-examples.md
+++ b/doc/publishing-application-examples.md
@@ -196,7 +196,7 @@ Publishing API automatically creates redirects on behalf of content items when t
 It looks for previous content that matches the content_id of the incoming content and checks whether their base paths differ.
 If there is a difference, a redirect content item is created in draft. When the content with the updated base path is published, so is the redirect.
 
-If there was a previously published content item at the base path, its state will be changed to 'withdrawn', rather than 'superseded'.
+If there was a previously published content item at the base path, its state will be changed to 'unpublished', rather than 'superseded'.
 this is in order to prevent potential conflicts of state/version if that content is subsequently reinstated.
 The diagram below shows this workflow:
 
@@ -221,7 +221,7 @@ The diagram below shows this workflow:
                                      |
                                       -----------------> [ Redirect published ]
                                      |
-                                      -----------------> [ Previously published item withdrawn ]
+                                      -----------------> [ Previously published item unpublished ]
 ```
 
 ---

--- a/spec/commands/v2/publish_spec.rb
+++ b/spec/commands/v2/publish_spec.rb
@@ -92,11 +92,11 @@ RSpec.describe Commands::V2::Publish do
         )
       }
 
-      it "withdraws the content item which is in the way" do
+      it "unpublishes the content item which is in the way" do
         described_class.call(payload)
 
         state = State.find_by!(content_item: other_content_item)
-        expect(state.name).to eq("withdrawn")
+        expect(state.name).to eq("unpublished")
 
         translation = Translation.find_by!(content_item: other_content_item)
         expect(translation.locale).to eq(draft_locale)
@@ -118,7 +118,7 @@ RSpec.describe Commands::V2::Publish do
         )
       }
 
-      it "does not withdraw the content item" do
+      it "does not unpublish the content item" do
         described_class.call(payload)
 
         state = State.find_by!(content_item: other_content_item)
@@ -292,13 +292,13 @@ RSpec.describe Commands::V2::Publish do
         expect(redirect.format).to eq("redirect")
       end
 
-      it "withdraws the previously published item" do
+      it "unpublishes the previously published item" do
         described_class.call(payload)
 
         state = State.find_by!(content_item: live_item)
-        expect(state.name).to eq("withdrawn"),
+        expect(state.name).to eq("unpublished"),
           "If this is failing because the content item has been superseded,
-          check that withdrawl is happening before superseding."
+          check that unpublishing is happening before superseding."
       end
     end
 

--- a/spec/commands/v2/put_content_spec.rb
+++ b/spec/commands/v2/put_content_spec.rb
@@ -210,18 +210,18 @@ RSpec.describe Commands::V2::PutContent do
       end
     end
 
-    context "when creating a draft for a previously withdrawn content item" do
+    context "when creating a draft for a previously unpublished content item" do
       before do
         FactoryGirl.create(
           :content_item,
           content_id: content_id,
-          state: "withdrawn",
+          state: "unpublished",
           lock_version: 2,
           user_facing_version: 5,
         )
       end
 
-      it "creates the draft's lock version using the withdrawn lock version as a starting point" do
+      it "creates the draft's lock version using the unpublished lock version as a starting point" do
         described_class.call(payload)
 
         content_item = ContentItem.last
@@ -232,7 +232,7 @@ RSpec.describe Commands::V2::PutContent do
         expect(LockVersion.find_by!(target: content_item).number).to eq(3)
       end
 
-      it "creates the draft's user-facing version using the withdrawn user-facing version as a starting point" do
+      it "creates the draft's user-facing version using the unpublished user-facing version as a starting point" do
         described_class.call(payload)
 
         content_item = ContentItem.last
@@ -244,12 +244,12 @@ RSpec.describe Commands::V2::PutContent do
       end
     end
 
-    context "when creating a draft when there are multiple withdrawn and published items" do
+    context "when creating a draft when there are multiple unpublished and published items" do
       before do
         FactoryGirl.create(
           :content_item,
           content_id: content_id,
-          state: "withdrawn",
+          state: "unpublished",
           lock_version: 2,
           user_facing_version: 5,
         )
@@ -265,7 +265,7 @@ RSpec.describe Commands::V2::PutContent do
         FactoryGirl.create(
           :content_item,
           content_id: content_id,
-          state: "withdrawn",
+          state: "unpublished",
           lock_version: 5,
           user_facing_version: 6,
         )
@@ -302,11 +302,11 @@ RSpec.describe Commands::V2::PutContent do
         )
       }
 
-      it "withdraws the content item which is in the way" do
+      it "unpublishes the content item which is in the way" do
         described_class.call(payload)
 
         state = State.find_by!(content_item: other_content_item)
-        expect(state.name).to eq("withdrawn")
+        expect(state.name).to eq("unpublished")
 
         translation = Translation.find_by!(content_item: other_content_item)
         expect(translation.locale).to eq(locale)
@@ -326,7 +326,7 @@ RSpec.describe Commands::V2::PutContent do
         )
       }
 
-      it "does not withdraw the content item" do
+      it "does not unpublish the content item" do
         described_class.call(payload)
 
         state = State.find_by!(content_item: other_content_item)

--- a/spec/factories/unpublishing.rb
+++ b/spec/factories/unpublishing.rb
@@ -1,0 +1,8 @@
+FactoryGirl.define do
+  factory :unpublishing do
+    content_item
+    type "gone"
+    explanation "Removed for testing reasons"
+    alternative_url "http://example.com/unpublishing"
+  end
+end

--- a/spec/helpers/substitution_helper_spec.rb
+++ b/spec/helpers/substitution_helper_spec.rb
@@ -46,9 +46,9 @@ RSpec.describe SubstitutionHelper do
   context "when the content_id is the same as the existing item" do
     let(:new_content_id) { existing_item.content_id }
 
-    it "does not withdraw the existing item" do
+    it "does not unpublish the existing item" do
       state = State.find_by!(content_item: existing_item)
-      expect(state.name).not_to eq("withdrawn")
+      expect(state.name).not_to eq("unpublished")
     end
   end
 
@@ -58,37 +58,37 @@ RSpec.describe SubstitutionHelper do
     context "when the existing item has a format that is substitutable" do
       let(:existing_format) { "gone" }
 
-      it "withdraws the existing item" do
+      it "unpublishes the existing item" do
         state = State.find_by!(content_item: existing_item)
-        expect(state.name).to eq("withdrawn")
+        expect(state.name).to eq("unpublished")
       end
 
-      it "doesn't withdraw any other items" do
-        expect(State.find_by!(content_item: live_item).name).not_to eq("withdrawn")
-        expect(State.find_by!(content_item: french_item).name).not_to eq("withdrawn")
-        expect(State.find_by!(content_item: item_elsewhere).name).not_to eq("withdrawn")
+      it "doesn't unpublish any other items" do
+        expect(State.find_by!(content_item: live_item).name).not_to eq("unpublished")
+        expect(State.find_by!(content_item: french_item).name).not_to eq("unpublished")
+        expect(State.find_by!(content_item: item_elsewhere).name).not_to eq("unpublished")
       end
     end
 
     context "when the new item has a format that is substitutable" do
       let(:new_format) { "gone" }
 
-      it "withdraws the existing item" do
+      it "unpublishes the existing item" do
         state = State.find_by!(content_item: existing_item)
-        expect(state.name).to eq("withdrawn")
+        expect(state.name).to eq("unpublished")
       end
 
-      it "doesn't withdraw any other items" do
-        expect(State.find_by!(content_item: live_item).name).not_to eq("withdrawn")
-        expect(State.find_by!(content_item: french_item).name).not_to eq("withdrawn")
-        expect(State.find_by!(content_item: item_elsewhere).name).not_to eq("withdrawn")
+      it "doesn't unpublish any other items" do
+        expect(State.find_by!(content_item: live_item).name).not_to eq("unpublished")
+        expect(State.find_by!(content_item: french_item).name).not_to eq("unpublished")
+        expect(State.find_by!(content_item: item_elsewhere).name).not_to eq("unpublished")
       end
     end
 
     context "when neither item has a format that is substitutable" do
-      it "does not withdraw the existing item" do
+      it "does not unpublish the existing item" do
         state = State.find_by!(content_item: existing_item)
-        expect(state.name).not_to eq("withdrawn")
+        expect(state.name).not_to eq("unpublished")
       end
     end
   end

--- a/spec/integration/redirecting_spec.rb
+++ b/spec/integration/redirecting_spec.rb
@@ -73,9 +73,9 @@ RSpec.describe "Redirecting content items that are redrafted" do
 
         content_item = ContentItem.first
         expect(content_item.format).to eq("guide")
-        expect(state(content_item)).to eq("withdrawn"),
-          "This content item is eligible for both superseding and withdrawl.
-          When this happens, the 'withdrawn' state should be chosen."
+        expect(state(content_item)).to eq("unpublished"),
+          "This content item is eligible for both superseding and unpublishing.
+          When this happens, the 'unpublished' state should be chosen."
         expect(path(content_item)).to eq("/foo")
         expect(version(content_item)).to eq(1)
 
@@ -134,9 +134,9 @@ RSpec.describe "Redirecting content items that are redrafted" do
 
         content_item = ContentItem.first
         expect(content_item.format).to eq("guide")
-        expect(state(content_item)).to eq("withdrawn"),
-          "This content item is eligible for both superseding and withdrawl.
-          When this happens, the 'withdrawn' state should be chosen."
+        expect(state(content_item)).to eq("unpublished"),
+          "This content item is eligible for both superseding and unpublishing.
+          When this happens, the 'unpublished' state should be chosen."
         expect(path(content_item)).to eq("/foo")
         expect(version(content_item)).to eq(1)
 

--- a/spec/integration/reinstating_spec.rb
+++ b/spec/integration/reinstating_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe "Reinstating Content Items that were previously withdrawn" do
+RSpec.describe "Reinstating Content Items that were previously unpublished" do
   let(:put_content_command) { Commands::V2::PutContent }
   let(:publish_command) { Commands::V2::Publish }
 
@@ -49,7 +49,7 @@ RSpec.describe "Reinstating Content Items that were previously withdrawn" do
     }
   end
 
-  describe "after the content item is withdrawn" do
+  describe "after the content item is unpublished" do
     before do
       2.times do
         put_content_command.call(guide_draft_payload)
@@ -64,23 +64,23 @@ RSpec.describe "Reinstating Content Items that were previously withdrawn" do
       expect(ContentItem.count).to eq(3)
 
       superseded_item = ContentItem.first
-      withdrawn_item = ContentItem.second
+      unpublished_item = ContentItem.second
       published_item = ContentItem.third
 
       superseded = State.find_by!(content_item: superseded_item)
-      withdrawn = State.find_by!(content_item: withdrawn_item)
+      unpublished = State.find_by!(content_item: unpublished_item)
       published = State.find_by!(content_item: published_item)
 
       expect(superseded.name).to eq("superseded")
-      expect(withdrawn.name).to eq("withdrawn")
+      expect(unpublished.name).to eq("unpublished")
       expect(published.name).to eq("published")
 
       superseded_version = UserFacingVersion.find_by!(content_item: superseded_item)
-      withdrawn_version = UserFacingVersion.find_by!(content_item: withdrawn_item)
+      unpublished_version = UserFacingVersion.find_by!(content_item: unpublished_item)
       published_version = UserFacingVersion.find_by!(content_item: published_item)
 
       expect(superseded_version.number).to eq(1)
-      expect(withdrawn_version.number).to eq(2)
+      expect(unpublished_version.number).to eq(2)
       expect(published_version.number).to eq(1),
         "The redirect should be regarded as a new piece of content"
     end
@@ -95,28 +95,28 @@ RSpec.describe "Reinstating Content Items that were previously withdrawn" do
         expect(ContentItem.count).to eq(4)
 
         superseded_item = ContentItem.first
-        withdrawn1_item = ContentItem.second
-        withdrawn2_item = ContentItem.third
+        unpublished1_item = ContentItem.second
+        unpublished2_item = ContentItem.third
         published_item = ContentItem.fourth
 
         superseded = State.find_by!(content_item: superseded_item)
-        withdrawn1 = State.find_by!(content_item: withdrawn1_item)
-        withdrawn2 = State.find_by!(content_item: withdrawn2_item)
+        unpublished1 = State.find_by!(content_item: unpublished1_item)
+        unpublished2 = State.find_by!(content_item: unpublished2_item)
         published = State.find_by!(content_item: published_item)
 
         expect(superseded.name).to eq("superseded")
-        expect(withdrawn1.name).to eq("withdrawn")
-        expect(withdrawn2.name).to eq("withdrawn")
+        expect(unpublished1.name).to eq("unpublished")
+        expect(unpublished2.name).to eq("unpublished")
         expect(published.name).to eq("published")
 
         superseded_version = UserFacingVersion.find_by!(content_item: superseded_item)
-        withdrawn1_version = UserFacingVersion.find_by!(content_item: withdrawn1_item)
-        withdrawn2_version = UserFacingVersion.find_by!(content_item: withdrawn2_item)
+        unpublished1_version = UserFacingVersion.find_by!(content_item: unpublished1_item)
+        unpublished2_version = UserFacingVersion.find_by!(content_item: unpublished2_item)
         published_version = UserFacingVersion.find_by!(content_item: published_item)
 
         expect(superseded_version.number).to eq(1)
-        expect(withdrawn1_version.number).to eq(2)
-        expect(withdrawn2_version.number).to eq(1)
+        expect(unpublished1_version.number).to eq(2)
+        expect(unpublished2_version.number).to eq(1)
         expect(published_version.number).to eq(3)
       end
 
@@ -130,32 +130,32 @@ RSpec.describe "Reinstating Content Items that were previously withdrawn" do
           expect(ContentItem.count).to eq(5)
 
           superseded1_item = ContentItem.first
-          withdrawn1_item = ContentItem.second
-          withdrawn2_item = ContentItem.third
+          unpublished1_item = ContentItem.second
+          unpublished2_item = ContentItem.third
           superseded2_item = ContentItem.fourth
           published_item = ContentItem.fifth
 
           superseded1 = State.find_by!(content_item: superseded1_item)
-          withdrawn1 = State.find_by!(content_item: withdrawn1_item)
-          withdrawn2 = State.find_by!(content_item: withdrawn2_item)
+          unpublished1 = State.find_by!(content_item: unpublished1_item)
+          unpublished2 = State.find_by!(content_item: unpublished2_item)
           superseded2 = State.find_by!(content_item: superseded2_item)
           published = State.find_by!(content_item: published_item)
 
           expect(superseded1.name).to eq("superseded")
-          expect(withdrawn1.name).to eq("withdrawn")
-          expect(withdrawn2.name).to eq("withdrawn")
+          expect(unpublished1.name).to eq("unpublished")
+          expect(unpublished2.name).to eq("unpublished")
           expect(superseded2.name).to eq("superseded")
           expect(published.name).to eq("published")
 
           superseded1_version = UserFacingVersion.find_by!(content_item: superseded1_item)
-          withdrawn1_version = UserFacingVersion.find_by!(content_item: withdrawn1_item)
-          withdrawn2_version = UserFacingVersion.find_by!(content_item: withdrawn2_item)
+          unpublished1_version = UserFacingVersion.find_by!(content_item: unpublished1_item)
+          unpublished2_version = UserFacingVersion.find_by!(content_item: unpublished2_item)
           superseded2_version = UserFacingVersion.find_by!(content_item: superseded2_item)
           published_version = UserFacingVersion.find_by!(content_item: published_item)
 
           expect(superseded1_version.number).to eq(1)
-          expect(withdrawn1_version.number).to eq(2)
-          expect(withdrawn2_version.number).to eq(1)
+          expect(unpublished1_version.number).to eq(2)
+          expect(unpublished2_version.number).to eq(1)
           expect(superseded2_version.number).to eq(3)
           expect(published_version.number).to eq(4)
         end

--- a/spec/integration/withdrawing_spec.rb
+++ b/spec/integration/withdrawing_spec.rb
@@ -31,43 +31,43 @@ RSpec.describe "Withdrawing Content Items" do
     }
   end
 
-  describe "after the first withdrawl" do
+  describe "after the first unpublishing" do
     before do
       put_content_command.call(guide_payload)
       put_content_command.call(gone_payload)
     end
 
-    it "withdraws the previous draft content item" do
+    it "unpublishes the previous draft content item" do
       expect(ContentItem.count).to eq(2)
 
-      withdrawn_item = ContentItem.first
+      unpublished_item = ContentItem.first
       draft_item = ContentItem.second
 
-      withdrawn = State.find_by!(content_item: withdrawn_item)
+      unpublished = State.find_by!(content_item: unpublished_item)
       draft = State.find_by!(content_item: draft_item)
 
-      expect(withdrawn.name).to eq("withdrawn")
+      expect(unpublished.name).to eq("unpublished")
       expect(draft.name).to eq("draft")
     end
 
-    describe "after the second withdrawl" do
+    describe "after the second unpublishing" do
       before do
         put_content_command.call(guide_payload)
       end
 
-      it "withdraws the second draft content item" do
+      it "unpublishes the second draft content item" do
         expect(ContentItem.count).to eq(3)
 
-        withdrawn1_item = ContentItem.first
-        withdrawn2_item = ContentItem.second
+        unpublished1_item = ContentItem.first
+        unpublished2_item = ContentItem.second
         draft_item = ContentItem.third
 
-        withdrawn1 = State.find_by!(content_item: withdrawn1_item)
-        withdrawn2 = State.find_by!(content_item: withdrawn2_item)
+        unpublished1 = State.find_by!(content_item: unpublished1_item)
+        unpublished2 = State.find_by!(content_item: unpublished2_item)
         draft = State.find_by!(content_item: draft_item)
 
-        expect(withdrawn1.name).to eq("withdrawn")
-        expect(withdrawn2.name).to eq("withdrawn")
+        expect(unpublished1.name).to eq("unpublished")
+        expect(unpublished2.name).to eq("unpublished")
         expect(draft.name).to eq("draft")
       end
     end

--- a/spec/models/state_spec.rb
+++ b/spec/models/state_spec.rb
@@ -72,5 +72,19 @@ RSpec.describe State do
         described_class.unpublish(draft_item)
       }.to change { draft_state.reload.name }.to("unpublished")
     end
+
+    it "creates an unpublishing" do
+      expect {
+        described_class.unpublish(draft_item)
+      }.to change(Unpublishing, :count).by(1)
+
+      unpublishing = Unpublishing.last
+
+      expect(unpublishing.content_item).to eq(draft_item)
+      expect(unpublishing.type).to eq("substitute")
+      expect(unpublishing.explanation).to eq(
+        "Automatically unpublished to make way for another content item"
+      )
+    end
   end
 end

--- a/spec/models/state_spec.rb
+++ b/spec/models/state_spec.rb
@@ -63,14 +63,14 @@ RSpec.describe State do
     end
   end
 
-  describe ".withdraw" do
+  describe ".unpublish" do
     let(:draft_item) { FactoryGirl.create(:draft_content_item, title: "Draft Title") }
     let(:draft_state) { State.find_by!(content_item: draft_item) }
 
-    it "changes the state name to 'withdrawn'" do
+    it "changes the state name to 'unpublished'" do
       expect {
-        described_class.withdraw(draft_item)
-      }.to change { draft_state.reload.name }.to("withdrawn")
+        described_class.unpublish(draft_item)
+      }.to change { draft_state.reload.name }.to("unpublished")
     end
   end
 end

--- a/spec/models/unpublishing_spec.rb
+++ b/spec/models/unpublishing_spec.rb
@@ -1,0 +1,43 @@
+require "rails_helper"
+
+RSpec.describe Unpublishing do
+  describe "validations" do
+    subject { FactoryGirl.build(:unpublishing) }
+
+    it "is valid for the default factory" do
+      expect(subject).to be_valid
+    end
+
+    it "requires a type" do
+      subject.type = nil
+      expect(subject).to be_invalid
+      expect(subject.errors[:type].size).to eq(1)
+    end
+
+    it "does not require an explanation for a 'gone'" do
+      subject.type = "gone"
+      subject.explanation = nil
+      expect(subject).to be_valid
+    end
+
+    it "requires an explanation for a 'withdrawal'" do
+      subject.type = "withdrawal"
+      subject.explanation = nil
+      expect(subject).to be_invalid
+      expect(subject.errors[:explanation].size).to eq(1)
+    end
+
+    it "does not require an alternative_url for a 'gone'" do
+      subject.type = "gone"
+      subject.alternative_url = nil
+      expect(subject).to be_valid
+    end
+
+    it "requires an alternative_url for a 'redirect'" do
+      subject.type = "redirect"
+      subject.alternative_url = nil
+      expect(subject).to be_invalid
+      expect(subject.errors[:alternative_url].size).to eq(1)
+    end
+  end
+end

--- a/spec/substitution_helper_spec.rb
+++ b/spec/substitution_helper_spec.rb
@@ -47,9 +47,9 @@ RSpec.describe SubstitutionHelper do
     context "when the content_id is the same as the existing item" do
       let(:new_content_id) { existing_item.content_id }
 
-      it "does not withdraw the existing item" do
+      it "does not unpublish the existing item" do
         state = State.find_by!(content_item: existing_item)
-        expect(state.name).not_to eq("withdrawn")
+        expect(state.name).not_to eq("unpublished")
       end
     end
 
@@ -59,37 +59,37 @@ RSpec.describe SubstitutionHelper do
       context "when the existing item has a format that is substitutable" do
         let(:existing_format) { "gone" }
 
-        it "withdraws the existing item" do
+        it "unpublishes the existing item" do
           state = State.find_by!(content_item: existing_item)
-          expect(state.name).to eq("withdrawn")
+          expect(state.name).to eq("unpublished")
         end
 
-        it "doesn't withdraw any other items" do
-          expect(State.find_by!(content_item: live_item).name).not_to eq("withdrawn")
-          expect(State.find_by!(content_item: french_item).name).not_to eq("withdrawn")
-          expect(State.find_by!(content_item: item_elsewhere).name).not_to eq("withdrawn")
+        it "doesn't unpublish any other items" do
+          expect(State.find_by!(content_item: live_item).name).not_to eq("unpublished")
+          expect(State.find_by!(content_item: french_item).name).not_to eq("unpublished")
+          expect(State.find_by!(content_item: item_elsewhere).name).not_to eq("unpublished")
         end
       end
 
       context "when the new item has a format that is substitutable" do
         let(:new_format) { "gone" }
 
-        it "withdraws the existing item" do
+        it "unpublishes the existing item" do
           state = State.find_by!(content_item: existing_item)
-          expect(state.name).to eq("withdrawn")
+          expect(state.name).to eq("unpublished")
         end
 
-        it "doesn't withdraw any other items" do
-          expect(State.find_by!(content_item: live_item).name).not_to eq("withdrawn")
-          expect(State.find_by!(content_item: french_item).name).not_to eq("withdrawn")
-          expect(State.find_by!(content_item: item_elsewhere).name).not_to eq("withdrawn")
+        it "doesn't unpublish any other items" do
+          expect(State.find_by!(content_item: live_item).name).not_to eq("unpublished")
+          expect(State.find_by!(content_item: french_item).name).not_to eq("unpublished")
+          expect(State.find_by!(content_item: item_elsewhere).name).not_to eq("unpublished")
         end
       end
 
       context "when neither item has a format that is substitutable" do
-        it "does not withdraw the existing item" do
+        it "does not unpublish the existing item" do
           state = State.find_by!(content_item: existing_item)
-          expect(state.name).not_to eq("withdrawn")
+          expect(state.name).not_to eq("unpublished")
         end
       end
     end

--- a/spec/validators/content_item_uniqueness_validator_spec.rb
+++ b/spec/validators/content_item_uniqueness_validator_spec.rb
@@ -73,14 +73,14 @@ RSpec.describe ContentItemUniquenessValidator do
     end
   end
 
-  context "when a duplicate content item exists in a withdrawn state" do
+  context "when a duplicate content item exists in a unpublished state" do
     let!(:content_item) do
-      FactoryGirl.create(:content_item, state: "withdrawn")
+      FactoryGirl.create(:content_item, state: "unpublished")
     end
 
     it "allows duplicates and does not raise an error" do
       expect {
-        FactoryGirl.create(:content_item, state: "withdrawn")
+        FactoryGirl.create(:content_item, state: "unpublished")
       }.not_to raise_error
 
       expect(ContentItem.count).to eq(2)


### PR DESCRIPTION
- Renames "withdrawn" to "unpublished" (and other conjugations)
- Creates the `unpublishings` table
- Populates from existing data

https://trello.com/c/zhSso5gS/699-change-all-withdrawn-content-states-to-unpublished