### PR TITLE
Support new linkables endpoint

### DIFF
--- a/app/commands/v2/discard_draft.rb
+++ b/app/commands/v2/discard_draft.rb
@@ -64,6 +64,7 @@ module Commands
         UserFacingVersion.find_by(content_item: draft).try(:destroy)
         LockVersion.find_by(target: draft).try(:destroy)
         AccessLimit.find_by(content_item: draft).try(:destroy)
+        Linkable.find_by(content_item: draft).try(:destroy)
       end
 
       def increment_live_lock_version

--- a/app/commands/v2/publish.rb
+++ b/app/commands/v2/publish.rb
@@ -42,6 +42,7 @@ module Commands
         set_public_updated_at(content_item, previous_item, update_type)
         set_first_published_at(content_item)
         State.publish(content_item)
+        update_linkable(content_item)
 
         AccessLimit.find_by(content_item: content_item).try(:destroy)
 
@@ -68,6 +69,11 @@ module Commands
 
       def valid_update_types
         %w(major minor republish links)
+      end
+
+      def update_linkable(content_item)
+        linkable = Linkable.find_by(content_item: content_item)
+        linkable.update_attributes(state: "published") if linkable
       end
 
       def find_draft_content_item

--- a/app/commands/v2/put_content.rb
+++ b/app/commands/v2/put_content.rb
@@ -115,11 +115,23 @@ module Commands
       end
 
       def create_supporting_objects(content_item)
-        Location.create!(content_item: content_item, base_path: base_path) if base_path_required?
         State.create!(content_item: content_item, name: "draft")
         Translation.create!(content_item: content_item, locale: locale)
         UserFacingVersion.create!(content_item: content_item, number: user_facing_version_number_for_new_draft)
         LockVersion.create!(target: content_item, number: lock_version_number_for_new_draft)
+
+        if base_path_required?
+          Location.create!(content_item: content_item, base_path: base_path)
+
+          if locale == ContentItem::DEFAULT_LOCALE && !Linkable.exists?(base_path: base_path)
+            Linkable.create!(
+              content_item: content_item,
+              base_path: base_path,
+              state: "draft",
+              document_type: content_item.document_type,
+            )
+          end
+        end
       end
 
       def ensure_link_set_exists(content_item)

--- a/app/commands/v2/unpublish.rb
+++ b/app/commands/v2/unpublish.rb
@@ -46,6 +46,8 @@ module Commands
           raise_command_error(422, message, fields: {})
         end
 
+        delete_linkable(content_item)
+
         Success.new(content_id: content_id)
       end
 
@@ -93,6 +95,10 @@ module Commands
         )
 
         send_downstream(gone)
+      end
+
+      def delete_linkable(content_item)
+        Linkable.find_by(content_item: content_item).try(:destroy)
       end
 
       def send_downstream(downstream_payload)

--- a/app/models/linkable.rb
+++ b/app/models/linkable.rb
@@ -1,7 +1,7 @@
 class Linkable < ActiveRecord::Base
   belongs_to :content_item
 
-  validates :base_path, presence: true
+  validates :base_path, presence: true, uniqueness: true
   validates :state, presence: true
   validates :content_item, presence: true
   validates :document_type, presence: true

--- a/app/models/linkable.rb
+++ b/app/models/linkable.rb
@@ -1,0 +1,8 @@
+class Linkable < ActiveRecord::Base
+  belongs_to :content_item
+
+  validates :base_path, presence: true
+  validates :state, presence: true
+  validates :content_item, presence: true
+  validates :document_type, presence: true
+end

--- a/app/presenters/queries/linkable_presenter.rb
+++ b/app/presenters/queries/linkable_presenter.rb
@@ -1,0 +1,44 @@
+module Presenters
+  module Queries
+    class LinkablePresenter
+      def self.present(linkable)
+        self.new(
+          content_item: linkable.content_item,
+          linkable: linkable,
+        ).present
+      end
+
+      def initialize(content_item:, linkable:)
+        @content_item = content_item
+        @linkable = linkable
+      end
+
+      def present
+        {
+          title: content_item.title,
+          content_id: content_item.content_id,
+          publication_state: publication_state,
+          base_path: linkable.base_path,
+          internal_name: internal_name,
+        }
+      end
+
+    private
+
+      attr_reader :content_item, :linkable
+
+      def internal_name
+        content_item.details[:internal_name] || content_item.title
+      end
+
+      def publication_state
+        case linkable.state
+        when "published"
+          "live"
+        else
+          linkable.state
+        end
+      end
+    end
+  end
+end

--- a/app/queries/get_linkables.rb
+++ b/app/queries/get_linkables.rb
@@ -1,0 +1,20 @@
+module Queries
+  class GetLinkables
+    def initialize(document_type:)
+      @document_type = document_type
+    end
+
+    def call
+      Linkable
+        .where(document_type: document_type)
+        .includes(:content_item)
+        .map { |linkable|
+          Presenters::Queries::LinkablePresenter.present(linkable)
+        }
+    end
+
+  private
+
+    attr_reader :document_type
+  end
+end

--- a/app/substitution_helper.rb
+++ b/app/substitution_helper.rb
@@ -11,6 +11,7 @@ module SubstitutionHelper
 
         if mismatch && allowed_to_substitute
           State.substitute(blocking_item)
+          Linkable.find_by(content_item: blocking_item).try(:destroy)
         end
       end
     end

--- a/db/migrate/20160517134907_create_linkables.rb
+++ b/db/migrate/20160517134907_create_linkables.rb
@@ -1,0 +1,13 @@
+class CreateLinkables < ActiveRecord::Migration
+  def change
+    create_table :linkables do |t|
+      t.references :content_item, null: false
+      t.string :state, null: false
+      t.string :base_path, null: false
+      t.string :document_type, null: false
+      t.timestamps
+    end
+
+    add_index :linkables, :document_type
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160516135536) do
+ActiveRecord::Schema.define(version: 20160517134907) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -72,6 +72,17 @@ ActiveRecord::Schema.define(version: 20160516135536) do
   end
 
   add_index "link_sets", ["content_id"], name: "index_link_sets_on_content_id", unique: true, using: :btree
+
+  create_table "linkables", force: :cascade do |t|
+    t.integer  "content_item_id", null: false
+    t.string   "state",           null: false
+    t.string   "base_path",       null: false
+    t.string   "document_type",   null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
+
+  add_index "linkables", ["document_type"], name: "index_linkables_on_document_type", using: :btree
 
   create_table "links", force: :cascade do |t|
     t.integer  "link_set_id"

--- a/lib/tasks/linkables.rake
+++ b/lib/tasks/linkables.rake
@@ -1,0 +1,39 @@
+namespace :linkables do
+  desc "Populates the linkables table"
+  task populate: :environment do
+    scope = ContentItem.all
+    scope = Translation.filter(scope, locale: "en")
+    scope = State.filter(scope, name: %w[published draft])
+    scope = Location.join_content_items(scope)
+    scope = UserFacingVersion.join_content_items(scope)
+                                                                     # state  version
+    scope = scope.select(:id, :content_id, :document_type, :base_path, :name, :number)
+
+    scope.find_each do |ci|
+      if ci.name == "draft" && ci.number == 1
+        # Never published
+        puts "Creating draft linkable for #{ci.document_type} ##{ci.id} (#{ci.content_id})"
+        Linkable.create!(
+          content_item_id: ci.id,
+          base_path: ci.base_path,
+          document_type: ci.document_type,
+          state: "draft",
+        )
+      elsif ci.name == "published"
+        puts "Creating published linkable for #{ci.document_type} ##{ci.id} (#{ci.content_id})"
+        Linkable.create!(
+          content_item_id: ci.id,
+          base_path: ci.base_path,
+          document_type: ci.document_type,
+          state: "published",
+        )
+      end
+
+      # If the content item is redrafted we don't
+      # want to create a linkable with draft
+      # content if there's a live one available,
+      # so we do nothing and wait for the published
+      # one to come around.
+    end
+  end
+end

--- a/spec/commands/v2/publish_spec.rb
+++ b/spec/commands/v2/publish_spec.rb
@@ -13,6 +13,14 @@ RSpec.describe Commands::V2::Publish do
       )
     end
 
+    let!(:linkable) {
+      FactoryGirl.create(:linkable,
+        content_item: draft_item,
+        base_path: base_path,
+        state: "draft",
+      )
+    }
+
     let(:expected_content_store_payload) { { base_path: base_path } }
     let(:content_id) { SecureRandom.uuid }
 
@@ -36,6 +44,12 @@ RSpec.describe Commands::V2::Publish do
         update_type: "major",
         previous_version: 2,
       }
+    end
+
+    it "sets the linkable to 'published'" do
+      described_class.call(payload)
+      linkable.reload
+      expect(linkable.state).to eq("published")
     end
 
     context "with no update_type" do

--- a/spec/commands/v2/publish_spec.rb
+++ b/spec/commands/v2/publish_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe Commands::V2::Publish do
       end
     end
 
-    context "when a lock version of the content item was previously published" do
+    context "when the content item was previously published" do
       let!(:live_item) do
         FactoryGirl.create(:live_content_item,
           content_id: draft_item.content_id,

--- a/spec/commands/v2/put_content_spec.rb
+++ b/spec/commands/v2/put_content_spec.rb
@@ -86,7 +86,10 @@ RSpec.describe Commands::V2::PutContent do
 
     context "when the base path has been reserved by another publishing app" do
       before do
-        FactoryGirl.create(:path_reservation, base_path: "/vat-rates", publishing_app: "something-else")
+        FactoryGirl.create(:path_reservation,
+          base_path: base_path,
+          publishing_app: "something-else"
+        )
       end
 
       it "raises an error" do
@@ -105,6 +108,7 @@ RSpec.describe Commands::V2::PutContent do
           lock_version: 2,
           user_facing_version: 5,
           first_published_at: first_published_at,
+          base_path: base_path,
         )
       end
 
@@ -165,7 +169,7 @@ RSpec.describe Commands::V2::PutContent do
           described_class.call(payload)
 
           redirect = ContentItemFilter.filter(
-            base_path: "/vat-rates",
+            base_path: base_path,
             state: "draft",
           ).first
 
@@ -174,14 +178,14 @@ RSpec.describe Commands::V2::PutContent do
           expect(redirect.publishing_app).to eq("publisher")
 
           expect(redirect.redirects).to eq([{
-            path: "/vat-rates",
+            path: base_path,
             type: "exact",
             destination: "/moved",
           }])
         end
 
         it "sends a create request to the draft content store for the redirect" do
-          allow(Presenters::ContentStorePresenter).to receive(:present).and_return(base_path: "/vat-rates")
+          allow(Presenters::ContentStorePresenter).to receive(:present).and_return(base_path: base_path)
           expect(PresentedContentStoreWorker).to receive(:perform_async)
             .with(
               content_store: Adapters::DraftContentStore,
@@ -233,12 +237,12 @@ RSpec.describe Commands::V2::PutContent do
 
     context "when creating a draft for a previously unpublished content item" do
       before do
-        FactoryGirl.create(
-          :content_item,
+        FactoryGirl.create(:content_item,
           content_id: content_id,
           state: "unpublished",
           lock_version: 2,
           user_facing_version: 5,
+          base_path: base_path,
         )
       end
 
@@ -267,28 +271,28 @@ RSpec.describe Commands::V2::PutContent do
 
     context "when creating a draft when there are multiple unpublished and published items" do
       before do
-        FactoryGirl.create(
-          :content_item,
+        FactoryGirl.create(:content_item,
           content_id: content_id,
           state: "unpublished",
           lock_version: 2,
           user_facing_version: 5,
+          base_path: base_path,
         )
 
-        FactoryGirl.create(
-          :content_item,
+        FactoryGirl.create(:content_item,
           content_id: content_id,
           state: "published",
           lock_version: 3,
           user_facing_version: 8,
+          base_path: base_path,
         )
 
-        FactoryGirl.create(
-          :content_item,
+        FactoryGirl.create(:content_item,
           content_id: content_id,
           state: "unpublished",
           lock_version: 5,
           user_facing_version: 6,
+          base_path: base_path,
         )
       end
 
@@ -490,11 +494,11 @@ RSpec.describe Commands::V2::PutContent do
             {
               path: "/old-path",
               type: "exact",
-              destination: "/vat-rates"
+              destination: base_path
             }, {
               path: "/old-path.atom",
               type: "exact",
-              destination: "/vat-rates.atom"
+              destination: "#{base_path}.atom"
             }
           ])
         end
@@ -652,12 +656,10 @@ RSpec.describe Commands::V2::PutContent do
       let(:link_target) { SecureRandom.uuid }
 
       let!(:link_set) do
-        FactoryGirl.create(
-          :link_set,
+        FactoryGirl.create(:link_set,
           content_id: content_id,
           links: [
-            FactoryGirl.create(
-              :link,
+            FactoryGirl.create(:link,
               link_type: "parent",
               target_content_id: link_target,
             )

--- a/spec/commands/v2/put_content_spec.rb
+++ b/spec/commands/v2/put_content_spec.rb
@@ -414,6 +414,17 @@ RSpec.describe Commands::V2::PutContent do
         location = Location.find_by!(content_item: content_item)
         expect(location.base_path).to eq(base_path)
       end
+
+      it "creates a linkable for the content item" do
+        described_class.call(payload)
+
+        content_item = ContentItem.last
+
+        linkable = Linkable.find_by!(content_item: content_item)
+        expect(linkable.base_path).to eq(base_path)
+        expect(linkable.state).to eq("draft")
+        expect(linkable.document_type).to eq(content_item.document_type)
+      end
     end
 
     context "when the payload is for an already drafted content item" do
@@ -459,6 +470,14 @@ RSpec.describe Commands::V2::PutContent do
 
         lock_version = LockVersion.find_by!(target: previously_drafted_item)
         expect(lock_version.number).to eq(2)
+      end
+
+      it "does not create a new linkable" do
+        expect {
+          described_class.call(payload)
+        }.not_to change {
+          Linkable.count
+        }
       end
 
       context "when the base path has changed" do

--- a/spec/commands/v2/unpublish_spec.rb
+++ b/spec/commands/v2/unpublish_spec.rb
@@ -26,6 +26,13 @@ RSpec.describe Commands::V2::Unpublish do
         )
       end
 
+      before do
+        FactoryGirl.create(:linkable,
+          content_item: live_content_item,
+          base_path: base_path,
+        )
+      end
+
       it "sets the content item's state to `unpublished`" do
         described_class.call(payload)
 
@@ -40,6 +47,13 @@ RSpec.describe Commands::V2::Unpublish do
         expect(unpublishing.type).to eq("gone")
         expect(unpublishing.explanation).to eq("Removed for testing porpoises")
         expect(unpublishing.alternative_path).to eq("/new-path")
+      end
+
+      it "deletes the linkable" do
+        described_class.call(payload)
+
+        linkable = Linkable.find_by(base_path: base_path)
+        expect(linkable).to be_nil
       end
 
       it "sends an unpublishing to the live content store" do

--- a/spec/factories/content_item.rb
+++ b/spec/factories/content_item.rb
@@ -28,7 +28,7 @@ FactoryGirl.define do
       lock_version 1
       state "draft"
       locale "en"
-      base_path "/vat-rates"
+      sequence(:base_path) { |n| "/vat-rates-#{n}" }
       user_facing_version 1
     end
 

--- a/spec/factories/linkable.rb
+++ b/spec/factories/linkable.rb
@@ -1,0 +1,8 @@
+FactoryGirl.define do
+  factory :linkable do
+    content_item
+    base_path "/vat-rates"
+    state "draft"
+    document_type "policy"
+  end
+end

--- a/spec/filters/content_item_filter_spec.rb
+++ b/spec/filters/content_item_filter_spec.rb
@@ -2,10 +2,12 @@ require "rails_helper"
 
 RSpec.describe ContentItemFilter do
   let(:content_id) { "b2844cad-4140-46db-81eb-db717370fee1" }
+  let(:base_path) { "/vat-rates" }
 
   let!(:content_item) {
     FactoryGirl.create(:content_item,
-      content_id: content_id
+      content_id: content_id,
+      base_path: base_path,
     )
   }
 
@@ -18,19 +20,22 @@ RSpec.describe ContentItemFilter do
   let!(:french_content_item) {
     FactoryGirl.create(:content_item,
       content_id: content_id,
-      locale: "fr"
+      locale: "fr",
+      base_path: base_path,
     )
   }
   let!(:superseded_content_item) {
     FactoryGirl.create(:content_item,
       content_id: content_id,
-      state: "superseded"
+      state: "superseded",
+      base_path: base_path,
     )
   }
   let!(:new_version_content_item) {
     FactoryGirl.create(:content_item,
       content_id: content_id,
       user_facing_version: 2,
+      base_path: base_path,
     )
   }
 
@@ -92,7 +97,7 @@ RSpec.describe ContentItemFilter do
 
   describe ".filter(locale: nil, base_path: nil, state: nil)" do
     context "when a base path is given" do
-      let(:params) { { base_path: "/vat-rates" } }
+      let(:params) { { base_path: base_path } }
 
       it "returns a scope of the expected content items" do
         result = described_class.filter(params)

--- a/spec/models/linkable_spec.rb
+++ b/spec/models/linkable_spec.rb
@@ -17,6 +17,13 @@ RSpec.describe Linkable do
     expect(subject).not_to be_valid
   end
 
+  it "requires a unique base_path" do
+    linkable = FactoryGirl.create(:linkable)
+
+    subject.base_path = linkable.base_path
+    expect(subject).not_to be_valid
+  end
+
   it "requires a state" do
     subject.state = nil
     expect(subject).not_to be_valid

--- a/spec/models/linkable_spec.rb
+++ b/spec/models/linkable_spec.rb
@@ -1,0 +1,29 @@
+require "rails_helper"
+
+RSpec.describe Linkable do
+  subject { FactoryGirl.build(:linkable) }
+
+  it "is valid out of the factory" do
+    expect(subject).to be_valid
+  end
+
+  it "requires a content item" do
+    subject.content_item_id = nil
+    expect(subject).not_to be_valid
+  end
+
+  it "requires a base_path" do
+    subject.base_path = nil
+    expect(subject).not_to be_valid
+  end
+
+  it "requires a state" do
+    subject.state = nil
+    expect(subject).not_to be_valid
+  end
+
+  it "requires a document_type" do
+    subject.document_type = nil
+    expect(subject).not_to be_valid
+  end
+end

--- a/spec/models/location_spec.rb
+++ b/spec/models/location_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe Location do
 
   describe "routes and redirects" do
     subject { FactoryGirl.build(:location) }
-    let(:content_item) { FactoryGirl.build(:content_item) }
+    let(:content_item) { FactoryGirl.build(:content_item, base_path: "/vat-rates") }
 
     before do
       subject.content_item = content_item

--- a/spec/models/lock_version_spec.rb
+++ b/spec/models/lock_version_spec.rb
@@ -94,18 +94,19 @@ RSpec.describe LockVersion do
 
   describe "validations" do
     let(:content_id) { SecureRandom.uuid }
+    let(:base_path) { "/vat-rates" }
 
     let!(:draft) do
-      FactoryGirl.create(
-        :draft_content_item,
+      FactoryGirl.create(:draft_content_item,
         content_id: content_id,
+        base_path: base_path,
       )
     end
 
     let!(:live) do
-      FactoryGirl.create(
-        :live_content_item,
+      FactoryGirl.create(:live_content_item,
         content_id: content_id,
+        base_path: base_path
       )
     end
 

--- a/spec/models/state_spec.rb
+++ b/spec/models/state_spec.rb
@@ -9,12 +9,20 @@ RSpec.describe State do
     end
 
     context "when another content item has identical supporting objects" do
+      let(:base_path) { "/vat-rates" }
+
       before do
-        FactoryGirl.create(:content_item, state: "published")
+        FactoryGirl.create(:content_item,
+          state: "published",
+          base_path: base_path,
+        )
       end
 
       let(:content_item) do
-        FactoryGirl.create(:content_item, state: "draft")
+        FactoryGirl.create(:content_item,
+          state: "draft",
+          base_path: base_path,
+        )
       end
 
       subject { FactoryGirl.build(:state, content_item: content_item, name: "published") }

--- a/spec/models/user_facing_version_spec.rb
+++ b/spec/models/user_facing_version_spec.rb
@@ -35,18 +35,19 @@ RSpec.describe UserFacingVersion do
 
   describe "validations" do
     let(:content_id) { SecureRandom.uuid }
+    let(:base_path) { "/vat-rates" }
 
     let!(:draft) do
-      FactoryGirl.create(
-        :draft_content_item,
+      FactoryGirl.create(:draft_content_item,
         content_id: content_id,
+        base_path: base_path,
       )
     end
 
     let!(:live) do
-      FactoryGirl.create(
-        :live_content_item,
+      FactoryGirl.create(:live_content_item,
         content_id: content_id,
+        base_path: base_path,
       )
     end
 
@@ -55,11 +56,17 @@ RSpec.describe UserFacingVersion do
 
     context "when another content item has identical supporting objects" do
       before do
-        FactoryGirl.create(:content_item, user_facing_version: 3)
+        FactoryGirl.create(:content_item,
+          user_facing_version: 3,
+          base_path: base_path,
+        )
       end
 
       let(:content_item) do
-        FactoryGirl.create(:content_item, user_facing_version: 2)
+        FactoryGirl.create(:content_item,
+          user_facing_version: 2,
+          base_path: base_path,
+        )
       end
 
       subject {

--- a/spec/presenters/downstream_presenter_spec.rb
+++ b/spec/presenters/downstream_presenter_spec.rb
@@ -6,10 +6,12 @@ RSpec.describe Presenters::DownstreamPresenter do
   subject(:result) { described_class.present(content_item, fallback_order: fallback_order) }
 
   describe "V2" do
+    let(:base_path) { "/vat-rates" }
+
     let(:expected) {
       {
         content_id: content_item.content_id,
-        base_path: "/vat-rates",
+        base_path: base_path,
         analytics_identifier: "GDS01",
         description: "VAT rates for goods and services",
         details: { body: "<p>Something about VAT</p>\n" },
@@ -25,7 +27,7 @@ RSpec.describe Presenters::DownstreamPresenter do
         publishing_app: "publisher",
         redirects: [],
         rendering_app: "frontend",
-        routes: [{ path: "/vat-rates", type: "exact" }],
+        routes: [{ path: base_path, type: "exact" }],
         schema_name: "guide",
         title: "VAT rates",
         update_type: "minor"
@@ -33,7 +35,7 @@ RSpec.describe Presenters::DownstreamPresenter do
     }
 
     context "for a live content item" do
-      let(:content_item) { FactoryGirl.create(:live_content_item) }
+      let(:content_item) { FactoryGirl.create(:live_content_item, base_path: base_path) }
       let!(:link_set)    { FactoryGirl.create(:link_set, content_id: content_item.content_id) }
 
       it "presents the object graph for the content store" do
@@ -42,7 +44,7 @@ RSpec.describe Presenters::DownstreamPresenter do
     end
 
     context "for a draft content item" do
-      let(:content_item) { FactoryGirl.create(:draft_content_item) }
+      let(:content_item) { FactoryGirl.create(:draft_content_item, base_path: base_path) }
       let!(:link_set) { FactoryGirl.create(:link_set, content_id: content_item.content_id) }
 
       it "presents the object graph for the content store" do
@@ -51,7 +53,7 @@ RSpec.describe Presenters::DownstreamPresenter do
     end
 
     context "for a withdrawn content item" do
-      let!(:content_item) { FactoryGirl.create(:withdrawn_content_item) }
+      let!(:content_item) { FactoryGirl.create(:withdrawn_content_item, base_path: base_path) }
       let!(:link_set) { FactoryGirl.create(:link_set, content_id: content_item.content_id) }
 
       it "merges in a withdrawal notice" do

--- a/spec/presenters/queries/content_item_presenter_spec.rb
+++ b/spec/presenters/queries/content_item_presenter_spec.rb
@@ -2,10 +2,14 @@ require 'rails_helper'
 
 RSpec.describe Presenters::Queries::ContentItemPresenter do
   let(:content_id) { SecureRandom.uuid }
+  let(:base_path) { "/vat-rates" }
 
   describe "present" do
     let!(:content_item) do
-      FactoryGirl.create(:draft_content_item, content_id: content_id)
+      FactoryGirl.create(:draft_content_item,
+        content_id: content_id,
+        base_path: base_path
+      )
     end
 
     let(:result) { described_class.present(content_item) }
@@ -20,7 +24,7 @@ RSpec.describe Presenters::Queries::ContentItemPresenter do
       expect(result).to eq(
         "content_id" => content_id,
         "locale" => "en",
-        "base_path" => "/vat-rates",
+        "base_path" => base_path,
         "title" => "VAT rates",
         "format" => "guide",
         "internal_name" => "VAT rates",
@@ -29,7 +33,7 @@ RSpec.describe Presenters::Queries::ContentItemPresenter do
         "public_updated_at" => "2014-05-14T13:00:06Z",
         "first_published_at" => "2014-01-02T03:04:05Z",
         "details" => { "body" => "<p>Something about VAT</p>\n" },
-        "routes" => [{ "path" => "/vat-rates", "type" => "exact" }],
+        "routes" => [{ "path" => base_path, "type" => "exact" }],
         "redirects" => [],
         "publishing_app" => "publisher",
         "rendering_app" => "frontend",
@@ -90,8 +94,7 @@ RSpec.describe Presenters::Queries::ContentItemPresenter do
 
   describe "#present_many" do
     let!(:content_item) do
-      FactoryGirl.create(
-        :content_item,
+      FactoryGirl.create(:content_item,
         content_id: content_id,
       )
     end

--- a/spec/presenters/queries/linkable_presenter_spec.rb
+++ b/spec/presenters/queries/linkable_presenter_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+
+RSpec.describe Presenters::Queries::LinkablePresenter do
+  describe ".present" do
+    let!(:linkable) {
+      FactoryGirl.create(:linkable)
+    }
+
+    it "loads some fields from the Linkable" do
+      output = described_class.present(linkable)
+
+      expect(output[:base_path]).to eq(linkable.base_path)
+    end
+
+    it "loads some fields from the ContentItem" do
+      output = described_class.present(linkable)
+
+      expect(output[:title]).to eq(linkable.content_item.title)
+      expect(output[:content_id]).to eq(linkable.content_item.content_id)
+    end
+
+    it "defaults the internal name to the title if not present" do
+      linkable.content_item.update_attributes(details: { internal_name: "An internal name" })
+      output = described_class.present(linkable)
+      expect(output[:internal_name]).to eq("An internal name")
+
+      linkable.content_item.update_attributes(details: {})
+      linkable.content_item.update_attributes(title: "A title")
+      output = described_class.present(linkable)
+      expect(output[:internal_name]).to eq("A title")
+    end
+
+    it "shows the publication_state as 'live' if published" do
+      linkable.update_attributes(state: "published")
+      output = described_class.present(linkable)
+      expect(output[:publication_state]).to eq("live")
+
+      linkable.update_attributes(state: "draft")
+      output = described_class.present(linkable)
+      expect(output[:publication_state]).to eq("draft")
+    end
+  end
+end

--- a/spec/queries/get_content_spec.rb
+++ b/spec/queries/get_content_spec.rb
@@ -13,9 +13,9 @@ RSpec.describe Queries::GetContent do
 
   context "when a content item exists for the content_id" do
     before do
-      FactoryGirl.create(
-        :content_item,
+      FactoryGirl.create(:content_item,
         content_id: content_id,
+        base_path: "/vat-rates",
       )
     end
 
@@ -38,15 +38,13 @@ RSpec.describe Queries::GetContent do
 
   context "when a draft and a live content item exists for the content_id" do
     before do
-      FactoryGirl.create(
-        :draft_content_item,
+      FactoryGirl.create(:draft_content_item,
         content_id: content_id,
         title: "Draft Title",
         user_facing_version: 2,
       )
 
-      FactoryGirl.create(
-        :live_content_item,
+      FactoryGirl.create(:live_content_item,
         content_id: content_id,
         title: "Live Title",
         user_facing_version: 1,
@@ -61,16 +59,14 @@ RSpec.describe Queries::GetContent do
 
   context "when content items exist in non-draft, non-live states" do
     before do
-      FactoryGirl.create(
-        :content_item,
+      FactoryGirl.create(:content_item,
         content_id: content_id,
         user_facing_version: 1,
         title: "Published Title",
         state: "published",
       )
 
-      FactoryGirl.create(
-        :content_item,
+      FactoryGirl.create(:content_item,
         content_id: content_id,
         user_facing_version: 2,
         title: "Submitted Title",
@@ -86,16 +82,14 @@ RSpec.describe Queries::GetContent do
 
   context "when content items exist in multiple locales" do
     before do
-      FactoryGirl.create(
-        :content_item,
+      FactoryGirl.create(:content_item,
         content_id: content_id,
         user_facing_version: 2,
         title: "French Title",
         locale: "fr",
       )
 
-      FactoryGirl.create(
-        :content_item,
+      FactoryGirl.create(:content_item,
         content_id: content_id,
         user_facing_version: 1,
         title: "English Title",

--- a/spec/queries/get_linked_spec.rb
+++ b/spec/queries/get_linked_spec.rb
@@ -34,15 +34,13 @@ RSpec.describe Queries::GetLinked do
 
     context "when a content item with no draft exists" do
       before do
-        FactoryGirl.create(
-          :live_content_item,
+        FactoryGirl.create(:live_content_item,
           content_id: content_id,
           base_path: "/vat-rules-2020",
           title: "VAT rules 2020",
         )
 
-        FactoryGirl.create(
-          :live_content_item,
+        FactoryGirl.create(:live_content_item,
           content_id: target_content_id,
           base_path: "/vat-org",
         )
@@ -76,8 +74,7 @@ RSpec.describe Queries::GetLinked do
 
     context "when a content item with draft exists "do
       before do
-        FactoryGirl.create(
-          :live_content_item,
+        FactoryGirl.create(:live_content_item,
           :with_draft,
           content_id: target_content_id,
           base_path: "/pay-now"
@@ -110,13 +107,12 @@ RSpec.describe Queries::GetLinked do
 
       context "content items link to the wanted content item" do
         before do
-          FactoryGirl.create(
-            :live_content_item,
+          FactoryGirl.create(:live_content_item,
             content_id: content_id,
-            title: "VAT and VATy things"
+            title: "VAT and VATy things",
+            base_path: "/vat-rates",
           )
-          FactoryGirl.create(
-            :link_set,
+          FactoryGirl.create(:link_set,
             content_id: content_id,
             links: [
               FactoryGirl.create(
@@ -127,23 +123,19 @@ RSpec.describe Queries::GetLinked do
             ]
           )
 
-          content_item = FactoryGirl.create(
-            :live_content_item,
+          content_item = FactoryGirl.create(:live_content_item,
             base_path: '/vatty',
             content_id: SecureRandom.uuid,
             title: "Another VATTY thing"
           )
-          FactoryGirl.create(
-            :link_set,
+          FactoryGirl.create(:link_set,
             content_id: content_item.content_id,
             links: [
-              FactoryGirl.create(
-                :link,
+              FactoryGirl.create(:link,
                 link_type: "organisations",
                 target_content_id: target_content_id
               ),
-              FactoryGirl.create(
-                :link,
+              FactoryGirl.create(:link,
                 link_type: "related_links",
                 target_content_id: target_content_id
               )

--- a/spec/requests/content_item_requests/downstream_requests_spec.rb
+++ b/spec/requests/content_item_requests/downstream_requests_spec.rb
@@ -86,8 +86,7 @@ RSpec.describe "Downstream requests", type: :request do
 
     context "when a link set exists for the content item" do
       let(:link_set) do
-        FactoryGirl.create(
-          :link_set,
+        FactoryGirl.create(:link_set,
           content_id: v2_content_item[:content_id]
         )
       end
@@ -151,6 +150,7 @@ RSpec.describe "Downstream requests", type: :request do
       before do
         draft = FactoryGirl.create(:draft_content_item,
           content_id: content_id,
+          base_path: base_path,
         )
 
         FactoryGirl.create(:lock_version, target: draft, number: 1)
@@ -183,6 +183,7 @@ RSpec.describe "Downstream requests", type: :request do
       before do
         FactoryGirl.create(:live_content_item,
           content_id: content_id,
+          base_path: base_path,
         )
       end
 
@@ -208,6 +209,7 @@ RSpec.describe "Downstream requests", type: :request do
       before do
         draft = FactoryGirl.create(:draft_content_item,
           content_id: content_id,
+          base_path: base_path,
         )
 
         FactoryGirl.create(:access_limit,
@@ -217,6 +219,7 @@ RSpec.describe "Downstream requests", type: :request do
 
         FactoryGirl.create(:live_content_item,
           content_id: content_id,
+          base_path: base_path,
         )
       end
 
@@ -272,7 +275,11 @@ RSpec.describe "Downstream requests", type: :request do
       end
 
       before do
-        draft = FactoryGirl.create(:draft_content_item, v2_content_item.slice(*ContentItem::TOP_LEVEL_FIELDS))
+        draft = FactoryGirl.create(:draft_content_item,
+          v2_content_item
+            .slice(*ContentItem::TOP_LEVEL_FIELDS)
+            .merge(base_path: base_path)
+        )
         FactoryGirl.create(:lock_version, target: draft, number: 1)
         FactoryGirl.create(:access_limit, content_item: draft, users: access_limit_params.fetch(:users))
       end
@@ -300,6 +307,7 @@ RSpec.describe "Downstream requests", type: :request do
     let!(:draft) {
       FactoryGirl.create(:draft_content_item,
         content_id: content_id,
+        base_path: base_path,
       )
     }
 

--- a/spec/requests/content_item_requests/downstream_timeouts_spec.rb
+++ b/spec/requests/content_item_requests/downstream_timeouts_spec.rb
@@ -83,10 +83,20 @@ RSpec.describe "Downstream timeouts", type: :request do
     let(:request_body) { links_attributes.to_json }
     let(:request_path) { "/v2/links/#{content_id}" }
     let(:request_method) { :patch }
+    let(:base_path) { "/vat-rates" }
 
     before do
-      FactoryGirl.create(:live_content_item, v2_content_item.slice(*ContentItem::TOP_LEVEL_FIELDS))
-      draft = FactoryGirl.create(:draft_content_item, v2_content_item.slice(*ContentItem::TOP_LEVEL_FIELDS))
+      FactoryGirl.create(:live_content_item,
+        v2_content_item
+          .slice(*ContentItem::TOP_LEVEL_FIELDS)
+          .merge(base_path: base_path)
+      )
+
+      draft = FactoryGirl.create(:draft_content_item,
+        v2_content_item
+          .slice(*ContentItem::TOP_LEVEL_FIELDS)
+          .merge(base_path: base_path)
+      )
 
       FactoryGirl.create(:access_limit,
         content_item: draft,

--- a/spec/requests/content_item_requests/message_bus_spec.rb
+++ b/spec/requests/content_item_requests/message_bus_spec.rb
@@ -75,9 +75,9 @@ RSpec.describe "Message bus", type: :request do
 
     context "with a live content item" do
       let!(:live_content_item) {
-        FactoryGirl.create(
-          :live_content_item,
+        FactoryGirl.create(:live_content_item,
           content_id: content_id,
+          base_path: base_path,
         )
       }
 
@@ -95,9 +95,9 @@ RSpec.describe "Message bus", type: :request do
 
     context "with a draft content item" do
       let!(:draft_content_item) {
-        FactoryGirl.create(
-          :draft_content_item,
+        FactoryGirl.create(:draft_content_item,
           content_id: content_id,
+          base_path: base_path,
         )
       }
 
@@ -113,10 +113,10 @@ RSpec.describe "Message bus", type: :request do
 
   context "/v2/publish" do
     before do
-      FactoryGirl.create(
-        :draft_content_item,
+      FactoryGirl.create(:draft_content_item,
         content_id: content_id,
         format: "guide",
+        base_path: base_path,
       )
     end
 

--- a/spec/requests/linkables_spec.rb
+++ b/spec/requests/linkables_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe "GET /v2/linkables", type: :request do
       state: "published",
       document_type: "policy",
       title: "Policy 2",
+      base_path: "/vat-rates",
     )
   }
 

--- a/spec/requests/logging_requests_spec.rb
+++ b/spec/requests/logging_requests_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe "Logging requests", type: :request do
   end
 
   it "adds a request uuid to the message bus" do
-    draft_content_item = FactoryGirl.create(:draft_content_item)
+    draft_content_item = FactoryGirl.create(:draft_content_item, base_path: base_path)
 
     expect(PublishingAPI.service(:queue_publisher)).to receive(:send_message)
       .with(hash_including(govuk_request_id: govuk_request_id))

--- a/spec/substitution_helper_spec.rb
+++ b/spec/substitution_helper_spec.rb
@@ -32,6 +32,14 @@ RSpec.describe SubstitutionHelper do
     )
   }
 
+  before do
+    FactoryGirl.create(:linkable,
+      content_item: existing_item,
+      document_type: existing_item.document_type,
+      base_path: existing_base_path,
+      state: "draft",
+    )
+  end
 
   context "given a base_path" do
     before do
@@ -64,6 +72,11 @@ RSpec.describe SubstitutionHelper do
           expect(state.name).to eq("unpublished")
         end
 
+        it "deletes the Linkable" do
+          linkable = Linkable.find_by(content_item: existing_item)
+          expect(linkable).to be_nil
+        end
+
         it "doesn't unpublish any other items" do
           expect(State.find_by!(content_item: live_item).name).not_to eq("unpublished")
           expect(State.find_by!(content_item: french_item).name).not_to eq("unpublished")
@@ -77,6 +90,11 @@ RSpec.describe SubstitutionHelper do
         it "unpublishes the existing item" do
           state = State.find_by!(content_item: existing_item)
           expect(state.name).to eq("unpublished")
+        end
+
+        it "deletes the Linkable" do
+          linkable = Linkable.find_by(content_item: existing_item)
+          expect(linkable).to be_nil
         end
 
         it "doesn't unpublish any other items" do

--- a/spec/validators/content_item_uniqueness_validator_spec.rb
+++ b/spec/validators/content_item_uniqueness_validator_spec.rb
@@ -11,9 +11,13 @@ RSpec.describe ContentItemUniquenessValidator do
     expect(record.errors[:content_item]).to eq(errors)
   end
 
+  let(:base_path) { "/vat-rates" }
+
   context "for a content item with unique supporting objects" do
     before do
-      FactoryGirl.create(:content_item)
+      FactoryGirl.create(:content_item,
+        base_path: base_path,
+      )
     end
 
     it "has valid supporting objects" do
@@ -26,16 +30,21 @@ RSpec.describe ContentItemUniquenessValidator do
 
   context "for a content item with duplicate supporting objects" do
     before do
-      FactoryGirl.create(:content_item, user_facing_version: 2)
+      FactoryGirl.create(:content_item,
+        user_facing_version: 2,
+        base_path: base_path,
+      )
     end
 
     let(:content_item) do
-      FactoryGirl.create(:content_item, user_facing_version: 1)
+      FactoryGirl.create(:content_item,
+        user_facing_version: 1,
+        base_path: base_path,
+      )
     end
 
     it "has an invalid supporting object" do
-      user_facing_version = FactoryGirl.build(
-        :user_facing_version,
+      user_facing_version = FactoryGirl.build(:user_facing_version,
         content_item: content_item,
         number: 2,
       )
@@ -47,9 +56,13 @@ RSpec.describe ContentItemUniquenessValidator do
 
   context "for a content item with a differentiating supporting object" do
     before do
-      FactoryGirl.create(:content_item)
-
-      FactoryGirl.create(:content_item, user_facing_version: 2)
+      FactoryGirl.create(:content_item,
+        base_path: base_path,
+      )
+      FactoryGirl.create(:content_item,
+        user_facing_version: 2,
+        base_path: base_path,
+      )
     end
 
     it "has valid supporting objects" do
@@ -62,7 +75,7 @@ RSpec.describe ContentItemUniquenessValidator do
 
   context "for a content item with a missing supporting object" do
     before do
-      content_item = FactoryGirl.create(:content_item)
+      content_item = FactoryGirl.create(:content_item, base_path: base_path)
       Translation.find_by!(content_item: content_item).destroy
     end
 
@@ -75,12 +88,18 @@ RSpec.describe ContentItemUniquenessValidator do
 
   context "when a duplicate content item exists in a unpublished state" do
     let!(:content_item) do
-      FactoryGirl.create(:content_item, state: "unpublished")
+      FactoryGirl.create(:content_item,
+        state: "unpublished",
+        base_path: base_path,
+      )
     end
 
     it "allows duplicates and does not raise an error" do
       expect {
-        FactoryGirl.create(:content_item, state: "unpublished")
+        FactoryGirl.create(:content_item,
+          state: "unpublished",
+          base_path: base_path,
+        )
       }.not_to raise_error
 
       expect(ContentItem.count).to eq(2)


### PR DESCRIPTION
https://trello.com/c/3PfssMJ2/716-more-robust-linkables-endpoint

Builds a slightly denormalised table to support quick reads for the `/v2/linkables` endpoint.  This is the sort of approach I'd like to recommend for many of our read endpoints where possible, since even a single table approach would require dealing with grouping and sub-sorting to find e.g. the latest of a given content item with state fallbacks.

There's another branch to switch the endpoint over to reading from this table once everything is deployed and ready: https://github.com/alphagov/publishing-api/tree/activate-new-linkables-endpoint