### PR TITLE
Revert "Set document_type of specialist documents to be more specific"

### DIFF
--- a/db/migrate/20160511145349_update_format_to_dual_specialist_publisher.rb
+++ b/db/migrate/20160511145349_update_format_to_dual_specialist_publisher.rb
@@ -1,6 +1,0 @@
-class UpdateFormatToDualSpecialistPublisher < ActiveRecord::Migration
-  def change
-    ContentItem.where(document_type: ['specialist_document', 'placeholder_specialist_document'])
-      .update_all("document_type = (details #>> '{metadata,document_type}')")
-  end
-end


### PR DESCRIPTION
This reverts commit 7611ba79bdd9319682347d743267f4a2b364589d.

We've decided to back out of this data migration as it doesn't amend
the event log to reflect this change. Instead, we'll look at doing
a bulk republish from Specialist Publisher.

This hasn't been deployed to production yet and so data replication
will fix integration's data when it next runs.