### PR TITLE
Add an order parameter to /v2/content

### DIFF
--- a/app/pagination.rb
+++ b/app/pagination.rb
@@ -4,7 +4,7 @@ class Pagination
 
   def initialize(options = {})
     @options = options
-    @order = { public_updated_at: :desc }
+    @order = order_from_options(options)
     @page = options[:page] || 1
     @per_page = options.fetch(:per_page, PER_PAGE).to_i
 
@@ -25,5 +25,56 @@ private
 
   def offset_from_page
     options.fetch(:offset, (page.to_i - 1) * per_page).to_i
+  end
+
+  def order_from_options(options)
+    order = options.fetch(:order, "-public_updated_at")
+
+    if order.start_with?("-")
+      field = order[1..-1].to_sym
+      direction = :desc
+    else
+      field = order.to_sym
+      direction = :asc
+    end
+
+    raise_unless_valid_order_field(field)
+
+    { field => direction }
+  end
+
+  def raise_unless_valid_order_field(field)
+    return if valid_order_fields.include?(field)
+
+    message = "Invalid order field: #{field}."
+    message += " Valid order fields: [#{valid_order_fields.join(', ')}]"
+
+    raise CommandError.new(
+      code: 422,
+      message: "Invalid order field: #{field}",
+      error_details: {
+        error: {
+          code: 422,
+          message: message,
+        }
+      }
+    )
+  end
+
+  # These fields have indexes and so we can use them to order results. If we
+  # need to add an order field, ensure that it has an index or query performance
+  # will be hampered.
+  def valid_order_fields
+    [
+      :content_id,
+      :document_type,
+      :format,
+      :public_updated_at,
+      :publishing_app,
+      :rendering_app,
+      :base_path,
+      :locale,
+      :updated_at,
+    ]
   end
 end

--- a/app/presenters/queries/content_item_presenter.rb
+++ b/app/presenters/queries/content_item_presenter.rb
@@ -13,6 +13,7 @@ module Presenters
         :locale,
         :lock_version,
         :internal_name,
+        :updated_at,
       ]
 
       def self.present_many(scope, params = {})

--- a/db/migrate/20160512122441_index_content_items_on_updated_at.rb
+++ b/db/migrate/20160512122441_index_content_items_on_updated_at.rb
@@ -1,0 +1,5 @@
+class IndexContentItemsOnUpdatedAt < ActiveRecord::Migration
+  def change
+    add_index :content_items, :updated_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160505133601) do
+ActiveRecord::Schema.define(version: 20160512122441) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -51,6 +51,7 @@ ActiveRecord::Schema.define(version: 20160505133601) do
   add_index "content_items", ["public_updated_at"], name: "index_content_items_on_public_updated_at", using: :btree
   add_index "content_items", ["publishing_app"], name: "index_content_items_on_publishing_app", using: :btree
   add_index "content_items", ["rendering_app"], name: "index_content_items_on_rendering_app", using: :btree
+  add_index "content_items", ["updated_at"], name: "index_content_items_on_updated_at", using: :btree
 
   create_table "events", force: :cascade do |t|
     t.string   "action",                  null: false

--- a/doc/publishing-api-syntactic-usage.md
+++ b/doc/publishing-api-syntactic-usage.md
@@ -180,12 +180,14 @@ No downstream requests will be sent if the content item doesn't exist yet.
   - Can optionally return content items in all locales by specifying a `locale` of 'all'
   - Can return the `publication_state` of the content item by including it in the `fields[]`
   - Can search for queries against `base_path` or `title`
+  - Can order ascending or descending by: content_id, document_type, format, public_updated_at, publishing_app, rendering_app, base_path, locale, updated_at
 
 ### Required request params:
   - `document_type` the type of content item to return
   - `locale` (optional) is used to restrict returned content items to a given locale (defaults to 'en')
   - `fields[]` an array of fields that are validated against `ContentItem` column fields. Any invalid requested field will raise a `400`.
   - `q` (optional) the search term to match against `base_path` or `title`
+  - `order` (optional) the field to sort results by. Ordered ascending unless prefixed with a hyphen, e.g. `-updated_at`. Defaults to `public_updated_at` descending.
 
 ## `GET /v2/linkables`
 

--- a/spec/controllers/v2/content_items_controller_spec.rb
+++ b/spec/controllers/v2/content_items_controller_spec.rb
@@ -177,6 +177,93 @@ RSpec.describe V2::ContentItemsController do
       end
     end
 
+    context "with an order param" do
+      before do
+        @en_draft_content.update!(updated_at: Date.new(2016, 1, 1))
+        @ar_draft_content.update!(updated_at: Date.new(2016, 2, 2))
+
+        get :index, document_type: "topic", locale: "all", order: order, fields: fields
+      end
+
+      context "when ordering by updated_at ascending" do
+        let(:order) { "updated_at" }
+        let(:fields) { ["updated_at"] }
+
+        it "returns the ordered results" do
+          results = JSON.parse(response.body)["results"]
+
+          expect(results).to eq([
+            { "updated_at" => "2016-01-01 00:00:00" },
+            { "updated_at" => "2016-02-02 00:00:00" },
+          ])
+        end
+      end
+
+      context "when ordering by updated_at ascending" do
+        let(:order) { "-updated_at" }
+        let(:fields) { ["updated_at"] }
+
+        it "returns the ordered results" do
+          results = JSON.parse(response.body)["results"]
+
+          expect(results).to eq([
+            { "updated_at" => "2016-02-02 00:00:00" },
+            { "updated_at" => "2016-01-01 00:00:00" },
+          ])
+        end
+      end
+
+      context "when ordering by base_path ascending" do
+        let(:order) { "base_path" }
+        let(:fields) { ["base_path"] }
+
+        it "returns the ordered results" do
+          results = JSON.parse(response.body)["results"]
+
+          expect(results).to eq([
+            { "base_path" => "/content.ar" },
+            { "base_path" => "/content.en" },
+          ])
+        end
+      end
+
+      context "when ordering by base_path ascending" do
+        let(:order) { "-base_path" }
+        let(:fields) { ["base_path"] }
+
+        it "returns the ordered results" do
+          results = JSON.parse(response.body)["results"]
+
+          expect(results).to eq([
+            { "base_path" => "/content.en" },
+            { "base_path" => "/content.ar" },
+          ])
+        end
+      end
+
+      context "when ordering by a field that doesn't exist" do
+        let(:order) { "doesnt_exist" }
+        let(:fields) { ["content_id"] }
+
+        it "responds with 422 and an error message" do
+          expect(response.status).to eq(422)
+          message = JSON.parse(response.body)["error"]["message"]
+          expect(message).to include(order)
+        end
+      end
+
+      context "when ordering by a field without an index" do
+        let(:order) { "created_at" }
+        let(:fields) { ["content_id"] }
+
+        it "responds with 422 and an error message" do
+          expect(response.status).to eq(422)
+          message = JSON.parse(response.body)["error"]["message"]
+          expect(message).to include(order)
+        end
+      end
+    end
+
     context "with link filtering params" do
       before do
         org_content_id = SecureRandom.uuid

--- a/spec/presenters/queries/content_item_presenter_spec.rb
+++ b/spec/presenters/queries/content_item_presenter_spec.rb
@@ -10,6 +10,12 @@ RSpec.describe Presenters::Queries::ContentItemPresenter do
 
     let(:result) { described_class.present(content_item) }
 
+    around do |example|
+      Timecop.freeze(Date.new(2016, 1, 1)) do
+        example.run
+      end
+    end
+
     it "presents content item attributes as a hash" do
       expect(result).to eq(
         "content_id" => content_id,
@@ -35,6 +41,7 @@ RSpec.describe Presenters::Queries::ContentItemPresenter do
         "publication_state" => "draft",
         "user_facing_version" => 1,
         "lock_version" => 1,
+        "updated_at" => "2016-01-01 00:00:00",
       )
     end
 


### PR DESCRIPTION
This pull request adds an order parameter to allow publishing apps to order their results by a field other than `public_updated_at` which was previously hardcoded. We have used the same interface as documented [here](https://github.com/alphagov/rummager/blob/master/docs/unified-search-api.md) as suggested by @tijmenb.

This work was completed as part of this ticket:
https://trello.com/c/XJRTeF9f/130-spv2-orders-by-the-wrong-timestamp-on-the-search-index

We decided to limit the fields that you may order by to those that had indexes and left a comment indicating that we should be careful to add an index to any additional fields with which we wish to order. Otherwise, performance would be affected when running the query.