### PR TITLE
Deduplicate links

### DIFF
--- a/app/commands/v2/patch_link_set.rb
+++ b/app/commands/v2/patch_link_set.rb
@@ -24,7 +24,7 @@ module Commands
           content_ids_to_create = payload_content_ids - existing_content_ids
           content_ids_to_delete = existing_content_ids - payload_content_ids
 
-          content_ids_to_create.each do |content_id|
+          content_ids_to_create.uniq.each do |content_id|
             links.create!(target_content_id: content_id)
           end
 

--- a/db/migrate/20160513163056_deduplicate_links.rb
+++ b/db/migrate/20160513163056_deduplicate_links.rb
@@ -1,0 +1,30 @@
+class DeduplicateLinks < ActiveRecord::Migration
+  def up
+    res = Link.connection.execute(<<-SQL
+      SELECT SUM(cnt), COUNT(cnt)
+      FROM (
+        SELECT
+          link_set_id,
+          target_content_id,
+          link_type,
+          COUNT(id) cnt
+        FROM links
+        WHERE target_content_id IS NOT NULL
+        GROUP BY 1,2,3
+        HAVING COUNT(id) > 1
+      ) sub
+      SQL
+    )
+    puts "#{res[0]["count"]} unique records of #{res[0]["sum"]} total duplicated"
+
+    res = Link.connection.execute(<<-SQL
+      DELETE FROM links USING links l2
+        WHERE links.link_set_id = l2.link_set_id
+        AND links.target_content_id = l2.target_content_id
+        AND links.link_type = l2.link_type
+        AND links.id < l2.id
+      SQL
+    )
+    puts "#{res.cmd_tuples} records deleted"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160512122441) do
+ActiveRecord::Schema.define(version: 20160513163056) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/spec/commands/v2/patch_link_set_spec.rb
+++ b/spec/commands/v2/patch_link_set_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Commands::V2::PatchLinkSet do
     {
       content_id: content_id,
       links: {
-        topics: topics,
+        topics: topics * 2, # test deduplication
         parent: parent,
       }
     }


### PR DESCRIPTION
Ensure links aren’t added twice for the same link type. Adds a migration to deduplicate the links.

Finds and deletes all duplicated rows that have an id greater than
another id in the duplicated set. This leaves the duplicated record
with the lowest id intact.

From development VM:

```
== 20160513163056 DeduplicateLinks: migrating =================================
417 unique records of 971 total duplicated
554 records deleted
== 20160513163056 DeduplicateLinks: migrated (1.0488s) ========================
```