### PR TITLE
Send a payload version to content store when unpublishing.

### DIFF
--- a/app/commands/v2/unpublish.rb
+++ b/app/commands/v2/unpublish.rb
@@ -100,8 +100,8 @@ module Commands
 
         PresentedContentStoreWorker.perform_async(
           content_store: Adapters::ContentStore,
-          payload: downstream_payload,
-          request_uuid: GdsApi::GovukHeaders.headers[:govuk_request_id]
+          payload: downstream_payload.merge(payload_version: event.id),
+          request_uuid: GdsApi::GovukHeaders.headers[:govuk_request_id],
         )
       end
 

--- a/spec/requests/unpublishing_spec.rb
+++ b/spec/requests/unpublishing_spec.rb
@@ -100,7 +100,8 @@ RSpec.describe "POST /v2/content/:content_id/unpublish", type: :request do
                   destination: "/new-path",
                 }
               ],
-            }
+              payload_version: anything,
+            },
           )
 
         post "/v2/content/#{content_id}/unpublish", redirect_params
@@ -160,7 +161,8 @@ RSpec.describe "POST /v2/content/:content_id/unpublish", type: :request do
                   type: "exact",
                 }
               ],
-            }
+              payload_version: anything,
+            },
           )
 
         post "/v2/content/#{content_id}/unpublish", gone_params


### PR DESCRIPTION
Required for locking.