### PR TITLE
Remove unpublishing for previously published item...

### DIFF
--- a/app/commands/v2/publish.rb
+++ b/app/commands/v2/publish.rb
@@ -37,6 +37,7 @@ module Commands
         State.supersede(previous_item) if previous_item
 
         clear_published_items_of_same_locale_and_base_path(content_item, translation, location)
+        remove_unpublishing(previous_item) if previous_item
 
         set_public_updated_at(content_item, previous_item, update_type)
         set_first_published_at(content_item)
@@ -148,6 +149,11 @@ module Commands
           payload: { content_item: content_item.id, payload_version: event.id },
           request_uuid: GdsApi::GovukHeaders.headers[:govuk_request_id]
         )
+      end
+
+      def remove_unpublishing(content_item)
+        unpublishing = Unpublishing.find_by(content_item: content_item)
+        unpublishing.destroy if unpublishing
       end
     end
   end

--- a/spec/commands/v2/publish_spec.rb
+++ b/spec/commands/v2/publish_spec.rb
@@ -378,6 +378,29 @@ RSpec.describe Commands::V2::Publish do
       end
     end
 
+    context "for a previously unpublished item" do
+      let!(:unpublished_item) do
+        FactoryGirl.create(
+          :content_item,
+          content_id: content_id,
+          state: "published",
+          lock_version: 2,
+        )
+      end
+
+      let!(:unpublishing) do
+        FactoryGirl.create(:unpublishing, content_item: unpublished_item)
+      end
+
+      it "removes the unpublishing" do
+        expect {
+          described_class.call(payload)
+        }.to change(Unpublishing, :count).by(-1)
+
+        expect(Unpublishing.find_by(content_item: unpublished_item)).to be nil
+      end
+    end
+
     it_behaves_like TransactionalCommand
   end
 end


### PR DESCRIPTION
Part of https://trello.com/c/78Q9mrDe/708-make-whitehall-use-unpublishing-endpoint-medium

When a content item is unpublished an `Unpublishing` record is created. If that content item is reinstated (_unwithdrawn_) the unpublishing should be removed.