### PR TITLE
Make expanded-links endpoint ready for use 

### DIFF
--- a/app/controllers/v2/link_sets_controller.rb
+++ b/app/controllers/v2/link_sets_controller.rb
@@ -5,7 +5,7 @@ module V2
     end
 
     def expanded_links
-      render json: Presenters::Queries::ExpandedLinkSet.new(link_set: LinkSet.find_by(content_id: content_id), fallback_order: [:draft, :published]).links
+      render json: Queries::GetExpandedLinks.call(content_id)
     end
 
     def patch_links

--- a/app/queries/get_expanded_links.rb
+++ b/app/queries/get_expanded_links.rb
@@ -1,7 +1,7 @@
 module Queries
   class GetExpandedLinks
     def self.call(content_id)
-      link_set = LinkSet.find_by(content_id: content_id)
+      link_set = find_link_set(content_id)
       lock_version = LockVersion.find_by(target: link_set)
       expanded_link_set = Presenters::Queries::ExpandedLinkSet.new(
         link_set: link_set,
@@ -13,6 +13,19 @@ module Queries
         expanded_links: expanded_link_set.links,
         version: lock_version ? lock_version.number : 0
       }
+    end
+
+    def self.find_link_set(content_id)
+      LinkSet.find_by!(content_id: content_id)
+    rescue ActiveRecord::RecordNotFound
+      error_details = {
+        error: {
+          code: 404,
+          message: "Could not find link set with content_id: #{content_id}"
+        }
+      }
+
+      raise CommandError.new(code: 404, error_details: error_details)
     end
   end
 end

--- a/app/queries/get_expanded_links.rb
+++ b/app/queries/get_expanded_links.rb
@@ -1,0 +1,14 @@
+module Queries
+  class GetExpandedLinks
+    def self.call(content_id)
+      link_set = LinkSet.find_by(content_id: content_id)
+
+      expanded_link_set = Presenters::Queries::ExpandedLinkSet.new(
+        link_set: link_set,
+        fallback_order: [:draft, :published]
+      )
+
+      expanded_link_set.links
+    end
+  end
+end

--- a/app/queries/get_expanded_links.rb
+++ b/app/queries/get_expanded_links.rb
@@ -2,14 +2,16 @@ module Queries
   class GetExpandedLinks
     def self.call(content_id)
       link_set = LinkSet.find_by(content_id: content_id)
-
+      lock_version = LockVersion.find_by(target: link_set)
       expanded_link_set = Presenters::Queries::ExpandedLinkSet.new(
         link_set: link_set,
         fallback_order: [:draft, :published]
       )
 
       {
+        content_id: content_id,
         expanded_links: expanded_link_set.links,
+        version: lock_version ? lock_version.number : 0
       }
     end
   end

--- a/app/queries/get_expanded_links.rb
+++ b/app/queries/get_expanded_links.rb
@@ -8,7 +8,9 @@ module Queries
         fallback_order: [:draft, :published]
       )
 
-      expanded_link_set.links
+      {
+        expanded_links: expanded_link_set.links,
+      }
     end
   end
 end

--- a/doc/publishing-api-syntactic-usage.md
+++ b/doc/publishing-api-syntactic-usage.md
@@ -108,6 +108,17 @@ Requests to update an existing draft content item:
 ### Required request params:
  - `content_id` the primary identifier for the content associated with the requested link set.
 
+## `GET /v2/expanded-links/:content_id`
+
+TODO: Request/Response detail
+
+ - Retrieves expanded link set for the given content_id.
+ - Presents the lock version of the link set in the response.
+ - Responds with 404 if no links are available for this content_id.
+
+### Required request params:
+ - `content_id` the primary identifier for the content associated with the requested link set.
+
 ## `PATCH /v2/links/:content_id`
 
 [Request/Response detail](https://pact-broker.dev.publishing.service.gov.uk/pacts/provider/Publishing%20API/consumer/GDS%20API%20Adapters/latest#a_request_to_update_the_linkset_at_version_3_given_the_linkset_for_bed722e6-db68-43e5-9079-063f623335a7_is_at_version_3)

--- a/spec/requests/expanded_links_endpoint_spec.rb
+++ b/spec/requests/expanded_links_endpoint_spec.rb
@@ -24,19 +24,21 @@ RSpec.describe "GET /v2/expanded-links/:id", type: :request do
     get "/v2/expanded-links/#{content_item.content_id}"
 
     expect(parsed_response).to eql({
-      "organisations" => [
-        {
-          "analytics_identifier" => "GDS01",
-          "api_url" => "http://www.dev.gov.uk/api/content/my-super-org",
-          "base_path" => "/my-super-org",
-          "content_id" => "9b5ae6f5-f127-4843-9333-c157a404dd2d",
-          "description" => "VAT rates for goods and services",
-          "locale" => "en",
-          "title" => "VAT rates",
-          "web_url" => "http://www.dev.gov.uk/my-super-org",
-          "expanded_links" => {}
-        }
-      ]
+      "expanded_links" => {
+        "organisations" => [
+          {
+            "analytics_identifier" => "GDS01",
+            "api_url" => "http://www.dev.gov.uk/api/content/my-super-org",
+            "base_path" => "/my-super-org",
+            "content_id" => "9b5ae6f5-f127-4843-9333-c157a404dd2d",
+            "description" => "VAT rates for goods and services",
+            "locale" => "en",
+            "title" => "VAT rates",
+            "web_url" => "http://www.dev.gov.uk/my-super-org",
+            "expanded_links" => {}
+          }
+        ]
+      }
     })
   end
 
@@ -53,6 +55,8 @@ RSpec.describe "GET /v2/expanded-links/:id", type: :request do
 
     get "/v2/expanded-links/#{content_item.content_id}"
 
-    expect(parsed_response).to eql({})
+    expect(parsed_response).to eql({
+      "expanded_links" => {}
+    })
   end
 end

--- a/spec/requests/expanded_links_endpoint_spec.rb
+++ b/spec/requests/expanded_links_endpoint_spec.rb
@@ -24,6 +24,8 @@ RSpec.describe "GET /v2/expanded-links/:id", type: :request do
     get "/v2/expanded-links/#{content_item.content_id}"
 
     expect(parsed_response).to eql({
+      "version" => 0,
+      "content_id" => content_item.content_id,
       "expanded_links" => {
         "organisations" => [
           {
@@ -49,13 +51,37 @@ RSpec.describe "GET /v2/expanded-links/:id", type: :request do
       title: "Some title",
     )
 
-    content_item = create(:link_set,
+    link_set = create(:link_set,
       content_id: content_item.content_id,
     )
 
-    get "/v2/expanded-links/#{content_item.content_id}"
+    get "/v2/expanded-links/#{link_set.content_id}"
 
     expect(parsed_response).to eql({
+      "version" => 0,
+      "content_id" => content_item.content_id,
+      "expanded_links" => {}
+    })
+  end
+
+  it "returns a version if the link set has a version" do
+    content_item = create(:content_item,
+      state: "published",
+      format: "placeholder",
+      title: "Some title",
+    )
+
+    link_set = create(:link_set,
+      content_id: content_item.content_id,
+    )
+
+    create(:lock_version, target: link_set, number: 11)
+
+    get "/v2/expanded-links/#{link_set.content_id}"
+
+    expect(parsed_response).to eql({
+      "version" => 11,
+      "content_id" => content_item.content_id,
       "expanded_links" => {}
     })
   end

--- a/spec/requests/expanded_links_endpoint_spec.rb
+++ b/spec/requests/expanded_links_endpoint_spec.rb
@@ -85,4 +85,16 @@ RSpec.describe "GET /v2/expanded-links/:id", type: :request do
       "expanded_links" => {}
     })
   end
+
+  it "returns 404 if the link set is not found" do
+    get "/v2/expanded-links/I-DO-NOT-EXIST"
+
+    expect(parsed_response).to eql({
+      "error" => {
+        "code" => 404,
+        "message" => "Could not find link set with content_id: I-DO-NOT-EXIST"
+        }
+      }
+    )
+  end
 end

--- a/spec/requests/expanded_links_endpoint_spec.rb
+++ b/spec/requests/expanded_links_endpoint_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe "GET /v2/expanded-links/:id", type: :request do
 
     get "/v2/expanded-links/#{content_item.content_id}"
 
-    expect(parsed_response).to eql({
+    expect(parsed_response).to eql(
       "version" => 0,
       "content_id" => content_item.content_id,
       "expanded_links" => {
@@ -37,11 +37,11 @@ RSpec.describe "GET /v2/expanded-links/:id", type: :request do
             "locale" => "en",
             "title" => "VAT rates",
             "web_url" => "http://www.dev.gov.uk/my-super-org",
-            "expanded_links" => {}
+            "expanded_links" => {},
           }
         ]
       }
-    })
+    )
   end
 
   it "returns empty expanded links if there are no links" do
@@ -57,11 +57,11 @@ RSpec.describe "GET /v2/expanded-links/:id", type: :request do
 
     get "/v2/expanded-links/#{link_set.content_id}"
 
-    expect(parsed_response).to eql({
+    expect(parsed_response).to eql(
       "version" => 0,
       "content_id" => content_item.content_id,
-      "expanded_links" => {}
-    })
+      "expanded_links" => {},
+    )
   end
 
   it "returns a version if the link set has a version" do
@@ -79,21 +79,20 @@ RSpec.describe "GET /v2/expanded-links/:id", type: :request do
 
     get "/v2/expanded-links/#{link_set.content_id}"
 
-    expect(parsed_response).to eql({
+    expect(parsed_response).to eql(
       "version" => 11,
       "content_id" => content_item.content_id,
-      "expanded_links" => {}
-    })
+      "expanded_links" => {},
+    )
   end
 
   it "returns 404 if the link set is not found" do
     get "/v2/expanded-links/I-DO-NOT-EXIST"
 
-    expect(parsed_response).to eql({
+    expect(parsed_response).to eql(
       "error" => {
         "code" => 404,
-        "message" => "Could not find link set with content_id: I-DO-NOT-EXIST"
-        }
+        "message" => "Could not find link set with content_id: I-DO-NOT-EXIST",
       }
     )
   end

--- a/spec/requests/expanded_links_endpoint_spec.rb
+++ b/spec/requests/expanded_links_endpoint_spec.rb
@@ -1,0 +1,58 @@
+require "rails_helper"
+
+RSpec.describe "GET /v2/expanded-links/:id", type: :request do
+  it "returns expanded links" do
+    organisation = create(:content_item,
+      state: "published",
+      format: "organisation",
+      base_path: "/my-super-org",
+      content_id: "9b5ae6f5-f127-4843-9333-c157a404dd2d",
+    )
+
+    content_item = create(:content_item,
+      state: "published",
+      format: "placeholder",
+      title: "Some title",
+    )
+
+    link_set = create(:link_set,
+      content_id: content_item.content_id,
+    )
+
+    create(:link, link_set: link_set, target_content_id: organisation.content_id, link_type: 'organisations')
+
+    get "/v2/expanded-links/#{content_item.content_id}"
+
+    expect(parsed_response).to eql({
+      "organisations" => [
+        {
+          "analytics_identifier" => "GDS01",
+          "api_url" => "http://www.dev.gov.uk/api/content/my-super-org",
+          "base_path" => "/my-super-org",
+          "content_id" => "9b5ae6f5-f127-4843-9333-c157a404dd2d",
+          "description" => "VAT rates for goods and services",
+          "locale" => "en",
+          "title" => "VAT rates",
+          "web_url" => "http://www.dev.gov.uk/my-super-org",
+          "expanded_links" => {}
+        }
+      ]
+    })
+  end
+
+  it "returns empty expanded links if there are no links" do
+    content_item = create(:content_item,
+      state: "published",
+      format: "placeholder",
+      title: "Some title",
+    )
+
+    content_item = create(:link_set,
+      content_id: content_item.content_id,
+    )
+
+    get "/v2/expanded-links/#{content_item.content_id}"
+
+    expect(parsed_response).to eql({})
+  end
+end


### PR DESCRIPTION
Finding Things will need an endpoint for the expanded links for use in Rummager (https://github.com/alphagov/rummager/pull/632).

This `GET /v2/expanded-links` endpoint was added for testing purposes in https://github.com/alphagov/publishing-api/pull/259. This PR intends to make it ready for general use.

It adds tests, documentation and makes it behave like the `/links` endpoint for consistency.