### PR TITLE
Provide a place to specify reverse link types.

### DIFF
--- a/app/queries/expansion_rules.rb
+++ b/app/queries/expansion_rules.rb
@@ -10,6 +10,12 @@ module Queries
       recursive_link_types.include?(link_type)
     end
 
+    def reverse(link_type)
+      {
+        parent: :child,
+      }[link_type]
+    end
+
   private
 
     def recursive_link_types

--- a/spec/queries/expansion_rules_spec.rb
+++ b/spec/queries/expansion_rules_spec.rb
@@ -32,4 +32,8 @@ RSpec.describe Queries::ExpansionRules do
     specify { expect(subject.recurse?(:parent)).to eq(true) }
     specify { expect(subject.recurse?(:foo)).to eq(false) }
   end
+
+  describe "#reverse(link_type)" do
+    specify { expect(subject.reverse(:parent)).to eq(:child) }
+  end
 end


### PR DESCRIPTION
This is to be used by reverse dependencies so the
lookup can follow certain link types backwards.

The same mechanism can be used to specify which
fields to expand in these new link types as is
used in the normal dependency resolution as we are
expecting the reverse of a link type to be unique.

https://trello.com/c/TeTOKJdm/672-6-add-reverse-dependency-information-to-publishing-api