### PR TITLE
Do not validate links schema

### DIFF
--- a/app/commands/v2/patch_link_set.rb
+++ b/app/commands/v2/patch_link_set.rb
@@ -3,7 +3,6 @@ module Commands
     class PatchLinkSet < BaseCommand
       def call
         raise_unless_links_hash_is_provided
-        validate_schema
 
         link_set = LinkSet.find_by(content_id: content_id)
 
@@ -113,22 +112,6 @@ module Commands
         )
 
         PublishingAPI.service(:queue_publisher).send_message(payload)
-      end
-
-      def schema_name
-        @schema_name ||= Queries::GetLatest.call(
-          ContentItem.where(content_id: content_id)
-        ).limit(1).pluck(:schema_name).last
-      end
-
-      def validate_schema
-        return unless schema_name
-
-        SchemaValidator.new(
-          { links: payload[:links] },
-          type: :links,
-          schema_name: schema_name,
-        ).validate
       end
     end
   end

--- a/app/validators/schema_validator.rb
+++ b/app/validators/schema_validator.rb
@@ -9,6 +9,7 @@ class SchemaValidator
   end
 
   def validate
+    return true if schema_name_exception?
     validate_schema
   end
 
@@ -36,5 +37,9 @@ private
 
   def schema_name
     @schema_name || payload[:schema_name] || payload[:format]
+  end
+
+  def schema_name_exception?
+    schema_name.to_s.match(/placeholder_/)
   end
 end

--- a/spec/commands/v2/patch_link_set_spec.rb
+++ b/spec/commands/v2/patch_link_set_spec.rb
@@ -396,31 +396,4 @@ RSpec.describe Commands::V2::PatchLinkSet do
   end
 
   it_behaves_like TransactionalCommand
-
-  context "Validation" do
-    context "with a content_item" do
-      let!(:content_item) do
-        FactoryGirl.create(:content_item,
-          content_id: content_id,
-          schema_name: "travel_advice",
-          document_type: "travel_advice",
-        )
-      end
-
-      it "validates against the schema" do
-        allow(SchemaValidator).to receive(:new).and_return(double("validator", validate: true))
-        expect(SchemaValidator).to receive(:new)
-          .with({ links: payload[:links] }, schema_name: "travel_advice", type: :links)
-
-        described_class.call(payload)
-      end
-    end
-
-    context "with no content_item" do
-      it "doesn't validate against the schema" do
-        expect(SchemaValidator).to_not receive(:new)
-        described_class.call(payload)
-      end
-    end
-  end
 end

--- a/spec/validators/schema_validator_spec.rb
+++ b/spec/validators/schema_validator_spec.rb
@@ -51,4 +51,13 @@ RSpec.describe SchemaValidator do
       expect(validator.validate).to be false
     end
   end
+
+  context "exceptions" do
+    let(:payload) { { schema_name: 'placeholder_test' } }
+
+    it "does not report to airbrake" do
+      expect(Airbrake).to_not receive(:notify_or_ignore)
+      validator.validate
+    end
+  end
 end


### PR DESCRIPTION
Links can be patched as individual links, so would be invalid, even
though the LinkSet as a whole would be valid.

Do not validate placeholder_* schemas
Those schema's are used for testing purposes, so should not be validated