### PR TITLE
Create index on linkables.base_path

### DIFF
--- a/db/migrate/20160524210649_create_index_on_linkables_base_path.rb
+++ b/db/migrate/20160524210649_create_index_on_linkables_base_path.rb
@@ -1,0 +1,5 @@
+class CreateIndexOnLinkablesBasePath < ActiveRecord::Migration
+  def change
+    add_index :linkables, :base_path
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160517134907) do
+ActiveRecord::Schema.define(version: 20160524210649) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -82,6 +82,7 @@ ActiveRecord::Schema.define(version: 20160517134907) do
     t.datetime "updated_at"
   end
 
+  add_index "linkables", ["base_path"], name: "index_linkables_on_base_path", using: :btree
   add_index "linkables", ["document_type"], name: "index_linkables_on_document_type", using: :btree
 
   create_table "links", force: :cascade do |t|


### PR DESCRIPTION
This is queried twice in `PutContent` as a `Linkables.exists?` call.
Without an index these queries takes 40ms each.

/cc @danielroseman @elliotcm 