### PR TITLE
Add rake task to requeue all published content items

### DIFF
--- a/app/commands/v2/patch_link_set.rb
+++ b/app/commands/v2/patch_link_set.rb
@@ -101,7 +101,6 @@ module Commands
       def send_to_message_queue(content_item)
         payload = Presenters::MessageQueuePresenter.present(
           content_item,
-          event,
           fallback_order: [:published],
           update_type: "links",
         )

--- a/app/commands/v2/publish.rb
+++ b/app/commands/v2/publish.rb
@@ -143,7 +143,6 @@ module Commands
 
         queue_payload = Presenters::MessageQueuePresenter.present(
           content_item,
-          event,
           fallback_order: [:published],
           update_type: update_type
         )

--- a/app/presenters/content_store_presenter.rb
+++ b/app/presenters/content_store_presenter.rb
@@ -1,8 +1,8 @@
 module Presenters
   class ContentStorePresenter
     def self.present(content_item, event, fallback_order:)
-      attributes = DownstreamPresenter.present(content_item, event, fallback_order: fallback_order)
-      attributes.except(:update_type)
+      attributes = DownstreamPresenter.present(content_item, fallback_order: fallback_order)
+      attributes.except(:update_type).merge(payload_version: event.id)
     end
   end
 end

--- a/app/presenters/downstream_presenter.rb
+++ b/app/presenters/downstream_presenter.rb
@@ -1,14 +1,13 @@
 module Presenters
   class DownstreamPresenter
-    def self.present(content_item, event, fallback_order:)
+    def self.present(content_item, fallback_order:)
       link_set = LinkSet.find_by(content_id: content_item.content_id)
-      new(content_item, link_set, event, fallback_order: fallback_order).present
+      new(content_item, link_set, fallback_order: fallback_order).present
     end
 
-    def initialize(content_item, link_set, event, fallback_order:)
+    def initialize(content_item, link_set, fallback_order:)
       self.content_item = content_item
       self.link_set = link_set
-      self.event = event
       self.fallback_order = fallback_order
     end
 
@@ -19,14 +18,13 @@ module Presenters
         .merge(public_updated_at)
         .merge(links)
         .merge(access_limited)
-        .merge(content_store_payload_version)
         .merge(base_path)
         .merge(locale)
     end
 
   private
 
-    attr_accessor :content_item, :link_set, :event, :fallback_order
+    attr_accessor :content_item, :link_set, :fallback_order
 
     def symbolized_attributes
       content_item.as_json.symbolize_keys
@@ -87,10 +85,6 @@ module Presenters
 
     def locale
       { locale: web_content_item.locale }
-    end
-
-    def content_store_payload_version
-      { payload_version: event.id }
     end
 
     class V1

--- a/app/presenters/message_queue_presenter.rb
+++ b/app/presenters/message_queue_presenter.rb
@@ -1,7 +1,7 @@
 module Presenters
   class MessageQueuePresenter
-    def self.present(content_item, event, fallback_order:, update_type:)
-      attributes = DownstreamPresenter.present(content_item, event, fallback_order: fallback_order)
+    def self.present(content_item, fallback_order:, update_type:)
+      attributes = DownstreamPresenter.present(content_item, fallback_order: fallback_order)
       attributes.merge(
         update_type: update_type,
         govuk_request_id: GdsApi::GovukHeaders.headers[:govuk_request_id],

--- a/lib/requeue_content.rb
+++ b/lib/requeue_content.rb
@@ -1,0 +1,38 @@
+class RequeueContent
+  def initialize(number_of_items: nil)
+    @number_of_items = number_of_items
+  end
+
+  attr_accessor :number_of_items
+
+  def call
+    if number_of_items.present?
+      ContentItemFilter.filter(state: :published).limit(number_of_items).each do |content_item|
+        publish_to_queue(content_item)
+      end
+    else
+      ContentItemFilter.filter(state: :published).find_each do |content_item|
+        publish_to_queue(content_item)
+      end
+    end
+  end
+
+private
+
+  def publish_to_queue(content_item)
+    queue_payload = Presenters::MessageQueuePresenter.present(
+      content_item,
+      fallback_order: [:published],
+      # FIXME: Rummager currently only listens to the message queue for the
+      # update type 'links'. This behaviour will eventually be updated so that
+      # it listens to other update types as well. This will happen as part of
+      # ongoing architectural work to make the message queue the sole source of
+      # search index updates. When that happens, the update_type below should
+      # be changed - perhaps to a newly introduced, more-appropriately named
+      # one. Maybe something like 'reindex'.
+      update_type: 'links'
+    )
+
+    PublishingAPI.service(:queue_publisher).send_message(queue_payload)
+  end
+end

--- a/lib/tasks/queue.rake
+++ b/lib/tasks/queue.rake
@@ -27,4 +27,9 @@ namespace :queue do
       EOT
     end
   end
+
+  desc "Add published content items to the message queue, optionally specifying a limit on the number of items"
+  task :requeue_content, [:number_of_items] => :environment do |_, args|
+    RequeueContent.new(number_of_items: args[:number_of_items]).call
+  end
 end

--- a/lib/tasks/queue.rake
+++ b/lib/tasks/queue.rake
@@ -19,11 +19,11 @@ namespace :queue do
 
     puts "Listening for messages"
     q.subscribe(block: true) do |delivery_info, properties, payload|
-      puts <<-EOT
------ New Message -----
-Routing_key: #{delivery_info.routing_key}
-Properties: #{properties.inspect}
-Payload: #{payload}
+      puts <<-EOT.strip_heredoc
+        ----- New Message -----
+        Routing_key: #{delivery_info.routing_key}
+        Properties: #{properties.inspect}
+        Payload: #{payload}
       EOT
     end
   end

--- a/spec/lib/requeue_content_spec.rb
+++ b/spec/lib/requeue_content_spec.rb
@@ -1,0 +1,22 @@
+require "rails_helper"
+
+RSpec.describe RequeueContent do
+  let!(:content_item1) { create(:live_content_item, base_path: '/ci1') }
+  let!(:content_item2) { create(:live_content_item, base_path: '/ci2') }
+  let!(:content_item3) { create(:live_content_item, base_path: '/ci3') }
+
+  describe "#call" do
+    it "by default, it republishes all content items" do
+      expect(PublishingAPI.service(:queue_publisher)).to receive(:send_message).exactly(3).times
+      RequeueContent.new.call
+    end
+
+    it "limits the number of items published, if a limit is provided" do
+      expect(PublishingAPI.service(:queue_publisher)).to receive(:send_message)
+        .exactly(1)
+        .times
+        .with(a_hash_including(content_id: content_item1.content_id))
+      RequeueContent.new(number_of_items: 1).call
+    end
+  end
+end

--- a/spec/presenters/downstream_presenter_spec.rb
+++ b/spec/presenters/downstream_presenter_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Presenters::DownstreamPresenter do
   let(:event) { double(:event, id: 123) }
   let(:fallback_order) { [] }
 
-  subject(:result) { described_class.present(content_item, event, fallback_order: fallback_order) }
+  subject(:result) { described_class.present(content_item, fallback_order: fallback_order) }
 
   describe "V2" do
     let(:expected) {
@@ -29,14 +29,13 @@ RSpec.describe Presenters::DownstreamPresenter do
         routes: [{ path: "/vat-rates", type: "exact" }],
         schema_name: "guide",
         title: "VAT rates",
-        payload_version: 123,
         update_type: "minor"
       }
     }
 
     context "for a live content item" do
       let(:content_item) { create(:live_content_item) }
-      let!(:link_set) { create(:link_set, content_id: content_item.content_id) }
+      let!(:link_set)    { create(:link_set, content_id: content_item.content_id) }
 
       it "presents the object graph for the content store" do
         expect(result).to eq(expected)
@@ -63,7 +62,7 @@ RSpec.describe Presenters::DownstreamPresenter do
       end
 
       it "expands the links for the content item" do
-        result = described_class.present(a, event, fallback_order: [:draft])
+        result = described_class.present(a, fallback_order: [:draft])
 
         expect(result[:expanded_links]).to eq(related: [{
           content_id: b.content_id,

--- a/spec/presenters/downstream_presenter_spec.rb
+++ b/spec/presenters/downstream_presenter_spec.rb
@@ -1,7 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe Presenters::DownstreamPresenter do
-  let(:event) { double(:event, id: 123) }
   let(:fallback_order) { [] }
 
   subject(:result) { described_class.present(content_item, fallback_order: fallback_order) }
@@ -100,7 +99,8 @@ RSpec.describe Presenters::DownstreamPresenter do
     end
   end
 
-  describe described_class::V1 do
+  describe "V1" do
+    let(:event) { double(:event, id: 123) }
     let(:attributes) do
       {
         content_id: "content_id",
@@ -114,7 +114,7 @@ RSpec.describe Presenters::DownstreamPresenter do
     end
 
     it "presents all attributes by default" do
-      result = described_class.present(attributes, event)
+      result = Presenters::DownstreamPresenter::V1.present(attributes, event)
 
       expect(result).to eq(
         content_id: "content_id",
@@ -125,7 +125,7 @@ RSpec.describe Presenters::DownstreamPresenter do
     end
 
     it "can optionally remove the update_type attribute" do
-      result = described_class.present(attributes, event, update_type: false)
+      result = Presenters::DownstreamPresenter::V1.present(attributes, event, update_type: false)
 
       expect(result).to eq(
         content_id: "content_id",
@@ -135,7 +135,7 @@ RSpec.describe Presenters::DownstreamPresenter do
     end
 
     it "can optionally remove the payload_version attribute" do
-      result = described_class.present(attributes, event, payload_version: false)
+      result = Presenters::DownstreamPresenter::V1.present(attributes, event, payload_version: false)
 
       expect(result).to eq(
         content_id: "content_id",

--- a/spec/presenters/message_queue_presenter_spec.rb
+++ b/spec/presenters/message_queue_presenter_spec.rb
@@ -2,15 +2,14 @@ require 'rails_helper'
 
 RSpec.describe Presenters::MessageQueuePresenter do
   let(:content_item) { FactoryGirl.create(:live_content_item) }
-  let(:event) { double(:event, id: 1) }
 
   it "mixes in the specified update_type to the presentation" do
-    presentation = described_class.present(content_item, event, fallback_order: [:published], update_type: "foo")
+    presentation = described_class.present(content_item, fallback_order: [:published], update_type: "foo")
     expect(presentation[:update_type]).to eq("foo")
   end
 
   it "leaves other fields intact" do
-    presentation = described_class.present(content_item, event, fallback_order: [:published], update_type: "foo")
+    presentation = described_class.present(content_item, fallback_order: [:published], update_type: "foo")
     expect(presentation).to have_key(:content_id)
     expect(presentation).to have_key(:title)
     expect(presentation).to have_key(:details)


### PR DESCRIPTION
The goal here is to allow us to requeue all published content
items and observe how the Rummager message queue workers perform under
this kind of load.

trello: https://trello.com/c/X3IbrAY7