### PR TITLE
Only pass links hash through to SchemaValidator when validating link_sets

### DIFF
--- a/app/commands/v2/patch_link_set.rb
+++ b/app/commands/v2/patch_link_set.rb
@@ -124,8 +124,9 @@ module Commands
         return unless schema_name
 
         SchemaValidator.new(
-          payload.merge(schema_name: schema_name),
-          type: :links
+          { links: payload[:links] },
+          type: :links,
+          schema_name: schema_name,
         ).validate
       end
     end

--- a/app/validators/schema_validator.rb
+++ b/app/validators/schema_validator.rb
@@ -1,10 +1,11 @@
 require 'json-schema'
 
 class SchemaValidator
-  def initialize(payload, type:, schema: nil)
+  def initialize(payload, type:, schema_name: nil, schema: nil)
     @payload = payload
     @type = type
     @schema = schema
+    @schema_name = schema_name
   end
 
   def validate
@@ -34,6 +35,6 @@ private
   end
 
   def schema_name
-    payload[:schema_name] || payload[:format]
+    @schema_name || payload[:schema_name] || payload[:format]
   end
 end

--- a/spec/commands/v2/patch_link_set_spec.rb
+++ b/spec/commands/v2/patch_link_set_spec.rb
@@ -399,15 +399,15 @@ RSpec.describe Commands::V2::PatchLinkSet do
       let!(:content_item) do
         FactoryGirl.create(:content_item,
           content_id: content_id,
-          schema_name: 'travel_advice',
-          document_type: 'travel_advice',
+          schema_name: "travel_advice",
+          document_type: "travel_advice",
         )
       end
 
       it "validates against the schema" do
-        allow(SchemaValidator).to receive(:new).and_return(double('validator', validate: true))
+        allow(SchemaValidator).to receive(:new).and_return(double("validator", validate: true))
         expect(SchemaValidator).to receive(:new)
-          .with(a_hash_including(schema_name: "travel_advice"), type: :links)
+          .with({ links: payload[:links] }, schema_name: "travel_advice", type: :links)
 
         described_class.call(payload)
       end


### PR DESCRIPTION
The other information in the payload is metadata that should not be
validated