### PR TITLE
Make rcov optional (and enable in jenkins).

### DIFF
--- a/jenkins.sh
+++ b/jenkins.sh
@@ -45,6 +45,7 @@ bundle exec govuk-lint-ruby \
 
 bundle exec rake db:drop db:create db:schema:load
 
+export RCOV=1
 if bundle exec rake ${TEST_TASK:-"default"}; then
   if [ -n "$PACT_TARGET_BRANCH" ]; then
     bundle exec rake pact:publish:branch

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,8 +1,12 @@
-require 'simplecov'
-require 'simplecov-rcov'
+if ENV["RCOV"]
+  require 'simplecov'
+  require 'simplecov-rcov'
+  SimpleCov.formatter = SimpleCov::Formatter::RcovFormatter
+  SimpleCov.start 'rails'
+end
+
 require 'pry'
-SimpleCov.formatter = SimpleCov::Formatter::RcovFormatter
-SimpleCov.start 'rails'
+
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 ENV['RAILS_ENV'] ||= 'test'
 require File.expand_path('../../config/environment', __FILE__)


### PR DESCRIPTION
Rcov and/or rbenv seem to have a bug which causes
it to take a very long time to do its coverage on
some systems.

We (almost?) never use this coverage locally so
we can disable it everywhere except jenkins or on
the machines of people who are using it for
something (if any).