### PR TITLE
Move the presentation of the ContentItem to the worker

### DIFF
--- a/app/adapters/content_store.rb
+++ b/app/adapters/content_store.rb
@@ -2,6 +2,7 @@
 # to
 module Adapters
   class ContentStore
+    DEPENDECY_FALLBACK_ORDER = [:published]
     def self.put_content_item(base_path, content_item)
       CommandError.with_error_handling do
         PublishingAPI.service(:live_content_store).put_content_item(

--- a/app/adapters/draft_content_store.rb
+++ b/app/adapters/draft_content_store.rb
@@ -1,5 +1,6 @@
 module Adapters
   class DraftContentStore
+    DEPENDECY_FALLBACK_ORDER = [:draft, :published]
     def self.put_content_item(base_path, content_item)
       CommandError.with_error_handling do
         PublishingAPI.service(:draft_content_store).put_content_item(

--- a/app/commands/v2/discard_draft.rb
+++ b/app/commands/v2/discard_draft.rb
@@ -47,7 +47,7 @@ module Commands
       def send_live_to_draft_content_store(live)
         PresentedContentStoreWorker.perform_async(
           content_store: Adapters::DraftContentStore,
-          payload: Presenters::ContentStorePresenter.present(live, event, fallback_order: [:draft, :published]),
+          payload: { content_item: live.id, payload_version: event.id },
           request_uuid: GdsApi::GovukHeaders.headers[:govuk_request_id],
         )
       end

--- a/app/commands/v2/patch_link_set.rb
+++ b/app/commands/v2/patch_link_set.rb
@@ -93,7 +93,7 @@ module Commands
       def send_to_content_store(content_item, content_store)
         PresentedContentStoreWorker.perform_async(
           content_store: content_store,
-          payload: Presenters::ContentStorePresenter.present(content_item, event, fallback_order: [:published]),
+          payload: { content_item: content_item.id, payload_version: event.id },
           request_uuid: GdsApi::GovukHeaders.headers[:govuk_request_id],
         )
       end

--- a/app/commands/v2/publish.rb
+++ b/app/commands/v2/publish.rb
@@ -133,11 +133,7 @@ module Commands
 
         PresentedContentStoreWorker.perform_async(
           content_store: Adapters::ContentStore,
-          payload: Presenters::ContentStorePresenter.present(
-            content_item,
-            event,
-            fallback_order: [:published]
-          ),
+          payload: { content_item: content_item.id, payload_version: event.id },
           request_uuid: GdsApi::GovukHeaders.headers[:govuk_request_id]
         )
 

--- a/app/commands/v2/put_content.rb
+++ b/app/commands/v2/put_content.rb
@@ -224,7 +224,7 @@ module Commands
 
         PresentedContentStoreWorker.perform_async(
           content_store: Adapters::DraftContentStore,
-          payload: Presenters::ContentStorePresenter.present(content_item, event, fallback_order: [:draft, :published]),
+          payload: { content_item: content_item.id, payload_version: event.id },
           request_uuid: GdsApi::GovukHeaders.headers[:govuk_request_id],
         )
       end

--- a/app/presenters/content_store_presenter.rb
+++ b/app/presenters/content_store_presenter.rb
@@ -1,8 +1,8 @@
 module Presenters
   class ContentStorePresenter
-    def self.present(content_item, event, fallback_order:)
+    def self.present(content_item, payload_version, fallback_order:)
       attributes = DownstreamPresenter.present(content_item, fallback_order: fallback_order)
-      attributes.except(:update_type).merge(payload_version: event.id)
+      attributes.except(:update_type).merge(payload_version: payload_version)
     end
   end
 end

--- a/app/workers/presented_content_store_worker.rb
+++ b/app/workers/presented_content_store_worker.rb
@@ -16,8 +16,11 @@ class PresentedContentStoreWorker
       content_store.delete_content_item(base_path)
     else
       payload = args.fetch(:payload)
-      base_path = payload.fetch(:base_path)
-      content_store.put_content_item(base_path, payload)
+      content_item = ContentItem.find(payload.fetch(:content_item))
+      payload_version = payload.fetch(:payload_version)
+      presented_payload = Presenters::ContentStorePresenter.present(content_item, payload_version, fallback_order: content_store::DEPENDECY_FALLBACK_ORDER)
+      base_path = presented_payload.fetch(:base_path)
+      content_store.put_content_item(base_path, presented_payload)
     end
 
   rescue => e

--- a/spec/commands/v2/discard_draft_spec.rb
+++ b/spec/commands/v2/discard_draft_spec.rb
@@ -123,20 +123,19 @@ RSpec.describe Commands::V2::DiscardDraft do
         end
 
         it "sends the published content item to the draft content store" do
-          expect(Presenters::ContentStorePresenter).to receive(:present).with(
-            published_item,
-            instance_of(Event),
-            fallback_order: [:draft, :published]
-          )
-
-          allow(PresentedContentStoreWorker).to receive(:perform_async)
           expect(PresentedContentStoreWorker).to receive(:perform_async)
             .with(
               content_store: Adapters::DraftContentStore,
-              payload: expected_content_store_payload,
+              base_path: "/vat-rates",
+              delete: true,
               request_uuid: "12345-67890",
             )
-
+          expect(PresentedContentStoreWorker).to receive(:perform_async)
+            .with(
+              content_store: Adapters::DraftContentStore,
+              payload: a_hash_including(:content_item, :payload_version),
+              request_uuid: "12345-67890",
+            )
           described_class.call(payload)
         end
 

--- a/spec/commands/v2/patch_link_set_spec.rb
+++ b/spec/commands/v2/patch_link_set_spec.rb
@@ -206,7 +206,7 @@ RSpec.describe Commands::V2::PatchLinkSet do
       expect(PresentedContentStoreWorker).to receive(:perform_async)
         .with(
           content_store: Adapters::DraftContentStore,
-          payload: expected_content_store_payload,
+          payload: a_hash_including(:content_item, :payload_version),
           request_uuid: "12345-67890",
         )
 
@@ -215,7 +215,7 @@ RSpec.describe Commands::V2::PatchLinkSet do
 
     it "presents the draft content item for the downstream request" do
       expect(Presenters::ContentStorePresenter).to receive(:present)
-        .with(draft_content_item, instance_of(Event), fallback_order: [:published])
+        .with(draft_content_item, an_instance_of(Fixnum), fallback_order: [:draft, :published])
 
       described_class.call(payload)
     end
@@ -238,14 +238,7 @@ RSpec.describe Commands::V2::PatchLinkSet do
 
         it "sends the draft content item for that locale downstream" do
           expect(Presenters::ContentStorePresenter).to receive(:present)
-            .with(draft_content_item, instance_of(Event), fallback_order: [:published])
-
-          expect(PresentedContentStoreWorker).to receive(:perform_async)
-            .with(
-              content_store: Adapters::DraftContentStore,
-              payload: expected_content_store_payload,
-              request_uuid: "12345-67890",
-            )
+            .with(draft_content_item, an_instance_of(Fixnum), fallback_order: [:draft, :published])
 
           described_class.call(payload)
         end
@@ -288,7 +281,7 @@ RSpec.describe Commands::V2::PatchLinkSet do
       expect(PresentedContentStoreWorker).to receive(:perform_async)
         .with(
           content_store: Adapters::ContentStore,
-          payload: expected_content_store_payload,
+          payload: a_hash_including(:content_item, :payload_version),
           request_uuid: "12345-67890",
         )
 
@@ -297,7 +290,7 @@ RSpec.describe Commands::V2::PatchLinkSet do
 
     it "presents the live content item for the downstream request" do
       expect(Presenters::ContentStorePresenter).to receive(:present)
-        .with(live_content_item, instance_of(Event), fallback_order: [:published])
+        .with(live_content_item, an_instance_of(Fixnum), fallback_order: [:published])
 
       described_class.call(payload)
     end
@@ -335,7 +328,7 @@ RSpec.describe Commands::V2::PatchLinkSet do
           expect(PresentedContentStoreWorker).to receive(:perform_async)
             .with(
               content_store: Adapters::ContentStore,
-              payload: expected_content_store_payload,
+              payload: a_hash_including(:content_item, :payload_version),
               request_uuid: "12345-67890",
             )
 

--- a/spec/commands/v2/publish_spec.rb
+++ b/spec/commands/v2/publish_spec.rb
@@ -157,7 +157,7 @@ RSpec.describe Commands::V2::Publish do
           .to receive(:perform_async)
           .with(
             content_store: Adapters::ContentStore,
-            payload: expected_content_store_payload,
+            payload: a_hash_including(:content_item, :payload_version),
             request_uuid: "12345-67890",
           )
 
@@ -166,7 +166,7 @@ RSpec.describe Commands::V2::Publish do
 
       it "presents the content item for the downstream request" do
         expect(Presenters::ContentStorePresenter).to receive(:present)
-          .with(draft_item, instance_of(Event), fallback_order: [:published])
+          .with(draft_item, an_instance_of(Fixnum), fallback_order: [:published])
 
         described_class.call(payload)
       end
@@ -230,7 +230,7 @@ RSpec.describe Commands::V2::Publish do
               .to receive(:perform_async)
               .with(
                 content_store: Adapters::ContentStore,
-                payload: expected_content_store_payload,
+                payload: a_hash_including(:content_item, :payload_version),
                 request_uuid: "12345-67890",
               )
 
@@ -253,7 +253,7 @@ RSpec.describe Commands::V2::Publish do
               .to receive(:perform_async)
               .with(
                 content_store: Adapters::ContentStore,
-                payload: expected_content_store_payload,
+                payload: a_hash_including(:content_item, :payload_version),
                 request_uuid: "12345-67890",
               )
 

--- a/spec/commands/v2/put_content_spec.rb
+++ b/spec/commands/v2/put_content_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Commands::V2::PutContent do
       expect(PresentedContentStoreWorker).to receive(:perform_async)
         .with(
           content_store: Adapters::DraftContentStore,
-          payload: expected_content_store_payload,
+          payload: a_hash_including(:content_item, :payload_version),
           request_uuid: "12345-67890",
         )
 
@@ -53,7 +53,7 @@ RSpec.describe Commands::V2::PutContent do
       expect(PresentedContentStoreWorker).not_to receive(:perform_async)
         .with(
           content_store: Adapters::ContentStore,
-          payload: expected_content_store_payload,
+          payload: a_hash_including(:content_item, :payload_version),
         )
 
       described_class.call(payload)
@@ -177,7 +177,7 @@ RSpec.describe Commands::V2::PutContent do
           expect(PresentedContentStoreWorker).to receive(:perform_async)
             .with(
               content_store: Adapters::DraftContentStore,
-              payload: expected_content_store_payload,
+              payload: a_hash_including(:content_item, :payload_version),
               request_uuid: "12345-67890",
             ).twice
 
@@ -495,7 +495,7 @@ RSpec.describe Commands::V2::PutContent do
           expect(PresentedContentStoreWorker).to receive(:perform_async)
             .with(
               content_store: Adapters::DraftContentStore,
-              payload: expected_content_store_payload,
+              payload: a_hash_including(:content_item, :payload_version),
               request_uuid: "12345-67890",
             ).twice
 

--- a/spec/workers/presented_content_store_worker_spec.rb
+++ b/spec/workers/presented_content_store_worker_spec.rb
@@ -1,6 +1,7 @@
 require "rails_helper"
 
 RSpec.describe PresentedContentStoreWorker do
+  let(:content_item) { FactoryGirl.create(:content_item, base_path: "/foo") }
   before do
     stub_request(:put, "http://content-store.dev.gov.uk/content/foo").
       to_return(status: status, body: {}.to_json)
@@ -9,7 +10,7 @@ RSpec.describe PresentedContentStoreWorker do
   def do_request
     subject.perform(
       content_store: "Adapters::ContentStore",
-      payload: { some: "payload", base_path: "/foo" }
+      payload: { content_item: content_item.id, payload_version: "1" }
     )
   end
 
@@ -17,7 +18,7 @@ RSpec.describe PresentedContentStoreWorker do
     200 => { raises_error: false, logs_to_airbrake: false },
     202 => { raises_error: false, logs_to_airbrake: false },
     400 => { raises_error: false, logs_to_airbrake: true },
-    409 => { raises_error: false, logs_to_airbrake: true },
+    409 => { raises_error: false, logs_to_airbrake: false },
     500 => { raises_error: true, logs_to_airbrake: false },
   }
 


### PR DESCRIPTION
Moves the finding and presentation of the ContentItem into the worker.
Moves the dependency of fallback_order into the ContentStore adapters.