### PR TITLE
Handle nil error_details

### DIFF
--- a/app/commands/delete_publish_intent.rb
+++ b/app/commands/delete_publish_intent.rb
@@ -25,7 +25,7 @@ module Commands
         error: {
           code: upstream_error.code,
           message: upstream_error.message,
-          fields: upstream_error.error_details.fetch('errors', {})
+          fields: (upstream_error.error_details || {}).fetch('errors', {})
         }
       }
     end


### PR DESCRIPTION
`upstream_error.error_details` will be nil in the case of the response
body not being JSON encoded. We should handle this case by returning an
empty hash.

This is masking real errors in production: https://errbit.publishing.service.gov.uk/apps/552f95820da11577b4000032/problems/571fff906578631f8b522d00