### PR TITLE
Add a /debug endpoint to help debug content issues

### DIFF
--- a/app/controllers/debug_controller.rb
+++ b/app/controllers/debug_controller.rb
@@ -1,0 +1,5 @@
+class DebugController < ApplicationController
+  def show
+    @presenter = Presenters::DebugPresenter.new(params[:content_id])
+  end
+end

--- a/app/controllers/debug_controller.rb
+++ b/app/controllers/debug_controller.rb
@@ -1,4 +1,6 @@
 class DebugController < ApplicationController
+  skip_before_action :require_signin_permission!
+
   def show
     @presenter = Presenters::DebugPresenter.new(params[:content_id])
   end

--- a/app/presenters/debug_presenter.rb
+++ b/app/presenters/debug_presenter.rb
@@ -1,0 +1,96 @@
+module Presenters
+  class DebugPresenter
+    attr_reader :content_id
+
+    def initialize(content_id)
+      @content_id = content_id
+    end
+
+    def content_items
+      @content_items ||= ContentItem.where(content_id: content_id)
+    end
+
+    def user_facing_versions
+      UserFacingVersion.join_content_items(content_items).pluck("user_facing_versions.number")
+    end
+
+    def locales
+      State.join_content_items(
+        Translation
+        .join_content_items(content_items))
+        .reorder('')
+        .select("locale, content_items.id as id, states.name as state")
+    end
+
+    def latest_content_items
+      ::Queries::GetLatest.call(content_items)
+    end
+
+    def latest_state_with_locale
+      Translation.join_content_items(State.join_content_items(latest_content_items)).pluck("translations.locale, states.name")
+    end
+
+    def link_set
+      @link_set ||= LinkSet.find_by(content_id: content_id)
+    end
+
+    def expanded_links
+      links = ::Queries::GetExpandedLinks.call(content_id, "en")
+      rows = []
+      rows << [links[:content_id], '', 'current']
+      links[:expanded_links].each do |type, sub_links|
+        rows << [type, links[:content_id], 'current']
+        sub_links.each do |link|
+          rows << [
+            {
+              v: (link[:content_id].to_s + type.to_s),
+              f: "<a href='debug?content_id=#{link[:content_id]}'>#{link[:content_id]}</a>"
+            },
+            type,
+            ''
+          ]
+        end
+      end
+
+      rows
+    end
+
+    def states
+      @states = []
+      locales.group_by(&:locale).each do |locale, local_states|
+        @states << [locale, '', '']
+        @states << [{ v: local_states.first.id.to_s, f: local_states.first.state }, locale, '']
+        local_states[1..-1].each_with_index do |state, index|
+          @states << [{ v: state.id.to_s, f: state.state }, local_states[(index + 1) - 1].try(:id).to_s, '']
+        end
+      end
+      @states
+    end
+
+    def event_timeline
+      events.map do |event|
+        [event.action, '', event.id.to_s, event.created_at, event.created_at + 1.second]
+      end
+    end
+
+    def web_content_item
+      WebContentItem.new(latest_content_items.last)
+    end
+
+    def web_url
+      web_content_item.web_url
+    end
+
+    def title
+      web_content_item.title
+    end
+
+    def api_url
+      web_content_item.api_url
+    end
+
+    def events
+      Event.where(content_id: content_id).order(:created_at)
+    end
+  end
+end

--- a/app/views/debug/show.html.erb
+++ b/app/views/debug/show.html.erb
@@ -1,0 +1,118 @@
+<script type="text/javascript" src="https://www.gstatic.com/charts/loader.js"></script>
+<script type="text/javascript">
+  google.charts.load('current', {packages:["orgchart", "timeline"]});
+  google.charts.setOnLoadCallback(drawChart);
+
+  var links = <%=raw @presenter.expanded_links.to_json %>;
+      states = <%=raw @presenter.states.to_json %>,
+      events = <%=raw @presenter.event_timeline.to_json %>,
+      event_timeline,
+      event_table,
+      links_chart,
+      links_table;
+
+  function drawChart() {
+    var eventColumns = [
+      { type: 'string', id: 'event' },
+      { type: 'string', id: 'id' },
+      { type: 'string', role: 'tooltip' },
+      { type: 'date', id: 'start' },
+      { type: 'date', id: 'end' }
+    ];
+
+    var states_table = createTable([['base_path', 'string'], ['link', 'string'], ['content_id', 'string']]),
+        states_chart = new google.visualization.OrgChart(document.getElementById('states_chart_div')),
+        event_dates = events.map(function(event){ return [event[0], event[1], event[2], new Date(event[3]), new Date(event[4])] });
+
+    event_timeline = new google.visualization.Timeline(document.getElementById('events_chart_div'));
+    event_table = createTimelineTable(eventColumns);
+    links_chart = new google.visualization.OrgChart(document.getElementById('links_chart_div')),
+    links_table = createTable([['base_path', 'string'], ['link', 'string'], ['content_id', 'string']]),
+
+    links_table.addRows(links);
+    states_table.addRows(states);
+    event_table.addRows(event_dates);
+
+    links_chart.draw(links_table, {allowHtml:true});
+    states_chart.draw(states_table, {allowHtml:true});
+
+    google.visualization.events.addListener(links_chart, 'select', selectLinksHandler);
+    google.visualization.events.addListener(event_timeline, 'select', selectHandler);
+
+    event_timeline.draw(event_table, {allowHtml:true, tooltip: {trigger: 'selection'}});
+  };
+
+  function selectLinksHandler(a,b,c,d) {
+    selection = links_chart.getSelection()[0].row;
+    data = links_table.getValue(selection, 0);
+  }
+
+  function selectHandler() {
+    selection = event_timeline.getSelection()[0].row;
+    data = event_table.getValue(selection, 2);
+    events = document.getElementsByClassName('events');
+
+    for (i = 0; i < events.length; i++) {
+      events[i].style.backgroundColor = "#fff";
+    }
+
+    el = document.getElementById(data);
+    el.style.backgroundColor = '#E2B4B4';
+    el.scrollIntoView();
+  }
+
+  function createTimelineTable(columns) {
+    var table = new google.visualization.DataTable();
+    columns.forEach(function(column) {
+      table.addColumn(column);
+    });
+    return table;
+  }
+
+  function createTable(columns) {
+    var table = new google.visualization.DataTable();
+    columns.forEach(function(column) {
+      table.addColumn(column[1], column[0]);
+    });
+    return table;
+  };
+</script>
+
+<div style="width: 90%; margin: auto;">
+  <h2 style='text-align:center'>links</h2>
+  <div id="links_chart_div"></div>
+  <h2 style='text-align:center'>states</h2>
+  <div id="states_chart_div"></div>
+  <h2 style='text-align:center'>events</h2>
+  <div id="events_chart_div" ></div>
+
+  <h3>Title</h3>
+  <div>
+    <%= @presenter.title  %>
+  </div>
+
+  <h3>Web</h3>
+  <%= link_to 'web', @presenter.web_url  %>
+
+  <h3>JSON</h3>
+  <%= link_to 'json', @presenter.api_url  %>
+
+  <h3>Current state</h3>
+  <%= @presenter.latest_state_with_locale %>
+
+  <h3>User facing verisons</h3>
+  <%= @presenter.user_facing_versions %>
+
+  <h3>Events</h3>
+  <% @presenter.events.each do |event| %>
+    <div class='events' id="<%= event.id  %>">
+      <p><b><%= event.action %></b>, <%= event.created_at.strftime("%Y-%m-%d %H:%I:%S") %><br />
+      <span class='payload' >
+        <% event.payload.each do |k,v| %>
+          <%= k %>: <%= v %> <br />
+        <% end %>
+      <span>
+      </p>
+    </div>
+  <% end %>
+</div>

--- a/app/views/debug/show.html.erb
+++ b/app/views/debug/show.html.erb
@@ -1,9 +1,29 @@
+<style>
+table {
+  border-collapse: collapse;
+  margin-bottom: 10px;
+}
+
+table, th, td {
+  border: 1px solid #000;
+  padding: 2px;
+}
+
+table tr:nth-child(1) td:nth-child(2) {
+  font-weight: bold;
+}
+
+table.inner {
+  border: 1px solid red;
+}
+
+</style>
 <script type="text/javascript" src="https://www.gstatic.com/charts/loader.js"></script>
 <script type="text/javascript">
   google.charts.load('current', {packages:["orgchart", "timeline"]});
   google.charts.setOnLoadCallback(drawChart);
 
-  var links = <%=raw @presenter.expanded_links.to_json %>;
+  var links = <%=raw @presenter.expanded_links.to_json %>,
       states = <%=raw @presenter.states.to_json %>,
       events = <%=raw @presenter.event_timeline.to_json %>,
       event_timeline,
@@ -20,7 +40,7 @@
       { type: 'date', id: 'end' }
     ];
 
-    var states_table = createTable([['base_path', 'string'], ['link', 'string'], ['content_id', 'string']]),
+    var states_table = createTable([['base_path', 'string'], ['link', 'string']]),
         states_chart = new google.visualization.OrgChart(document.getElementById('states_chart_div')),
         event_dates = events.map(function(event){ return [event[0], event[1], event[2], new Date(event[3]), new Date(event[4])] });
 
@@ -106,13 +126,7 @@
   <h3>Events</h3>
   <% @presenter.events.each do |event| %>
     <div class='events' id="<%= event.id  %>">
-      <p><b><%= event.action %></b>, <%= event.created_at.strftime("%Y-%m-%d %H:%I:%S") %><br />
-      <span class='payload' >
-        <% event.payload.each do |k,v| %>
-          <%= k %>: <%= v %> <br />
-        <% end %>
-      <span>
-      </p>
+      <%= @presenter.event_presenter(event.attributes.except('id')) %>
     </div>
   <% end %>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,5 +34,5 @@ Rails.application.routes.draw do
   end
 
   get '/healthcheck', to: proc { [200, {}, ['OK']] }
-  get '/debug', to: "debug#show"
+  get '/debug/:content_id', to: "debug#show"
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,4 +34,5 @@ Rails.application.routes.draw do
   end
 
   get '/healthcheck', to: proc { [200, {}, ['OK']] }
+  get '/debug', to: "debug#show"
 end


### PR DESCRIPTION
Graph of expanded link representation
Graph of states
Timeline of events which link to the specific event
Links to web representation and show other useful information

https://trello.com/c/INzLJqNi/726-add-a-debug-html-endpoint-to-help-developers-debug-content-issues

![screen shot 2016-06-03 at 14 47 16](https://cloud.githubusercontent.com/assets/288481/15780694/d176a32c-299a-11e6-91f2-d0dc15e971cf.png)

![screen shot 2016-06-06 at 10 51 57](https://cloud.githubusercontent.com/assets/288481/15819044/ae971356-2bd8-11e6-9941-458876ccc9a2.png)
