### PR TITLE
Require explicit FactoryGirl calls

### DIFF
--- a/spec/commands/put_content_with_links_spec.rb
+++ b/spec/commands/put_content_with_links_spec.rb
@@ -74,11 +74,11 @@ RSpec.describe Commands::PutContentWithLinks do
     stub_request(:put, "http://draft-content-store.dev.gov.uk/content/foo")
     stub_request(:put, "http://content-store.dev.gov.uk/content/foo")
 
-    content_item = create(:content_item)
-    link_set = create(:link_set, content_id: content_item.content_id)
-    protected_link = create(:link, link_set: link_set, link_type: 'alpha_taxons')
-    normal_link = create(:link, link_set: link_set, link_type: 'topics')
-    create(:lock_version, target: link_set)
+    content_item = FactoryGirl.create(:content_item)
+    link_set = FactoryGirl.create(:link_set, content_id: content_item.content_id)
+    protected_link = FactoryGirl.create(:link, link_set: link_set, link_type: 'alpha_taxons')
+    normal_link = FactoryGirl.create(:link, link_set: link_set, link_type: 'topics')
+    FactoryGirl.create(:lock_version, target: link_set)
 
     described_class.call(
       title: 'Test Title',
@@ -101,11 +101,11 @@ RSpec.describe Commands::PutContentWithLinks do
     stub_request(:put, "http://draft-content-store.dev.gov.uk/content/foo")
     stub_request(:put, "http://content-store.dev.gov.uk/content/foo")
 
-    link_set = create(:link_set, content_id: 'dc3643c0-ac02-43b8-a1c2-b93513878685')
-    link_1 = create(:link, link_set: link_set, link_type: 'organisations')
-    link_2 = create(:link, link_set: link_set, link_type: 'topics')
+    link_set = FactoryGirl.create(:link_set, content_id: 'dc3643c0-ac02-43b8-a1c2-b93513878685')
+    link_1 = FactoryGirl.create(:link, link_set: link_set, link_type: 'organisations')
+    link_2 = FactoryGirl.create(:link, link_set: link_set, link_type: 'topics')
 
-    create(:lock_version, target: link_set)
+    FactoryGirl.create(:lock_version, target: link_set)
 
     described_class.call(
       title: 'Test Title',

--- a/spec/commands/put_content_with_links_spec.rb
+++ b/spec/commands/put_content_with_links_spec.rb
@@ -139,11 +139,11 @@ RSpec.describe Commands::PutContentWithLinks do
     let(:target_id) { SecureRandom.uuid }
 
     before do
-      link_set = create(
+      link_set = FactoryGirl.create(
         :link_set,
         content_id: content_id,
         links: [
-          create(
+          FactoryGirl.create(
             :link,
             link_type: "related",
             target_content_id: target_id
@@ -151,7 +151,7 @@ RSpec.describe Commands::PutContentWithLinks do
         ]
       )
 
-      create(:lock_version, target: link_set)
+      FactoryGirl.create(:lock_version, target: link_set)
     end
 
     it "destroys the existing links before making new ones" do

--- a/spec/commands/put_draft_content_with_links_spec.rb
+++ b/spec/commands/put_draft_content_with_links_spec.rb
@@ -125,11 +125,11 @@ RSpec.describe Commands::PutDraftContentWithLinks do
     let(:target_id) { SecureRandom.uuid }
 
     before do
-      link_set = create(
+      link_set = FactoryGirl.create(
         :link_set,
         content_id: content_id,
         links: [
-          create(
+          FactoryGirl.create(
             :link,
             link_type: "related",
             target_content_id: target_id
@@ -137,7 +137,7 @@ RSpec.describe Commands::PutDraftContentWithLinks do
         ]
       )
 
-      create(:lock_version, target: link_set)
+      FactoryGirl.create(:lock_version, target: link_set)
     end
 
     it "destroys the existing links before making new ones" do

--- a/spec/commands/put_draft_content_with_links_spec.rb
+++ b/spec/commands/put_draft_content_with_links_spec.rb
@@ -61,10 +61,10 @@ RSpec.describe Commands::PutDraftContentWithLinks do
     stub_request(:put, "http://draft-content-store.dev.gov.uk/content/foo")
     stub_request(:put, "http://content-store.dev.gov.uk/content/foo")
 
-    link_set = create(:link_set, content_id: '60d81299-6ae7-4bab-b4fe-4235d518d50a')
-    protected_link = create(:link, link_set: link_set, link_type: 'alpha_taxons')
-    normal_link = create(:link, link_set: link_set, link_type: 'topics')
-    create(:lock_version, target: link_set)
+    link_set = FactoryGirl.create(:link_set, content_id: '60d81299-6ae7-4bab-b4fe-4235d518d50a')
+    protected_link = FactoryGirl.create(:link, link_set: link_set, link_type: 'alpha_taxons')
+    normal_link = FactoryGirl.create(:link, link_set: link_set, link_type: 'topics')
+    FactoryGirl.create(:lock_version, target: link_set)
 
     described_class.call(
       title: 'Test Title',
@@ -87,11 +87,11 @@ RSpec.describe Commands::PutDraftContentWithLinks do
     stub_request(:put, "http://draft-content-store.dev.gov.uk/content/foo")
     stub_request(:put, "http://content-store.dev.gov.uk/content/foo")
 
-    link_set = create(:link_set, content_id: 'dc3643c0-ac02-43b8-a1c2-b93513878685')
-    link_1 = create(:link, link_set: link_set, link_type: 'organisations')
-    link_2 = create(:link, link_set: link_set, link_type: 'topics')
+    link_set = FactoryGirl.create(:link_set, content_id: 'dc3643c0-ac02-43b8-a1c2-b93513878685')
+    link_1 = FactoryGirl.create(:link, link_set: link_set, link_type: 'organisations')
+    link_2 = FactoryGirl.create(:link, link_set: link_set, link_type: 'topics')
 
-    create(:lock_version, target: link_set)
+    FactoryGirl.create(:lock_version, target: link_set)
 
     described_class.call(
       title: 'Test Title',

--- a/spec/commands/v2/discard_draft_spec.rb
+++ b/spec/commands/v2/discard_draft_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Commands::V2::DiscardDraft do
 
     context "when a draft content item exists for the given content_id" do
       let!(:existing_draft_item) {
-        create(:access_limited_draft_content_item,
+        FactoryGirl.create(:access_limited_draft_content_item,
           content_id: content_id,
           base_path: base_path,
           lock_version: 5,
@@ -93,7 +93,7 @@ RSpec.describe Commands::V2::DiscardDraft do
 
       context "and a published content item exists" do
         let!(:published_item) {
-          create(:live_content_item,
+          FactoryGirl.create(:live_content_item,
             content_id: content_id,
             lock_version: 3,
             base_path: "/hat-rates",
@@ -166,7 +166,7 @@ RSpec.describe Commands::V2::DiscardDraft do
 
       context "when a locale is provided in the payload" do
         let!(:french_draft_item) {
-          create(:draft_content_item,
+          FactoryGirl.create(:draft_content_item,
             content_id: content_id,
             base_path: base_path,
             locale: "fr",
@@ -205,7 +205,7 @@ RSpec.describe Commands::V2::DiscardDraft do
 
       context "and a published content item exists" do
         before do
-          create(:live_content_item, content_id: content_id)
+          FactoryGirl.create(:live_content_item, content_id: content_id)
         end
 
         it "raises a command error with code 422" do

--- a/spec/commands/v2/patch_link_set_spec.rb
+++ b/spec/commands/v2/patch_link_set_spec.rb
@@ -39,8 +39,7 @@ RSpec.describe Commands::V2::PatchLinkSet do
     end
 
     it "doesn't reject an empty links hash, but doesn't delete links either" do
-      link_set = FactoryGirl.create(
-        :link_set,
+      link_set = FactoryGirl.create(:link_set,
         links: [
           FactoryGirl.create(:link)
         ]
@@ -86,22 +85,18 @@ RSpec.describe Commands::V2::PatchLinkSet do
     let(:related) { [SecureRandom.uuid] }
 
     before do
-      link_set = FactoryGirl.create(
-        :link_set,
+      link_set = FactoryGirl.create(:link_set,
         content_id: content_id,
         links: [
-          FactoryGirl.create(
-            :link,
+          FactoryGirl.create(:link,
             link_type: "topics",
             target_content_id: topics.first,
           ),
-          FactoryGirl.create(
-            :link,
+          FactoryGirl.create(:link,
             link_type: "topics",
             target_content_id: topics.second,
           ),
-          FactoryGirl.create(
-            :link,
+          FactoryGirl.create(:link,
             link_type: "related",
             target_content_id: related.first,
           ),
@@ -194,8 +189,7 @@ RSpec.describe Commands::V2::PatchLinkSet do
 
   context "when a draft content item exists for the content_id" do
     let!(:draft_content_item) do
-      create(
-        :draft_content_item,
+      FactoryGirl.create(:draft_content_item,
         content_id: content_id,
         base_path: "/some-path",
         title: "Some Title",
@@ -227,8 +221,7 @@ RSpec.describe Commands::V2::PatchLinkSet do
 
       context "and a draft content item exists for that locale" do
         let!(:draft_content_item) do
-          create(
-            :draft_content_item,
+          FactoryGirl.create(:draft_content_item,
             content_id: content_id,
             base_path: "/french-path",
             title: "French Title",
@@ -269,8 +262,7 @@ RSpec.describe Commands::V2::PatchLinkSet do
 
   context "when a live content item exists for the content_id" do
     let!(:live_content_item) do
-      create(
-        :live_content_item,
+      FactoryGirl.create(:live_content_item,
         content_id: content_id,
         base_path: "/some-path",
         title: "Some Title",
@@ -315,8 +307,7 @@ RSpec.describe Commands::V2::PatchLinkSet do
 
       context "and a live content item exists for that locale" do
         let!(:live_content_item) do
-          create(
-            :live_content_item,
+          FactoryGirl.create(:live_content_item,
             content_id: content_id,
             base_path: "/french-path",
             title: "French Title",

--- a/spec/commands/v2/patch_link_set_spec.rb
+++ b/spec/commands/v2/patch_link_set_spec.rb
@@ -39,14 +39,14 @@ RSpec.describe Commands::V2::PatchLinkSet do
     end
 
     it "doesn't reject an empty links hash, but doesn't delete links either" do
-      link_set = create(
+      link_set = FactoryGirl.create(
         :link_set,
         links: [
-          create(:link)
+          FactoryGirl.create(:link)
         ]
       )
 
-      create(:lock_version, target: link_set)
+      FactoryGirl.create(:lock_version, target: link_set)
 
       described_class.call(
         content_id: link_set.content_id,
@@ -86,21 +86,21 @@ RSpec.describe Commands::V2::PatchLinkSet do
     let(:related) { [SecureRandom.uuid] }
 
     before do
-      link_set = create(
+      link_set = FactoryGirl.create(
         :link_set,
         content_id: content_id,
         links: [
-          create(
+          FactoryGirl.create(
             :link,
             link_type: "topics",
             target_content_id: topics.first,
           ),
-          create(
+          FactoryGirl.create(
             :link,
             link_type: "topics",
             target_content_id: topics.second,
           ),
-          create(
+          FactoryGirl.create(
             :link,
             link_type: "related",
             target_content_id: related.first,
@@ -108,7 +108,7 @@ RSpec.describe Commands::V2::PatchLinkSet do
         ]
       )
 
-      create(:lock_version, target: link_set, number: 1)
+      FactoryGirl.create(:lock_version, target: link_set, number: 1)
     end
 
     it "creates links for groups that appear in the payload and not in the database" do

--- a/spec/commands/v2/publish_spec.rb
+++ b/spec/commands/v2/publish_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe Commands::V2::Publish do
   describe "call" do
     let!(:draft_item) do
-      create(
+      FactoryGirl.create(
         :draft_content_item,
         content_id: content_id,
         lock_version: 2,
@@ -67,7 +67,7 @@ RSpec.describe Commands::V2::Publish do
 
     context "when a lock version of the content item was previously published" do
       let!(:live_item) do
-        create(
+        FactoryGirl.create(
           :live_content_item,
           content_id: draft_item.content_id,
         )
@@ -86,7 +86,7 @@ RSpec.describe Commands::V2::Publish do
       let(:draft_base_path) { Location.find_by!(content_item: draft_item).base_path }
 
       let!(:other_content_item) {
-        create(:redirect_live_content_item,
+        FactoryGirl.create(:redirect_live_content_item,
           locale: draft_locale,
           base_path: draft_base_path,
         )
@@ -111,7 +111,7 @@ RSpec.describe Commands::V2::Publish do
       let(:draft_base_path) { Location.find_by!(content_item: draft_item).base_path }
 
       let!(:other_content_item) {
-        create(
+        FactoryGirl.create(
           :redirect_live_content_item,
           locale: new_locale,
           base_path: draft_base_path,
@@ -214,7 +214,7 @@ RSpec.describe Commands::V2::Publish do
           let(:public_updated_at_from_last_live_item) { Time.zone.now - 2.years }
 
           let!(:live_item) do
-            create(
+            FactoryGirl.create(
               :live_content_item,
               content_id: draft_item.content_id,
               public_updated_at: public_updated_at_from_last_live_item,
@@ -291,7 +291,7 @@ RSpec.describe Commands::V2::Publish do
 
     context "when the base_path differs from the previously published item" do
       let!(:live_item) do
-        create(
+        FactoryGirl.create(
           :live_content_item,
           content_id: draft_item.content_id,
           base_path: "/hat-rates",
@@ -299,7 +299,7 @@ RSpec.describe Commands::V2::Publish do
       end
 
       before do
-        create(
+        FactoryGirl.create(
           :redirect_draft_content_item,
           base_path: "/hat-rates",
         )
@@ -330,7 +330,7 @@ RSpec.describe Commands::V2::Publish do
 
     context "when an access limit is set on the draft content item" do
       before do
-        create(:access_limit, content_item: draft_item)
+        FactoryGirl.create(:access_limit, content_item: draft_item)
       end
 
       it "destroys the access limit" do
@@ -367,7 +367,7 @@ RSpec.describe Commands::V2::Publish do
 
       context "but a published item does exist" do
         before do
-          create(:live_content_item, content_id: content_id)
+          FactoryGirl.create(:live_content_item, content_id: content_id)
         end
 
         it "raises an error to indicate it has already been published" do

--- a/spec/commands/v2/put_content_spec.rb
+++ b/spec/commands/v2/put_content_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe Commands::V2::PutContent do
 
     context "when the base path has been reserved by another publishing app" do
       before do
-        create(:path_reservation, base_path: "/vat-rates", publishing_app: "something-else")
+        FactoryGirl.create(:path_reservation, base_path: "/vat-rates", publishing_app: "something-else")
       end
 
       it "raises an error" do
@@ -93,7 +93,7 @@ RSpec.describe Commands::V2::PutContent do
       let(:first_published_at) { 1.year.ago }
 
       before do
-        create(:live_content_item,
+        FactoryGirl.create(:live_content_item,
           content_id: content_id,
           lock_version: 2,
           user_facing_version: 5,
@@ -225,7 +225,7 @@ RSpec.describe Commands::V2::PutContent do
 
     context "when creating a draft for a previously unpublished content item" do
       before do
-        create(
+        FactoryGirl.create(
           :content_item,
           content_id: content_id,
           state: "unpublished",
@@ -259,7 +259,7 @@ RSpec.describe Commands::V2::PutContent do
 
     context "when creating a draft when there are multiple unpublished and published items" do
       before do
-        create(
+        FactoryGirl.create(
           :content_item,
           content_id: content_id,
           state: "unpublished",
@@ -267,7 +267,7 @@ RSpec.describe Commands::V2::PutContent do
           user_facing_version: 5,
         )
 
-        create(
+        FactoryGirl.create(
           :content_item,
           content_id: content_id,
           state: "published",
@@ -275,7 +275,7 @@ RSpec.describe Commands::V2::PutContent do
           user_facing_version: 8,
         )
 
-        create(
+        FactoryGirl.create(
           :content_item,
           content_id: content_id,
           state: "unpublished",
@@ -309,7 +309,7 @@ RSpec.describe Commands::V2::PutContent do
 
     context "with another draft content item blocking the put_content action" do
       let!(:other_content_item) {
-        create(:redirect_draft_content_item,
+        FactoryGirl.create(:redirect_draft_content_item,
           locale: locale,
           base_path: base_path,
         )
@@ -333,7 +333,7 @@ RSpec.describe Commands::V2::PutContent do
       let(:new_locale) { "fr" }
 
       let!(:other_content_item) {
-        create(:redirect_draft_content_item,
+        FactoryGirl.create(:redirect_draft_content_item,
           locale: new_locale,
           base_path: base_path,
         )
@@ -406,7 +406,7 @@ RSpec.describe Commands::V2::PutContent do
 
     context "when the payload is for an already drafted content item" do
       let!(:previously_drafted_item) {
-        create(:draft_content_item,
+        FactoryGirl.create(:draft_content_item,
           content_id: content_id,
           base_path: base_path,
           title: "Old Title",
@@ -555,7 +555,7 @@ RSpec.describe Commands::V2::PutContent do
 
       context "when the previous draft has an access limit" do
         let!(:access_limit) {
-          create(:access_limit, content_item: previously_drafted_item, users: ["old-user"])
+          FactoryGirl.create(:access_limit, content_item: previously_drafted_item, users: ["old-user"])
         }
 
         context "when the params includes an access limit" do
@@ -643,11 +643,11 @@ RSpec.describe Commands::V2::PutContent do
       let(:link_target) { SecureRandom.uuid }
 
       let!(:link_set) do
-        create(
+        FactoryGirl.create(
           :link_set,
           content_id: content_id,
           links: [
-            create(
+            FactoryGirl.create(
               :link,
               link_type: "parent",
               target_content_id: link_target,

--- a/spec/commands/v2/unpublish_spec.rb
+++ b/spec/commands/v2/unpublish_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Commands::V2::Unpublish do
 
     context "when the document is published" do
       let!(:live_content_item) do
-        create(:live_content_item,
+        FactoryGirl.create(:live_content_item,
           content_id: content_id,
           base_path: base_path,
         )
@@ -65,7 +65,7 @@ RSpec.describe Commands::V2::Unpublish do
 
     context "when only a draft is present" do
       before do
-        create(:draft_content_item,
+        FactoryGirl.create(:draft_content_item,
           content_id: content_id,
         )
       end
@@ -81,7 +81,7 @@ RSpec.describe Commands::V2::Unpublish do
 
     context "when the document is redrafted" do
       let!(:live_content_item) do
-        create(:live_content_item, :with_draft,
+        FactoryGirl.create(:live_content_item, :with_draft,
           content_id: content_id,
         )
       end
@@ -129,7 +129,7 @@ RSpec.describe Commands::V2::Unpublish do
 
     context "when the document is already unpublished" do
       let!(:unpublished_content_item) do
-        create(:unpublished_content_item,
+        FactoryGirl.create(:unpublished_content_item,
           content_id: content_id,
           base_path: base_path,
           explanation: "This explnatin has a typo",
@@ -184,7 +184,7 @@ RSpec.describe Commands::V2::Unpublish do
 
     context "with the `downstream` flag set to `false`" do
       before do
-        create(:live_content_item, :with_draft,
+        FactoryGirl.create(:live_content_item, :with_draft,
           content_id: content_id,
         )
       end
@@ -228,7 +228,7 @@ RSpec.describe Commands::V2::Unpublish do
 
     context "when trying to unpublish a content item with no location" do
       before do
-        content_item = create(:live_content_item,
+        content_item = FactoryGirl.create(:live_content_item,
           content_id: content_id,
           base_path: base_path,
         )

--- a/spec/controllers/v2/content_items_controller_spec.rb
+++ b/spec/controllers/v2/content_items_controller_spec.rb
@@ -412,10 +412,10 @@ RSpec.describe V2::ContentItemsController do
 
   describe "index" do
     before do
-      create(:draft_content_item, publishing_app: 'publisher', base_path: '/content')
-      create(:draft_content_item, publishing_app: 'whitehall', base_path: '/item1')
-      create(:draft_content_item, publishing_app: 'whitehall', base_path: '/item2')
-      create(:draft_content_item, publishing_app: 'specialist_publisher', base_path: '/item3')
+      FactoryGirl.create(:draft_content_item, publishing_app: 'publisher', base_path: '/content')
+      FactoryGirl.create(:draft_content_item, publishing_app: 'whitehall', base_path: '/item1')
+      FactoryGirl.create(:draft_content_item, publishing_app: 'whitehall', base_path: '/item2')
+      FactoryGirl.create(:draft_content_item, publishing_app: 'specialist_publisher', base_path: '/item3')
     end
 
     it "displays items filtered by the user's app_name" do

--- a/spec/controllers/v2/content_items_controller_spec.rb
+++ b/spec/controllers/v2/content_items_controller_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe V2::ContentItemsController do
   before do
     stub_request(:any, /content-store/)
 
-    @draft = create(
+    @draft = FactoryGirl.create(
       :draft_content_item,
       content_id: content_id,
       base_path: "/content.en",
@@ -19,7 +19,7 @@ RSpec.describe V2::ContentItemsController do
   describe "index" do
     before do
       @en_draft_content = @draft
-      @ar_draft_content = create(
+      @ar_draft_content = FactoryGirl.create(
         :draft_content_item,
         content_id: content_id,
         locale: "ar",
@@ -27,7 +27,7 @@ RSpec.describe V2::ContentItemsController do
         format: "topic",
         user_facing_version: 2,
       )
-      @en_live_content = create(
+      @en_live_content = FactoryGirl.create(
         :live_content_item,
         content_id: content_id,
         locale: "en",
@@ -35,7 +35,7 @@ RSpec.describe V2::ContentItemsController do
         format: "topic",
         user_facing_version: 1,
       )
-      @ar_live_content = create(
+      @ar_live_content = FactoryGirl.create(
         :live_content_item,
         content_id: content_id,
         locale: "ar",
@@ -48,14 +48,14 @@ RSpec.describe V2::ContentItemsController do
     context "searching a field" do
       context "when there is a valid query" do
         let(:previous_live_version) do
-          create(:live_content_item,
+          FactoryGirl.create(:live_content_item,
                              base_path: "/foo",
                              format: "topic",
                              title: "zip",
                              user_facing_version: 1)
         end
         let!(:content_item) do
-          create(:live_content_item,
+          FactoryGirl.create(:live_content_item,
                              base_path: "/foo",
                              content_id: previous_live_version.content_id,
                              format: "topic",
@@ -281,8 +281,8 @@ RSpec.describe V2::ContentItemsController do
     context "with link filtering params" do
       before do
         org_content_id = SecureRandom.uuid
-        link_set = create(:link_set, content_id: content_id)
-        create(:link, link_set: link_set, target_content_id: org_content_id)
+        link_set = FactoryGirl.create(:link_set, content_id: content_id)
+        FactoryGirl.create(:link, link_set: link_set, target_content_id: org_content_id)
 
         get :index, content_format: "topic", fields: ["content_id"], link_organisations: org_content_id.to_s
       end

--- a/spec/controllers/v2/link_sets_controller_spec.rb
+++ b/spec/controllers/v2/link_sets_controller_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe V2::LinkSetsController do
   let(:content_id) { SecureRandom.uuid }
 
   before do
-    create(:draft_content_item, content_id: content_id)
+    FactoryGirl.create(:draft_content_item, content_id: content_id)
     stub_request(:any, /content-store/)
   end
 

--- a/spec/event_logger_spec.rb
+++ b/spec/event_logger_spec.rb
@@ -39,14 +39,14 @@ RSpec.describe EventLogger do
     call_counter = 0
     EventLogger.log_command(command_class, payload) do
       if call_counter == 0
-        create(:live_content_item, content_id: content_id)
+        FactoryGirl.create(:live_content_item, content_id: content_id)
         call_counter += 1
         raise CommandRetryableError
       else
         # The original transaction should have been rolled back, so there should be no
         # corresponding ContentItem in the database
         expect(ContentItem.where(content_id: content_id).count).to eq(0)
-        create(:live_content_item, content_id: content_id)
+        FactoryGirl.create(:live_content_item, content_id: content_id)
       end
     end
 

--- a/spec/filters/content_item_filter_spec.rb
+++ b/spec/filters/content_item_filter_spec.rb
@@ -4,31 +4,31 @@ RSpec.describe ContentItemFilter do
   let(:content_id) { "b2844cad-4140-46db-81eb-db717370fee1" }
 
   let!(:content_item) {
-    create(:content_item,
+    FactoryGirl.create(:content_item,
       content_id: content_id
     )
   }
 
   let!(:oil_and_gas_content_item) {
-    create(:content_item,
+    FactoryGirl.create(:content_item,
       content_id: content_id,
       base_path: "/oil-and-gas"
     )
   }
   let!(:french_content_item) {
-    create(:content_item,
+    FactoryGirl.create(:content_item,
       content_id: content_id,
       locale: "fr"
     )
   }
   let!(:superseded_content_item) {
-    create(:content_item,
+    FactoryGirl.create(:content_item,
       content_id: content_id,
       state: "superseded"
     )
   }
   let!(:new_version_content_item) {
-    create(:content_item,
+    FactoryGirl.create(:content_item,
       content_id: content_id,
       user_facing_version: 2,
     )

--- a/spec/helpers/substitution_helper_spec.rb
+++ b/spec/helpers/substitution_helper_spec.rb
@@ -6,27 +6,27 @@ RSpec.describe SubstitutionHelper do
   let(:existing_base_path) { "/vat-rates" }
 
   let!(:existing_item) {
-    create(:draft_content_item,
+    FactoryGirl.create(:draft_content_item,
       format: existing_format,
       base_path: existing_base_path,
     )
   }
 
   let!(:live_item) {
-    create(:live_content_item,
+    FactoryGirl.create(:live_content_item,
       format: existing_format,
       base_path: existing_base_path,
     )
   }
   let!(:french_item) {
-    create(:draft_content_item,
+    FactoryGirl.create(:draft_content_item,
       format: existing_format,
       base_path: existing_base_path,
       locale: "fr",
     )
   }
   let!(:item_elsewhere) {
-    create(:draft_content_item,
+    FactoryGirl.create(:draft_content_item,
       format: existing_format,
       base_path: "/somewhere-else",
     )

--- a/spec/integration/pagination_spec.rb
+++ b/spec/integration/pagination_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe "Paging through content items" do
   before do
     5.times do |n|
-      create(
+      FactoryGirl.create(
         :draft_content_item,
         base_path: "/content-#{n}",
         format: "guide",

--- a/spec/lib/data_hygiene/access_limits_cleaner_spec.rb
+++ b/spec/lib/data_hygiene/access_limits_cleaner_spec.rb
@@ -1,15 +1,15 @@
 require "rails_helper"
 
 RSpec.describe DataHygiene::AccessLimitsCleaner, :cleanup do
-  let!(:unrelated_access_limit) { create(:access_limit) }
-  let(:draft_content_item) { create(:draft_content_item) }
-  let(:another_draft_content_item) { create(:draft_content_item) }
-  let!(:dupe_access_limit) { create(:access_limit, content_item: draft_content_item) }
-  let!(:another_dupe_access_limit) { create(:access_limit, content_item: draft_content_item) }
-  let!(:access_limit) { create(:access_limit, content_item: draft_content_item) }
+  let!(:unrelated_access_limit) { FactoryGirl.create(:access_limit) }
+  let(:draft_content_item) { FactoryGirl.create(:draft_content_item) }
+  let(:another_draft_content_item) { FactoryGirl.create(:draft_content_item) }
+  let!(:dupe_access_limit) { FactoryGirl.create(:access_limit, content_item: draft_content_item) }
+  let!(:another_dupe_access_limit) { FactoryGirl.create(:access_limit, content_item: draft_content_item) }
+  let!(:access_limit) { FactoryGirl.create(:access_limit, content_item: draft_content_item) }
 
-  let(:live_content_item) { create(:live_content_item) }
-  let!(:published_access_limit) { create(:access_limit, content_item: live_content_item) }
+  let(:live_content_item) { FactoryGirl.create(:live_content_item) }
+  let!(:published_access_limit) { FactoryGirl.create(:access_limit, content_item: live_content_item) }
 
   let(:log) { double(:log) }
 

--- a/spec/lib/requeue_content_spec.rb
+++ b/spec/lib/requeue_content_spec.rb
@@ -5,9 +5,9 @@ RSpec.describe RequeueContent do
     ContentItem.destroy_all
   end
 
-  let!(:content_item1) { create(:live_content_item, base_path: '/ci1') }
-  let!(:content_item2) { create(:live_content_item, base_path: '/ci2') }
-  let!(:content_item3) { create(:live_content_item, base_path: '/ci3') }
+  let!(:content_item1) { FactoryGirl.create(:live_content_item, base_path: '/ci1') }
+  let!(:content_item2) { FactoryGirl.create(:live_content_item, base_path: '/ci2') }
+  let!(:content_item3) { FactoryGirl.create(:live_content_item, base_path: '/ci3') }
 
   describe "#call" do
     it "by default, it republishes all content items" do

--- a/spec/lib/tasks/data_sanitizer_spec.rb
+++ b/spec/lib/tasks/data_sanitizer_spec.rb
@@ -2,21 +2,21 @@ require "rails_helper"
 
 RSpec.describe Tasks::DataSanitizer do
   let!(:non_limited_draft) do
-    create(
+    FactoryGirl.create(
       :draft_content_item,
       base_path: "/non-limited-draft",
     )
   end
 
   let!(:limited_draft) do
-    create(
+    FactoryGirl.create(
       :access_limited_draft_content_item,
       base_path: "/limited-draft",
     )
   end
 
   let!(:live_content_item) do
-    create(
+    FactoryGirl.create(
       :live_content_item,
       base_path: "/live-item",
     )

--- a/spec/lib/tasks/database_record_validator_spec.rb
+++ b/spec/lib/tasks/database_record_validator_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe Tasks::DatabaseRecordValidator do
-  let!(:valid_record) { create(:path_reservation) }
+  let!(:valid_record) { FactoryGirl.create(:path_reservation) }
 
   context "when all records are valid" do
     it "prints to stdout" do
@@ -13,7 +13,7 @@ RSpec.describe Tasks::DatabaseRecordValidator do
 
   context "when there are invalid records" do
     let!(:invalid_record) do
-      invalid_record = build(:path_reservation, base_path: "invalid")
+      invalid_record = FactoryGirl.build(:path_reservation, base_path: "invalid")
       invalid_record.save!(validate: false)
       invalid_record
     end

--- a/spec/lib/tasks/version_resolver_spec.rb
+++ b/spec/lib/tasks/version_resolver_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Tasks::VersionResolver, :resolve do
   let(:content_id) { SecureRandom.uuid }
 
   before do
-    create(
+    FactoryGirl.create(
       :content_item,
       content_id: content_id,
       state: "published",
@@ -12,7 +12,7 @@ RSpec.describe Tasks::VersionResolver, :resolve do
       locale: "en"
     )
 
-    create(
+    FactoryGirl.create(
       :content_item,
       content_id: content_id,
       state: "superseded",
@@ -20,7 +20,7 @@ RSpec.describe Tasks::VersionResolver, :resolve do
       locale: "en"
     )
 
-    create(
+    FactoryGirl.create(
       :content_item,
       content_id: content_id,
       state: "draft",
@@ -39,7 +39,7 @@ RSpec.describe Tasks::VersionResolver, :resolve do
 
   context "when two items of the same content_id have identical versions" do
     before do
-      create(
+      FactoryGirl.create(
         :content_item,
         content_id: content_id,
         state: "superseded",

--- a/spec/lib/tasks/version_validator_spec.rb
+++ b/spec/lib/tasks/version_validator_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Tasks::VersionValidator do
   let(:content_id) { SecureRandom.uuid }
 
   before do
-    create(
+    FactoryGirl.create(
       :content_item,
       content_id: content_id,
       state: "superseded",
@@ -12,7 +12,7 @@ RSpec.describe Tasks::VersionValidator do
       locale: "en"
     )
 
-    create(
+    FactoryGirl.create(
       :content_item,
       content_id: content_id,
       state: "published",

--- a/spec/models/access_limit_spec.rb
+++ b/spec/models/access_limit_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe AccessLimit do
   end
 
   context "a content item that is not access limited" do
-    let!(:content_item) { create(:draft_content_item) }
+    let!(:content_item) { FactoryGirl.create(:draft_content_item) }
 
     it "is not access limited" do
       expect(AccessLimit.viewable?(content_item)).to be(true)
@@ -24,7 +24,7 @@ RSpec.describe AccessLimit do
   end
 
   context "an access-limited content item" do
-    let!(:content_item) { create(:access_limited_draft_content_item) }
+    let!(:content_item) { FactoryGirl.create(:access_limited_draft_content_item) }
     let(:authorised_user_uid) {
       AccessLimit.find_by(content_item: content_item).users.first
     }

--- a/spec/models/access_limit_spec.rb
+++ b/spec/models/access_limit_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe AccessLimit do
-  subject { build(:access_limit) }
+  subject { FactoryGirl.build(:access_limit) }
 
   it "validates that user UIDs are strings" do
     subject.users << "a-string-uuid"

--- a/spec/models/content_item_spec.rb
+++ b/spec/models/content_item_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe ContentItem do
-  subject { build(:content_item) }
+  subject { FactoryGirl.build(:content_item) }
 
   def set_new_attributes(item)
     item.title = "New title"
@@ -12,9 +12,9 @@ RSpec.describe ContentItem do
   end
 
   describe ".renderable_content" do
-    let!(:guide) { create(:content_item, format: "guide") }
-    let!(:redirect) { create(:redirect_content_item) }
-    let!(:gone) { create(:gone_content_item) }
+    let!(:guide) { FactoryGirl.create(:content_item, format: "guide") }
+    let!(:redirect) { FactoryGirl.create(:redirect_content_item) }
+    let!(:gone) { FactoryGirl.create(:gone_content_item) }
 
     it "returns content items that do not have a format of 'redirect' or 'gone'" do
       expect(described_class.renderable_content).to eq [guide]
@@ -76,7 +76,7 @@ RSpec.describe ContentItem do
     end
 
     context "when the content item is not 'renderable'" do
-      subject { build(:redirect_content_item) }
+      subject { FactoryGirl.build(:redirect_content_item) }
 
       it "does not require a title" do
         subject.title = ""

--- a/spec/models/location_spec.rb
+++ b/spec/models/location_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe Location do
   describe "validations" do
-    subject { build(:location) }
+    subject { FactoryGirl.build(:location) }
 
     it "is valid for the default factory" do
       expect(subject).to be_valid
@@ -18,15 +18,15 @@ RSpec.describe Location do
 
     context "when another content item has identical supporting objects" do
       before do
-        create(:content_item, base_path: "/foo")
+        FactoryGirl.create(:content_item, base_path: "/foo")
       end
 
       let(:content_item) do
-        create(:content_item, base_path: "/bar")
+        FactoryGirl.create(:content_item, base_path: "/bar")
       end
 
       subject {
-        build(:location, content_item: content_item, base_path: "/foo")
+        FactoryGirl.build(:location, content_item: content_item, base_path: "/foo")
       }
 
       it "is invalid" do
@@ -39,8 +39,8 @@ RSpec.describe Location do
   end
 
   describe "routes and redirects" do
-    subject { build(:location) }
-    let(:content_item) { build(:content_item) }
+    subject { FactoryGirl.build(:location) }
+    let(:content_item) { FactoryGirl.build(:content_item) }
 
     before do
       subject.content_item = content_item
@@ -51,7 +51,7 @@ RSpec.describe Location do
 
   describe ".filter" do
     let!(:vat_item) do
-      create(
+      FactoryGirl.create(
         :content_item,
         title: "VAT Title",
         base_path: "/vat-rates",
@@ -59,7 +59,7 @@ RSpec.describe Location do
     end
 
     let!(:tax_item) do
-      create(
+      FactoryGirl.create(
         :content_item,
         title: "Tax Title",
         base_path: "/tax",

--- a/spec/models/lock_version_spec.rb
+++ b/spec/models/lock_version_spec.rb
@@ -1,21 +1,21 @@
 require "rails_helper"
 
 RSpec.describe LockVersion do
-  subject { build(:lock_version) }
+  subject { FactoryGirl.build(:lock_version) }
 
   it "starts version numbers at 0" do
-    content_item = create(:content_item)
+    content_item = FactoryGirl.create(:content_item)
     lock_version = LockVersion.create!(target: content_item)
     expect(lock_version.number).to be_zero
     expect(lock_version).to be_valid
   end
 
   describe "#copy_version_from" do
-    let(:target) { create(:link_set) }
+    let(:target) { FactoryGirl.create(:link_set) }
 
     context "when the target has a lock_version" do
       before do
-        create(:lock_version, target: target, number: 5)
+        FactoryGirl.create(:lock_version, target: target, number: 5)
       end
 
       it "copies the lock_version number from the target's lock_version" do
@@ -74,7 +74,7 @@ RSpec.describe LockVersion do
   describe "::in_bulk" do
     it "returns a hash of LockVersions for a set of items, keyed by item id" do
       items = 5.times.map do |i|
-        create(:draft_content_item, base_path: "/page-#{i}")
+        FactoryGirl.create(:draft_content_item, base_path: "/page-#{i}")
       end
 
       lock_versions = LockVersion.in_bulk(items, ContentItem)
@@ -96,14 +96,14 @@ RSpec.describe LockVersion do
     let(:content_id) { SecureRandom.uuid }
 
     let!(:draft) do
-      create(
+      FactoryGirl.create(
         :draft_content_item,
         content_id: content_id,
       )
     end
 
     let!(:live) do
-      create(
+      FactoryGirl.create(
         :live_content_item,
         content_id: content_id,
       )

--- a/spec/models/path_reservation_spec.rb
+++ b/spec/models/path_reservation_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe PathReservation, type: :model do
   describe ".reserve_base_path!(base_path, publishing_app)" do
     context "when the path reservation already exists" do
       before do
-        create(
+        FactoryGirl.create(
           :path_reservation,
           base_path: "/vat-rates",
           publishing_app: "something-else",

--- a/spec/models/path_reservation_spec.rb
+++ b/spec/models/path_reservation_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe PathReservation, type: :model do
   describe "validations" do
-    let(:reservation) { build(:path_reservation) }
+    let(:reservation) { FactoryGirl.build(:path_reservation) }
 
     describe "on base_path" do
       it "is required" do
@@ -18,7 +18,7 @@ RSpec.describe PathReservation, type: :model do
       end
 
       it "has a db level uniqueness constraint" do
-        create(:path_reservation, base_path: "/foo/bar")
+        FactoryGirl.create(:path_reservation, base_path: "/foo/bar")
         reservation.base_path = "/foo/bar"
         expect {
           reservation.save! validate: false
@@ -43,7 +43,7 @@ RSpec.describe PathReservation, type: :model do
   end
 
   it "supports base_paths longer than 255 chars" do
-    reservation = build(:path_reservation)
+    reservation = FactoryGirl.build(:path_reservation)
     reservation.base_path = "/" + 'x' * 300
     expect {
       reservation.save!

--- a/spec/models/state_spec.rb
+++ b/spec/models/state_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe State do
   describe "validations" do
-    subject { build(:state) }
+    subject { FactoryGirl.build(:state) }
 
     it "is valid for the default factory" do
       expect(subject).to be_valid
@@ -10,14 +10,14 @@ RSpec.describe State do
 
     context "when another content item has identical supporting objects" do
       before do
-        create(:content_item, state: "published")
+        FactoryGirl.create(:content_item, state: "published")
       end
 
       let(:content_item) do
-        create(:content_item, state: "draft")
+        FactoryGirl.create(:content_item, state: "draft")
       end
 
-      subject { build(:state, content_item: content_item, name: "published") }
+      subject { FactoryGirl.build(:state, content_item: content_item, name: "published") }
 
       it "is invalid" do
         expect(subject).to be_invalid
@@ -29,8 +29,8 @@ RSpec.describe State do
   end
 
   describe ".filter" do
-    let!(:draft_item) { create(:draft_content_item, title: "Draft Title") }
-    let!(:published_item) { create(:live_content_item, title: "Published Title") }
+    let!(:draft_item) { FactoryGirl.create(:draft_content_item, title: "Draft Title") }
+    let!(:published_item) { FactoryGirl.create(:live_content_item, title: "Published Title") }
 
     it "filters a content item scope by state name" do
       draft_items = described_class.filter(ContentItem.all, name: "draft")
@@ -42,7 +42,7 @@ RSpec.describe State do
   end
 
   describe ".supersede" do
-    let(:draft_item) { create(:draft_content_item) }
+    let(:draft_item) { FactoryGirl.create(:draft_content_item) }
     let(:draft_state) { State.find_by!(content_item: draft_item) }
 
     it "changes the state name to 'superseded'" do
@@ -53,7 +53,7 @@ RSpec.describe State do
   end
 
   describe ".publish" do
-    let(:draft_item) { create(:draft_content_item) }
+    let(:draft_item) { FactoryGirl.create(:draft_content_item) }
     let(:draft_state) { State.find_by!(content_item: draft_item) }
 
     it "changes the state name to 'published'" do
@@ -64,7 +64,7 @@ RSpec.describe State do
   end
 
   describe ".unpublish" do
-    let(:live_item) { create(:live_content_item) }
+    let(:live_item) { FactoryGirl.create(:live_content_item) }
     let(:live_state) { State.find_by!(content_item: live_item) }
 
     it "changes the state name to 'unpublished'" do
@@ -92,7 +92,7 @@ RSpec.describe State do
   end
 
   describe ".substitute" do
-    let(:live_item) { create(:live_content_item) }
+    let(:live_item) { FactoryGirl.create(:live_content_item) }
     let(:live_state) { State.find_by!(content_item: live_item) }
 
     it "changes the state name to 'unpublished'" do

--- a/spec/models/symbolize_json_spec.rb
+++ b/spec/models/symbolize_json_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe SymbolizeJSON do
-  subject { build(:draft_content_item) }
+  subject { FactoryGirl.build(:draft_content_item) }
 
   it "doesn't affect non-json columns" do
     content_id = SecureRandom.uuid

--- a/spec/models/unpublishing_spec.rb
+++ b/spec/models/unpublishing_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe Unpublishing do
   describe "validations" do
-    subject { build(:unpublishing) }
+    subject { FactoryGirl.build(:unpublishing) }
 
     it "is valid for the default factory" do
       expect(subject).to be_valid

--- a/spec/models/user_facing_version_spec.rb
+++ b/spec/models/user_facing_version_spec.rb
@@ -1,10 +1,10 @@
 require "rails_helper"
 
 RSpec.describe UserFacingVersion do
-  subject { build(:user_facing_version) }
+  subject { FactoryGirl.build(:user_facing_version) }
 
   it "starts version numbers at 0" do
-    content_item = create(:content_item)
+    content_item = FactoryGirl.create(:content_item)
     user_facing_version = UserFacingVersion.create(content_item: content_item)
 
     expect(user_facing_version.number).to be_zero
@@ -23,8 +23,8 @@ RSpec.describe UserFacingVersion do
 
   describe ".latest" do
     before do
-      create(:content_item, user_facing_version: 2, title: "Latest")
-      create(:content_item, user_facing_version: 1)
+      FactoryGirl.create(:content_item, user_facing_version: 2, title: "Latest")
+      FactoryGirl.create(:content_item, user_facing_version: 1)
     end
 
     it "returns the content item with the latest user_facing version" do
@@ -37,14 +37,14 @@ RSpec.describe UserFacingVersion do
     let(:content_id) { SecureRandom.uuid }
 
     let!(:draft) do
-      create(
+      FactoryGirl.create(
         :draft_content_item,
         content_id: content_id,
       )
     end
 
     let!(:live) do
-      create(
+      FactoryGirl.create(
         :live_content_item,
         content_id: content_id,
       )
@@ -55,15 +55,15 @@ RSpec.describe UserFacingVersion do
 
     context "when another content item has identical supporting objects" do
       before do
-        create(:content_item, user_facing_version: 3)
+        FactoryGirl.create(:content_item, user_facing_version: 3)
       end
 
       let(:content_item) do
-        create(:content_item, user_facing_version: 2)
+        FactoryGirl.create(:content_item, user_facing_version: 2)
       end
 
       subject {
-        build(:user_facing_version, content_item: content_item, number: 3)
+        FactoryGirl.build(:user_facing_version, content_item: content_item, number: 3)
       }
 
       it "is invalid" do

--- a/spec/presenters/content_store_presenter_spec.rb
+++ b/spec/presenters/content_store_presenter_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe Presenters::ContentStorePresenter do
-  let(:content_item) { create(:live_content_item) }
+  let(:content_item) { FactoryGirl.create(:live_content_item) }
   let(:event) { double(:event, id: 123) }
   let(:fallback_order) { [:published] }
 

--- a/spec/presenters/downstream_presenter_spec.rb
+++ b/spec/presenters/downstream_presenter_spec.rb
@@ -33,8 +33,8 @@ RSpec.describe Presenters::DownstreamPresenter do
     }
 
     context "for a live content item" do
-      let(:content_item) { create(:live_content_item) }
-      let!(:link_set)    { create(:link_set, content_id: content_item.content_id) }
+      let(:content_item) { FactoryGirl.create(:live_content_item) }
+      let!(:link_set)    { FactoryGirl.create(:link_set, content_id: content_item.content_id) }
 
       it "presents the object graph for the content store" do
         expect(result).to eq(expected)
@@ -42,8 +42,8 @@ RSpec.describe Presenters::DownstreamPresenter do
     end
 
     context "for a draft content item" do
-      let(:content_item) { create(:draft_content_item) }
-      let!(:link_set) { create(:link_set, content_id: content_item.content_id) }
+      let(:content_item) { FactoryGirl.create(:draft_content_item) }
+      let!(:link_set) { FactoryGirl.create(:link_set, content_id: content_item.content_id) }
 
       it "presents the object graph for the content store" do
         expect(result).to eq(expected)
@@ -51,8 +51,8 @@ RSpec.describe Presenters::DownstreamPresenter do
     end
 
     context "for a withdrawn content item" do
-      let!(:content_item) { create(:withdrawn_content_item) }
-      let!(:link_set) { create(:link_set, content_id: content_item.content_id) }
+      let!(:content_item) { FactoryGirl.create(:withdrawn_content_item) }
+      let!(:link_set) { FactoryGirl.create(:link_set, content_id: content_item.content_id) }
 
       it "merges in a withdrawal notice" do
         unpublishing = Unpublishing.find_by(content_item: content_item)
@@ -96,8 +96,8 @@ RSpec.describe Presenters::DownstreamPresenter do
     end
 
     describe "conditional attributes" do
-      let!(:content_item) { create(:live_content_item) }
-      let!(:link_set) { create(:link_set, content_id: content_item.content_id) }
+      let!(:content_item) { FactoryGirl.create(:live_content_item) }
+      let!(:link_set) { FactoryGirl.create(:link_set, content_id: content_item.content_id) }
 
       context "when the link_set is not present" do
         before { link_set.destroy }
@@ -108,7 +108,7 @@ RSpec.describe Presenters::DownstreamPresenter do
       end
 
       context "when the public_updated_at is not present" do
-        let(:content_item) { create(:gone_draft_content_item) }
+        let(:content_item) { FactoryGirl.create(:gone_draft_content_item) }
 
         it "does not raise an error" do
           expect { result }.not_to raise_error

--- a/spec/presenters/downstream_presenter_spec.rb
+++ b/spec/presenters/downstream_presenter_spec.rb
@@ -69,12 +69,12 @@ RSpec.describe Presenters::DownstreamPresenter do
     end
 
     context "for a content item with dependencies" do
-      let(:a) { create(:content_item, base_path: "/a") }
-      let(:b) { create(:content_item, base_path: "/b") }
+      let(:a) { FactoryGirl.create(:content_item, base_path: "/a") }
+      let(:b) { FactoryGirl.create(:content_item, base_path: "/b") }
 
       before do
-        create(:link_set, content_id: a.content_id, links: [
-          create(:link, link_type: "related", target_content_id: b.content_id)
+        FactoryGirl.create(:link_set, content_id: a.content_id, links: [
+          FactoryGirl.create(:link, link_type: "related", target_content_id: b.content_id)
         ])
       end
 

--- a/spec/presenters/message_queue_presenter_spec.rb
+++ b/spec/presenters/message_queue_presenter_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe Presenters::MessageQueuePresenter do
-  let(:content_item) { create(:live_content_item) }
+  let(:content_item) { FactoryGirl.create(:live_content_item) }
 
   it "mixes in the specified update_type to the presentation" do
     presentation = described_class.present(content_item, fallback_order: [:published], update_type: "foo")

--- a/spec/presenters/queries/content_item_presenter_spec.rb
+++ b/spec/presenters/queries/content_item_presenter_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Presenters::Queries::ContentItemPresenter do
 
   describe "present" do
     let!(:content_item) do
-      create(:draft_content_item, content_id: content_id)
+      FactoryGirl.create(:draft_content_item, content_id: content_id)
     end
 
     let(:result) { described_class.present(content_item) }
@@ -75,7 +75,7 @@ RSpec.describe Presenters::Queries::ContentItemPresenter do
 
     context "when the content item exists in multiple locales" do
       let!(:french_item) do
-        create(:content_item, content_id: content_id, locale: "fr")
+        FactoryGirl.create(:content_item, content_id: content_id, locale: "fr")
       end
 
       it "presents the item with matching locale" do
@@ -90,7 +90,7 @@ RSpec.describe Presenters::Queries::ContentItemPresenter do
 
   describe "#present_many" do
     let!(:content_item) do
-      create(
+      FactoryGirl.create(
         :content_item,
         content_id: content_id,
       )
@@ -150,7 +150,7 @@ RSpec.describe Presenters::Queries::ContentItemPresenter do
 
     context "when the content item exists in multiple locales" do
       let!(:french_item) do
-        create(:content_item, content_id: content_id, locale: "fr")
+        FactoryGirl.create(:content_item, content_id: content_id, locale: "fr")
       end
 
       it "presents a content item for each locale" do

--- a/spec/presenters/queries/expanded_link_set_spec.rb
+++ b/spec/presenters/queries/expanded_link_set_spec.rb
@@ -2,12 +2,12 @@ require "rails_helper"
 
 RSpec.describe Presenters::Queries::ExpandedLinkSet do
   def create_link_set
-    link_set = create(:link_set, content_id: SecureRandom.uuid)
+    link_set = FactoryGirl.create(:link_set, content_id: SecureRandom.uuid)
     link_set.content_id
   end
 
   def create_content_item(content_id, base_path, state = "published")
-    create(
+    FactoryGirl.create(
       :content_item,
       content_id: content_id,
       base_path: base_path,
@@ -18,7 +18,7 @@ RSpec.describe Presenters::Queries::ExpandedLinkSet do
   def create_link(from, to, link_type)
     link_set = LinkSet.find_by(content_id: from)
 
-    create(
+    FactoryGirl.create(
       :link,
       link_set: link_set,
       target_content_id: to,

--- a/spec/presenters/queries/link_set_presenter_spec.rb
+++ b/spec/presenters/queries/link_set_presenter_spec.rb
@@ -3,11 +3,11 @@ require 'rails_helper'
 RSpec.describe Presenters::Queries::LinkSetPresenter do
   describe ".present" do
     before do
-      create(:lock_version, target: link_set, number: 101)
+      FactoryGirl.create(:lock_version, target: link_set, number: 101)
       @result = Presenters::Queries::LinkSetPresenter.present(link_set)
     end
 
-    let(:link_set) { create(:link_set, content_id: "foo") }
+    let(:link_set) { FactoryGirl.create(:link_set, content_id: "foo") }
 
     it "returns link set attributes as a hash" do
       expect(@result.fetch(:content_id)).to eq("foo")
@@ -20,7 +20,7 @@ RSpec.describe Presenters::Queries::LinkSetPresenter do
 
   context "#links" do
     describe "returns the links as a hash, grouping them by their link_type" do
-      let(:link_set) { create(:link_set) }
+      let(:link_set) { FactoryGirl.create(:link_set) }
       let(:links) { Presenters::Queries::LinkSetPresenter.new(link_set).links }
 
       it "returns and empty hash when no links are present" do
@@ -32,9 +32,9 @@ RSpec.describe Presenters::Queries::LinkSetPresenter do
         org_content_id_2 = SecureRandom.uuid
         rel_content_id_1 = SecureRandom.uuid
 
-        create(:link, link_set: link_set, link_type: "organisations", target_content_id: org_content_id_1)
-        create(:link, link_set: link_set, link_type: "organisations", target_content_id: org_content_id_2)
-        create(:link, link_set: link_set, link_type: "related_links", target_content_id: rel_content_id_1)
+        FactoryGirl.create(:link, link_set: link_set, link_type: "organisations", target_content_id: org_content_id_1)
+        FactoryGirl.create(:link, link_set: link_set, link_type: "organisations", target_content_id: org_content_id_2)
+        FactoryGirl.create(:link, link_set: link_set, link_type: "related_links", target_content_id: rel_content_id_1)
 
         expect(links[:organisations]).to match_array(
           [org_content_id_1, org_content_id_2]

--- a/spec/queries/content_dependencies_spec.rb
+++ b/spec/queries/content_dependencies_spec.rb
@@ -1,21 +1,21 @@
 require "rails_helper"
 
 RSpec.describe Queries::ContentDependencies do
-  let(:parent_content_item) { create(:content_item, base_path: "/tax") }
-  let(:child_content_item) { create(:content_item, base_path: "/vat-rates") }
-  let(:special_content_item) { create(:content_item, base_path: "/something-special") }
+  let(:parent_content_item) { FactoryGirl.create(:content_item, base_path: "/tax") }
+  let(:child_content_item) { FactoryGirl.create(:content_item, base_path: "/vat-rates") }
+  let(:special_content_item) { FactoryGirl.create(:content_item, base_path: "/something-special") }
 
-  let(:link_set) { create(:link_set, content_id: child_content_item.content_id) }
+  let(:link_set) { FactoryGirl.create(:link_set, content_id: child_content_item.content_id) }
 
   let!(:link) {
-    create(:link,
+    FactoryGirl.create(:link,
       link_set: link_set,
       link_type: 'special',
       target_content_id: special_content_item.content_id,
     )
   }
   let!(:link_2) {
-    create(:link,
+    FactoryGirl.create(:link,
       link_set: link_set,
       link_type: 'parent',
       target_content_id: parent_content_item.content_id,

--- a/spec/queries/get_content_collection_spec.rb
+++ b/spec/queries/get_content_collection_spec.rb
@@ -2,17 +2,17 @@ require "rails_helper"
 
 RSpec.describe Queries::GetContentCollection do
   it "returns the content items of the given format" do
-    create(
+    FactoryGirl.create(
       :draft_content_item,
       base_path: '/a',
       format: 'topic',
     )
-    create(
+    FactoryGirl.create(
       :draft_content_item,
       base_path: '/b',
       format: 'topic',
     )
-    create(
+    FactoryGirl.create(
       :draft_content_item,
       base_path: '/c',
       format: 'mainstream_browse_page',
@@ -28,12 +28,12 @@ RSpec.describe Queries::GetContentCollection do
   end
 
   it "returns the content items of the given format, and placeholder_format" do
-    create(
+    FactoryGirl.create(
       :draft_content_item,
       base_path: '/a',
       format: 'topic'
     )
-    create(
+    FactoryGirl.create(
       :draft_content_item,
       base_path: '/b',
       format: 'placeholder_topic'
@@ -49,12 +49,12 @@ RSpec.describe Queries::GetContentCollection do
   end
 
   it "includes the publishing state of the item" do
-    create(
+    FactoryGirl.create(
       :draft_content_item,
       base_path: '/draft',
       format: 'topic'
     )
-    create(
+    FactoryGirl.create(
       :live_content_item,
       base_path: '/live',
       format: 'topic'
@@ -91,19 +91,19 @@ RSpec.describe Queries::GetContentCollection do
 
   context "filtering by publishing_app" do
     before do
-      create(
+      FactoryGirl.create(
         :draft_content_item,
         base_path: '/a',
         format: 'topic',
         publishing_app: 'publisher'
       )
-      create(
+      FactoryGirl.create(
         :draft_content_item,
         base_path: '/b',
         format: 'topic',
         publishing_app: 'publisher'
       )
-      create(
+      FactoryGirl.create(
         :draft_content_item,
         base_path: '/c',
         format: 'topic',
@@ -136,10 +136,10 @@ RSpec.describe Queries::GetContentCollection do
 
   describe "the locale filter parameter" do
     before do
-      create(:draft_content_item, base_path: '/content.en', format: 'topic', locale: 'en')
-      create(:draft_content_item, base_path: '/content.ar', format: 'topic', locale: 'ar')
-      create(:live_content_item, base_path: '/content.en', format: 'topic', locale: 'en')
-      create(:live_content_item, base_path: '/content.ar', format: 'topic', locale: 'ar')
+      FactoryGirl.create(:draft_content_item, base_path: '/content.en', format: 'topic', locale: 'en')
+      FactoryGirl.create(:draft_content_item, base_path: '/content.ar', format: 'topic', locale: 'ar')
+      FactoryGirl.create(:live_content_item, base_path: '/content.en', format: 'topic', locale: 'en')
+      FactoryGirl.create(:live_content_item, base_path: '/content.ar', format: 'topic', locale: 'ar')
     end
 
     it "returns the content items filtered by 'en' locale by default" do
@@ -186,32 +186,32 @@ RSpec.describe Queries::GetContentCollection do
       draft_2_content_id = SecureRandom.uuid
       live_1_content_id = SecureRandom.uuid
 
-      create(
+      FactoryGirl.create(
         :draft_content_item,
         content_id: draft_1_content_id,
         base_path: "/foo",
         publishing_app: "specialist-publisher"
       )
 
-      create(
+      FactoryGirl.create(
         :draft_content_item,
         content_id: draft_2_content_id,
         base_path: "/bar"
       )
 
-      create(
+      FactoryGirl.create(
         :live_content_item,
         content_id: live_1_content_id,
         base_path: "/baz"
       )
 
-      link_set_1 = create(:link_set, content_id: draft_1_content_id)
-      link_set_2 = create(:link_set, content_id: draft_2_content_id)
-      link_set_3 = create(:link_set, content_id: live_1_content_id)
+      link_set_1 = FactoryGirl.create(:link_set, content_id: draft_1_content_id)
+      link_set_2 = FactoryGirl.create(:link_set, content_id: draft_2_content_id)
+      link_set_3 = FactoryGirl.create(:link_set, content_id: live_1_content_id)
 
-      create(:link, link_set: link_set_1, target_content_id: someorg_content_id)
-      create(:link, link_set: link_set_2, target_content_id: otherorg_content_id)
-      create(:link, link_set: link_set_3, target_content_id: someorg_content_id)
+      FactoryGirl.create(:link, link_set: link_set_1, target_content_id: someorg_content_id)
+      FactoryGirl.create(:link, link_set: link_set_2, target_content_id: otherorg_content_id)
+      FactoryGirl.create(:link, link_set: link_set_3, target_content_id: someorg_content_id)
     end
 
     it "filters content items by organisation" do
@@ -337,10 +337,10 @@ RSpec.describe Queries::GetContentCollection do
 
   describe "result order" do
     before do
-      create(:content_item, base_path: "/c4", title: 'D', public_updated_at: DateTime.parse('2014-06-14'))
-      create(:content_item, base_path: "/c1", title: 'A', public_updated_at: DateTime.parse('2014-06-13'))
-      create(:content_item, base_path: "/c3", title: 'C', public_updated_at: DateTime.parse('2014-06-17'))
-      create(:content_item, base_path: "/c2", title: 'B', public_updated_at: DateTime.parse('2014-06-15'))
+      FactoryGirl.create(:content_item, base_path: "/c4", title: 'D', public_updated_at: DateTime.parse('2014-06-14'))
+      FactoryGirl.create(:content_item, base_path: "/c1", title: 'A', public_updated_at: DateTime.parse('2014-06-13'))
+      FactoryGirl.create(:content_item, base_path: "/c3", title: 'C', public_updated_at: DateTime.parse('2014-06-17'))
+      FactoryGirl.create(:content_item, base_path: "/c2", title: 'B', public_updated_at: DateTime.parse('2014-06-15'))
     end
 
     it "returns content items in default order" do
@@ -368,8 +368,8 @@ RSpec.describe Queries::GetContentCollection do
 
   describe "#total" do
     it "returns the number of content items" do
-      create(:content_item, base_path: '/a', format: 'topic')
-      create(:content_item, base_path: '/b', format: 'topic')
+      FactoryGirl.create(:content_item, base_path: '/a', format: 'topic')
+      FactoryGirl.create(:content_item, base_path: '/b', format: 'topic')
 
       expect(Queries::GetContentCollection.new(
         document_type: 'topic',
@@ -381,7 +381,7 @@ RSpec.describe Queries::GetContentCollection do
       before do
         content_id = SecureRandom.uuid
 
-        create(
+        FactoryGirl.create(
           :content_item,
           content_id: content_id,
           format: 'topic',
@@ -389,7 +389,7 @@ RSpec.describe Queries::GetContentCollection do
           user_facing_version: 1,
         )
 
-        create(
+        FactoryGirl.create(
           :content_item,
           content_id: content_id,
           format: 'topic',

--- a/spec/queries/get_content_collection_spec.rb
+++ b/spec/queries/get_content_collection_spec.rb
@@ -243,8 +243,8 @@ RSpec.describe Queries::GetContentCollection do
 
   context "when details hash is requested" do
     it "returns the details hash" do
-      create(:draft_content_item, base_path: '/z', details: { foo: :bar }, format: 'topic', publishing_app: 'publisher')
-      create(:draft_content_item, base_path: '/b', details: { baz: :bat }, format: 'placeholder_topic', publishing_app: 'publisher')
+      FactoryGirl.create(:draft_content_item, base_path: '/z', details: { foo: :bar }, format: 'topic', publishing_app: 'publisher')
+      FactoryGirl.create(:draft_content_item, base_path: '/b', details: { baz: :bat }, format: 'placeholder_topic', publishing_app: 'publisher')
       expect(Queries::GetContentCollection.new(
         document_type: 'topic',
         fields: %w(details publication_state),
@@ -257,8 +257,8 @@ RSpec.describe Queries::GetContentCollection do
   end
 
   describe "search_fields" do
-    let!(:content_item_foo) { create(:live_content_item, base_path: '/bar/foo', format: 'topic', title: "Baz") }
-    let!(:content_item_zip) { create(:live_content_item, base_path: '/baz', format: 'topic', title: 'zip') }
+    let!(:content_item_foo) { FactoryGirl.create(:live_content_item, base_path: '/bar/foo', format: 'topic', title: "Baz") }
+    let!(:content_item_zip) { FactoryGirl.create(:live_content_item, base_path: '/baz', format: 'topic', title: 'zip') }
     subject do
       Queries::GetContentCollection.new(
         document_type: 'topic',
@@ -285,12 +285,12 @@ RSpec.describe Queries::GetContentCollection do
   describe "pagination" do
     context "with multiple content items" do
       before do
-        create(:draft_content_item, base_path: '/a', format: 'topic', public_updated_at: "2010-01-06")
-        create(:draft_content_item, base_path: '/b', format: 'topic', public_updated_at: "2010-01-05")
-        create(:draft_content_item, base_path: '/c', format: 'topic', public_updated_at: "2010-01-04")
-        create(:draft_content_item, base_path: '/d', format: 'topic', public_updated_at: "2010-01-03")
-        create(:live_content_item, base_path: '/live1', format: 'topic', public_updated_at: "2010-01-02")
-        create(:live_content_item, base_path: '/live2', format: 'topic', public_updated_at: "2010-01-01")
+        FactoryGirl.create(:draft_content_item, base_path: '/a', format: 'topic', public_updated_at: "2010-01-06")
+        FactoryGirl.create(:draft_content_item, base_path: '/b', format: 'topic', public_updated_at: "2010-01-05")
+        FactoryGirl.create(:draft_content_item, base_path: '/c', format: 'topic', public_updated_at: "2010-01-04")
+        FactoryGirl.create(:draft_content_item, base_path: '/d', format: 'topic', public_updated_at: "2010-01-03")
+        FactoryGirl.create(:live_content_item, base_path: '/live1', format: 'topic', public_updated_at: "2010-01-02")
+        FactoryGirl.create(:live_content_item, base_path: '/live2', format: 'topic', public_updated_at: "2010-01-01")
       end
 
       it "limits the results returned" do

--- a/spec/queries/get_content_spec.rb
+++ b/spec/queries/get_content_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Queries::GetContent do
 
   context "when a content item exists for the content_id" do
     before do
-      create(
+      FactoryGirl.create(
         :content_item,
         content_id: content_id,
       )
@@ -38,14 +38,14 @@ RSpec.describe Queries::GetContent do
 
   context "when a draft and a live content item exists for the content_id" do
     before do
-      create(
+      FactoryGirl.create(
         :draft_content_item,
         content_id: content_id,
         title: "Draft Title",
         user_facing_version: 2,
       )
 
-      create(
+      FactoryGirl.create(
         :live_content_item,
         content_id: content_id,
         title: "Live Title",
@@ -61,7 +61,7 @@ RSpec.describe Queries::GetContent do
 
   context "when content items exist in non-draft, non-live states" do
     before do
-      create(
+      FactoryGirl.create(
         :content_item,
         content_id: content_id,
         user_facing_version: 1,
@@ -69,7 +69,7 @@ RSpec.describe Queries::GetContent do
         state: "published",
       )
 
-      create(
+      FactoryGirl.create(
         :content_item,
         content_id: content_id,
         user_facing_version: 2,
@@ -86,7 +86,7 @@ RSpec.describe Queries::GetContent do
 
   context "when content items exist in multiple locales" do
     before do
-      create(
+      FactoryGirl.create(
         :content_item,
         content_id: content_id,
         user_facing_version: 2,
@@ -94,7 +94,7 @@ RSpec.describe Queries::GetContent do
         locale: "fr",
       )
 
-      create(
+      FactoryGirl.create(
         :content_item,
         content_id: content_id,
         user_facing_version: 1,

--- a/spec/queries/get_dependees_spec.rb
+++ b/spec/queries/get_dependees_spec.rb
@@ -4,14 +4,14 @@ RSpec.describe Queries::GetDependees do
   subject { described_class.new }
 
   def create_node
-    link_set = create(:link_set, content_id: SecureRandom.uuid)
+    link_set = FactoryGirl.create(:link_set, content_id: SecureRandom.uuid)
     link_set.content_id
   end
 
   def create_edge(from, to, link_type)
     link_set = LinkSet.find_by(content_id: from)
 
-    create(
+    FactoryGirl.create(
       :link,
       link_set: link_set,
       target_content_id: to,

--- a/spec/queries/get_dependents_spec.rb
+++ b/spec/queries/get_dependents_spec.rb
@@ -4,14 +4,14 @@ RSpec.describe Queries::GetDependents do
   subject { described_class.new }
 
   def create_node
-    link_set = create(:link_set, content_id: SecureRandom.uuid)
+    link_set = FactoryGirl.create(:link_set, content_id: SecureRandom.uuid)
     link_set.content_id
   end
 
   def create_edge(from, to, link_type)
     link_set = LinkSet.find_by(content_id: from)
 
-    create(
+    FactoryGirl.create(
       :link,
       link_set: link_set,
       target_content_id: to,

--- a/spec/queries/get_latest_spec.rb
+++ b/spec/queries/get_latest_spec.rb
@@ -6,15 +6,15 @@ RSpec.describe Queries::GetLatest do
   let(:c) { SecureRandom.uuid }
 
   before do
-    create(:content_item, content_id: a, user_facing_version: 2, base_path: "/a2")
-    create(:content_item, content_id: a, user_facing_version: 1, base_path: "/a1")
-    create(:content_item, content_id: a, user_facing_version: 3, base_path: "/a3")
+    FactoryGirl.create(:content_item, content_id: a, user_facing_version: 2, base_path: "/a2")
+    FactoryGirl.create(:content_item, content_id: a, user_facing_version: 1, base_path: "/a1")
+    FactoryGirl.create(:content_item, content_id: a, user_facing_version: 3, base_path: "/a3")
 
-    create(:content_item, content_id: b, user_facing_version: 1, base_path: "/b1")
-    create(:content_item, content_id: b, user_facing_version: 2, locale: "fr", base_path: "/b2")
+    FactoryGirl.create(:content_item, content_id: b, user_facing_version: 1, base_path: "/b1")
+    FactoryGirl.create(:content_item, content_id: b, user_facing_version: 2, locale: "fr", base_path: "/b2")
 
-    create(:content_item, content_id: c, user_facing_version: 1, base_path: "/c1")
-    create(:content_item, content_id: c, user_facing_version: 2, base_path: "/c2")
+    FactoryGirl.create(:content_item, content_id: c, user_facing_version: 1, base_path: "/c1")
+    FactoryGirl.create(:content_item, content_id: c, user_facing_version: 2, base_path: "/c2")
   end
 
   def base_paths(result)

--- a/spec/queries/get_link_set_spec.rb
+++ b/spec/queries/get_link_set_spec.rb
@@ -5,11 +5,11 @@ RSpec.describe Queries::GetLinkSet do
 
   context "when the link set exists" do
     let!(:link_set) do
-      create(:link_set, content_id: content_id)
+      FactoryGirl.create(:link_set, content_id: content_id)
     end
 
     before do
-      create(:lock_version, target: link_set, number: 5)
+      FactoryGirl.create(:lock_version, target: link_set, number: 5)
     end
 
     context "and it has some links" do
@@ -17,21 +17,21 @@ RSpec.describe Queries::GetLinkSet do
       let(:related) { [SecureRandom.uuid, SecureRandom.uuid] }
 
       before do
-        create(
+        FactoryGirl.create(
           :link,
           link_set: link_set,
           link_type: "parent",
           target_content_id: parent.first
         )
 
-        create(
+        FactoryGirl.create(
           :link,
           link_set: link_set,
           link_type: "related",
           target_content_id: related.first
         )
 
-        create(
+        FactoryGirl.create(
           :link,
           link_set: link_set,
           link_type: "related",

--- a/spec/queries/get_linked_spec.rb
+++ b/spec/queries/get_linked_spec.rb
@@ -34,14 +34,14 @@ RSpec.describe Queries::GetLinked do
 
     context "when a content item with no draft exists" do
       before do
-        create(
+        FactoryGirl.create(
           :live_content_item,
           content_id: content_id,
           base_path: "/vat-rules-2020",
           title: "VAT rules 2020",
         )
 
-        create(
+        FactoryGirl.create(
           :live_content_item,
           content_id: target_content_id,
           base_path: "/vat-org",
@@ -60,8 +60,8 @@ RSpec.describe Queries::GetLinked do
 
       context "where another content item is linked to it" do
         before do
-          link_set = create(:link_set, content_id: content_id)
-          create(:link, link_set: link_set, target_content_id: target_content_id)
+          link_set = FactoryGirl.create(:link_set, content_id: content_id)
+          FactoryGirl.create(:link, link_set: link_set, target_content_id: target_content_id)
         end
 
         it "should return the linked item" do
@@ -76,7 +76,7 @@ RSpec.describe Queries::GetLinked do
 
     context "when a content item with draft exists "do
       before do
-        create(
+        FactoryGirl.create(
           :live_content_item,
           :with_draft,
           content_id: target_content_id,
@@ -110,16 +110,16 @@ RSpec.describe Queries::GetLinked do
 
       context "content items link to the wanted content item" do
         before do
-          create(
+          FactoryGirl.create(
             :live_content_item,
             content_id: content_id,
             title: "VAT and VATy things"
           )
-          create(
+          FactoryGirl.create(
             :link_set,
             content_id: content_id,
             links: [
-              create(
+              FactoryGirl.create(
                 :link,
                 link_type: "organisations",
                 target_content_id: target_content_id
@@ -127,22 +127,22 @@ RSpec.describe Queries::GetLinked do
             ]
           )
 
-          content_item = create(
+          content_item = FactoryGirl.create(
             :live_content_item,
             base_path: '/vatty',
             content_id: SecureRandom.uuid,
             title: "Another VATTY thing"
           )
-          create(
+          FactoryGirl.create(
             :link_set,
             content_id: content_item.content_id,
             links: [
-              create(
+              FactoryGirl.create(
                 :link,
                 link_type: "organisations",
                 target_content_id: target_content_id
               ),
-              create(
+              FactoryGirl.create(
                 :link,
                 link_type: "related_links",
                 target_content_id: target_content_id
@@ -193,24 +193,24 @@ RSpec.describe Queries::GetLinked do
 
       context "draft items linking to the wanted draft item" do
         before do
-          create(
+          FactoryGirl.create(
             :live_content_item,
             :with_draft,
             content_id: another_target_content_id,
             base_path: "/send-now"
           )
 
-          create(
+          FactoryGirl.create(
             :draft_content_item,
             content_id: content_id,
             title: "HMRC documents"
           )
 
-          create(
+          FactoryGirl.create(
             :link_set,
             content_id: content_id,
             links: [
-              create(
+              FactoryGirl.create(
                 :link,
                 link_type: "organisations",
                 target_content_id: another_target_content_id
@@ -218,23 +218,23 @@ RSpec.describe Queries::GetLinked do
             ]
           )
 
-          content_item = create(
+          content_item = FactoryGirl.create(
             :draft_content_item,
             base_path: '/other-hmrc-document',
             content_id: SecureRandom.uuid,
             title: "Another HMRC document"
           )
 
-          create(
+          FactoryGirl.create(
             :link_set,
             content_id: content_item.content_id,
             links: [
-              create(
+              FactoryGirl.create(
                 :link,
                 link_type: "organisations",
                 target_content_id: another_target_content_id
               ),
-              create(
+              FactoryGirl.create(
                 :link,
                 link_type: "related_links",
                 target_content_id: SecureRandom.uuid

--- a/spec/requests/content_item_requests/downstream_requests_spec.rb
+++ b/spec/requests/content_item_requests/downstream_requests_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe "Downstream requests", type: :request do
 
     context "when a link set exists for the content item" do
       let(:link_set) do
-        create(
+        FactoryGirl.create(
           :link_set,
           content_id: v2_content_item[:content_id]
         )
@@ -132,13 +132,13 @@ RSpec.describe "Downstream requests", type: :request do
 
     context "when only a draft content item exists for the link set" do
       before do
-        draft = create(:draft_content_item,
+        draft = FactoryGirl.create(:draft_content_item,
           content_id: content_id,
         )
 
-        create(:lock_version, target: draft, number: 1)
+        FactoryGirl.create(:lock_version, target: draft, number: 1)
 
-        create(:access_limit,
+        FactoryGirl.create(:access_limit,
           users: access_limit_params.fetch(:users),
           content_item: draft,
         )
@@ -164,7 +164,7 @@ RSpec.describe "Downstream requests", type: :request do
 
     context "when only a live content item exists for the link set" do
       before do
-        create(:live_content_item,
+        FactoryGirl.create(:live_content_item,
           content_id: content_id,
         )
       end
@@ -189,16 +189,16 @@ RSpec.describe "Downstream requests", type: :request do
 
     context "when draft and live content items exists for the link set" do
       before do
-        draft = create(:draft_content_item,
+        draft = FactoryGirl.create(:draft_content_item,
           content_id: content_id,
         )
 
-        create(:access_limit,
+        FactoryGirl.create(:access_limit,
           users: access_limit_params.fetch(:users),
           content_item: draft,
         )
 
-        create(:live_content_item,
+        FactoryGirl.create(:live_content_item,
           content_id: content_id,
         )
       end
@@ -255,9 +255,9 @@ RSpec.describe "Downstream requests", type: :request do
       end
 
       before do
-        draft = create(:draft_content_item, v2_content_item.slice(*ContentItem::TOP_LEVEL_FIELDS))
-        create(:lock_version, target: draft, number: 1)
-        create(:access_limit, content_item: draft, users: access_limit_params.fetch(:users))
+        draft = FactoryGirl.create(:draft_content_item, v2_content_item.slice(*ContentItem::TOP_LEVEL_FIELDS))
+        FactoryGirl.create(:lock_version, target: draft, number: 1)
+        FactoryGirl.create(:access_limit, content_item: draft, users: access_limit_params.fetch(:users))
       end
 
       it "sends to the draft content store" do
@@ -281,7 +281,7 @@ RSpec.describe "Downstream requests", type: :request do
   context "/v2/publish" do
     let(:content_id) { SecureRandom.uuid }
     let!(:draft) {
-      create(:draft_content_item,
+      FactoryGirl.create(:draft_content_item,
         content_id: content_id,
       )
     }

--- a/spec/requests/content_item_requests/downstream_timeouts_spec.rb
+++ b/spec/requests/content_item_requests/downstream_timeouts_spec.rb
@@ -85,10 +85,10 @@ RSpec.describe "Downstream timeouts", type: :request do
     let(:request_method) { :patch }
 
     before do
-      create(:live_content_item, v2_content_item.slice(*ContentItem::TOP_LEVEL_FIELDS))
-      draft = create(:draft_content_item, v2_content_item.slice(*ContentItem::TOP_LEVEL_FIELDS))
+      FactoryGirl.create(:live_content_item, v2_content_item.slice(*ContentItem::TOP_LEVEL_FIELDS))
+      draft = FactoryGirl.create(:draft_content_item, v2_content_item.slice(*ContentItem::TOP_LEVEL_FIELDS))
 
-      create(:access_limit,
+      FactoryGirl.create(:access_limit,
         content_item: draft,
         users: access_limit_params.fetch(:users),
       )

--- a/spec/requests/content_item_requests/endpoint_behaviour_spec.rb
+++ b/spec/requests/content_item_requests/endpoint_behaviour_spec.rb
@@ -291,14 +291,14 @@ RSpec.describe "Endpoint behaviour", type: :request do
 
     context "when the content item exists" do
       let!(:content_item) {
-        create(
+        FactoryGirl.create(
           :draft_content_item,
           content_id: content_id,
         )
       }
 
       before do
-        create(:lock_version, target: content_item, number: 2)
+        FactoryGirl.create(:lock_version, target: content_item, number: 2)
       end
 
       it "responds with 200" do
@@ -316,7 +316,7 @@ RSpec.describe "Endpoint behaviour", type: :request do
       end
 
       it "responds with the presented content item for the correct locale" do
-        create(:draft_content_item, content_id: content_id, locale: "ar")
+        FactoryGirl.create(:draft_content_item, content_id: content_id, locale: "ar")
         presented_content_item = Presenters::Queries::ContentItemPresenter.present(content_item)
 
         get "/v2/content/#{content_id}"

--- a/spec/requests/content_item_requests/message_bus_spec.rb
+++ b/spec/requests/content_item_requests/message_bus_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe "Message bus", type: :request do
 
     context "with a live content item" do
       let!(:live_content_item) {
-        create(
+        FactoryGirl.create(
           :live_content_item,
           content_id: content_id,
         )
@@ -95,7 +95,7 @@ RSpec.describe "Message bus", type: :request do
 
     context "with a draft content item" do
       let!(:draft_content_item) {
-        create(
+        FactoryGirl.create(
           :draft_content_item,
           content_id: content_id,
         )
@@ -113,7 +113,7 @@ RSpec.describe "Message bus", type: :request do
 
   context "/v2/publish" do
     before do
-      create(
+      FactoryGirl.create(
         :draft_content_item,
         content_id: content_id,
         format: "guide",

--- a/spec/requests/content_item_requests/reallocating_base_path_spec.rb
+++ b/spec/requests/content_item_requests/reallocating_base_path_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "Reallocating base paths of content items" do
   end
 
   let(:regular_payload) do
-    build(:draft_content_item,
+    FactoryGirl.build(:draft_content_item,
       content_id: content_id,
     ).as_json.deep_symbolize_keys.merge(base_path: base_path)
   end
@@ -17,7 +17,7 @@ RSpec.describe "Reallocating base paths of content items" do
   describe "/v2/content" do
     context "when a base path is occupied by a 'regular' content item" do
       before do
-        create(
+        FactoryGirl.create(
           :draft_content_item,
           base_path: base_path,
         )
@@ -40,20 +40,20 @@ RSpec.describe "Reallocating base paths of content items" do
 
     context "when both content items are 'regular' content items" do
       before do
-        draft = create(
+        draft = FactoryGirl.create(
           :draft_content_item,
           content_id: draft_content_id,
           base_path: base_path
         )
 
-        live = create(
+        live = FactoryGirl.create(
           :live_content_item,
           content_id: live_content_id,
           base_path: base_path
         )
 
-        create(:lock_version, target: live, number: 5)
-        create(:lock_version, target: draft, number: 3)
+        FactoryGirl.create(:lock_version, target: live, number: 5)
+        FactoryGirl.create(:lock_version, target: draft, number: 3)
       end
 
       it "raises an error" do
@@ -68,7 +68,7 @@ RSpec.describe "Reallocating base paths of content items" do
   describe "/content" do
     context "when a base path is occupied by a not-yet-published regular content item" do
       before do
-        create(
+        FactoryGirl.create(
           :draft_content_item,
           base_path: base_path
         )
@@ -82,7 +82,7 @@ RSpec.describe "Reallocating base paths of content items" do
 
     context "when a base path is occupied by a published regular content item" do
       before do
-        create(
+        FactoryGirl.create(
           :live_content_item,
           :with_draft,
           base_path: base_path

--- a/spec/requests/discard_draft_request_spec.rb
+++ b/spec/requests/discard_draft_request_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "Discard draft requests", type: :request do
   describe "POST /v2/content/:content_id/discard-draft" do
     context "when a draft content item exists" do
       let!(:draft_content_item) do
-        create(:draft_content_item,
+        FactoryGirl.create(:draft_content_item,
           content_id: content_id,
           title: "draft",
           base_path: base_path,
@@ -36,7 +36,7 @@ RSpec.describe "Discard draft requests", type: :request do
         let(:french_base_path) { "/tva-tarifs" }
 
         let!(:french_draft_content_item) do
-          create(:draft_content_item,
+          FactoryGirl.create(:draft_content_item,
             content_id: content_id,
             title: "draft",
             locale: "fr",
@@ -86,7 +86,7 @@ RSpec.describe "Discard draft requests", type: :request do
 
       context "and a live content item exists" do
         before do
-          create(:live_content_item,
+          FactoryGirl.create(:live_content_item,
             content_id: content_id,
           )
         end

--- a/spec/requests/expanded_links_endpoint_spec.rb
+++ b/spec/requests/expanded_links_endpoint_spec.rb
@@ -2,24 +2,24 @@ require "rails_helper"
 
 RSpec.describe "GET /v2/expanded-links/:id", type: :request do
   it "returns expanded links" do
-    organisation = create(:content_item,
+    organisation = FactoryGirl.create(:content_item,
       state: "published",
       format: "organisation",
       base_path: "/my-super-org",
       content_id: "9b5ae6f5-f127-4843-9333-c157a404dd2d",
     )
 
-    content_item = create(:content_item,
+    content_item = FactoryGirl.create(:content_item,
       state: "published",
       format: "placeholder",
       title: "Some title",
     )
 
-    link_set = create(:link_set,
+    link_set = FactoryGirl.create(:link_set,
       content_id: content_item.content_id,
     )
 
-    create(:link, link_set: link_set, target_content_id: organisation.content_id, link_type: 'organisations')
+    FactoryGirl.create(:link, link_set: link_set, target_content_id: organisation.content_id, link_type: 'organisations')
 
     get "/v2/expanded-links/#{content_item.content_id}"
 
@@ -45,13 +45,13 @@ RSpec.describe "GET /v2/expanded-links/:id", type: :request do
   end
 
   it "returns empty expanded links if there are no links" do
-    content_item = create(:content_item,
+    content_item = FactoryGirl.create(:content_item,
       state: "published",
       format: "placeholder",
       title: "Some title",
     )
 
-    link_set = create(:link_set,
+    link_set = FactoryGirl.create(:link_set,
       content_id: content_item.content_id,
     )
 
@@ -65,17 +65,17 @@ RSpec.describe "GET /v2/expanded-links/:id", type: :request do
   end
 
   it "returns a version if the link set has a version" do
-    content_item = create(:content_item,
+    content_item = FactoryGirl.create(:content_item,
       state: "published",
       format: "placeholder",
       title: "Some title",
     )
 
-    link_set = create(:link_set,
+    link_set = FactoryGirl.create(:link_set,
       content_id: content_item.content_id,
     )
 
-    create(:lock_version, target: link_set, number: 11)
+    FactoryGirl.create(:lock_version, target: link_set, number: 11)
 
     get "/v2/expanded-links/#{link_set.content_id}"
 

--- a/spec/requests/index_spec.rb
+++ b/spec/requests/index_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe "GET /v2/content", type: :request do
   let!(:policy_1) {
-    create(:content_item,
+    FactoryGirl.create(:content_item,
       state: "draft",
       format: "policy",
       title: "Policy 1",
@@ -11,7 +11,7 @@ RSpec.describe "GET /v2/content", type: :request do
   }
 
   let!(:policy_2) {
-    create(:content_item,
+    FactoryGirl.create(:content_item,
       state: "published",
       format: "policy",
       title: "Policy 2",

--- a/spec/requests/linkables_spec.rb
+++ b/spec/requests/linkables_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe "GET /v2/linkables", type: :request do
   let!(:policy_1) {
-    create(:content_item,
+    FactoryGirl.create(:content_item,
       state: "draft",
       document_type: "policy",
       title: "Policy 1",
@@ -14,7 +14,7 @@ RSpec.describe "GET /v2/linkables", type: :request do
   }
 
   let!(:policy_2) {
-    create(:content_item,
+    FactoryGirl.create(:content_item,
       state: "published",
       document_type: "policy",
       title: "Policy 2",

--- a/spec/requests/logging_requests_spec.rb
+++ b/spec/requests/logging_requests_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe "Logging requests", type: :request do
   end
 
   it "adds a request uuid to the message bus" do
-    draft_content_item = create(:draft_content_item)
+    draft_content_item = FactoryGirl.create(:draft_content_item)
 
     expect(PublishingAPI.service(:queue_publisher)).to receive(:send_message)
       .with(hash_including(govuk_request_id: govuk_request_id))

--- a/spec/requests/lookups_spec.rb
+++ b/spec/requests/lookups_spec.rb
@@ -2,9 +2,9 @@ require "rails_helper"
 
 RSpec.describe "POST /lookup-by-base-path", type: :request do
   it "returns content_ids for base_paths" do
-    create(:content_item, state: "published", base_path: "/my-page", content_id: "b9b2da0a-ec50-4b0e-b29c-b7cbc8195307")
-    create(:content_item, state: "draft", base_path: "/my-page", content_id: "f7cdb359-c8ab-4d6d-b1f0-5c5640b24c09")
-    create(:content_item, state: "published", base_path: "/other-page", content_id: "b879bcdb-6160-4bfd-b758-f546bbb408c4")
+    FactoryGirl.create(:content_item, state: "published", base_path: "/my-page", content_id: "b9b2da0a-ec50-4b0e-b29c-b7cbc8195307")
+    FactoryGirl.create(:content_item, state: "draft", base_path: "/my-page", content_id: "f7cdb359-c8ab-4d6d-b1f0-5c5640b24c09")
+    FactoryGirl.create(:content_item, state: "published", base_path: "/other-page", content_id: "b879bcdb-6160-4bfd-b758-f546bbb408c4")
 
     post "/lookup-by-base-path", base_paths: ["/my-page", "/other-page", "/does-not-exist"]
 

--- a/spec/requests/unpublishing_spec.rb
+++ b/spec/requests/unpublishing_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "POST /v2/content/:content_id/unpublish", type: :request do
   let(:content_id) { SecureRandom.uuid }
   let(:base_path) { "/vat-rates" }
   let!(:content_item) {
-    create(:live_content_item,
+    FactoryGirl.create(:live_content_item,
       content_id: content_id,
       base_path: base_path,
     )

--- a/spec/substitution_helper_spec.rb
+++ b/spec/substitution_helper_spec.rb
@@ -6,27 +6,27 @@ RSpec.describe SubstitutionHelper do
   let(:existing_base_path) { "/vat-rates" }
 
   let!(:existing_item) {
-    create(:draft_content_item,
+    FactoryGirl.create(:draft_content_item,
       format: existing_format,
       base_path: existing_base_path,
     )
   }
 
   let!(:live_item) {
-    create(:live_content_item,
+    FactoryGirl.create(:live_content_item,
       format: existing_format,
       base_path: existing_base_path,
     )
   }
   let!(:french_item) {
-    create(:draft_content_item,
+    FactoryGirl.create(:draft_content_item,
       format: existing_format,
       base_path: existing_base_path,
       locale: "fr",
     )
   }
   let!(:item_elsewhere) {
-    create(:draft_content_item,
+    FactoryGirl.create(:draft_content_item,
       format: existing_format,
       base_path: "/somewhere-else",
     )

--- a/spec/support/authentication_helper.rb
+++ b/spec/support/authentication_helper.rb
@@ -9,7 +9,7 @@ module AuthenticationHelper
     end
 
     def login_as_stub_user
-      user = create(:user, permissions: ['signin'])
+      user = FactoryGirl.create(:user, permissions: ['signin'])
       login_as(user)
     end
   end
@@ -21,7 +21,7 @@ module AuthenticationHelper
     end
 
     def login_as_stub_user
-      user = create(:user, permissions: ['signin'])
+      user = FactoryGirl.create(:user, permissions: ['signin'])
       login_as(user)
     end
   end

--- a/spec/support/factory_girl.rb
+++ b/spec/support/factory_girl.rb
@@ -1,3 +1,0 @@
-RSpec.configure do |config|
-  config.include FactoryGirl::Syntax::Methods
-end

--- a/spec/support/transactional_command.rb
+++ b/spec/support/transactional_command.rb
@@ -15,7 +15,7 @@ RSpec.shared_examples_for TransactionalCommand do
 
     it "wraps the command in a transaction" do
       allow_any_instance_of(described_class).to receive(:call) do
-        create(:content_item, state: "published")
+        FactoryGirl.create(:content_item, state: "published")
         raise "Uh oh, command failed half-way through processing"
       end
 

--- a/spec/validators/content_item_uniqueness_validator_spec.rb
+++ b/spec/validators/content_item_uniqueness_validator_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe ContentItemUniquenessValidator do
 
   context "for a content item with unique supporting objects" do
     before do
-      create(:content_item)
+      FactoryGirl.create(:content_item)
     end
 
     it "has valid supporting objects" do
@@ -26,15 +26,15 @@ RSpec.describe ContentItemUniquenessValidator do
 
   context "for a content item with duplicate supporting objects" do
     before do
-      create(:content_item, user_facing_version: 2)
+      FactoryGirl.create(:content_item, user_facing_version: 2)
     end
 
     let(:content_item) do
-      create(:content_item, user_facing_version: 1)
+      FactoryGirl.create(:content_item, user_facing_version: 1)
     end
 
     it "has an invalid supporting object" do
-      user_facing_version = build(
+      user_facing_version = FactoryGirl.build(
         :user_facing_version,
         content_item: content_item,
         number: 2,
@@ -47,9 +47,9 @@ RSpec.describe ContentItemUniquenessValidator do
 
   context "for a content item with a differentiating supporting object" do
     before do
-      create(:content_item)
+      FactoryGirl.create(:content_item)
 
-      create(:content_item, user_facing_version: 2)
+      FactoryGirl.create(:content_item, user_facing_version: 2)
     end
 
     it "has valid supporting objects" do
@@ -62,7 +62,7 @@ RSpec.describe ContentItemUniquenessValidator do
 
   context "for a content item with a missing supporting object" do
     before do
-      content_item = create(:content_item)
+      content_item = FactoryGirl.create(:content_item)
       Translation.find_by!(content_item: content_item).destroy
     end
 
@@ -75,12 +75,12 @@ RSpec.describe ContentItemUniquenessValidator do
 
   context "when a duplicate content item exists in a unpublished state" do
     let!(:content_item) do
-      create(:content_item, state: "unpublished")
+      FactoryGirl.create(:content_item, state: "unpublished")
     end
 
     it "allows duplicates and does not raise an error" do
       expect {
-        create(:content_item, state: "unpublished")
+        FactoryGirl.create(:content_item, state: "unpublished")
       }.not_to raise_error
 
       expect(ContentItem.count).to eq(2)

--- a/spec/workers/presented_content_store_worker_spec.rb
+++ b/spec/workers/presented_content_store_worker_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe PresentedContentStoreWorker do
-  let(:content_item) { create(:content_item, base_path: "/foo") }
+  let(:content_item) { FactoryGirl.create(:content_item, base_path: "/foo") }
   before do
     stub_request(:put, "http://content-store.dev.gov.uk/content/foo").
       to_return(status: status, body: {}.to_json)


### PR DESCRIPTION
We've been using these inconsistently but leaning
towards the explicit version (in line with reducing
sneaky RSpec monkeypatching in general).

This makes it a requirement.