### PR TITLE
Send latest item to draft content store

### DIFF
--- a/app/commands/v2/patch_link_set.rb
+++ b/app/commands/v2/patch_link_set.rb
@@ -78,7 +78,8 @@ module Commands
         return unless downstream
 
         filter = ContentItemFilter.new(scope: ContentItem.where(content_id: content_id))
-        draft_content_items = filter.filter(state: "draft")
+        draft_content_items = Queries::GetLatest.call(
+          filter.filter(state: %w{draft published}))
         live_content_items = filter.filter(state: "published")
 
         draft_content_items.each do |draft_content_item|

--- a/spec/commands/v2/patch_link_set_spec.rb
+++ b/spec/commands/v2/patch_link_set_spec.rb
@@ -278,6 +278,7 @@ RSpec.describe Commands::V2::PatchLinkSet do
     end
 
     it "sends a request to the live content store" do
+      allow(PresentedContentStoreWorker).to receive(:perform_async_in_queue)
       expect(PresentedContentStoreWorker).to receive(:perform_async_in_queue)
         .with(
           "content_store_high",
@@ -290,6 +291,7 @@ RSpec.describe Commands::V2::PatchLinkSet do
     end
 
     it "sends a low priority request to the live content store for bulk publishing" do
+      allow(PresentedContentStoreWorker).to receive(:perform_async_in_queue)
       expect(PresentedContentStoreWorker).to receive(:perform_async_in_queue)
         .with(
           "content_store_low",
@@ -332,6 +334,7 @@ RSpec.describe Commands::V2::PatchLinkSet do
       end
 
       it "sends the live content item for all locales downstream" do
+        allow(PresentedContentStoreWorker).to receive(:perform_async_in_queue)
         [live_content_item, french_live_content_item].each do |ci|
           expect(PresentedContentStoreWorker).to receive(:perform_async_in_queue)
             .with(

--- a/spec/requests/content_item_requests/downstream_requests_spec.rb
+++ b/spec/requests/content_item_requests/downstream_requests_spec.rb
@@ -189,10 +189,16 @@ RSpec.describe "Downstream requests", type: :request do
         )
       end
 
-      it "only sends to the live content store" do
-        expect(PublishingAPI.service(:draft_content_store)).to receive(:put_content_item).never
-        expect(WebMock).not_to have_requested(:any, /draft-content-store.*/)
+      it "sends the live item to both content stores" do
+        allow(PublishingAPI.service(:draft_content_store)).to receive(:put_content_item).with(anything)
         allow(PublishingAPI.service(:live_content_store)).to receive(:put_content_item).with(anything)
+
+        expect(PublishingAPI.service(:draft_content_store)).to receive(:put_content_item)
+          .with(
+            base_path: base_path,
+            content_item: content_item_for_live_content_store
+              .merge(payload_version: anything)
+          )
 
         expect(PublishingAPI.service(:live_content_store)).to receive(:put_content_item)
           .with(


### PR DESCRIPTION
Send the latest version of each locale of a content item to the draft
content store during a patch_link_set call.

