### PR TITLE
Correct the order of grouped content results

### DIFF
--- a/app/queries/get_grouped_content_and_links.rb
+++ b/app/queries/get_grouped_content_and_links.rb
@@ -33,7 +33,7 @@ module Queries
         page_size: page_size
       )
 
-      group_results(content_results(content_ids), link_set_results(content_ids))
+      group_results(content_ids, content_results(content_ids), link_set_results(content_ids))
     end
 
   private
@@ -55,14 +55,14 @@ module Queries
       page.pluck(:content_id)
     end
 
-    def group_results(content_results, link_set_results)
+    def group_results(content_ids, content_results, link_set_results)
       grouped_content_items = group_by_content_id(content_results)
       grouped_links = group_by_content_id(link_set_results)
 
-      grouped_content_items.map do |content_id, content_items|
+      content_ids.map do |content_id|
         {
           "content_id" => content_id,
-          "content_items" => content_items,
+          "content_items" => grouped_content_items[content_id],
           "links" => grouped_links[content_id] || []
         }
       end

--- a/spec/queries/get_grouped_content_and_links_spec.rb
+++ b/spec/queries/get_grouped_content_and_links_spec.rb
@@ -28,6 +28,17 @@ RSpec.describe Queries::GetGroupedContentAndLinks do
       end
     end
 
+    context "when many content ids are returned" do
+      it "returns content ids in lexicographic order" do
+        create_content_items(described_class::PAGE_SIZE + 1)
+
+        content_ids = subject.call.map { |result| result['content_id'] }
+        content_ids.each_cons(2) do |a, b|
+          expect(a).to be < b
+        end
+      end
+    end
+
     context "when no pagination is specified" do
       it "returns page with default page size" do
         create_content_items(described_class::PAGE_SIZE + 1)
@@ -195,18 +206,18 @@ RSpec.describe Queries::GetGroupedContentAndLinks do
             expect(results[0]).to include("links")
             expect(results[0]["links"]).to eq([
               {
-                "content_id" => ordered_content_ids.last,
-                "link_type"  => "topics",
-                "target_content_id" => second_target_content_id,
+                "content_id" => ordered_content_ids.first,
+                "link_type" => "topics",
+                "target_content_id" => first_target_content_id,
               }
             ])
 
             expect(results[1]).to include("links")
             expect(results[1]["links"]).to eq([
               {
-                "content_id" => ordered_content_ids.first,
-                "link_type"  => "topics",
-                "target_content_id" => first_target_content_id,
+                "content_id" => ordered_content_ids.last,
+                "link_type" => "topics",
+                "target_content_id" => second_target_content_id,
               }
             ])
           end


### PR DESCRIPTION
The order of the results for the groupd_content_and_links
endpoint was incorrect.
This meant that any client code would have a hard time paging
because the last_seen_content_id which determines which page
comes next would be wrongly reported.

@matmoore and @benhyland