### PR TITLE
Improve performance of uniqueness validator

### DIFF
--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -28,6 +28,15 @@ class ContentItem < ActiveRecord::Base
   NON_RENDERABLE_FORMATS = %w(redirect gone).freeze
   EMPTY_BASE_PATH_FORMATS = %w(government).freeze
 
+  has_one :state
+  has_one :location
+  has_one :translation
+  has_one :user_facing_version
+
+  scope :with_supporting_objects, -> {
+    eager_load(:state, :location, :translation, :user_facing_version)
+  }
+
   scope :renderable_content, -> { where.not(format: NON_RENDERABLE_FORMATS) }
 
   validates_with SchemaNameFormatValidator

--- a/app/validators/content_item_uniqueness_validator.rb
+++ b/app/validators/content_item_uniqueness_validator.rb
@@ -1,16 +1,17 @@
 class ContentItemUniquenessValidator < ActiveModel::Validator
   def validate(record)
-    content_item = record.content_item
+    content_item = ContentItem.with_supporting_objects.where(id: record.content_item_id).first
+    return unless content_item
 
     state = record if record.is_a?(State)
     translation = record if record.is_a?(Translation)
     location = record if record.is_a?(Location)
     user_facing_version = record if record.is_a?(UserFacingVersion)
 
-    state ||= State.find_by(content_item: content_item)
-    translation ||= Translation.find_by(content_item: content_item)
-    location ||= Location.find_by(content_item: content_item)
-    user_facing_version ||= UserFacingVersion.find_by(content_item: content_item)
+    state ||= content_item.state
+    translation ||= content_item.translation
+    location ||= content_item.location
+    user_facing_version ||= content_item.user_facing_version
 
     return unless state && translation && location && user_facing_version
 
@@ -29,16 +30,15 @@ class ContentItemUniquenessValidator < ActiveModel::Validator
     base_path = location.base_path
     user_version = user_facing_version.number
 
-    matching_items = ContentItemFilter.filter(
+    other_content_items = ContentItem.where("content_items.id <> #{content_item.id}")
+    matching_items = ContentItemFilter.new(scope: other_content_items).filter(
       state: state_name,
       locale: locale,
       base_path: base_path,
       user_version: user_version,
     )
 
-    additional_items = matching_items - [content_item]
-
-    if additional_items.any?
+    if matching_items.any?
       error = "conflicts with a duplicate: "
       error << "state=#{state_name}, "
       error << "locale=#{locale}, "

--- a/bench/content_item_uniqueness_validator.rb
+++ b/bench/content_item_uniqueness_validator.rb
@@ -1,0 +1,21 @@
+# /usr/bin/env ruby
+
+require ::File.expand_path('../../config/environment', __FILE__)
+require 'benchmark'
+
+max_content_id = ContentItem.maximum(:id)
+
+random_ids = 100.times.map { rand(max_content_id - 1) + 1 }
+
+puts Benchmark.measure {
+  random_ids.each do |id|
+    state = State.where(content_item_id: id).first
+    if state
+      ContentItemUniquenessValidator.new.validate(state)
+      print "."
+    else
+      print "x"
+    end
+  end
+  puts ""
+}


### PR DESCRIPTION
Uses Rails’ eager loading of relationships to reduce round trips to the
database, and allows Postgres to optimise queries better.

Also uses the database to filter out the current content item when
calculating uniqueness, instead of instantiating records and performing
set math.

Adds supporting object relationships and scope to `ContentItem`, which
will be useful for other performance improvements.

Before (over 100 random records):
```
$ bundle exec ruby bench/content_item_uniqueness_validator.rb
....................................................................................................
  0.590000   0.050000   0.640000 (  1.721408)
```

After:
```
$ bundle exec ruby bench/content_item_uniqueness_validator.rb
....................................................................................................
  0.550000   0.040000   0.590000 (  1.390422)
```

I ran the above benchmarks multiple times and they were consistent enough for me to present this with confidence. 