### PR TITLE
Migrate withdrawn_notice data

### DIFF
--- a/db/migrate/20160601134855_move_existing_withdrawn_notices.rb
+++ b/db/migrate/20160601134855_move_existing_withdrawn_notices.rb
@@ -1,0 +1,22 @@
+class MoveExistingWithdrawnNotices < ActiveRecord::Migration
+  def change
+    Unpublishing.where(type: "withdrawal").find_each do |unpublishing|
+      content_item = unpublishing.content_item
+      event = Event.create!(
+        action: "Unpublish",
+        content_id: content_item.content_id,
+        payload: {
+          content_id: content_item.content_id,
+          type: "withdrawal",
+          publishing_app: content_item.publishing_app
+        },
+      )
+
+      PresentedContentStoreWorker.perform_async(
+        content_store: Adapters::ContentStore,
+        payload: { content_item_id: unpublishing.content_item_id, payload_version: event.id },
+        request_uuid: GdsApi::GovukHeaders.headers[:govuk_request_id],
+      )
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160524210649) do
+ActiveRecord::Schema.define(version: 20160601134855) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
https://trello.com/c/l3oyxKgq/723-add-withdrawn-notice-to-schema-metadata-and-use-in-frontends

We need to migrate the `withdrawn_notice` property from the details hash of existing withdrawal Unpublishings to the top level property so that they can render correctly on frontends.