### PR TITLE
Add dependees to expansion group.

### DIFF
--- a/app/presenters/queries/expand_link.rb
+++ b/app/presenters/queries/expand_link.rb
@@ -1,60 +1,23 @@
 module Presenters
   module Queries
     class ExpandLink
-      attr_reader :item, :type, :visited
+      attr_reader :item, :type
 
-      def initialize(item, type, visited, set:)
+      def initialize(item, type, rules)
         @item = item
         @type = type
-        @visited = visited
-        @set = set
+        @rules = rules
       end
 
       def expand_link
-        expanded = rules.expansion_fields(type).each_with_object({}) do |field, subhash|
+        rules.expansion_fields(type).each_with_object({}) do |field, subhash|
           subhash[field] = item.public_send(field)
         end
-        expanded.merge(expanded_links: expanded_links)
       end
 
     private
 
-      def expanded_links
-        return {} if invalid?
-        { type => recursive_links }
-      end
-
-      def invalid?
-        visited.include?(item.content_id) ||
-          recursive_target_content_ids.empty? ||
-          recursive_links.empty?
-      end
-
-      def recursive_links
-        @recurseive_links ||= @set.expand_links(
-          recursive_target_content_ids, type, visited << item.content_id
-        )
-      end
-
-      def recursive_target_content_ids
-        @recursive_target_content_ids ||= links.select { |link| recurse?(link.link_type) }.map(&:target_content_id)
-      end
-
-      def links
-        @links ||= link_set.links.where(link_type: type)
-      end
-
-      def link_set
-        LinkSet.find_by(content_id: item.content_id) || OpenStruct.new(links: Link.none)
-      end
-
-      def recurse?(type)
-        rules.recurse?(type.to_sym)
-      end
-
-      def rules
-        ::Queries::ExpansionRules
-      end
+      attr_reader :rules
     end
   end
 end

--- a/app/queries/expansion_rules.rb
+++ b/app/queries/expansion_rules.rb
@@ -7,12 +7,18 @@ module Queries
     end
 
     def recurse?(link_type)
-      recursive_link_types.include?(link_type)
+      recursive_link_types.include?(link_type.to_sym)
     end
 
     module Reverse
       extend ExpansionRules
       extend self
+
+      def reverse_name_for(link_type)
+        {
+          parent: "children",
+        }[link_type.to_sym]
+      end
 
     private
 

--- a/spec/queries/content_dependencies_spec.rb
+++ b/spec/queries/content_dependencies_spec.rb
@@ -33,13 +33,12 @@ RSpec.describe Queries::ContentDependencies do
 
     context "link_sets" do
       let(:fields) { [:base_path] }
-      let(:direct_link_types) { %w(parent) }
 
       it "calculates the correct link_types" do
         expect_any_instance_of(Queries::GetDependents).to receive(:call).with(
           content_id: parent_content_item.content_id,
-          recursive_link_types: [],
-          direct_link_types: direct_link_types
+          recursive_link_types: %w(parent),
+          direct_link_types: [],
         )
         dependents.call
       end
@@ -71,13 +70,12 @@ RSpec.describe Queries::ContentDependencies do
 
     context "link_sets" do
       let(:fields) { [:base_path] }
-      let(:direct_link_types) { %w(special parent) }
 
       it "calculates the correct link_types" do
         expect_any_instance_of(Queries::GetDependees).to receive(:call).with(
           content_id: child_content_item.content_id,
-          recursive_link_types: [],
-          direct_link_types: direct_link_types
+          recursive_link_types: %w(parent),
+          direct_link_types: %w(special)
         )
         dependees.call
       end

--- a/spec/queries/reverse_expansion_rules_spec.rb
+++ b/spec/queries/reverse_expansion_rules_spec.rb
@@ -32,4 +32,8 @@ RSpec.describe Queries::ExpansionRules::Reverse do
     specify { expect(subject.recurse?(:parent)).to eq(true) }
     specify { expect(subject.recurse?(:foo)).to eq(false) }
   end
+
+  describe "#reverse_name_for(link_type)" do
+    specify { expect(subject.reverse_name_for(:parent)).to eq("children") }
+  end
 end

--- a/spec/support/request_helpers/mocks.rb
+++ b/spec/support/request_helpers/mocks.rb
@@ -56,9 +56,7 @@ module RequestHelpers
         links: {
           organisations: ["30986e26-f504-4e14-a93f-a9593c34a8d9"]
         },
-        expanded_links: {
-          organisations: []
-        },
+        expanded_links: {},
       }
     end
 


### PR DESCRIPTION
https://trello.com/c/2BMiIf0y/671-8-add-reverse-dependency-groups-to-the-expanded-links-field

This also changes the behaviour to not include keys
for link types if there are no valid content items
to expand for that link type.