### PR TITLE
New batch read endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@
 
 # Ignore the generated pact
 spec/pacts/publishing_api-content_store.json
+.DS_Store

--- a/app/controllers/v2/grouped_content_and_links_controller.rb
+++ b/app/controllers/v2/grouped_content_and_links_controller.rb
@@ -1,0 +1,26 @@
+module V2
+  #
+  # This controller provides endpoints for querying content and links together.
+  #
+  class GroupedContentAndLinksController < ApplicationController
+    #
+    # Query all content items and links. This can be used to extract data for
+    # batch processing tasks.
+    #
+    # Results are grouped by content id and are paginated using the
+    # last_seen_content_id parameter.
+    #
+    def index
+      query = Queries::GetGroupedContentAndLinks.new(
+        last_seen_content_id: params[:last_seen_content_id],
+        page_size: params[:page_size],
+      )
+
+      if query.valid?
+        render json: Presenters::Queries::GroupedContentAndLinks.new(query.call).present
+      else
+        render json: { errors: query.errors.full_messages }, status: 422
+      end
+    end
+  end
+end

--- a/app/presenters/queries/grouped_content_and_links.rb
+++ b/app/presenters/queries/grouped_content_and_links.rb
@@ -1,0 +1,65 @@
+module Presenters
+  module Queries
+    class GroupedContentAndLinks
+      def initialize(results)
+        self.results = results
+      end
+
+      def present
+        {
+          "last_seen_content_id" => last_seen_content_id,
+          "results" => present_results,
+        }
+      end
+
+    private
+
+      attr_accessor :results
+
+      def present_results
+        results.map { |result| present_result(result) }
+      end
+
+      def last_seen_content_id
+        return if results.empty?
+
+        results.last["content_id"]
+      end
+
+      def present_result(query_result)
+        {
+          "content_id" => query_result["content_id"],
+          "content_items" => present_content_items(query_result["content_items"]),
+          "links" => present_links(query_result["links"])
+        }
+      end
+
+      def present_content_items(content_items)
+        content_items.map { |content_item| present_content_item(content_item) }
+      end
+
+      def present_content_item(content_item)
+        content_item.slice(
+          "locale",
+          "base_path",
+          "publishing_app",
+          "format",
+          "user_facing_version",
+          "state"
+        )
+      end
+
+      # Links is an array of individual link rows
+      # So we need to group them by type
+      def present_links(links)
+        groups = links.group_by { |link| link.fetch("link_type") }
+
+        groups.each_with_object({}) do |(link_type, type_links), links_hash|
+          links_hash[link_type] = type_links.map do |link|
+            link.fetch("target_content_id")
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/queries/get_grouped_content_and_links.rb
+++ b/app/queries/get_grouped_content_and_links.rb
@@ -1,0 +1,128 @@
+module Queries
+  class GetGroupedContentAndLinks
+    PAGE_SIZE = 10
+    MAX_PAGE_SIZE = 1000
+
+    include ActiveModel::Validations
+
+    attr_accessor :last_seen_content_id, :page_size
+
+    validates_numericality_of :page_size, less_than_or_equal_to: MAX_PAGE_SIZE, greater_than: 0
+
+    def initialize(last_seen_content_id: nil, page_size: nil)
+      @last_seen_content_id = last_seen_content_id
+      @page_size = page_size || PAGE_SIZE
+    end
+
+    # Returns an array of hashes where each hash contains a content_id, an
+    # array of content item rows, and an array of link rows.
+    #
+    # The pagination works differently to other requests because content ids
+    # are not generated in any kind of order. When paging through the results
+    # we need to be sure of:
+    #
+    # - not missing a content_id that already existed when we started the
+    #   first page
+    #
+    # - not seeing any content_id twice
+    #
+    # - seeing complete and consistent data for each content_id returned
+    def call
+      content_ids = query_content_ids_for_page(
+        last_seen_content_id: last_seen_content_id,
+        page_size: page_size
+      )
+
+      group_results(content_results(content_ids), link_set_results(content_ids))
+    end
+
+  private
+
+    def query_content_ids_for_page(last_seen_content_id:, page_size:)
+      groups = ContentItem.group(:content_id)
+
+      if last_seen_content_id.nil?
+        page = groups
+          .limit(page_size)
+          .order(:content_id)
+      else
+        page = groups
+          .having("content_id > ?", last_seen_content_id)
+          .limit(page_size)
+          .order(:content_id)
+      end
+
+      page.pluck(:content_id)
+    end
+
+    def group_results(content_results, link_set_results)
+      grouped_content_items = group_by_content_id(content_results)
+      grouped_links = group_by_content_id(link_set_results)
+
+      grouped_content_items.map do |content_id, content_items|
+        {
+          "content_id" => content_id,
+          "content_items" => content_items,
+          "links" => grouped_links[content_id] || []
+        }
+      end
+    end
+
+    def group_by_content_id(results)
+      results.group_by { |item| item["content_id"] }
+    end
+
+    def content_results(content_ids)
+      return [] if content_ids.empty?
+
+      query = <<-SQL
+        SELECT
+          content_items.content_id,
+          content_items.id AS content_item_id,
+          translations.locale,
+          locations.base_path,
+          states.name AS state,
+          user_facing_versions.number AS user_facing_version,
+          content_items.publishing_app,
+          content_items.format
+        FROM content_items
+        JOIN translations
+          ON translations.content_item_id = content_items.id
+        JOIN locations
+          ON locations.content_item_id = content_items.id
+        JOIN states
+          ON states.content_item_id = content_items.id
+        JOIN user_facing_versions
+          ON user_facing_versions.content_item_id = content_items.id
+        WHERE
+          content_items.content_id IN (#{sql_value_placeholders(content_ids.size)})
+        ORDER BY
+          content_items.updated_at DESC
+      SQL
+
+      ActiveRecord::Base.connection.raw_connection.exec(query, content_ids)
+    end
+
+    def link_set_results(content_ids)
+      return [] if content_ids.empty?
+
+      query = <<-SQL
+        SELECT
+          link_sets.content_id,
+          links.link_type,
+          links.target_content_id
+        FROM link_sets
+        JOIN links
+          ON link_sets.id = links.link_set_id
+        WHERE
+          link_sets.content_id IN (#{sql_value_placeholders(content_ids.size)})
+      SQL
+
+      ActiveRecord::Base.connection.raw_connection.exec(query, content_ids)
+    end
+
+    def sql_value_placeholders(number)
+      (1).upto(number).map { |i| "$#{i}" }.join(',')
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,6 +27,8 @@ Rails.application.routes.draw do
       get "/linked/:content_id", to: "link_sets#get_linked"
 
       get "/linkables", to: "content_items#linkables"
+
+      get "/grouped-content-and-links", to: "grouped_content_and_links#index"
     end
   end
 

--- a/spec/factories/link_set.rb
+++ b/spec/factories/link_set.rb
@@ -1,5 +1,22 @@
 FactoryGirl.define do
   factory :link_set do
     content_id { SecureRandom.uuid }
+
+    transient do
+      links_hash({})
+    end
+
+    after(:create) do |link_set, evaluator|
+      evaluator.links_hash.each do |link_type, target_content_ids|
+        target_content_ids.each do |target_content_id|
+          create(
+            :link,
+            link_type: link_type,
+            link_set: link_set,
+            target_content_id: target_content_id
+          )
+        end
+      end
+    end
   end
 end

--- a/spec/lib/requeue_content_spec.rb
+++ b/spec/lib/requeue_content_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe RequeueContent do
       expect(PublishingAPI.service(:queue_publisher)).to receive(:send_message)
         .exactly(1)
         .times
-        .with(a_hash_including(content_id: content_item1.content_id))
+        .with(a_hash_including(:content_id))
       RequeueContent.new(number_of_items: 1).call
     end
   end

--- a/spec/presenters/queries/grouped_content_and_links_spec.rb
+++ b/spec/presenters/queries/grouped_content_and_links_spec.rb
@@ -1,0 +1,89 @@
+require "rails_helper"
+
+RSpec.describe Presenters::Queries::GroupedContentAndLinks do
+  describe "#present" do
+    context "when receives an empty array" do
+      it "returns a hash with empty results" do
+        presenter = Presenters::Queries::GroupedContentAndLinks.new([])
+
+        expect(presenter.present).to eq(
+          "last_seen_content_id" => nil,
+          "results" => []
+        )
+      end
+    end
+
+    context "when receives an array of results" do
+      let(:content_id) { SecureRandom.uuid }
+      let(:topic_content_id) { SecureRandom.uuid }
+
+      before do
+        FactoryGirl.create(
+          :content_item,
+          content_id: content_id,
+          base_path: "/vat-rates",
+          publishing_app: "whitehall",
+          locale: "en",
+          format: "guide",
+          user_facing_version: 1,
+          state: "published"
+        )
+
+        FactoryGirl.create(
+          :content_item,
+          content_id: content_id,
+          base_path: "/vat-rates",
+          publishing_app: "whitehall",
+          locale: "en",
+          format: "guide",
+          user_facing_version: 2,
+          state: "draft",
+        )
+
+        FactoryGirl.create(
+          :link_set,
+          content_id: content_id,
+          links_hash: {
+            "topics" => [topic_content_id]
+          }
+        )
+      end
+
+      it "returns a hash with grouped results" do
+        results = ::Queries::GetGroupedContentAndLinks.new.call
+        presenter = Presenters::Queries::GroupedContentAndLinks.new(results)
+
+        presented_results = presenter.present["results"]
+
+        expect(presented_results).to eq(
+          [
+            {
+              "content_id" => content_id,
+              "content_items" => [
+                {
+                  "locale" => "en",
+                  "base_path" => "/vat-rates",
+                  "publishing_app" => "whitehall",
+                  "format" => "guide",
+                  "user_facing_version" => "2",
+                  "state" => "draft",
+                },
+                {
+                  "locale" => "en",
+                  "base_path" => "/vat-rates",
+                  "publishing_app" => "whitehall",
+                  "format" => "guide",
+                  "user_facing_version" => "1",
+                  "state" => "published",
+                },
+              ],
+              "links" => {
+                "topics" => [topic_content_id],
+              }
+            }
+          ]
+        )
+      end
+    end
+  end
+end

--- a/spec/queries/get_grouped_content_and_links_spec.rb
+++ b/spec/queries/get_grouped_content_and_links_spec.rb
@@ -1,0 +1,217 @@
+require "rails_helper"
+
+RSpec.describe Queries::GetGroupedContentAndLinks do
+  let(:ordered_content_ids) do
+    %w(
+      5f612a9f-7d3f-4b4c-a35e-ebd0b1e79019
+      fd161210-3e12-41e7-8e5e-c8cef607a95f
+    )
+  end
+
+  def new_content_item
+    SecureRandom.uuid
+  end
+
+  describe "#call" do
+    context "when no results exist" do
+      it "returns an empty array" do
+        expect(subject.call).to be_empty
+      end
+    end
+
+    def create_content_items(quantity)
+      quantity.times do
+        FactoryGirl.create(
+          :content_item,
+          base_path: "/random-base-path-#{Random.rand}",
+        )
+      end
+    end
+
+    context "when no pagination is specified" do
+      it "returns page with default page size" do
+        create_content_items(described_class::PAGE_SIZE + 1)
+        expect(subject.call.size).to eql(described_class::PAGE_SIZE)
+      end
+    end
+
+    context "when retrieving the next page" do
+      it "returns items after last seen" do
+        item = FactoryGirl.create(
+          :content_item,
+          base_path: '/random',
+          content_id: ordered_content_ids.first
+        )
+
+        item2 = FactoryGirl.create(
+          :content_item,
+          content_id: ordered_content_ids.last
+        )
+
+        results = described_class.new(last_seen_content_id: item.content_id).call
+
+        expect(results.size).to eq(1)
+        expect(results[0]["content_id"]).to eql(item2.content_id)
+      end
+    end
+
+    context "when there are documents" do
+      before do
+        @content_item = FactoryGirl.create(
+          :content_item,
+          content_id: ordered_content_ids.first,
+          base_path: "/capital-gains-tax",
+          state: "published"
+        )
+      end
+
+      context "with no links" do
+        it "returns a single result hash" do
+          results = subject.call
+
+          expect(results.size).to eq(1)
+          expect(results.first["content_id"]).to eq(@content_item.content_id)
+        end
+
+        it "returns the content item" do
+          results = subject.call
+          result = results.first
+          content_item = result["content_items"].first
+
+          expect(content_item).not_to be_nil
+          expect(content_item["locale"]).to eq("en")
+          expect(content_item["base_path"]).to eq("/capital-gains-tax")
+          expect(content_item["state"]).to eq("published")
+          expect(content_item["user_facing_version"]).to eq("1")
+        end
+
+        it "returns an empty array for the links" do
+          results = subject.call
+          result = results.first
+
+          expect(result).to include("links")
+          expect(result["links"]).to eq([])
+        end
+      end
+
+      context "with links" do
+        let(:target_content_id) { SecureRandom.uuid }
+
+        before do
+          FactoryGirl.create(
+            :link_set,
+            content_id: ordered_content_ids.first,
+            links_hash: {
+              "topics" => [
+                target_content_id
+              ]
+            }
+          )
+        end
+
+        it "returns an array of links" do
+          results = subject.call
+          expect(results.size).to eq(1)
+          expect(results[0]).to include("links")
+          expect(results[0]["links"]).to eq(
+            [
+              {
+                "content_id" => ordered_content_ids.first,
+                "link_type"  => "topics",
+                "target_content_id" => target_content_id,
+              }
+            ]
+          )
+        end
+      end
+
+      context "with multiple editions (draft & published)" do
+        before do
+          FactoryGirl.create(
+            :content_item,
+            content_id: ordered_content_ids.first,
+            base_path: "/vat-rates",
+            state: "published"
+          )
+
+          FactoryGirl.create(
+            :content_item,
+            content_id: ordered_content_ids.first,
+            base_path: "/vat-rates",
+            state: "draft"
+          )
+
+          FactoryGirl.create(
+            :content_item,
+            content_id: ordered_content_ids.last,
+            base_path: "/register-to-vote",
+            state: "published"
+          )
+        end
+
+        context "with no links" do
+          it "returns the content item with empty links" do
+            results = subject.call
+
+            expect(results.size).to eq(2)
+            expect(results[0]).to include("links")
+            expect(results[0]["links"]).to eq([])
+
+            expect(results[1]).to include("links")
+            expect(results[1]["links"]).to eq([])
+          end
+        end
+
+        context "with links" do
+          let(:first_target_content_id) { SecureRandom.uuid }
+          let(:second_target_content_id) { SecureRandom.uuid }
+
+          before do
+            FactoryGirl.create(
+              :link_set,
+              links_hash: {
+                "topics" => [
+                  first_target_content_id
+                ]
+              },
+              content_id: ordered_content_ids.first
+            )
+
+            FactoryGirl.create(
+              :link_set,
+              links_hash: {
+                "topics" => [
+                  second_target_content_id
+                ]
+              },
+              content_id: ordered_content_ids.last
+            )
+          end
+
+          it "returns the content item with links" do
+            results = subject.call
+
+            expect(results.size).to eq(2)
+            expect(results[0]).to include("links")
+            expect(results[0]["links"]).to eq([
+              {
+                "content_id" => ordered_content_ids.last,
+                "link_type"  => "topics",
+                "target_content_id" => second_target_content_id,
+              }
+            ])
+
+            expect(results[1]).to include("links")
+            expect(results[1]["links"]).to eq([
+              {
+                "content_id" => ordered_content_ids.first,
+                "link_type"  => "topics",
+                "target_content_id" => first_target_content_id,
+              }
+            ])
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/requests/grouped_content_and_links_spec.rb
+++ b/spec/requests/grouped_content_and_links_spec.rb
@@ -1,0 +1,149 @@
+require "rails_helper"
+
+RSpec.describe "GET /v2/grouped-content-and-links", type: :request do
+  context "input parameter validation" do
+    it "defaults to the first batch when last_seen_content_id is not provided" do
+      create_content_items('0001', '0002', '0003')
+
+      expected_result = [
+        hash_including("content_id" => make_test_id('0001')),
+      ]
+
+      get "/v2/grouped-content-and-links", page_size: 1
+
+      expect(response.status).to eq(200)
+      expect(parsed_response["results"]).to match_array(expected_result)
+    end
+
+    it "defaults to a reasonable batch size when page_size is not provided" do
+      create_n_content_items(11)
+
+      get "/v2/grouped-content-and-links", last_seen_content_id: '00000000-0000-0000-0000-000000000000'
+
+      expect(response.status).to eq(200)
+      expect(parsed_response["results"].size).to eq(10)
+    end
+
+    it "422s when page_size is not parsed as an integer" do
+      get "/v2/grouped-content-and-links", page_size: 'not a valid integer'
+
+      expect(response.status).to eq(422)
+    end
+
+    it "422s when page_size is too large" do
+      get "/v2/grouped-content-and-links", page_size: 1001
+
+      expect(response.status).to eq(422)
+    end
+
+    it "returns an empty result set for invalid UUIDs" do
+      get "/v2/grouped-content-and-links", last_seen_content_id: 'not a valid uuid', page_size: 1
+
+      expect(response.status).to eq(200)
+    end
+  end
+
+  context "batching by content_id" do
+    it "delivers all content items matching the content_ids contained in the batch" do
+      create_content_items('0001', '0002', '0003', '0005', '0007', '0008')
+
+      expected_result = [
+        hash_including("content_id" => make_test_id('0005')),
+        hash_including("content_id" => make_test_id('0007')),
+      ]
+
+      get "/v2/grouped-content-and-links", last_seen_content_id: make_test_id('0003'), page_size: 2
+
+      expect(response.status).to eq(200)
+      expect(parsed_response["results"]).to match_array(expected_result)
+    end
+
+    it "delivers a partial batch when reaching the final content_id" do
+      create_content_items('0001', '0002', '0003', '0005', '0007', '0008')
+
+      expected_result = [
+        hash_including("content_id" => make_test_id('0008')),
+      ]
+
+      get "/v2/grouped-content-and-links", last_seen_content_id: make_test_id('0007'), page_size: 2
+
+      expect(response.status).to eq(200)
+      expect(parsed_response["results"]).to match_array(expected_result)
+    end
+
+    it "delivers an empty batch when reading beyond the final content_id" do
+      create_content_items('0001', '0002', '0003', '0005', '0007', '0008')
+
+      expected_result = []
+
+      get "/v2/grouped-content-and-links", last_seen_content_id: make_test_id('0008'), page_size: 2
+
+      expect(response.status).to eq(200)
+      expect(parsed_response["results"]).to match_array(expected_result)
+    end
+  end
+
+  context "response format" do
+    it "delivers expected content fields" do
+      create_content_items('0001')
+      test_content_id = make_test_id('0001')
+      test_base_path = make_base_path(test_content_id)
+      links_hash = {
+        "topics" => [make_test_id('0002'), make_test_id('0003')],
+        "organisations" => [make_test_id('0004'), make_test_id('0005')],
+      }
+
+      FactoryGirl.create(
+        :link_set,
+        content_id: test_content_id,
+        links_hash: links_hash,
+      )
+
+      expected_result = [
+        {
+          "content_id" => test_content_id,
+          "content_items" => [
+            hash_including(
+              "base_path" => test_base_path,
+            )
+          ],
+          "links" => links_hash
+        }
+      ]
+
+
+      get "/v2/grouped-content-and-links", page_size: 1
+
+      expect(response.status).to eq(200)
+      expect(parsed_response["results"]).to match_array(expected_result)
+    end
+  end
+
+private
+
+  def create_n_content_items(count)
+    create_content_items(*((1..count).to_a.map { |i| i.to_s.rjust(4, '0') }))
+  end
+
+  def create_content_items(*ids)
+    ids.each { |id| create_content_item(id) }
+  end
+
+  def create_content_item(id)
+    test_content_id = make_test_id(id)
+    FactoryGirl.create(:content_item,
+                       content_id: test_content_id,
+                       base_path: make_base_path(test_content_id),
+    )
+  end
+
+  # requires a 4-digit id string
+  def make_test_id(id)
+    # arbitrary type-4 uuid with easier ordering for readable tests
+    "7c88c837-b76c-496d-b112-9a5a50b0#{id}"
+  end
+
+  def make_base_path(content_id)
+    "/#{content_id}"
+  end
+end


### PR DESCRIPTION
This is a first pass at https://trello.com/c/DYFgXNYr/621-automate-link-checker-tool
Paired with @Davidslv and @benhyland 

This new endpoint allows us to page through content ids and retrieve all the content items
and links associated with that content id.

a response item looks like this:
```ruby
{
                  "content_id" => content_id,
                  "content_items" => [
                    {
                      "locale" => "en",
                      "base_path" => "/such-base-path",
                      "publishing_app" => "whitehall",
                      "format" => "guide",
                      "user_facing_version" => "2",
                      "state" => "draft",
                    },
                    {
                      "locale" => "en",
                      "base_path" => "/such-base-path",
                      "publishing_app" => "whitehall",
                      "format" => "guide",
                      "user_facing_version" => "1",
                      "state" => "published",
                    },
                  ],
                  "links" => {
                    "topics" => [topic_content_id],
                  }
}
```

## Motivation
We are planning to use this in tooling that will check consistency between
rummager and publishing api:
https://github.com/alphagov/finding-things-migration-checker

Content is currently indexed to rummager from multiple sources, and we don't
have a reliable way of rebuilding the index from scratch at the moment. In the
future, content will only be indexed from publishing api.  We want to ensure
that data is kept in sync until then.

We are also in the middle of a data migration from the old tagging
infrastructure (panopticon/content API) to the new one (publishing api/content
store).  Rummager is currently the most complete source of tagging data for
historical content, so comparing publishing API to that gives us a view on any
remaining discrepencies.

## Data returned
For now, we don't apply any filtering (e.g. by publication state). We also
don't want to expand the links hash to include things like base paths, since
this requires more information to uniquely identify the target content item
(such as locale) and we don't actually need this for our usage.

The fields returned for content items are based on the things that influence
content item uniqueness (see doc/object-model-explanation.md), plus
publishing-app and format. We could add more details, but we don't need this
now either.

The data is retrieved using 3 queries. A content ID has many content items and
many links. We query these separately because otherwise we would get a
cartesian product of rows (# of links x # of content items for each content
id).

The pagination works differently to other requests because content id does not
have an inherent ordering. This means that if we define a page by a limit and
and an offset, somebody could publish new content that appears in the middle of
our page between successive queries.

To ensure that the queries links and content items match up to the same set of
content ids, we query all the content ids on the page first, and then pass
those to the other queries.

## Suggestions for code review

We'd like at least one person from the publishing platform team to check the approach we've taken. 

The main commit adds a controller, a query, and a presenter.

The query itself runs all three queries and returns the results grouped together into an array of hashes.

We chose to mixin ActiveModel validations here as we had some fairly standard input validation to do and this seemed like a simple way of managing it. If there is a better way to do this please let us know. We're aware that the format of `render json: { errors: query.errors.full_messages }, status: 422` isn't quite correct for the publishing api but we wanted some feedback before we fix this.

We're using raw SQL because we thought the queries might get complicated, but it seems like we could do the same queries using activerecord too. Do you have a preference one way or the other?

The presenter takes the array returned by the query and returns something that can be returned as JSON to the client. We didn't use ResultPresenter because we are doing pagination a little differently. Passing in the last seen content id for pagination guarantees that if the requester pages through everything, they will never see the same item twice.

## Tests
While testing this I noticed a small issue that breaks CI sometimes:
 https://ci.dev.publishing.service.gov.uk/view/Publishing/job/govuk_publishing-api/303/console

The 2nd commit makes the expectation less strict. I can split this off into a separate PR if you want.