### PR TITLE
Disambiguate updated_at when ordering on /v2/content

### DIFF
--- a/app/pagination.rb
+++ b/app/pagination.rb
@@ -39,6 +39,7 @@ private
     end
 
     raise_unless_valid_order_field(field)
+    field = disambiguate_field(field)
 
     { field => direction }
   end
@@ -76,5 +77,9 @@ private
       :locale,
       :updated_at,
     ]
+  end
+
+  def disambiguate_field(field)
+    field == :updated_at ? :"content_items.updated_at" : field
   end
 end

--- a/spec/controllers/v2/content_items_controller_spec.rb
+++ b/spec/controllers/v2/content_items_controller_spec.rb
@@ -262,6 +262,20 @@ RSpec.describe V2::ContentItemsController do
           expect(message).to include(order)
         end
       end
+
+      context "ordering by a updated_at when it's not selected" do
+        let(:order) { "updated_at" }
+        let(:fields) { ["base_path"] }
+
+        it "returns the ordered results" do
+          results = parsed_response["results"]
+
+          expect(results).to eq([
+            { "base_path" => "/content.en" },
+            { "base_path" => "/content.ar" },
+          ])
+        end
+      end
     end
 
     context "with link filtering params" do


### PR DESCRIPTION
There’s an edge case we missed whereby you request
content ordered by updated_at without selecting
that field. Postgres doesn’t know which table the
column belongs to and it raises an ambiguous query
error. This fixes that edge case.