### PR TITLE
Fix validation failure on redirects

### DIFF
--- a/app/commands/v2/publish.rb
+++ b/app/commands/v2/publish.rb
@@ -127,7 +127,7 @@ module Commands
           downstream: downstream,
           callbacks: callbacks,
           nested: true,
-        )
+        ) if draft_redirect
       end
 
       def lookup_published_item(content_item)

--- a/app/commands/v2/put_content.rb
+++ b/app/commands/v2/put_content.rb
@@ -43,7 +43,6 @@ module Commands
             create_redirect(
               from_path: from_path,
               to_path: base_path,
-              locale: locale,
               routes: previous_routes,
             )
           end
@@ -72,7 +71,6 @@ module Commands
           create_redirect(
             from_path: from_path,
             to_path: base_path,
-            locale: locale,
             routes: previous_routes,
           )
         end
@@ -220,12 +218,11 @@ module Commands
         lock_version.save!
       end
 
-      def create_redirect(from_path:, to_path:, locale:, routes:)
+      def create_redirect(from_path:, to_path:, routes:)
         RedirectHelper.create_redirect(
           publishing_app: publishing_app,
           old_base_path: from_path,
           new_base_path: to_path,
-          locale: locale,
           routes: routes,
           callbacks: callbacks,
         )

--- a/app/helpers/redirect_helper.rb
+++ b/app/helpers/redirect_helper.rb
@@ -1,9 +1,8 @@
 module RedirectHelper
-  def self.create_redirect(old_base_path:, new_base_path:, publishing_app:, callbacks:, content_id: nil, locale: "en", routes: [])
+  def self.create_redirect(old_base_path:, new_base_path:, publishing_app:, callbacks:, content_id: nil, routes: [])
     payload = {
       content_id: content_id || SecureRandom.uuid,
       base_path: old_base_path,
-      locale: locale,
       format: 'redirect',
       public_updated_at: Time.zone.now,
       redirects: redirects_for(routes, old_base_path, new_base_path),


### PR DESCRIPTION
When an item is automatically redirected, don't send a `locale` parameter as it is not a permitted field.