### PR TITLE
Add available_translations to expanded links

### DIFF
--- a/app/models/web_content_item.rb
+++ b/app/models/web_content_item.rb
@@ -1,16 +1,14 @@
 require "forwardable"
 
 class WebContentItem
-  NullLocation = Struct.new(:base_path)
-  NullTranslation = Struct.new(:locale)
-
-  attr_reader :content_item, :location, :translation
   extend Forwardable
 
-  def initialize(content_item)
+  attr_reader :content_item, :base_path, :locale
+
+  def initialize(content_item, base_path: nil, locale: nil)
     @content_item = content_item
-    @location = Location.find_by(content_item: content_item) || NullLocation.new
-    @translation = Translation.find_by(content_item: content_item) || NullTranslation.new
+    @base_path = base_path || Location.find_by(content_item: content_item).try(:base_path)
+    @locale = locale || Translation.find_by(content_item: content_item).try(:locale)
   end
 
   CONTENT_ITEM_METHODS = [
@@ -18,8 +16,6 @@ class WebContentItem
   ]
 
   def_delegators :@content_item, *CONTENT_ITEM_METHODS
-  def_delegators :@location, :base_path
-  def_delegators :@translation, :locale
 
   def api_url
     return unless base_path

--- a/app/presenters/queries/available_translations.rb
+++ b/app/presenters/queries/available_translations.rb
@@ -1,0 +1,49 @@
+module Presenters
+  module Queries
+    class AvailableTranslations
+      def initialize(content_id, state_fallback_order)
+        @content_id = content_id
+        @state_fallback_order = state_fallback_order
+      end
+
+      def translations
+        if expanded_translations.present?
+          { available_translations: expanded_translations }
+        else
+          {}
+        end
+      end
+
+    private
+
+      attr_reader :content_id, :state_fallback_order, :expanded_translations
+
+      def scope
+        scope = ContentItem.where(content_id: content_id)
+        scope = State.join_content_items(scope)
+        scope = Translation.join_content_items(scope)
+        scope.select(*(WebContentItem::CONTENT_ITEM_METHODS + %w(id locale name)))
+      end
+
+      def filter_states
+        scope.where("states.name" => state_fallback_order)
+      end
+
+      def grouped_translations
+        filter_states
+          .sort_by { |item| state_fallback_order.index(item.name.to_sym) }
+          .group_by(&:locale)
+      end
+
+      def expand_translation(item)
+        expansion_rules = ::Queries::DependentExpansionRules
+        web_item = WebContentItem.new(item, locale: item.locale)
+        ExpandLink.new(web_item, :available_translations, expansion_rules).expand_link
+      end
+
+      def expanded_translations
+        @expanded_translations ||= grouped_translations.map { |_, items| expand_translation(items.first) }
+      end
+    end
+  end
+end

--- a/app/presenters/queries/expanded_link_set.rb
+++ b/app/presenters/queries/expanded_link_set.rb
@@ -11,7 +11,7 @@ module Presenters
 
       def links
         if top_level?
-          dependees.merge(dependents)
+          dependees.merge(dependents).merge(translations)
         else
           dependees
         end
@@ -124,6 +124,10 @@ module Presenters
         end
 
         @content_item[target_content_id]
+      end
+
+      def translations
+        AvailableTranslations.new(link_set.content_id, state_fallback_order).translations
       end
     end
   end

--- a/spec/presenters/downstream_presenter_spec.rb
+++ b/spec/presenters/downstream_presenter_spec.rb
@@ -83,17 +83,29 @@ RSpec.describe Presenters::DownstreamPresenter do
       it "expands the links for the content item" do
         result = described_class.present(a, state_fallback_order: [:draft])
 
-        expect(result[:expanded_links]).to eq(related: [{
-          content_id: b.content_id,
-          base_path: "/b",
-          title: "VAT rates",
-          description: "VAT rates for goods and services",
-          locale: "en",
-          api_url: "http://www.dev.gov.uk/api/content/b",
-          web_url: "http://www.dev.gov.uk/b",
-          analytics_identifier: "GDS01",
-          expanded_links: {},
-        }])
+        expect(result[:expanded_links]).to eq(
+          related: [{
+            content_id: b.content_id,
+            base_path: "/b",
+            title: "VAT rates",
+            description: "VAT rates for goods and services",
+            locale: "en",
+            api_url: "http://www.dev.gov.uk/api/content/b",
+            web_url: "http://www.dev.gov.uk/b",
+            analytics_identifier: "GDS01",
+            expanded_links: {},
+          }],
+          available_translations: [{
+            analytics_identifier: "GDS01",
+            api_url: "http://www.dev.gov.uk/api/content/a",
+            base_path: "/a",
+            content_id: a.content_id,
+            description: "VAT rates for goods and services",
+            locale: "en",
+            title: "VAT rates",
+            web_url: "http://www.dev.gov.uk/a",
+          }],
+        )
       end
     end
 

--- a/spec/presenters/queries/available_translations_spec.rb
+++ b/spec/presenters/queries/available_translations_spec.rb
@@ -1,0 +1,80 @@
+require 'rails_helper'
+
+RSpec.describe Presenters::Queries::AvailableTranslations do
+  subject(:translations) {
+    described_class.new(
+      link_set.content_id,
+      state_fallback_order,
+    ).translations[:available_translations]
+  }
+
+  def create_content_item(base_path, state = "published", locale = "en")
+    FactoryGirl.create(
+      :content_item,
+      content_id: link_set.content_id,
+      base_path: base_path,
+      state: state,
+      locale: locale,
+    )
+  end
+
+  let(:link_set) { FactoryGirl.create(:link_set) }
+
+  context "with items in a matching state" do
+    let(:state_fallback_order) { [:published] }
+
+    before do
+      create_content_item("/a", "published")
+      create_content_item("/a.ar", "published", "ar")
+      create_content_item("/a.es", "published", "es")
+    end
+
+    it "returns all the items" do
+      expect(translations).to match_array([
+        a_hash_including(base_path: "/a", locale: "en"),
+        a_hash_including(base_path: "/a.ar", locale: "ar"),
+        a_hash_including(base_path: "/a.es", locale: "es"),
+      ])
+    end
+  end
+
+  context "with items in more than one state" do
+    let!(:en) { create_content_item("/a", "published") }
+    let!(:ar) { create_content_item("/a.ar", "draft", "ar") }
+    let!(:es) { create_content_item("/a.es", "published", "es") }
+
+    context "with multiple states in the fallback order" do
+      let(:state_fallback_order) { [:draft, :published] }
+
+      it "returns items in all states in the fallback order" do
+        expect(translations).to match_array([
+          a_hash_including(base_path: "/a", locale: "en"),
+          a_hash_including(base_path: "/a.ar", locale: "ar"),
+          a_hash_including(base_path: "/a.es", locale: "es"),
+        ])
+      end
+
+      it "takes the item in the first matching state" do
+        es.update_attribute("title", "no habla español")
+        draft_es = create_content_item("/a.es", "draft", "es")
+        draft_es.update_attribute("title", "mais on parle français")
+        expect(translations).to match_array([
+          a_hash_including(base_path: "/a", locale: "en"),
+          a_hash_including(base_path: "/a.ar", locale: "ar"),
+          a_hash_including(base_path: "/a.es", locale: "es", title: "mais on parle français"),
+        ])
+      end
+    end
+
+    context "with a single state in the fallback order" do
+      let(:state_fallback_order) { [:published] }
+
+      it "does not return items with states not in the fallback order" do
+        expect(translations).to match_array([
+          a_hash_including(base_path: "/a", locale: "en"),
+          a_hash_including(base_path: "/a.es", locale: "es"),
+        ])
+      end
+    end
+  end
+end

--- a/spec/requests/content_item_requests/downstream_requests_spec.rb
+++ b/spec/requests/content_item_requests/downstream_requests_spec.rb
@@ -64,7 +64,9 @@ RSpec.describe "Downstream requests", type: :request do
       v2_content_item
         .except(:update_type)
         .merge(links: {})
-        .merge(expanded_links: {})
+        .merge(expanded_links: {
+          available_translations: available_translations
+        })
     }
 
     it "only sends to the draft content store" do
@@ -105,14 +107,14 @@ RSpec.describe "Downstream requests", type: :request do
       it "sends to the draft content store" do
         allow(PublishingAPI.service(:draft_content_store)).to receive(:put_content_item).with(anything)
 
-        expect(PublishingAPI.service(:draft_content_store)).to receive(:put_content_item)
+        put "/v2/content/#{content_id}", v2_content_item.to_json
+        expect(PublishingAPI.service(:draft_content_store)).to have_received(:put_content_item)
           .with(
             base_path: base_path,
             content_item: content_item_for_draft_content_store
               .merge(payload_version: anything)
           )
 
-        put "/v2/content/#{content_id}", v2_content_item.to_json
         expect(response).to be_ok, response.body
       end
 

--- a/spec/requests/expanded_links_endpoint_spec.rb
+++ b/spec/requests/expanded_links_endpoint_spec.rb
@@ -1,18 +1,38 @@
 require "rails_helper"
 
 RSpec.describe "GET /v2/expanded-links/:id", type: :request do
+  let(:translations) {
+    [
+      {
+        "analytics_identifier" => "GDS01",
+        "api_url" => "http://www.dev.gov.uk/api/content/some-path",
+        "base_path" => "/some-path",
+        "content_id" => "10529c0d-f4b3-4c7d-9589-35ba6a6d1a12",
+        "description" => "Some description",
+        "locale" => "en",
+        "title" => "Some title",
+        "web_url" => "http://www.dev.gov.uk/some-path"
+      }
+    ]
+  }
+
+  let(:content_item) {
+    FactoryGirl.create(:content_item,
+      state: "published",
+      format: "placeholder",
+      title: "Some title",
+      base_path: "/some-path",
+      description: "Some description",
+      content_id: "10529c0d-f4b3-4c7d-9589-35ba6a6d1a12"
+    )
+  }
+
   it "returns expanded links" do
     organisation = FactoryGirl.create(:content_item,
       state: "published",
       format: "organisation",
       base_path: "/my-super-org",
       content_id: "9b5ae6f5-f127-4843-9333-c157a404dd2d",
-    )
-
-    content_item = FactoryGirl.create(:content_item,
-      state: "published",
-      format: "placeholder",
-      title: "Some title",
     )
 
     link_set = FactoryGirl.create(:link_set,
@@ -39,18 +59,13 @@ RSpec.describe "GET /v2/expanded-links/:id", type: :request do
             "web_url" => "http://www.dev.gov.uk/my-super-org",
             "expanded_links" => {},
           }
-        ]
+        ],
+        "available_translations" => translations,
       }
     )
   end
 
-  it "returns empty expanded links if there are no links" do
-    content_item = FactoryGirl.create(:content_item,
-      state: "published",
-      format: "placeholder",
-      title: "Some title",
-    )
-
+  it "returns only translations if there are no links" do
     link_set = FactoryGirl.create(:link_set,
       content_id: content_item.content_id,
     )
@@ -60,17 +75,13 @@ RSpec.describe "GET /v2/expanded-links/:id", type: :request do
     expect(parsed_response).to eql(
       "version" => 0,
       "content_id" => content_item.content_id,
-      "expanded_links" => {},
+      "expanded_links" => {
+        "available_translations" => translations,
+      },
     )
   end
 
   it "returns a version if the link set has a version" do
-    content_item = FactoryGirl.create(:content_item,
-      state: "published",
-      format: "placeholder",
-      title: "Some title",
-    )
-
     link_set = FactoryGirl.create(:link_set,
       content_id: content_item.content_id,
     )
@@ -82,7 +93,9 @@ RSpec.describe "GET /v2/expanded-links/:id", type: :request do
     expect(parsed_response).to eql(
       "version" => 11,
       "content_id" => content_item.content_id,
-      "expanded_links" => {},
+      "expanded_links" => {
+        "available_translations" => translations,
+      },
     )
   end
 

--- a/spec/support/request_helpers/mocks.rb
+++ b/spec/support/request_helpers/mocks.rb
@@ -56,8 +56,25 @@ module RequestHelpers
         links: {
           organisations: ["30986e26-f504-4e14-a93f-a9593c34a8d9"]
         },
-        expanded_links: {},
+        expanded_links: {
+          available_translations: available_translations
+        }
       }
+    end
+
+    def available_translations
+      [
+        {
+          analytics_identifier: "GDS01",
+          api_url: "http://www.dev.gov.uk/api/content/vat-rates",
+          base_path: "/vat-rates",
+          content_id: content_id,
+          description: "VAT rates for goods and services",
+          locale: "en",
+          title: "VAT rates",
+          web_url: "http://www.dev.gov.uk/vat-rates"
+        }
+      ]
     end
 
     def redirect_content_item


### PR DESCRIPTION
Content store adds an "available_translations" key to the links hash, containing all translations for the  content item (including the current locale). This replicates this functionality in the expanded_links hash calculated in publishing-api.