### PR TITLE
Do not validate PatchLinkSet link schema when there is no ContentItem

### DIFF
--- a/app/commands/v2/patch_link_set.rb
+++ b/app/commands/v2/patch_link_set.rb
@@ -115,12 +115,14 @@ module Commands
       end
 
       def schema_name
-        Queries::GetLatest.call(
+        @schema_name ||= Queries::GetLatest.call(
           ContentItem.where(content_id: content_id)
         ).limit(1).pluck(:schema_name).last
       end
 
       def validate_schema
+        return unless schema_name
+
         SchemaValidator.new(
           payload.merge(schema_name: schema_name),
           type: :links

--- a/app/validators/schema_validator.rb
+++ b/app/validators/schema_validator.rb
@@ -19,7 +19,7 @@ private
     JSON::Validator.validate!(schema, payload)
   rescue JSON::Schema::ValidationError => error
     Airbrake.notify_or_ignore(error, parameters: {
-      explanation: "schema validation error"
+      explanation: "#{payload} schema validation error"
     })
     false
   end
@@ -28,7 +28,7 @@ private
     @schema || File.read("govuk-content-schemas/formats/#{schema_name}/publisher_v2/#{type}.json")
   rescue Errno::ENOENT => error
     Airbrake.notify_or_ignore(error, parameters: {
-      explanation: "schema_name #{schema_name} or type #{type} is not known"
+      explanation: "#{payload} is missing schema_name #{schema_name} or type #{type}"
     })
     return {}
   end

--- a/spec/commands/v2/patch_link_set_spec.rb
+++ b/spec/commands/v2/patch_link_set_spec.rb
@@ -395,20 +395,29 @@ RSpec.describe Commands::V2::PatchLinkSet do
   it_behaves_like TransactionalCommand
 
   context "Validation" do
-    let!(:content_item) do
-      FactoryGirl.create(:content_item,
-        content_id: content_id,
-        schema_name: 'travel_advice',
-        document_type: 'travel_advice',
-      )
+    context "with a content_item" do
+      let!(:content_item) do
+        FactoryGirl.create(:content_item,
+          content_id: content_id,
+          schema_name: 'travel_advice',
+          document_type: 'travel_advice',
+        )
+      end
+
+      it "validates against the schema" do
+        allow(SchemaValidator).to receive(:new).and_return(double('validator', validate: true))
+        expect(SchemaValidator).to receive(:new)
+          .with(a_hash_including(schema_name: "travel_advice"), type: :links)
+
+        described_class.call(payload)
+      end
     end
 
-    it "validates against the schema" do
-      allow(SchemaValidator).to receive(:new).and_return(double('validator', validate: true))
-      expect(SchemaValidator).to receive(:new)
-        .with(a_hash_including(schema_name: "travel_advice"), type: :links)
-
-      described_class.call(payload)
+    context "with no content_item" do
+      it "doesn't validate against the schema" do
+        expect(SchemaValidator).to_not receive(:new)
+        described_class.call(payload)
+      end
     end
   end
 end


### PR DESCRIPTION
There is no way to determine which schema to validate against for link
sets without a content_item, unless that information was provided in the
payload.

Until the time where we can add that information to the payload, or
ensure there is a content_item before creating the link set. This will
remove errors that we can't determine which schema to validate against