### PR TITLE
Fix typo in spec context description

### DIFF
--- a/spec/controllers/v2/content_items_controller_spec.rb
+++ b/spec/controllers/v2/content_items_controller_spec.rb
@@ -199,7 +199,7 @@ RSpec.describe V2::ContentItemsController do
         end
       end
 
-      context "when ordering by updated_at ascending" do
+      context "when ordering by updated_at descending" do
         let(:order) { "-updated_at" }
         let(:fields) { ["updated_at"] }
 


### PR DESCRIPTION
The original spec was introduced in #298.

/cc @tuzz 