### PR TITLE
[Discuss] Don't present full content item to caller

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,4 +46,5 @@ group :development, :test do
   gem "factory_girl_rails", "4.5.0"
   gem "pact_broker-client"
   gem "govuk-lint"
+  gem "faker", require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -92,6 +92,8 @@ GEM
     factory_girl_rails (4.5.0)
       factory_girl (~> 4.5.0)
       railties (>= 3.0.0)
+    faker (1.6.3)
+      i18n (~> 0.5)
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
     find_a_port (1.0.1)
@@ -364,6 +366,7 @@ DEPENDENCIES
   database_cleaner
   deprecated_columns
   factory_girl_rails (= 4.5.0)
+  faker
   gds-api-adapters (= 30.2.0)
   gds-sso (= 11.2.1)
   govuk-client-url_arbiter (= 0.0.3)

--- a/app/commands/v2/put_content.rb
+++ b/app/commands/v2/put_content.rb
@@ -14,13 +14,11 @@ module Commands
           fill_out_new_content_item(content_item)
         end
 
-        response_hash = Presenters::Queries::ContentItemPresenter.present(content_item)
-
         after_transaction_commit do
           send_downstream(content_item)
         end
 
-        Success.new(response_hash)
+        Success.new(content_id: content_item.content_id)
       end
 
     private

--- a/bench/put_content.rb
+++ b/bench/put_content.rb
@@ -1,0 +1,55 @@
+# /usr/bin/env ruby
+
+require ::File.expand_path('../../config/environment', __FILE__)
+require 'benchmark'
+require 'securerandom'
+
+require 'faker'
+
+ContentItem.where("(routes->>0)::json->>'path' LIKE '/performance-testing/%'").each do |ci|
+  State.where(content_item: ci).destroy_all
+  Location.where(content_item: ci).destroy_all
+  Translation.where(content_item: ci).destroy_all
+  UserFacingVersion.where(content_item: ci).destroy_all
+  LinkSet.where(content_id: ci.content_id).destroy_all
+  ci.destroy
+end
+
+content_items = 100.times.map do
+  title = Faker::Company.catch_phrase
+  {
+    content_id: SecureRandom.uuid,
+    format: "placeholder",
+    schema_name: "placeholder",
+    document_type: "placeholder",
+    title: title,
+    base_path: "/performance-testing/#{title.parameterize}",
+    description: Faker::Lorem.paragraph,
+    public_updated_at: Time.now.iso8601,
+    locale: "en",
+    routes: [
+      {path: "/performance-testing/#{title.parameterize}", type: "exact"}
+    ],
+    redirects: [],
+    publishing_app: "test",
+    rendering_app: "test",
+    details: {
+      body: "<p>#{Faker::Lorem.paragraph}</p>"
+    }
+  }
+end
+
+$queries = 0
+ActiveSupport::Notifications.subscribe "sql.active_record" do |name, started, finished, unique_id, data|
+  $queries += 1
+end
+
+puts Benchmark.measure {
+  content_items.each do |item|
+    Commands::V2::PutContent.call(item)
+    print "."
+  end
+  puts ""
+}
+
+puts "#{$queries} SQL queries"


### PR DESCRIPTION
Rendering the full content item on every PutContent call is expensive
and possibly unnecessary. Clients probably won’t need to have their
request rendered back to them. Whitehall certainly doesn’t, I haven’t
checked other apps.

Before:
```
$ bundle exec ruby bench/put_content.rb
....................................................................................................
  4.730000   0.220000   4.950000 (  7.536762)
4806 SQL queries
```

After:
```
$ bundle exec ruby bench/put_content.rb
....................................................................................................
  4.280000   0.210000   4.490000 (  6.338519)
4606 SQL queries
```