### PR TITLE
Remove content_id from the payload to be validated

### DIFF
--- a/app/commands/v2/put_content.rb
+++ b/app/commands/v2/put_content.rb
@@ -270,7 +270,7 @@ module Commands
       end
 
       def validate_schema
-        SchemaValidator.new(payload, type: :schema).validate
+        SchemaValidator.new(payload.except(:content_id), type: :schema).validate
       end
     end
   end

--- a/spec/commands/v2/put_content_spec.rb
+++ b/spec/commands/v2/put_content_spec.rb
@@ -784,7 +784,7 @@ RSpec.describe Commands::V2::PutContent do
     it "validate against schema" do
       allow(SchemaValidator).to receive(:new).and_return(double('validator', validate: true))
       expect(SchemaValidator).to receive(:new)
-        .with(a_hash_including(format: "guide"), type: :schema)
+        .with(payload.except(:content_id), type: :schema)
 
       described_class.call(payload)
     end


### PR DESCRIPTION
Schemas do not require content_id, so should not be validated against