### PR TITLE
Migrate format to dual fields specialist pub

### DIFF
--- a/db/migrate/20160511145349_update_format_to_dual_specialist_publisher.rb
+++ b/db/migrate/20160511145349_update_format_to_dual_specialist_publisher.rb
@@ -1,0 +1,6 @@
+class UpdateFormatToDualSpecialistPublisher < ActiveRecord::Migration
+  def change
+    ContentItem.where(document_type: ['specialist_document', 'placeholder_specialist_document'])
+      .update_all("document_type = (details #>> '{metadata,document_type}')")
+  end
+end


### PR DESCRIPTION
> Specialist publisher has a separate document_type from schema
> name. Currently, these are set to the same thing. This
> migration sets the document_type from details.metadata.document_type