### PR TITLE
Remove redundant Special Education Needs policy

### DIFF
--- a/db/migrate/20160506124002_remove_redundant_special_education_needs_policy.rb
+++ b/db/migrate/20160506124002_remove_redundant_special_education_needs_policy.rb
@@ -1,0 +1,16 @@
+class RemoveRedundantSpecialEducationNeedsPolicy < ActiveRecord::Migration
+  # Remove government/policies/special-education-needs-sen
+  def change
+    content_items = ContentItem.where(content_id: "f656d065-43aa-4ab0-91f7-a6809ce5b68b")
+    Translation.where(content_item: content_items).destroy_all
+    Location.where(content_item: content_items).destroy_all
+    State.where(content_item: content_items).destroy_all
+    UserFacingVersion.where(content_item: content_items).destroy_all
+    AccessLimit.where(content_item: content_items).destroy_all
+    LockVersion.where(target: content_items).destroy_all
+    content_items.destroy_all
+
+    link_sets = LinkSet.where(content_id: "f656d065-43aa-4ab0-91f7-a6809ce5b68b")
+    link_sets.destroy_all
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160505133601) do
+ActiveRecord::Schema.define(version: 20160506124002) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
- There are two copies of this policy. This removes one of them as per
  this [Zendesk ticket](https://govuk.zendesk.com/agent/tickets/1299583).

cc @elliotcm @tijmenb 