### PR TITLE
Content store safety check

### DIFF
--- a/app/workers/presented_content_store_worker.rb
+++ b/app/workers/presented_content_store_worker.rb
@@ -9,7 +9,7 @@ class PresentedContentStoreWorker
   sidekiq_options queue: HIGH_QUEUE
 
   def perform(args = {})
-    assing_attributes(args.deep_symbolize_keys)
+    assign_attributes(args.deep_symbolize_keys)
     set_headers
 
     if params[:delete]
@@ -57,7 +57,7 @@ private
     params.fetch(:content_store).constantize
   end
 
-  def assing_attributes(params)
+  def assign_attributes(params)
     @params = params
     @request_uuid = @params[:request_uuid]
   end

--- a/app/workers/presented_content_store_worker.rb
+++ b/app/workers/presented_content_store_worker.rb
@@ -27,6 +27,16 @@ private
 
   def send_to_content_store
     if content_item_id
+      content_item_is_draft = (State.where(content_item_id: content_item_id).pluck(:name) == ["draft"])
+      content_store_is_live = (content_store == Adapters::ContentStore)
+
+      if content_item_is_draft && content_store_is_live
+        raise CommandError.new(
+          code: 500,
+          message: "Will not send a draft content item to the live content store",
+        )
+      end
+
       base_path = presented_payload.fetch(:base_path)
       content_store.put_content_item(base_path, presented_payload)
     else

--- a/spec/workers/presented_content_store_worker_spec.rb
+++ b/spec/workers/presented_content_store_worker_spec.rb
@@ -1,52 +1,105 @@
 require "rails_helper"
 
 RSpec.describe PresentedContentStoreWorker do
-  let(:content_item) { FactoryGirl.create(:content_item, base_path: "/foo") }
+  let(:content_item) { FactoryGirl.create(:live_content_item, base_path: "/foo") }
+
   before do
-    stub_request(:put, "http://content-store.dev.gov.uk/content/foo").
-      to_return(status: status, body: {}.to_json)
+    stub_request(:put, %r{.*content-store.*/content/.*})
   end
 
-  def do_request
-    subject.perform(
-      content_store: "Adapters::ContentStore",
-      payload: { content_item_id: content_item.id, payload_version: "1" }
-    )
+  describe "raised errors" do
+    before do
+      stub_request(:put, "http://content-store.dev.gov.uk/content/foo").
+        to_return(status: status, body: {}.to_json)
+    end
+
+    def do_request
+      subject.perform(
+        content_store: "Adapters::ContentStore",
+        payload: { content_item_id: content_item.id, payload_version: "1" }
+      )
+    end
+
+    expectations = {
+      200 => { raises_error: false, logs_to_airbrake: false },
+      202 => { raises_error: false, logs_to_airbrake: false },
+      400 => { raises_error: false, logs_to_airbrake: true },
+      409 => { raises_error: false, logs_to_airbrake: false },
+      500 => { raises_error: true, logs_to_airbrake: false },
+    }
+
+    expectations.each do |status, expectation|
+      context "when the content store responds with a #{status}" do
+        let(:status) { status }
+
+        if expectation.fetch(:raises_error)
+          it "raises an error" do
+            expect { do_request }.to raise_error(CommandError)
+          end
+        else
+          it "does not raise an error" do
+            expect { do_request }.to_not raise_error
+          end
+        end
+
+        if expectation.fetch(:logs_to_airbrake)
+          it "logs the response to airbrake" do
+            expect(Airbrake).to receive(:notify_or_ignore)
+            do_request rescue CommandError
+          end
+        else
+          it "does not log the response to airbrake" do
+            expect(Airbrake).to_not receive(:notify_or_ignore)
+            do_request rescue CommandError
+          end
+        end
+      end
+    end
   end
 
-  expectations = {
-    200 => { raises_error: false, logs_to_airbrake: false },
-    202 => { raises_error: false, logs_to_airbrake: false },
-    400 => { raises_error: false, logs_to_airbrake: true },
-    409 => { raises_error: false, logs_to_airbrake: false },
-    500 => { raises_error: true, logs_to_airbrake: false },
-  }
+  describe "draft-to-live protection" do
+    it "prevents draft content items being sent to the live content store" do
+      draft = FactoryGirl.create(:draft_content_item)
 
-  expectations.each do |status, expectation|
-    context "when the content store responds with a #{status}" do
-      let(:status) { status }
+      expect {
+        subject.perform(
+          content_store: "Adapters::ContentStore",
+          payload: { content_item_id: draft.id, payload_version: "1" }
+        )
+      }.to raise_error(CommandError)
+    end
 
-      if expectation.fetch(:raises_error)
-        it "raises an error" do
-          expect { do_request }.to raise_error(CommandError)
-        end
-      else
-        it "does not raise an error" do
-          expect { do_request }.to_not raise_error
-        end
-      end
+    it "allows draft content items to be sent to the draft content store" do
+      draft = FactoryGirl.create(:draft_content_item)
 
-      if expectation.fetch(:logs_to_airbrake)
-        it "logs the response to airbrake" do
-          expect(Airbrake).to receive(:notify_or_ignore)
-          do_request rescue CommandError
-        end
-      else
-        it "does not log the response to airbrake" do
-          expect(Airbrake).to_not receive(:notify_or_ignore)
-          do_request rescue CommandError
-        end
-      end
+      expect {
+        subject.perform(
+          content_store: "Adapters::DraftContentStore",
+          payload: { content_item_id: draft.id, payload_version: "1" }
+        )
+      }.not_to raise_error
+    end
+
+    it "allows live content items to be sent to the live content store" do
+      live = FactoryGirl.create(:live_content_item)
+
+      expect {
+        subject.perform(
+          content_store: "Adapters::ContentStore",
+          payload: { content_item_id: live.id, payload_version: "1" }
+        )
+      }.not_to raise_error
+    end
+
+    it "allows live content items to be sent to the draft content store" do
+      live = FactoryGirl.create(:live_content_item)
+
+      expect {
+        subject.perform(
+          content_store: "Adapters::DraftContentStore",
+          payload: { content_item_id: live.id, payload_version: "1" }
+        )
+      }.not_to raise_error
     end
   end
 end


### PR DESCRIPTION
Prevents draft content items from being sent to the
live content store at the worker level, reducing
the chance of doing so accidentally in the future.