### PR TITLE
Validate content_item and links against schema

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,7 @@ gem "sidekiq", "3.5.1"
 gem "sidekiq-logging-json", "0.0.14"
 gem "sidekiq-statsd", "0.1.5"
 gem "deprecated_columns"
+gem "json-schema", require: false
 
 group :development do
   # Access an IRB console on exception pages or by using <%= console %> in views

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -129,6 +129,8 @@ GEM
       multi_xml (>= 0.5.2)
     i18n (0.7.0)
     json (1.8.3)
+    json-schema (2.5.2)
+      addressable (~> 2.3.8)
     jwt (1.5.2)
     kgio (2.9.3)
     link_header (0.0.8)
@@ -368,6 +370,7 @@ DEPENDENCIES
   gds-sso (= 11.2.1)
   govuk-client-url_arbiter (= 0.0.3)
   govuk-lint
+  json-schema
   logstasher (= 0.6.2)
   pact
   pact_broker-client

--- a/app/commands/v2/patch_link_set.rb
+++ b/app/commands/v2/patch_link_set.rb
@@ -114,15 +114,15 @@ module Commands
         PublishingAPI.service(:queue_publisher).send_message(payload)
       end
 
-      def format
+      def schema_name
         Queries::GetLatest.call(
           ContentItem.where(content_id: content_id)
-        ).last.try(:format)
+        ).limit(1).pluck(:schema_name).last
       end
 
       def validate_schema
         SchemaValidator.new(
-          payload.merge(format: format),
+          payload.merge(schema_name: schema_name),
           type: :links
         ).validate
       end

--- a/app/commands/v2/patch_link_set.rb
+++ b/app/commands/v2/patch_link_set.rb
@@ -3,6 +3,7 @@ module Commands
     class PatchLinkSet < BaseCommand
       def call
         raise_unless_links_hash_is_provided
+        validate_schema
 
         link_set = LinkSet.find_by(content_id: content_id)
 
@@ -111,6 +112,19 @@ module Commands
         )
 
         PublishingAPI.service(:queue_publisher).send_message(payload)
+      end
+
+      def format
+        Queries::GetLatest.call(
+          ContentItem.where(content_id: content_id)
+        ).last.try(:format)
+      end
+
+      def validate_schema
+        SchemaValidator.new(
+          payload.merge(format: format),
+          type: :links
+        ).validate
       end
     end
   end

--- a/app/commands/v2/put_content.rb
+++ b/app/commands/v2/put_content.rb
@@ -3,6 +3,7 @@ module Commands
     class PutContent < BaseCommand
       def call
         raise_if_links_is_provided
+        validate_schema
 
         PathReservation.reserve_base_path!(base_path, publishing_app) if base_path_required?
         content_item = find_previously_drafted_content_item
@@ -266,6 +267,10 @@ module Commands
             }
           }
         )
+      end
+
+      def validate_schema
+        SchemaValidator.new(payload, type: :schema).validate
       end
     end
   end

--- a/app/validators/schema_validator.rb
+++ b/app/validators/schema_validator.rb
@@ -1,0 +1,39 @@
+require 'json-schema'
+
+class SchemaValidator
+  def initialize(payload, type:, schema: nil)
+    @payload = payload
+    @type = type
+    @schema = schema
+  end
+
+  def validate
+    validate_schema
+  end
+
+private
+
+  attr_reader :payload, :type
+
+  def validate_schema
+    JSON::Validator.validate!(schema, payload)
+  rescue JSON::Schema::ValidationError => error
+    Airbrake.notify_or_ignore(error, parameters: {
+      explanation: "schema validation error"
+    })
+    false
+  end
+
+  def schema
+    @schema || File.read("govuk-content-schemas/formats/#{format}/publisher_v2/#{type}.json")
+  rescue Errno::ENOENT => error
+    Airbrake.notify_or_ignore(error, parameters: {
+      explanation: "format #{format} or type #{type} is not known"
+    })
+    return {}
+  end
+
+  def format
+    payload[:format]
+  end
+end

--- a/app/validators/schema_validator.rb
+++ b/app/validators/schema_validator.rb
@@ -25,15 +25,15 @@ private
   end
 
   def schema
-    @schema || File.read("govuk-content-schemas/formats/#{format}/publisher_v2/#{type}.json")
+    @schema || File.read("govuk-content-schemas/formats/#{schema_name}/publisher_v2/#{type}.json")
   rescue Errno::ENOENT => error
     Airbrake.notify_or_ignore(error, parameters: {
-      explanation: "format #{format} or type #{type} is not known"
+      explanation: "schema_name #{schema_name} or type #{type} is not known"
     })
     return {}
   end
 
-  def format
-    payload[:format]
+  def schema_name
+    payload[:schema_name] || payload[:format]
   end
 end

--- a/spec/commands/v2/patch_link_set_spec.rb
+++ b/spec/commands/v2/patch_link_set_spec.rb
@@ -393,4 +393,21 @@ RSpec.describe Commands::V2::PatchLinkSet do
   end
 
   it_behaves_like TransactionalCommand
+
+  context "Validation" do
+    let!(:content_item) do
+      FactoryGirl.create(:content_item,
+        content_id: content_id,
+        format: 'travel_advice'
+      )
+    end
+
+    it "validates against the schema" do
+      allow(SchemaValidator).to receive(:new).and_return(double('validator', validate: true))
+      expect(SchemaValidator).to receive(:new)
+        .with(a_hash_including(format: "travel_advice"), type: :links)
+
+      described_class.call(payload)
+    end
+  end
 end

--- a/spec/commands/v2/patch_link_set_spec.rb
+++ b/spec/commands/v2/patch_link_set_spec.rb
@@ -398,14 +398,15 @@ RSpec.describe Commands::V2::PatchLinkSet do
     let!(:content_item) do
       FactoryGirl.create(:content_item,
         content_id: content_id,
-        format: 'travel_advice'
+        schema_name: 'travel_advice',
+        document_type: 'travel_advice',
       )
     end
 
     it "validates against the schema" do
       allow(SchemaValidator).to receive(:new).and_return(double('validator', validate: true))
       expect(SchemaValidator).to receive(:new)
-        .with(a_hash_including(format: "travel_advice"), type: :links)
+        .with(a_hash_including(schema_name: "travel_advice"), type: :links)
 
       described_class.call(payload)
     end

--- a/spec/commands/v2/put_content_spec.rb
+++ b/spec/commands/v2/put_content_spec.rb
@@ -780,5 +780,13 @@ RSpec.describe Commands::V2::PutContent do
     end
 
     it_behaves_like TransactionalCommand
+
+    it "validate against schema" do
+      allow(SchemaValidator).to receive(:new).and_return(double('validator', validate: true))
+      expect(SchemaValidator).to receive(:new)
+        .with(a_hash_including(format: "guide"), type: :schema)
+
+      described_class.call(payload)
+    end
   end
 end

--- a/spec/validators/schema_validator_spec.rb
+++ b/spec/validators/schema_validator_spec.rb
@@ -1,0 +1,54 @@
+require "rails_helper"
+
+RSpec.describe SchemaValidator do
+  let(:schema) do
+    {
+      "type" => "object",
+      "required" => ["a"],
+      "properties" => {
+        "a" => { "type" => "integer" }
+      }
+    }
+  end
+
+  subject(:validator) do
+    SchemaValidator.new(payload, type: :schema, schema: schema)
+  end
+
+  context "schema" do
+    let(:schema) { nil }
+    let(:payload) { { format: 'test' } }
+
+    it "logs to airbrake with an unknown format" do
+      expect(Airbrake).to receive(:notify_or_ignore)
+        .with(an_instance_of(Errno::ENOENT), a_hash_including(:parameters))
+      validator.validate
+    end
+  end
+
+  context "valid payload" do
+    let(:payload) { { a: 1 } }
+
+    it "does not report to airbrake" do
+      expect(Airbrake).to_not receive(:notify_or_ignore)
+      validator.validate
+    end
+
+    it "logs to airbrake when the payload is invalid" do
+      expect(validator.validate).to be true
+    end
+  end
+
+  context "invalid payload" do
+    let(:payload) { { b: 1 } }
+
+    it "reports to airbrake" do
+      expect(Airbrake).to receive(:notify_or_ignore)
+      validator.validate
+    end
+
+    it "logs to airbrake when the payload is invalid" do
+      expect(validator.validate).to be false
+    end
+  end
+end

--- a/spec/validators/schema_validator_spec.rb
+++ b/spec/validators/schema_validator_spec.rb
@@ -17,9 +17,9 @@ RSpec.describe SchemaValidator do
 
   context "schema" do
     let(:schema) { nil }
-    let(:payload) { { format: 'test' } }
+    let(:payload) { { schema_name: 'test' } }
 
-    it "logs to airbrake with an unknown format" do
+    it "logs to airbrake with an unknown schema_name" do
       expect(Airbrake).to receive(:notify_or_ignore)
         .with(an_instance_of(Errno::ENOENT), a_hash_including(:parameters))
       validator.validate


### PR DESCRIPTION
Schema's are made available to the application by syncing them to the
repo in production. This validates against them and sends any errors to
errbit for the time being so as to not block.

https://trello.com/c/O8qZQlLh/720-validate-schemas-in-publishing-api-for-error-messaging