### PR TITLE
Use explicit base_path in content store pacts.

### DIFF
--- a/spec/pacts/content_store/put_endpoint_spec.rb
+++ b/spec/pacts/content_store/put_endpoint_spec.rb
@@ -7,7 +7,8 @@ RSpec.describe "PUT endpoint pact with the Content Store", pact: true do
   let!(:content_item) do
     FactoryGirl.create(
       :live_content_item,
-      content_id: content_id
+      content_id: content_id,
+      base_path: "/vat-rates"
     )
   end
 


### PR DESCRIPTION
Pacts were broken because the items in the routes hash were using an autoincremented value.