### PR TITLE
Remove state scope from GetContent query

### DIFF
--- a/app/queries/get_content.rb
+++ b/app/queries/get_content.rb
@@ -5,7 +5,6 @@ module Queries
 
       content_items = ContentItem.where(content_id: content_id)
       content_items = Translation.filter(content_items, locale: locale)
-      content_items = State.filter(content_items, name: %w(draft published))
 
       response = Presenters::Queries::ContentItemPresenter.present_many(content_items).first
 

--- a/spec/queries/get_content_spec.rb
+++ b/spec/queries/get_content_spec.rb
@@ -74,9 +74,9 @@ RSpec.describe Queries::GetContent do
       )
     end
 
-    it "excludes content items that aren't in draft or published states" do
+    it "includes these content items" do
       result = subject.call(content_id)
-      expect(result.fetch("title")).to eq("Published Title")
+      expect(result.fetch("title")).to eq("Submitted Title")
     end
   end
 


### PR DESCRIPTION
https://trello.com/c/NfUjL6lz/735-unblock-sp-team-ability-to-retrieve-a-single-content-item-that-has-been-unpublished

The content item index endpoint doesn't apply a default state filter, so remove it from the get content item endpoint as publishing apps have the need to get unpublished content, eg. withdrawn items.