### PR TITLE
Don't instantiate AR objects for dep resolution

### DIFF
--- a/app/presenters/queries/link_set_presenter.rb
+++ b/app/presenters/queries/link_set_presenter.rb
@@ -33,11 +33,11 @@ module Presenters
         #   organisations: [ UUID ],
         # }
 
-        link_set.links.map.with_object({}) do |link, hash|
-          type = link.link_type.to_sym
+        link_set.links.pluck(:link_type, :target_content_id, :passthrough_hash).map.with_object({}) do |link, hash|
+          type = link[0].to_sym
 
           hash[type] ||= []
-          hash[type] << link.target_content_id
+          hash[type] << (link[1] || link[2].deep_symbolize_keys)
         end
       end
 

--- a/bench/downstream_presenter.rb
+++ b/bench/downstream_presenter.rb
@@ -1,0 +1,40 @@
+# /usr/bin/env ruby
+
+require ::File.expand_path('../../config/environment', __FILE__)
+require 'benchmark'
+
+large_reverse_content_item = Queries::GetLatest.(ContentItemFilter.new(
+  scope: ContentItem.where(content_id: '6667cce2-e809-4e21-ae09-cb0bdc1ddda3')
+).filter(state: 'published')).first
+
+puts "Reverse dependencies"
+puts Benchmark.measure {
+  10.times do |i|
+    Rails.logger.debug "Iteration #{i}"
+    Rails.logger.debug "-----------"
+    Presenters::DownstreamPresenter.present(
+      large_reverse_content_item,
+      state_fallback_order: Adapters::ContentStore::DEPENDENCY_FALLBACK_ORDER
+    )
+    print "."
+  end
+  puts ""
+}
+
+large_forward_content_item = Queries::GetLatest.(ContentItemFilter.new(
+  scope: ContentItem.where(content_id: '5eb84e7c-7631-11e4-a3cb-005056011aef')
+).filter(state: 'published')).first
+
+puts "Forward dependencies"
+puts Benchmark.measure {
+  10.times do |i|
+    Rails.logger.debug "Iteration #{i}"
+    Rails.logger.debug "-----------"
+    Presenters::DownstreamPresenter.present(
+      large_reverse_content_item,
+      state_fallback_order: Adapters::ContentStore::DEPENDENCY_FALLBACK_ORDER
+    )
+    print "."
+  end
+  puts ""
+}

--- a/bench/downstream_presenter.rb
+++ b/bench/downstream_presenter.rb
@@ -3,38 +3,68 @@
 require ::File.expand_path('../../config/environment', __FILE__)
 require 'benchmark'
 
-large_reverse_content_item = Queries::GetLatest.(ContentItemFilter.new(
-  scope: ContentItem.where(content_id: '6667cce2-e809-4e21-ae09-cb0bdc1ddda3')
-).filter(state: 'published')).first
+large_reverse = Link.find_by_sql(<<-SQL).first[:target_content_id]
+  SELECT target_content_id
+  FROM links
+  GROUP BY target_content_id
+  ORDER BY COUNT (*) DESC
+  LIMIT 1
+SQL
 
-puts "Reverse dependencies"
-puts Benchmark.measure {
-  10.times do |i|
-    Rails.logger.debug "Iteration #{i}"
-    Rails.logger.debug "-----------"
-    Presenters::DownstreamPresenter.present(
-      large_reverse_content_item,
-      state_fallback_order: Adapters::ContentStore::DEPENDENCY_FALLBACK_ORDER
-    )
-    print "."
-  end
-  puts ""
+large_forward = LinkSet.find_by_sql(<<-SQL).first[:content_id]
+  SELECT content_id
+  FROM link_sets
+  WHERE id IN (
+    SELECT link_set_id
+    FROM links
+    GROUP BY link_set_id
+    ORDER BY COUNT(*) DESC
+    LIMIT 1
+  )
+SQL
+
+no_links = Link.find_by_sql(<<-SQL).first[:content_id]
+  SELECT content_id
+  FROM link_sets
+  LEFT JOIN links
+  ON links.link_set_id = link_sets.id
+  OR links.target_content_id = link_sets.content_id
+  WHERE links.id IS NULL
+  LIMIT 1
+SQL
+
+single_link = Link.find_by_sql(<<-SQL).first[:content_id]
+  SELECT content_id
+  FROM link_sets
+  INNER JOIN links ON links.target_content_id = link_sets.content_id
+  GROUP BY content_id
+  HAVING COUNT(*) = 1
+  LIMIT 1
+SQL
+
+benchmarks = {
+  'Many reverse dependencies' => large_reverse,
+  'Many forward dependencies' => large_forward,
+  'No dependencies' => no_links,
+  'Single link each way' => single_link
 }
 
-large_forward_content_item = Queries::GetLatest.(ContentItemFilter.new(
-  scope: ContentItem.where(content_id: '5eb84e7c-7631-11e4-a3cb-005056011aef')
-).filter(state: 'published')).first
+benchmarks.each do |name, content_id|
+  content_item = Queries::GetLatest.(ContentItemFilter.new(
+    scope: ContentItem.where(content_id: content_id)
+  ).filter(state: 'published')).first
 
-puts "Forward dependencies"
-puts Benchmark.measure {
-  10.times do |i|
-    Rails.logger.debug "Iteration #{i}"
-    Rails.logger.debug "-----------"
-    Presenters::DownstreamPresenter.present(
-      large_reverse_content_item,
-      state_fallback_order: Adapters::ContentStore::DEPENDENCY_FALLBACK_ORDER
-    )
-    print "."
-  end
-  puts ""
-}
+  puts "#{name}: #{content_id}"
+  puts Benchmark.measure {
+    10.times do |i|
+      Rails.logger.debug "Iteration #{i}"
+      Rails.logger.debug "-----------"
+      Presenters::DownstreamPresenter.present(
+        content_item,
+        state_fallback_order: Adapters::ContentStore::DEPENDENCY_FALLBACK_ORDER
+      )
+      print "."
+    end
+    puts ""
+  }
+end


### PR DESCRIPTION
Some content items have thousands of links forwards and backwards.
Instantiating AR objects for each of these is very expensive.

This prefers using `pluck` to fetch an array of just the values needed
for dependency resolution.

There is some logic required where it needs to choose between a
`content_id` or a `passthrough_hash`, but the `passthrough_hash` workaround will be going
away soon so this logic won’t need to remain for long.

Benchmarks using largest sets of forward and reverse links (10 iterations):

Before:

```
$ bundle exec rails r bench/downstream_presenter.rb
Reverse dependencies
..........
 12.370000   0.610000  12.980000 ( 14.230377)
Forward dependencies
..........
 11.790000   0.450000  12.240000 ( 13.463747)
```

After:

```
$ bundle exec rails r bench/downstream_presenter.rb
Reverse dependencies
..........
  2.040000   0.130000   2.170000 (  4.054558)
Forward dependencies
..........
  1.870000   0.090000   1.960000 (  3.355650)
```