### PR TITLE
Delete HTML publications from publishing api

### DIFF
--- a/db/migrate/20160606142809_delete_html_publications.rb
+++ b/db/migrate/20160606142809_delete_html_publications.rb
@@ -1,0 +1,26 @@
+class DeleteHtmlPublications < ActiveRecord::Migration
+  def up
+    # Safety check to ensure this doesn't get run more than once.
+    # At time of writing, the max content_item_id in production
+    # is 796460. Refuse to run this migration if there are no
+    # HTML publications lower than this ID, as this means that
+    # this migration has already been run.
+
+    return if ContentItem.where("id < 796460").where(document_type: "html_publication").empty?
+
+    ContentItem.transaction do
+      results = ContentItem.where(document_type: "html_publication").pluck(:id, :content_id)
+      ids = results.map { |r| r[0] }.uniq
+      content_ids = results.map { |r| r[1] }.uniq
+
+      State.where(content_item_id: ids).delete_all
+      Location.where(content_item_id: ids).delete_all
+      Translation.where(content_item_id: ids).delete_all
+      UserFacingVersion.where(content_item_id: ids).delete_all
+      ContentItem.where(id: ids).delete_all
+
+      Link.joins(:link_set).where(link_sets: {content_id: content_ids}).delete_all
+      LinkSet.where(content_id: content_ids).delete_all
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160601134855) do
+ActiveRecord::Schema.define(version: 20160606142809) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
Due to the various stages of migration of HTML publications, it's best to clear out the partially migrated content items and start from scratch. Example reasons we need to do this:

- Some HTML publications had different content ids across their various editions
- Some HTML publications had their locale set to en when it wasn't, which causes `patch_link_set` calls to send the wrong locale to the Content Store

These are not currently used anywhere in production code. I've included a safety check to prevent this migration being run twice accidentally in production.

Q: This covers links and supporting objects. Are there other tables I should be deleting rows from?

/cc @elliotcm 