### PR TITLE
Expand links according to locale

### DIFF
--- a/app/commands/v2/patch_link_set.rb
+++ b/app/commands/v2/patch_link_set.rb
@@ -105,7 +105,7 @@ module Commands
       def send_to_message_queue(content_item)
         payload = Presenters::MessageQueuePresenter.present(
           content_item,
-          fallback_order: [:published],
+          state_fallback_order: [:published],
           update_type: "links",
         )
 

--- a/app/commands/v2/publish.rb
+++ b/app/commands/v2/publish.rb
@@ -138,7 +138,7 @@ module Commands
 
         queue_payload = Presenters::MessageQueuePresenter.present(
           content_item,
-          fallback_order: [:published],
+          state_fallback_order: [:published],
           update_type: update_type
         )
 

--- a/app/controllers/v2/link_sets_controller.rb
+++ b/app/controllers/v2/link_sets_controller.rb
@@ -5,7 +5,7 @@ module V2
     end
 
     def expanded_links
-      render json: Queries::GetExpandedLinks.call(content_id)
+      render json: Queries::GetExpandedLinks.call(content_id, params[:locale])
     end
 
     def patch_links

--- a/app/presenters/content_store_presenter.rb
+++ b/app/presenters/content_store_presenter.rb
@@ -1,7 +1,7 @@
 module Presenters
   class ContentStorePresenter
-    def self.present(content_item, payload_version, fallback_order:)
-      attributes = DownstreamPresenter.present(content_item, fallback_order: fallback_order)
+    def self.present(content_item, payload_version, state_fallback_order:)
+      attributes = DownstreamPresenter.present(content_item, state_fallback_order: state_fallback_order)
       attributes.except(:update_type).merge(payload_version: payload_version)
     end
   end

--- a/app/presenters/downstream_presenter.rb
+++ b/app/presenters/downstream_presenter.rb
@@ -1,14 +1,14 @@
 module Presenters
   class DownstreamPresenter
-    def self.present(content_item, fallback_order:)
+    def self.present(content_item, state_fallback_order:)
       link_set = LinkSet.find_by(content_id: content_item.content_id)
-      new(content_item, link_set, fallback_order: fallback_order).present
+      new(content_item, link_set, state_fallback_order: state_fallback_order).present
     end
 
-    def initialize(content_item, link_set, fallback_order:)
+    def initialize(content_item, link_set, state_fallback_order:)
       self.content_item = content_item
       self.link_set = link_set
-      self.fallback_order = fallback_order
+      self.state_fallback_order = state_fallback_order
     end
 
     def present
@@ -25,7 +25,7 @@ module Presenters
 
   private
 
-    attr_accessor :content_item, :link_set, :fallback_order
+    attr_accessor :content_item, :link_set, :state_fallback_order
 
     def symbolized_attributes
       content_item.as_json.symbolize_keys
@@ -55,7 +55,7 @@ module Presenters
     def expanded_link_set_presenter
       Presenters::Queries::ExpandedLinkSet.new(
         link_set: link_set,
-        fallback_order: fallback_order,
+        state_fallback_order: state_fallback_order,
       )
     end
 

--- a/app/presenters/downstream_presenter.rb
+++ b/app/presenters/downstream_presenter.rb
@@ -56,6 +56,7 @@ module Presenters
       Presenters::Queries::ExpandedLinkSet.new(
         link_set: link_set,
         state_fallback_order: state_fallback_order,
+        locale_fallback_order: locale_fallback_order
       )
     end
 
@@ -65,6 +66,10 @@ module Presenters
 
     def web_content_item
       @web_content_item ||= WebContentItem.new(content_item)
+    end
+
+    def locale_fallback_order
+      [web_content_item.locale, ContentItem::DEFAULT_LOCALE].uniq
     end
 
     def first_published_at

--- a/app/presenters/message_queue_presenter.rb
+++ b/app/presenters/message_queue_presenter.rb
@@ -1,7 +1,7 @@
 module Presenters
   class MessageQueuePresenter
-    def self.present(content_item, fallback_order:, update_type:)
-      attributes = DownstreamPresenter.present(content_item, fallback_order: fallback_order)
+    def self.present(content_item, state_fallback_order:, update_type:)
+      attributes = DownstreamPresenter.present(content_item, state_fallback_order: state_fallback_order)
       attributes.merge(
         update_type: update_type,
         govuk_request_id: GdsApi::GovukHeaders.headers[:govuk_request_id],

--- a/app/presenters/queries/expanded_link_set.rb
+++ b/app/presenters/queries/expanded_link_set.rb
@@ -1,7 +1,7 @@
 module Presenters
   module Queries
     class ExpandedLinkSet
-      def initialize(link_set:, state_fallback_order:, locale_fallback_order: "en", visited_link_sets: [], recursing_type: nil)
+      def initialize(link_set:, state_fallback_order:, locale_fallback_order: ContentItem::DEFAULT_LOCALE, visited_link_sets: [], recursing_type: nil)
         @link_set = link_set
         @state_fallback_order = Array(state_fallback_order)
         @locale_fallback_order = Array(locale_fallback_order)
@@ -110,18 +110,20 @@ module Presenters
       end
 
       def content_item(target_content_id)
+        content_item_filter = ContentItemFilter.new(
+          scope: ContentItem.where(content_id: target_content_id)
+        )
+
         @content_item ||= {}
 
-        state_fallback_order.each do |state|
-          @content_item[target_content_id] ||=
-            content_item_for_state(state, target_content_id)
+        locale_fallback_order.each do |locale|
+          state_fallback_order.each do |state|
+            @content_item[target_content_id] ||=
+              content_item_filter.filter(state: state, locale: locale).first
+          end
         end
 
         @content_item[target_content_id]
-      end
-
-      def content_item_for_state(state, content_id)
-        State.filter(ContentItem.all, name: state).find_by(content_id: content_id)
       end
     end
   end

--- a/app/presenters/queries/expanded_link_set.rb
+++ b/app/presenters/queries/expanded_link_set.rb
@@ -1,9 +1,10 @@
 module Presenters
   module Queries
     class ExpandedLinkSet
-      def initialize(link_set:, fallback_order:, visited_link_sets: [], recursing_type: nil)
+      def initialize(link_set:, state_fallback_order:, locale_fallback_order: "en", visited_link_sets: [], recursing_type: nil)
         @link_set = link_set
-        @fallback_order = Array(fallback_order)
+        @state_fallback_order = Array(state_fallback_order)
+        @locale_fallback_order = Array(locale_fallback_order)
         @visited_link_sets = visited_link_sets
         @recursing_type = recursing_type
       end
@@ -18,7 +19,7 @@ module Presenters
 
     private
 
-      attr_reader :fallback_order, :link_set, :visited_link_sets, :recursing_type
+      attr_reader :state_fallback_order, :locale_fallback_order, :link_set, :visited_link_sets, :recursing_type
 
       def top_level?
         visited_link_sets.empty?
@@ -50,7 +51,8 @@ module Presenters
 
         self.class.new(
           link_set: next_link_set,
-          fallback_order: fallback_order,
+          state_fallback_order: state_fallback_order,
+          locale_fallback_order: locale_fallback_order,
           visited_link_sets: (visited_link_sets << link_set),
           recursing_type: type,
         ).links
@@ -110,7 +112,7 @@ module Presenters
       def content_item(target_content_id)
         @content_item ||= {}
 
-        fallback_order.each do |state|
+        state_fallback_order.each do |state|
           @content_item[target_content_id] ||=
             content_item_for_state(state, target_content_id)
         end

--- a/app/queries/get_expanded_links.rb
+++ b/app/queries/get_expanded_links.rb
@@ -5,7 +5,7 @@ module Queries
       lock_version = LockVersion.find_by(target: link_set)
       expanded_link_set = Presenters::Queries::ExpandedLinkSet.new(
         link_set: link_set,
-        fallback_order: [:draft, :published]
+        state_fallback_order: [:draft, :published]
       )
 
       {

--- a/app/queries/get_expanded_links.rb
+++ b/app/queries/get_expanded_links.rb
@@ -1,11 +1,12 @@
 module Queries
   class GetExpandedLinks
-    def self.call(content_id)
+    def self.call(content_id, locale)
       link_set = find_link_set(content_id)
       lock_version = LockVersion.find_by(target: link_set)
       expanded_link_set = Presenters::Queries::ExpandedLinkSet.new(
         link_set: link_set,
-        state_fallback_order: [:draft, :published]
+        state_fallback_order: [:draft, :published],
+        locale_fallback_order: [locale, ContentItem::DEFAULT_LOCALE].compact
       )
 
       {

--- a/app/workers/presented_content_store_worker.rb
+++ b/app/workers/presented_content_store_worker.rb
@@ -32,7 +32,7 @@ private
   end
 
   def presented_payload
-    Presenters::ContentStorePresenter.present(content_item, payload_version, fallback_order: content_store::DEPENDENCY_FALLBACK_ORDER)
+    Presenters::ContentStorePresenter.present(content_item, payload_version, state_fallback_order: content_store::DEPENDENCY_FALLBACK_ORDER)
   end
 
   def payload_version

--- a/lib/requeue_content.rb
+++ b/lib/requeue_content.rb
@@ -22,7 +22,7 @@ private
   def publish_to_queue(content_item)
     queue_payload = Presenters::MessageQueuePresenter.present(
       content_item,
-      fallback_order: [:published],
+      state_fallback_order: [:published],
       # FIXME: Rummager currently only listens to the message queue for the
       # update type 'links'. This behaviour will eventually be updated so that
       # it listens to other update types as well. This will happen as part of

--- a/spec/commands/v2/patch_link_set_spec.rb
+++ b/spec/commands/v2/patch_link_set_spec.rb
@@ -209,7 +209,7 @@ RSpec.describe Commands::V2::PatchLinkSet do
 
     it "presents the draft content item for the downstream request" do
       expect(Presenters::ContentStorePresenter).to receive(:present)
-        .with(draft_content_item, an_instance_of(Fixnum), fallback_order: [:draft, :published])
+        .with(draft_content_item, an_instance_of(Fixnum), state_fallback_order: [:draft, :published])
 
       described_class.call(payload)
     end
@@ -231,7 +231,7 @@ RSpec.describe Commands::V2::PatchLinkSet do
 
         it "sends the draft content item for that locale downstream" do
           expect(Presenters::ContentStorePresenter).to receive(:present)
-            .with(draft_content_item, an_instance_of(Fixnum), fallback_order: [:draft, :published])
+            .with(draft_content_item, an_instance_of(Fixnum), state_fallback_order: [:draft, :published])
 
           described_class.call(payload)
         end
@@ -282,7 +282,7 @@ RSpec.describe Commands::V2::PatchLinkSet do
 
     it "presents the live content item for the downstream request" do
       expect(Presenters::ContentStorePresenter).to receive(:present)
-        .with(live_content_item, an_instance_of(Fixnum), fallback_order: [:published])
+        .with(live_content_item, an_instance_of(Fixnum), state_fallback_order: [:published])
 
       described_class.call(payload)
     end

--- a/spec/commands/v2/publish_spec.rb
+++ b/spec/commands/v2/publish_spec.rb
@@ -167,7 +167,7 @@ RSpec.describe Commands::V2::Publish do
 
       it "presents the content item for the downstream request" do
         expect(Presenters::ContentStorePresenter).to receive(:present)
-          .with(draft_item, an_instance_of(Fixnum), fallback_order: [:published])
+          .with(draft_item, an_instance_of(Fixnum), state_fallback_order: [:published])
 
         described_class.call(payload)
       end

--- a/spec/pacts/content_store/put_endpoint_spec.rb
+++ b/spec/pacts/content_store/put_endpoint_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe "PUT endpoint pact with the Content Store", pact: true do
   let!(:link_set) { FactoryGirl.create(:link_set, content_id: content_id) }
 
   let(:client) { ContentStoreWriter.new("http://localhost:3093") }
-  let(:body) { Presenters::ContentStorePresenter.present(content_item, event.id, fallback_order: [:published]) }
+  let(:body) { Presenters::ContentStorePresenter.present(content_item, event.id, state_fallback_order: [:published]) }
 
   context "when a content item exists that has an older payload_version than the request" do
     before do

--- a/spec/presenters/content_store_presenter_spec.rb
+++ b/spec/presenters/content_store_presenter_spec.rb
@@ -3,15 +3,15 @@ require 'rails_helper'
 RSpec.describe Presenters::ContentStorePresenter do
   let(:content_item) { FactoryGirl.create(:live_content_item) }
   let(:event) { double(:event, id: 123) }
-  let(:fallback_order) { [:published] }
+  let(:state_fallback_order) { [:published] }
 
   it "excludes the update_type from the presentation" do
-    presentation = described_class.present(content_item, event, fallback_order: fallback_order)
+    presentation = described_class.present(content_item, event, state_fallback_order: state_fallback_order)
     expect(presentation).to_not have_key(:update_type)
   end
 
   it "leaves other fields intact" do
-    presentation = described_class.present(content_item, event, fallback_order: fallback_order)
+    presentation = described_class.present(content_item, event, state_fallback_order: state_fallback_order)
     expect(presentation).to have_key(:content_id)
     expect(presentation).to have_key(:title)
     expect(presentation).to have_key(:details)

--- a/spec/presenters/downstream_presenter_spec.rb
+++ b/spec/presenters/downstream_presenter_spec.rb
@@ -1,9 +1,9 @@
 require 'rails_helper'
 
 RSpec.describe Presenters::DownstreamPresenter do
-  let(:fallback_order) { [] }
+  let(:state_fallback_order) { [] }
 
-  subject(:result) { described_class.present(content_item, fallback_order: fallback_order) }
+  subject(:result) { described_class.present(content_item, state_fallback_order: state_fallback_order) }
 
   describe "V2" do
     let(:expected) {
@@ -79,7 +79,7 @@ RSpec.describe Presenters::DownstreamPresenter do
       end
 
       it "expands the links for the content item" do
-        result = described_class.present(a, fallback_order: [:draft])
+        result = described_class.present(a, state_fallback_order: [:draft])
 
         expect(result[:expanded_links]).to eq(related: [{
           content_id: b.content_id,

--- a/spec/presenters/message_queue_presenter_spec.rb
+++ b/spec/presenters/message_queue_presenter_spec.rb
@@ -4,12 +4,12 @@ RSpec.describe Presenters::MessageQueuePresenter do
   let(:content_item) { FactoryGirl.create(:live_content_item) }
 
   it "mixes in the specified update_type to the presentation" do
-    presentation = described_class.present(content_item, fallback_order: [:published], update_type: "foo")
+    presentation = described_class.present(content_item, state_fallback_order: [:published], update_type: "foo")
     expect(presentation[:update_type]).to eq("foo")
   end
 
   it "leaves other fields intact" do
-    presentation = described_class.present(content_item, fallback_order: [:published], update_type: "foo")
+    presentation = described_class.present(content_item, state_fallback_order: [:published], update_type: "foo")
     expect(presentation).to have_key(:content_id)
     expect(presentation).to have_key(:title)
     expect(presentation).to have_key(:details)

--- a/spec/presenters/queries/expanded_link_set_spec.rb
+++ b/spec/presenters/queries/expanded_link_set_spec.rb
@@ -31,7 +31,15 @@ RSpec.describe Presenters::Queries::ExpandedLinkSet do
   let(:c) { create_link_set }
   let(:d) { create_link_set }
 
-  subject(:expanded_links) { described_class.new(link_set: LinkSet.find_by(content_id: a), fallback_order: fallback_order).links }
+  let(:locale_fallback_order) { "en" }
+
+  subject(:expanded_links) {
+    described_class.new(
+      link_set: LinkSet.find_by(content_id: a),
+      state_fallback_order: state_fallback_order,
+      locale_fallback_order: locale_fallback_order
+    ).links
+  }
 
   context "with content items in a draft state" do
     let!(:draft_a) { create_content_item(a, "/a", "draft") }
@@ -39,7 +47,7 @@ RSpec.describe Presenters::Queries::ExpandedLinkSet do
     let!(:draft_c) { create_content_item(c, "/c", "draft") }
     let!(:draft_d) { create_content_item(d, "/d", "draft") }
 
-    let(:fallback_order) { [:draft] }
+    let(:state_fallback_order) { [:draft] }
 
     context "a simple non-recursive graph" do
       it "expands the links for node a correctly" do
@@ -173,7 +181,7 @@ RSpec.describe Presenters::Queries::ExpandedLinkSet do
       end
 
       context "when requested with a draft state" do
-        let(:fallback_order) { [:draft] }
+        let(:state_fallback_order) { [:draft] }
 
         it "expands the links for node a correctly" do
           expect(expanded_links[:related]).to match([
@@ -183,7 +191,7 @@ RSpec.describe Presenters::Queries::ExpandedLinkSet do
       end
 
       context "when requested with a published state" do
-        let(:fallback_order) { [:published] }
+        let(:state_fallback_order) { [:published] }
 
         it "expands the links for node a correctly" do
           expect(expanded_links[:related]).to match([
@@ -208,7 +216,7 @@ RSpec.describe Presenters::Queries::ExpandedLinkSet do
       end
 
       context "when requested with a draft state" do
-        let(:fallback_order) { [:draft] }
+        let(:state_fallback_order) { [:draft] }
 
         it "expands the links for node a correctly" do
           expect(expanded_links[:parent]).to match([
@@ -218,7 +226,7 @@ RSpec.describe Presenters::Queries::ExpandedLinkSet do
       end
 
       context "when requested with a published state" do
-        let(:fallback_order) { [:published] }
+        let(:state_fallback_order) { [:published] }
 
         it "expands the links for node a correctly" do
           expect(expanded_links[:parent]).to match([
@@ -235,7 +243,7 @@ RSpec.describe Presenters::Queries::ExpandedLinkSet do
     # to the draft content store. This means that we need to try to find a
     # draft, but fall back to the published item (if it exists).
     context "when an array of states is provided" do
-      let(:fallback_order) { [:draft, :published] }
+      let(:state_fallback_order) { [:draft, :published] }
 
       before do
         create_link(a, b, "parent")
@@ -262,7 +270,7 @@ RSpec.describe Presenters::Queries::ExpandedLinkSet do
   end
 
   context "when a link has a 'passthrough_hash'" do
-    let(:fallback_order) { [:draft, :published] }
+    let(:state_fallback_order) { [:draft, :published] }
 
     before do
       create_link(a, b, "parent")
@@ -285,7 +293,7 @@ RSpec.describe Presenters::Queries::ExpandedLinkSet do
   end
 
   describe "expanding dependees" do
-    let(:fallback_order) { [:draft, :published] }
+    let(:state_fallback_order) { [:draft, :published] }
 
     before do
       create_content_item(a, "/a")

--- a/spec/requests/content_item_requests/downstream_requests_spec.rb
+++ b/spec/requests/content_item_requests/downstream_requests_spec.rb
@@ -99,7 +99,7 @@ RSpec.describe "Downstream requests", type: :request do
         v2_content_item.except(:update_type).merge(
           links: Presenters::Queries::LinkSetPresenter.new(link_set).links
         ).merge(
-          expanded_links: Presenters::Queries::ExpandedLinkSet.new(link_set: link_set, fallback_order: [:draft, :published]).links
+          expanded_links: Presenters::Queries::ExpandedLinkSet.new(link_set: link_set, state_fallback_order: [:draft, :published]).links
         )
       end
 


### PR DESCRIPTION
When expanding links for an item in a non-default locale, return items in that same locale if they exist, otherwise fall back to the default locale.