### PR TITLE
Unpublishing endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ content. It is used when paths need to be reserved before that content enters
 the system
 - **Event Log**: A log of all requests to the Publishing API that have the
 potential to mutate its internal state
+- **Unpublishing**: An object indicating a previously published content item
+which has been removed from the live site.  Can be "gone", "withdrawal", or "redirect".
 
 For more information, refer to [doc/semantics-of-the-publishing-api.md](doc/semantics-of-the-publishing-api.md)
 and [doc/object-model-explanation.md](doc/object-model-explanation.md).

--- a/app/commands/base_command.rb
+++ b/app/commands/base_command.rb
@@ -46,21 +46,28 @@ module Commands
         "(#{previous_version_number}) is not the same as the current " +
         "lock version of the content item (#{current_version.number})."
 
-      conflict_error = CommandError.new(
-        code: 409,
-        message: "Conflict",
+      fields = {
+        fields: {
+          previous_version: ["does not match"],
+        },
+      }
+
+      if current_version.conflicts_with?(previous_version_number)
+        raise_command_error(409, "Conflict", fields, friendly_message: friendly_message)
+      end
+    end
+
+    def raise_command_error(code, message, fields, friendly_message: nil)
+      raise CommandError.new(
+        code: code,
+        message: message,
         error_details: {
           error: {
-            code: 409,
-            message: friendly_message,
-            fields: {
-              previous_version: ["does not match"],
-            }
-          }
+            code: code,
+            message: friendly_message || message,
+          }.merge(fields)
         }
       )
-
-      raise conflict_error if current_version.conflicts_with?(previous_version_number)
     end
   end
 end

--- a/app/commands/v2/publish.rb
+++ b/app/commands/v2/publish.rb
@@ -129,8 +129,6 @@ module Commands
       end
 
       def send_downstream(content_item, update_type)
-        return unless downstream
-
         PresentedContentStoreWorker.perform_async(
           content_store: Adapters::ContentStore,
           payload: Presenters::ContentStorePresenter.present(

--- a/app/commands/v2/publish.rb
+++ b/app/commands/v2/publish.rb
@@ -147,19 +147,6 @@ module Commands
 
         PublishingAPI.service(:queue_publisher).send_message(queue_payload)
       end
-
-      def raise_command_error(code, message, fields)
-        raise CommandError.new(
-          code: code,
-          message: message,
-          error_details: {
-            error: {
-              code: code,
-              message: message,
-            }.merge(fields)
-          }
-        )
-      end
     end
   end
 end

--- a/app/commands/v2/unpublish.rb
+++ b/app/commands/v2/unpublish.rb
@@ -43,7 +43,8 @@ module Commands
 
       def send_redirect_downstream(base_path:, publishing_app:, destination:)
         downstream_payload = {
-          format: "redirect",
+          document_type: "redirect",
+          schema_name: "redirect",
           base_path: base_path,
           publishing_app: publishing_app,
           public_updated_at: Time.zone.now.iso8601,

--- a/app/commands/v2/unpublish.rb
+++ b/app/commands/v2/unpublish.rb
@@ -24,13 +24,16 @@ module Commands
           end
         end
 
-        case payload.fetch(:type)
+        case type = payload.fetch(:type)
         when "withdrawal"
           withdraw(content_item)
         when "redirect"
           redirect(content_item)
         when "gone"
           gone(content_item)
+        else
+          message = "#{type} is not a valid unpublishing type"
+          raise_command_error(422, message, fields: {})
         end
 
         Success.new(content_id: content_id)

--- a/app/commands/v2/unpublish.rb
+++ b/app/commands/v2/unpublish.rb
@@ -20,20 +20,18 @@ module Commands
     private
 
       def withdraw(content_item)
-        unpublishing = Unpublishing.create!(
+        unpublishing = State.unpublish(content_item,
           type: "withdrawal",
           explanation: payload.fetch(:explanation),
-          content_item: content_item,
         )
 
         send_content_item_downstream(content_item, unpublishing) if downstream
       end
 
       def redirect(content_item)
-        unpublishing = Unpublishing.create!(
+        unpublishing = State.unpublish(content_item,
           type: "redirect",
           alternative_path: payload.fetch(:alternative_path),
-          content_item: content_item,
         )
 
         send_arbitrary_downstream(RedirectPresenter.present(
@@ -45,11 +43,10 @@ module Commands
       end
 
       def gone(content_item)
-        unpublishing = Unpublishing.create!(
+        unpublishing = State.unpublish(content_item,
           type: "gone",
           alternative_path: payload[:alternative_path],
           explanation: payload[:explanation],
-          content_item: content_item,
         )
 
         send_arbitrary_downstream(GonePresenter.present(

--- a/app/commands/v2/unpublish.rb
+++ b/app/commands/v2/unpublish.rb
@@ -71,7 +71,7 @@ module Commands
           public_updated_at: Time.zone.now,
         )
 
-        send_arbitrary_downstream(redirect) if downstream
+        send_downstream(redirect) if downstream
       end
 
       def gone(content_item)
@@ -88,10 +88,10 @@ module Commands
           explanation: payload[:explanation],
         )
 
-        send_arbitrary_downstream(gone) if downstream
+        send_downstream(gone) if downstream
       end
 
-      def send_arbitrary_downstream(downstream_payload)
+      def send_downstream(downstream_payload)
         PresentedContentStoreWorker.perform_async(
           content_store: Adapters::ContentStore,
           payload: downstream_payload,

--- a/app/commands/v2/unpublish.rb
+++ b/app/commands/v2/unpublish.rb
@@ -45,12 +45,12 @@ module Commands
     private
 
       def withdraw(content_item)
-        unpublishing = State.unpublish(content_item,
+        State.unpublish(content_item,
           type: "withdrawal",
           explanation: payload.fetch(:explanation),
         )
 
-        send_content_item_downstream(content_item, unpublishing) if downstream
+        send_content_item_downstream(content_item) if downstream
       end
 
       def redirect(content_item)
@@ -112,18 +112,11 @@ module Commands
         filter.filter(locale: locale, state: "draft").exists?
       end
 
-      def send_content_item_downstream(content_item, unpublishing)
+      def send_content_item_downstream(content_item)
         downstream_payload = Presenters::ContentStorePresenter.present(
           content_item,
           event,
           fallback_order: [:published]
-        )
-
-        downstream_payload.merge!(
-          withdrawn_notice: {
-            explanation: unpublishing.explanation,
-            withdrawn_at: unpublishing.created_at.iso8601,
-          }
         )
 
         PresentedContentStoreWorker.perform_async(

--- a/app/commands/v2/unpublish.rb
+++ b/app/commands/v2/unpublish.rb
@@ -1,0 +1,55 @@
+module Commands
+  module V2
+    class Unpublish < BaseCommand
+      def call
+        content_item = find_live_content_item
+
+        unpublishing = Unpublishing.create!(
+          type: "withdrawal",
+          explanation: payload.fetch(:explanation),
+          content_item: content_item,
+        )
+
+        send_downstream(content_item, unpublishing) if downstream
+
+        Success.new(content_id: content_id)
+      end
+
+    private
+
+      def content_id
+        payload[:content_id]
+      end
+
+      def locale
+        payload.fetch(:locale, ContentItem::DEFAULT_LOCALE)
+      end
+
+      def find_live_content_item
+        filter = ContentItemFilter.new(scope: ContentItem.where(content_id: content_id))
+        filter.filter(locale: locale, state: "published").first
+      end
+
+      def send_downstream(content_item, unpublishing)
+        downstream_payload = Presenters::ContentStorePresenter.present(
+          content_item,
+          event,
+          fallback_order: [:published]
+        )
+
+        downstream_payload.merge!(
+          withdrawn_notice: {
+            explanation: unpublishing.explanation,
+            withdrawn_at: unpublishing.created_at.iso8601,
+          }
+        )
+
+        PresentedContentStoreWorker.perform_async(
+          content_store: Adapters::ContentStore,
+          payload: downstream_payload,
+          request_uuid: GdsApi::GovukHeaders.headers[:govuk_request_id]
+        )
+      end
+    end
+  end
+end

--- a/app/commands/v2/unpublish.rb
+++ b/app/commands/v2/unpublish.rb
@@ -10,6 +10,11 @@ module Commands
           raise_command_error(404, message, fields: {})
         end
 
+        unless Location.where(content_item: content_item).exists?
+          message = "Cannot unpublish content with no location"
+          raise_command_error(422, message, fields: {})
+        end
+
         check_version_and_raise_if_conflicting(content_item, previous_version_number)
 
         if draft_present?(content_id)

--- a/app/commands/v2/unpublish.rb
+++ b/app/commands/v2/unpublish.rb
@@ -9,6 +9,8 @@ module Commands
           raise_command_error(404, message, fields: {})
         end
 
+        check_version_and_raise_if_conflicting(content_item, previous_version_number)
+
         if draft_present?(content_id)
           if payload[:discard_drafts] == true
             DiscardDraft.call(
@@ -89,6 +91,10 @@ module Commands
 
       def locale
         payload.fetch(:locale, ContentItem::DEFAULT_LOCALE)
+      end
+
+      def previous_version_number
+        payload[:previous_version].to_i if payload[:previous_version]
       end
 
       def find_unpublishable_content_item(content_id)

--- a/app/controllers/v2/content_items_controller.rb
+++ b/app/controllers/v2/content_items_controller.rb
@@ -45,6 +45,11 @@ module V2
       render status: response.code, json: response
     end
 
+    def unpublish
+      response = Commands::V2::Unpublish.call(content_item)
+      render status: response.code, json: response
+    end
+
     def discard_draft
       response = Commands::V2::DiscardDraft.call(content_item)
       render status: response.code, json: response

--- a/app/models/state.rb
+++ b/app/models/state.rb
@@ -22,11 +22,19 @@ class State < ActiveRecord::Base
     change_state(content_item, name: "published")
   end
 
-  def self.unpublish(content_item)
+  def self.unpublish(content_item, type:, explanation: nil, alternative_path: nil)
     change_state(content_item, name: "unpublished")
 
     Unpublishing.create!(
       content_item: content_item,
+      type: type,
+      explanation: explanation,
+      alternative_path: alternative_path,
+    )
+  end
+
+  def self.substitute(content_item)
+    unpublish(content_item,
       type: "substitute",
       explanation: "Automatically unpublished to make way for another content item",
     )

--- a/app/models/state.rb
+++ b/app/models/state.rb
@@ -25,12 +25,20 @@ class State < ActiveRecord::Base
   def self.unpublish(content_item, type:, explanation: nil, alternative_path: nil)
     change_state(content_item, name: "unpublished")
 
-    Unpublishing.create!(
-      content_item: content_item,
-      type: type,
-      explanation: explanation,
-      alternative_path: alternative_path,
-    )
+    if unpublishing = Unpublishing.find_by(content_item: content_item)
+      unpublishing.update_attributes(
+        type: type,
+        explanation: explanation,
+        alternative_path: alternative_path,
+      )
+    else
+      Unpublishing.create!(
+        content_item: content_item,
+        type: type,
+        explanation: explanation,
+        alternative_path: alternative_path,
+      )
+    end
   end
 
   def self.substitute(content_item)

--- a/app/models/state.rb
+++ b/app/models/state.rb
@@ -25,7 +25,9 @@ class State < ActiveRecord::Base
   def self.unpublish(content_item, type:, explanation: nil, alternative_path: nil)
     change_state(content_item, name: "unpublished")
 
-    if unpublishing = Unpublishing.find_by(content_item: content_item)
+    unpublishing = Unpublishing.find_by(content_item: content_item)
+
+    if unpublishing.present?
       unpublishing.update_attributes(
         type: type,
         explanation: explanation,

--- a/app/models/unpublishing.rb
+++ b/app/models/unpublishing.rb
@@ -3,8 +3,15 @@ class Unpublishing < ActiveRecord::Base
 
   belongs_to :content_item
 
+  VALID_TYPES = %w(
+    gone
+    withdrawal
+    redirect
+    substitute
+  ).freeze
+
   validates :content_item, presence: true, uniqueness: true
-  validates :type, presence: true
+  validates :type, presence: true, inclusion: { in: VALID_TYPES }
   validates :explanation, presence: true, if: :withdrawal?
   validates :alternative_path, presence: true, if: :redirect?
 

--- a/app/models/unpublishing.rb
+++ b/app/models/unpublishing.rb
@@ -6,7 +6,7 @@ class Unpublishing < ActiveRecord::Base
   validates :content_item, presence: true, uniqueness: true
   validates :type, presence: true
   validates :explanation, presence: true, if: :withdrawal?
-  validates :alternative_url, presence: true, if: :redirect?
+  validates :alternative_path, presence: true, if: :redirect?
 
   def withdrawal?
     type == "withdrawal"

--- a/app/presenters/downstream_presenter.rb
+++ b/app/presenters/downstream_presenter.rb
@@ -20,6 +20,7 @@ module Presenters
         .merge(access_limited)
         .merge(base_path)
         .merge(locale)
+        .merge(withdrawal_notice)
     end
 
   private
@@ -85,6 +86,21 @@ module Presenters
 
     def locale
       { locale: web_content_item.locale }
+    end
+
+    def withdrawal_notice
+      unpublishing = Unpublishing.find_by(content_item: content_item)
+
+      if unpublishing && unpublishing.withdrawal?
+        {
+          withdrawn_notice: {
+            explanation: unpublishing.explanation,
+            withdrawn_at: unpublishing.created_at.iso8601,
+          },
+        }
+      else
+        {}
+      end
     end
 
     class V1

--- a/app/presenters/gone_presenter.rb
+++ b/app/presenters/gone_presenter.rb
@@ -1,0 +1,20 @@
+module GonePresenter
+  def self.present(base_path:, publishing_app:, alternative_path:, explanation:)
+    {
+      document_type: "gone",
+      schema_name: "gone",
+      base_path: base_path,
+      publishing_app: publishing_app,
+      details: {
+        explanation: explanation,
+        alternative_path: alternative_path,
+      },
+      routes: [
+        {
+          path: base_path,
+          type: "exact",
+        }
+      ],
+    }
+  end
+end

--- a/app/presenters/redirect_presenter.rb
+++ b/app/presenters/redirect_presenter.rb
@@ -1,0 +1,18 @@
+module RedirectPresenter
+  def self.present(base_path:, publishing_app:, destination:, public_updated_at:)
+    {
+      document_type: "redirect",
+      schema_name: "redirect",
+      base_path: base_path,
+      publishing_app: publishing_app,
+      public_updated_at: public_updated_at.iso8601,
+      redirects: [
+        {
+          path: base_path,
+          type: "exact",
+          destination: destination,
+        }
+      ],
+    }
+  end
+end

--- a/app/substitution_helper.rb
+++ b/app/substitution_helper.rb
@@ -10,7 +10,7 @@ module SubstitutionHelper
         allowed_to_substitute = (substitute?(new_item_format) || substitute?(blocking_item.format))
 
         if mismatch && allowed_to_substitute
-          State.unpublish(blocking_item)
+          State.substitute(blocking_item)
         end
       end
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,7 @@ Rails.application.routes.draw do
       put "/content/:content_id", to: "content_items#put_content"
       get "/content/:content_id", to: "content_items#show"
       post "/content/:content_id/publish", to: "content_items#publish"
+      post "/content/:content_id/unpublish", to: "content_items#unpublish"
       post "/content/:content_id/discard-draft", to: "content_items#discard_draft"
 
       get "/links/:content_id", to: "link_sets#get_links"

--- a/db/migrate/20160505133601_rename_alternative_url.rb
+++ b/db/migrate/20160505133601_rename_alternative_url.rb
@@ -1,0 +1,5 @@
+class RenameAlternativeUrl < ActiveRecord::Migration
+  def change
+    rename_column :unpublishings, :alternative_url, :alternative_path
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160429123756) do
+ActiveRecord::Schema.define(version: 20160505133601) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -136,10 +136,10 @@ ActiveRecord::Schema.define(version: 20160429123756) do
   add_index "translations", ["content_item_id", "locale"], name: "index_translations_on_content_item_id_and_locale", using: :btree
 
   create_table "unpublishings", force: :cascade do |t|
-    t.integer  "content_item_id", null: false
-    t.string   "type",            null: false
+    t.integer  "content_item_id",  null: false
+    t.string   "type",             null: false
     t.string   "explanation"
-    t.string   "alternative_url"
+    t.string   "alternative_path"
     t.datetime "created_at"
     t.datetime "updated_at"
   end

--- a/doc/publishing-api-syntactic-usage.md
+++ b/doc/publishing-api-syntactic-usage.md
@@ -68,6 +68,35 @@ Requests to update an existing draft content item:
  - `locale` (optional) specifies the locale of the content item to be published.
  - `previous_version` (optional but advised) is used to ensure the request is publishing the latest lock version of this draft. ie. optimistic locking.
 
+ ## `POST /v2/content/:content_id/unpublish`
+
+ [Request/Response detail]()
+
+  - Will refuse to unpublish a lone draft.
+  - Will refuse to unpublish a redrafted document unless `discard_drafts` is `true`.
+  - Validates that unpublishing `type` is one of `withdrawal`, `gone` or `redirect` and raises a 422 otherwise.
+  - Retrieves the live content item with the matching content_id and locale and changes its state to `unpublished`.
+  - Creates an `Unpublishing` with the provided details.
+  - Will update the `Unpublishing` if the document is already unpublished.
+  - Sends the gone/redirect/withdrawal to the live content store.
+  - Does not send to the draft content store (unless a draft was discarded).
+  - Does not send to the message queue.
+  - Returns 200 along with the content_id of the unpublished item.
+
+ ### Required request params:
+  - `content_id` the primary identifier for the content to publish.
+  - `type` the type of unpublishing to create/perform.
+
+ ### Other request params:
+  - `explanation` (optional) Message to display on page for `gone`,
+                  (required) for `withdrawal`,
+                  (ignored) for `redirect`.
+  - `alternative_path` (optional) path to turn into a URL to display on page for `gone`,
+                       (required) path to redirect to if `redirect`,
+                       (ignored) if `withdrawal`.
+  - `discard_drafts` (optional) anything other than `true` is considered `false`,
+    including being absent.
+
 ## `GET /v2/links/:content_id`
 
 [Request/Response detail](https://pact-broker.dev.publishing.service.gov.uk/pacts/provider/Publishing%20API/consumer/GDS%20API%20Adapters/latest#a_get-links_request_given_empty_links_exist_for_content_id_bed722e6-db68-43e5-9079-063f623335a7)

--- a/lib/tasks/pact.rake
+++ b/lib/tasks/pact.rake
@@ -1,4 +1,5 @@
 unless Rails.env.production?
+  require 'pact/tasks'
 
   desc "Verifies the pact files for latest release and master"
   task "pact:verify" do

--- a/spec/commands/v2/unpublish_spec.rb
+++ b/spec/commands/v2/unpublish_spec.rb
@@ -185,5 +185,49 @@ RSpec.describe Commands::V2::Unpublish do
         described_class.call(payload)
       end
     end
+
+    context "with the `downstream` flag set to `false`" do
+      before do
+        FactoryGirl.create(:live_content_item, :with_draft,
+          content_id: content_id,
+        )
+      end
+
+      it "does not send to any downstream system for a 'gone'" do
+        expect(PublishingAPI.service(:live_content_store)).not_to receive(:put_content_item)
+        expect(PublishingAPI.service(:draft_content_store)).not_to receive(:put_content_item)
+        expect(PublishingAPI.service(:queue_publisher)).not_to receive(:send_message)
+
+        redraft_payload = payload.merge(
+          type: "gone",
+          discard_drafts: true,
+        )
+        described_class.call(redraft_payload, downstream: false)
+      end
+
+      it "does not send to any downstream system for a 'redirect'" do
+        expect(PublishingAPI.service(:live_content_store)).not_to receive(:put_content_item)
+        expect(PublishingAPI.service(:draft_content_store)).not_to receive(:put_content_item)
+        expect(PublishingAPI.service(:queue_publisher)).not_to receive(:send_message)
+
+        redraft_payload = payload.merge(
+          type: "redirect",
+          discard_drafts: true,
+        )
+        described_class.call(redraft_payload, downstream: false)
+      end
+
+      it "does not send to any downstream system for a 'withdrawal'" do
+        expect(PublishingAPI.service(:live_content_store)).not_to receive(:put_content_item)
+        expect(PublishingAPI.service(:draft_content_store)).not_to receive(:put_content_item)
+        expect(PublishingAPI.service(:queue_publisher)).not_to receive(:send_message)
+
+        redraft_payload = payload.merge(
+          type: "withdrawal",
+          discard_drafts: true,
+        )
+        described_class.call(redraft_payload, downstream: false)
+      end
+    end
   end
 end

--- a/spec/commands/v2/unpublish_spec.rb
+++ b/spec/commands/v2/unpublish_spec.rb
@@ -229,5 +229,24 @@ RSpec.describe Commands::V2::Unpublish do
         described_class.call(redraft_payload, downstream: false)
       end
     end
+
+    context "when trying to unpublish a content item with no location" do
+      before do
+        content_item = FactoryGirl.create(:live_content_item,
+          content_id: content_id,
+          base_path: base_path,
+        )
+
+        Location.find_by(content_item: content_item).destroy
+      end
+
+      it "rejects the request with a 422" do
+        expect {
+          described_class.call(payload)
+        }.to raise_error(CommandError, "Cannot unpublish content with no location") { |error|
+          expect(error.code).to eq(422)
+        }
+      end
+    end
   end
 end

--- a/spec/commands/v2/unpublish_spec.rb
+++ b/spec/commands/v2/unpublish_spec.rb
@@ -75,9 +75,9 @@ RSpec.describe Commands::V2::Unpublish do
       it "rejects the request with a 404" do
         expect {
           described_class.call(payload)
-        }.to raise_error(CommandError, "Could not find a content item to unpublish") do |error|
+        }.to raise_error(CommandError, "Could not find a content item to unpublish") { |error|
           expect(error.code).to eq(404)
-        end
+        }
       end
     end
 
@@ -91,9 +91,9 @@ RSpec.describe Commands::V2::Unpublish do
       it "rejects the request with a 422" do
         expect {
           described_class.call(payload)
-        }.to raise_error(CommandError, "Cannot unpublish with a draft present") do |error|
+        }.to raise_error(CommandError, "Cannot unpublish with a draft present") { |error|
           expect(error.code).to eq(422)
-        end
+        }
       end
 
       context "with `discard_drafts` set to true" do

--- a/spec/commands/v2/unpublish_spec.rb
+++ b/spec/commands/v2/unpublish_spec.rb
@@ -1,0 +1,189 @@
+require "rails_helper"
+
+RSpec.describe Commands::V2::Unpublish do
+  let(:content_id) { SecureRandom.uuid }
+  let(:base_path) { "/vat-rates" }
+
+  describe "call" do
+    let(:payload) do
+      {
+        content_id: content_id,
+        type: "gone",
+        explanation: "Removed for testing porpoises",
+        alternative_path: "/new-path",
+      }
+    end
+
+    before do
+      stub_request(:put, %r{.*content-store.*/content/.*})
+    end
+
+    context "when the document is published" do
+      let!(:live_content_item) do
+        FactoryGirl.create(:live_content_item,
+          content_id: content_id,
+          base_path: base_path,
+        )
+      end
+
+      it "sets the content item's state to `unpublished`" do
+        described_class.call(payload)
+
+        state = State.find_by(content_item: live_content_item)
+        expect(state.name).to eq("unpublished")
+      end
+
+      it "creates an Unpublishing" do
+        described_class.call(payload)
+
+        unpublishing = Unpublishing.find_by(content_item: live_content_item)
+        expect(unpublishing.type).to eq("gone")
+        expect(unpublishing.explanation).to eq("Removed for testing porpoises")
+        expect(unpublishing.alternative_path).to eq("/new-path")
+      end
+
+      it "sends an unpublishing to the live content store" do
+        Timecop.freeze do
+          expect(PublishingAPI.service(:live_content_store)).to receive(:put_content_item)
+            .with(
+              base_path: base_path,
+              content_item: a_hash_including(
+                document_type: "gone",
+              )
+            )
+
+          described_class.call(payload)
+        end
+      end
+
+      it "does not send to any other downstream system" do
+        allow(PublishingAPI.service(:live_content_store)).to receive(:put_content_item)
+        expect(PublishingAPI.service(:draft_content_store)).not_to receive(:put_content_item)
+        expect(PublishingAPI.service(:queue_publisher)).not_to receive(:send_message)
+
+        described_class.call(payload)
+      end
+    end
+
+    context "when only a draft is present" do
+      before do
+        FactoryGirl.create(:draft_content_item,
+          content_id: content_id,
+        )
+      end
+
+      it "rejects the request with a 404" do
+        expect {
+          described_class.call(payload)
+        }.to raise_error(CommandError, "Could not find a content item to unpublish") do |error|
+          expect(error.code).to eq(404)
+        end
+      end
+    end
+
+    context "when the document is redrafted" do
+      let!(:live_content_item) do
+        FactoryGirl.create(:live_content_item, :with_draft,
+          content_id: content_id,
+        )
+      end
+
+      it "rejects the request with a 422" do
+        expect {
+          described_class.call(payload)
+        }.to raise_error(CommandError, "Cannot unpublish with a draft present") do |error|
+          expect(error.code).to eq(422)
+        end
+      end
+
+      context "with `discard_drafts` set to true" do
+        let(:payload) do
+          {
+            content_id: content_id,
+            type: "gone",
+            discard_drafts: true,
+          }
+        end
+
+        before do
+          stub_request(:delete, %r{.*content-store.*/content/.*})
+        end
+
+        it "discards the draft" do
+          described_class.call(payload)
+
+          content_items = ContentItem.where(content_id: content_id)
+          expect(content_items.count).to eq(1)
+
+          state = State.find_by(content_item: content_items.first)
+          expect(state.name).to eq("unpublished")
+        end
+
+        it "unpublishes the content item" do
+          described_class.call(payload)
+          live_content_item.reload
+
+          unpublishing = Unpublishing.find_by(content_item: live_content_item)
+          expect(unpublishing).not_to be_nil
+        end
+      end
+    end
+
+    context "when the document is already unpublished" do
+      let!(:unpublished_content_item) do
+        FactoryGirl.create(:unpublished_content_item,
+          content_id: content_id,
+          base_path: base_path,
+          explanation: "This explnatin has a typo",
+          alternative_path: "/new-path",
+        )
+      end
+
+      let(:payload) do
+        {
+          content_id: content_id,
+          type: "gone",
+          explanation: "This explanation is correct",
+        }
+      end
+
+      it "updates the Unpublishing" do
+        unpublishing = Unpublishing.find_by(content_item: unpublished_content_item)
+        expect(unpublishing.explanation).to eq("This explnatin has a typo")
+
+        described_class.call(payload)
+
+        unpublishing.reload
+
+        expect(unpublishing.explanation).to eq("This explanation is correct")
+        expect(unpublishing.alternative_path).to be_nil
+      end
+
+      it "sends an unpublishing to the live content store" do
+        Timecop.freeze do
+          expect(PublishingAPI.service(:live_content_store)).to receive(:put_content_item)
+            .with(
+              base_path: base_path,
+              content_item: a_hash_including(
+                document_type: "gone",
+                details: {
+                  explanation: "This explanation is correct",
+                  alternative_path: nil,
+                }
+              )
+            )
+
+          described_class.call(payload)
+        end
+      end
+
+      it "does not send to any other downstream system" do
+        allow(PublishingAPI.service(:live_content_store)).to receive(:put_content_item)
+        expect(PublishingAPI.service(:draft_content_store)).not_to receive(:put_content_item)
+        expect(PublishingAPI.service(:queue_publisher)).not_to receive(:send_message)
+
+        described_class.call(payload)
+      end
+    end
+  end
+end

--- a/spec/factories/unpublished_content_item.rb
+++ b/spec/factories/unpublished_content_item.rb
@@ -1,0 +1,19 @@
+FactoryGirl.define do
+  factory :unpublished_content_item, parent: :content_item do
+    transient do
+      state "unpublished"
+      unpublishing_type "gone"
+      explanation "Removed for testing reasons"
+      alternative_path "/new-path"
+    end
+
+    after(:create) do |content_item, evaluator|
+      FactoryGirl.create(:unpublishing,
+        content_item: content_item,
+        type: evaluator.unpublishing_type,
+        explanation: evaluator.explanation,
+        alternative_path: evaluator.alternative_path,
+      )
+    end
+  end
+end

--- a/spec/factories/unpublished_content_item.rb
+++ b/spec/factories/unpublished_content_item.rb
@@ -16,4 +16,10 @@ FactoryGirl.define do
       )
     end
   end
+
+  factory :withdrawn_content_item, parent: :unpublished_content_item do
+    transient do
+      unpublishing_type "withdrawal"
+    end
+  end
 end

--- a/spec/factories/unpublishing.rb
+++ b/spec/factories/unpublishing.rb
@@ -3,6 +3,6 @@ FactoryGirl.define do
     content_item
     type "gone"
     explanation "Removed for testing reasons"
-    alternative_url "http://example.com/unpublishing"
+    alternative_path "/new-path"
   end
 end

--- a/spec/models/lock_version_spec.rb
+++ b/spec/models/lock_version_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe LockVersion do
       end
 
       lock_versions = LockVersion.in_bulk(items, ContentItem)
-      expect(lock_versions.keys).to eq(items.map(&:id))
+      expect(lock_versions.keys).to match_array(items.map(&:id))
     end
   end
 

--- a/spec/models/state_spec.rb
+++ b/spec/models/state_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe State do
   end
 
   describe ".supersede" do
-    let(:draft_item) { FactoryGirl.create(:draft_content_item, title: "Draft Title") }
+    let(:draft_item) { FactoryGirl.create(:draft_content_item) }
     let(:draft_state) { State.find_by!(content_item: draft_item) }
 
     it "changes the state name to 'superseded'" do
@@ -53,7 +53,7 @@ RSpec.describe State do
   end
 
   describe ".publish" do
-    let(:draft_item) { FactoryGirl.create(:draft_content_item, title: "Draft Title") }
+    let(:draft_item) { FactoryGirl.create(:draft_content_item) }
     let(:draft_state) { State.find_by!(content_item: draft_item) }
 
     it "changes the state name to 'published'" do

--- a/spec/models/unpublishing_spec.rb
+++ b/spec/models/unpublishing_spec.rb
@@ -8,10 +8,26 @@ RSpec.describe Unpublishing do
       expect(subject).to be_valid
     end
 
-    it "requires a type" do
-      subject.type = nil
+    it "requires a valid type" do
+      valid_types = %w(
+        gone
+        withdrawal
+        redirect
+        substitute
+      )
+
+      valid_types.each do |type|
+        subject.type = type
+        expect(subject).to be_valid
+      end
+
+      subject.type = "anything-else"
       expect(subject).to be_invalid
       expect(subject.errors[:type].size).to eq(1)
+
+      subject.type = nil
+      expect(subject).to be_invalid
+      expect(subject.errors[:type].size).to eq(2)
     end
 
     it "does not require an explanation for a 'gone'" do

--- a/spec/models/unpublishing_spec.rb
+++ b/spec/models/unpublishing_spec.rb
@@ -27,17 +27,17 @@ RSpec.describe Unpublishing do
       expect(subject.errors[:explanation].size).to eq(1)
     end
 
-    it "does not require an alternative_url for a 'gone'" do
+    it "does not require an alternative_path for a 'gone'" do
       subject.type = "gone"
-      subject.alternative_url = nil
+      subject.alternative_path = nil
       expect(subject).to be_valid
     end
 
-    it "requires an alternative_url for a 'redirect'" do
+    it "requires an alternative_path for a 'redirect'" do
       subject.type = "redirect"
-      subject.alternative_url = nil
+      subject.alternative_path = nil
       expect(subject).to be_invalid
-      expect(subject.errors[:alternative_url].size).to eq(1)
+      expect(subject.errors[:alternative_path].size).to eq(1)
     end
   end
 end

--- a/spec/presenters/downstream_presenter_spec.rb
+++ b/spec/presenters/downstream_presenter_spec.rb
@@ -50,6 +50,24 @@ RSpec.describe Presenters::DownstreamPresenter do
       end
     end
 
+    context "for a withdrawn content item" do
+      let!(:content_item) { create(:withdrawn_content_item) }
+      let!(:link_set) { create(:link_set, content_id: content_item.content_id) }
+
+      it "merges in a withdrawal notice" do
+        unpublishing = Unpublishing.find_by(content_item: content_item)
+
+        expect(result).to eq(
+          expected.merge(
+            withdrawn_notice: {
+              explanation: unpublishing.explanation,
+              withdrawn_at: unpublishing.created_at.iso8601,
+            }
+          )
+        )
+      end
+    end
+
     context "for a content item with dependencies" do
       let(:a) { FactoryGirl.create(:content_item, base_path: "/a") }
       let(:b) { FactoryGirl.create(:content_item, base_path: "/b") }

--- a/spec/requests/unpublishing_spec.rb
+++ b/spec/requests/unpublishing_spec.rb
@@ -1,0 +1,66 @@
+require "rails_helper"
+
+# This spec covers the common success case for each
+# type of unpublishing.
+#
+# See the command spec for more detailed edge cases
+# and failure modes.
+#
+RSpec.describe "POST /v2/content/:content_id/unpublish", type: :request do
+  let(:content_id) { SecureRandom.uuid }
+  let(:base_path) { "/vat-rates" }
+  let!(:content_item) {
+    FactoryGirl.create(:live_content_item,
+      content_id: content_id,
+      base_path: base_path,
+    )
+  }
+
+  describe "withdrawing" do
+    let(:withdrawal_params) {
+      {
+        type: "withdrawal",
+        explanation: "Test withdrawal",
+      }.to_json
+    }
+
+    it "creates an Unpublishing" do
+      post "/v2/content/#{content_id}/unpublish", withdrawal_params
+
+      expect(response.status).to eq(200), response.body
+
+      unpublishing = Unpublishing.find_by(content_item: content_item)
+      expect(unpublishing.type).to eq("withdrawal")
+      expect(unpublishing.explanation).to eq("Test withdrawal")
+    end
+
+    it "sends the withdrawal information to the live content store" do
+      Timecop.freeze do
+        expect(PublishingAPI.service(:live_content_store)).to receive(:put_content_item)
+          .with(
+            base_path: base_path,
+            content_item: a_hash_including(
+              withdrawn_notice: {
+                explanation: "Test withdrawal",
+                withdrawn_at: Time.zone.now.iso8601,
+              }
+            )
+          )
+
+        post "/v2/content/#{content_id}/unpublish", withdrawal_params
+
+        expect(response.status).to eq(200), response.body
+      end
+    end
+
+    it "does not send to any other downstream system" do
+      allow(PublishingAPI.service(:live_content_store)).to receive(:put_content_item)
+      expect(PublishingAPI.service(:draft_content_store)).not_to receive(:put_content_item)
+      expect(PublishingAPI.service(:queue_publisher)).not_to receive(:send_message)
+
+      post "/v2/content/#{content_id}/unpublish", withdrawal_params
+
+      expect(response.status).to eq(200), response.body
+    end
+  end
+end

--- a/spec/requests/unpublishing_spec.rb
+++ b/spec/requests/unpublishing_spec.rb
@@ -88,7 +88,8 @@ RSpec.describe "POST /v2/content/:content_id/unpublish", type: :request do
           .with(
             base_path: base_path,
             content_item: {
-              format: "redirect",
+              document_type: "redirect",
+              schema_name: "redirect",
               base_path: base_path,
               publishing_app: content_item.publishing_app,
               public_updated_at: Time.zone.now.iso8601,

--- a/spec/requests/unpublishing_spec.rb
+++ b/spec/requests/unpublishing_spec.rb
@@ -179,4 +179,14 @@ RSpec.describe "POST /v2/content/:content_id/unpublish", type: :request do
       expect(response.status).to eq(200), response.body
     end
   end
+
+  describe "a bad unpublishing type" do
+    it "422s" do
+      post "/v2/content/#{content_id}/unpublish", {
+        type: "not-correct",
+      }.to_json
+
+      expect(response.status).to eq(422), response.body
+    end
+  end
 end

--- a/spec/service_consumers/pact_helper.rb
+++ b/spec/service_consumers/pact_helper.rb
@@ -119,6 +119,15 @@ Pact.provider_states_for "GDS API Adapters" do
     end
   end
 
+  provider_state "an unpublished content item exists with content_id: bed722e6-db68-43e5-9079-063f623335a7" do
+    set_up do
+      live = FactoryGirl.create(
+        :unpublished_content_item,
+        content_id: "bed722e6-db68-43e5-9079-063f623335a7"
+      )
+    end
+  end
+
   provider_state "organisation links exist for content_id bed722e6-db68-43e5-9079-063f623335a7" do
     set_up do
       link_set = FactoryGirl.create(:link_set,
@@ -324,6 +333,19 @@ Pact.provider_states_for "GDS API Adapters" do
     set_up do
       FactoryGirl.create(
         :draft_content_item,
+        content_id: "bed722e6-db68-43e5-9079-063f623335a7",
+        lock_version: 3
+      )
+
+      stub_request(:put, Regexp.new('\A' + Regexp.escape(Plek.find("content-store")) + "/content"))
+      stub_request(:put, Regexp.new('\A' + Regexp.escape(Plek.find("draft-content-store")) + "/content"))
+    end
+  end
+
+  provider_state "the published content item bed722e6-db68-43e5-9079-063f623335a7 is at version 3" do
+    set_up do
+      FactoryGirl.create(
+        :live_content_item,
         content_id: "bed722e6-db68-43e5-9079-063f623335a7",
         lock_version: 3
       )

--- a/spec/service_consumers/pact_helper.rb
+++ b/spec/service_consumers/pact_helper.rb
@@ -121,7 +121,7 @@ Pact.provider_states_for "GDS API Adapters" do
 
   provider_state "an unpublished content item exists with content_id: bed722e6-db68-43e5-9079-063f623335a7" do
     set_up do
-      live = FactoryGirl.create(
+      FactoryGirl.create(
         :unpublished_content_item,
         content_id: "bed722e6-db68-43e5-9079-063f623335a7"
       )


### PR DESCRIPTION
Add an endpoint for unpublishing content, including "gone" items, "withdrawal"s, and redirects.

More details here https://trello.com/c/vXVnrgbB/701-add-v2-content-content-id-unpublish-endpoint and in the included docs.