### PR TITLE
Allow V1 PUT content to consume schema_name/doc_type

### DIFF
--- a/app/controllers/content_items_controller.rb
+++ b/app/controllers/content_items_controller.rb
@@ -14,7 +14,9 @@ class ContentItemsController < ApplicationController
 private
 
   def validate_routing_key_fields
-    unless [:format, :update_type].all? { |field| content_item[field] =~ /\A[a-z0-9_]+\z/i }
+    routing_key_fields = [:update_type] + (content_item[:format] ? [:format] : [:schema_name, :document_type])
+
+    unless routing_key_fields.all? { |field| content_item[field] =~ /\A[a-z0-9_]+\z/i }
       head :unprocessable_entity
     end
   end

--- a/spec/commands/put_content_with_links_spec.rb
+++ b/spec/commands/put_content_with_links_spec.rb
@@ -46,6 +46,19 @@ RSpec.describe Commands::PutContentWithLinks do
     end
   end
 
+  context "when using document_type and schema_name instead of format" do
+    before do
+      payload[:format] = nil
+      payload[:document_type] = "guide"
+      payload[:schema_name] = "guide"
+    end
+
+    it "responds successfully" do
+      result = described_class.call(payload)
+      expect(result).to be_a(Commands::Success)
+    end
+  end
+
   it "responds successfully" do
     result = described_class.call(payload)
     expect(result).to be_a(Commands::Success)

--- a/spec/controllers/content_items_controller_spec.rb
+++ b/spec/controllers/content_items_controller_spec.rb
@@ -29,6 +29,12 @@ RSpec.describe ContentItemsController do
     }
   }
 
+  let(:content_item_without_format) {
+    base_content_item.tap { |item|
+      item[:schema_name] = item[:document_type] = item.delete(:format)
+    }
+  }
+
   describe 'put_live_content_item' do
     before do
       stub_request(:put, %r{.*content-store.*/content/.*})
@@ -65,6 +71,36 @@ RSpec.describe ContentItemsController do
         invalid_routing_keys.each do |routing_key|
           it "should respond with 422 if #{field} has value '#{routing_key}'" do
             content_item = base_content_item.merge(field => routing_key)
+
+            raw_json_put(
+              action: :put_live_content_item,
+              base_path: base_path,
+              json: content_item.to_json,
+            )
+
+            expect(response.status).to eq(422)
+          end
+        end
+      end
+
+      %w(schema_name document_type update_type).each do |field|
+        valid_routing_keys.each do |routing_key|
+          it "should respond with 200 if #{field} has value '#{routing_key}'" do
+            content_item = content_item_without_format.merge(field => routing_key)
+
+            raw_json_put(
+              action: :put_live_content_item,
+              base_path: base_path,
+              json: content_item.to_json,
+            )
+
+            expect(response.status).to eq(200)
+          end
+        end
+
+        invalid_routing_keys.each do |routing_key|
+          it "should respond with 422 if #{field} has value '#{routing_key}'" do
+            content_item = content_item_without_format.merge(field => routing_key)
 
             raw_json_put(
               action: :put_live_content_item,

--- a/spec/lib/requeue_content_spec.rb
+++ b/spec/lib/requeue_content_spec.rb
@@ -1,6 +1,10 @@
 require "rails_helper"
 
 RSpec.describe RequeueContent do
+  before do
+    ContentItem.destroy_all
+  end
+
   let!(:content_item1) { create(:live_content_item, base_path: '/ci1') }
   let!(:content_item2) { create(:live_content_item, base_path: '/ci2') }
   let!(:content_item3) { create(:live_content_item, base_path: '/ci3') }


### PR DESCRIPTION
We're changing the v1 specialist publisher payload to work without format, which is the driver for this work. This relates to this ticket:

https://trello.com/c/UuqdA5xq/127-documents-published-in-spv1-don-t-appear-in-sp-rebuild-index