### PR TITLE
Remove legacy_links column from link_set

### DIFF
--- a/db/migrate/20160516135536_remove_column_legacy_links_from_link_set.rb
+++ b/db/migrate/20160516135536_remove_column_legacy_links_from_link_set.rb
@@ -1,0 +1,5 @@
+class RemoveColumnLegacyLinksFromLinkSet < ActiveRecord::Migration
+  def change
+    remove_column :link_sets, :legacy_links, :json
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160513163056) do
+ActiveRecord::Schema.define(version: 20160516135536) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -67,7 +67,6 @@ ActiveRecord::Schema.define(version: 20160513163056) do
 
   create_table "link_sets", force: :cascade do |t|
     t.string   "content_id"
-    t.json     "legacy_links", default: {}, null: false
     t.datetime "created_at"
     t.datetime "updated_at"
   end


### PR DESCRIPTION
This existed because back in [Nov 26, 2015](https://github.com/alphagov/publishing-api/pull/137/commits/73e5b23582c7e7a4ca3f134efad90fb8ec56c55d) we didn't want to lose any data. 
Now, months later this has been quite forgotten, and we would like to remove this to avoid confusion to anyone that is not familiar with the code.

Trello: https://trello.com/c/DK8HFgDn/628-remove-the-legacy-links-column-from-publishing-api
