### PR TITLE
Ensure draft content is not exposed via expanded links

### DIFF
--- a/app/adapters/content_store.rb
+++ b/app/adapters/content_store.rb
@@ -2,7 +2,7 @@
 # to
 module Adapters
   class ContentStore
-    DEPENDENCY_FALLBACK_ORDER = [:published]
+    DEPENDENCY_FALLBACK_ORDER = [:published].freeze
 
     def self.put_content_item(base_path, content_item)
       CommandError.with_error_handling do

--- a/spec/adapters/content_store_spec.rb
+++ b/spec/adapters/content_store_spec.rb
@@ -1,0 +1,15 @@
+require "rails_helper"
+
+RSpec.describe Adapters::ContentStore do
+  describe "DEPENDENCY_FALLBACK_ORDER" do
+    it "should only fallback to :published for the live content store" do
+      expect(described_class::DEPENDENCY_FALLBACK_ORDER).to eq([:published])
+    end
+
+    it "cannot be modified" do
+      expect {
+        described_class::DEPENDENCY_FALLBACK_ORDER.unshift(:draft)
+      }.to raise_error(RuntimeError, "can't modify frozen Array")
+    end
+  end
+end

--- a/spec/presenters/queries/expanded_link_set_spec.rb
+++ b/spec/presenters/queries/expanded_link_set_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe Presenters::Queries::ExpandedLinkSet do
       end
     end
 
-    context "a connected acylic graph" do
+    context "a connected acyclic graph" do
       it "expands the links for node a correctly" do
         create_link(a, b, "parent")
         create_link(b, c, "parent")

--- a/spec/presenters/queries/expanded_link_set_spec.rb
+++ b/spec/presenters/queries/expanded_link_set_spec.rb
@@ -202,6 +202,30 @@ RSpec.describe Presenters::Queries::ExpandedLinkSet do
       end
     end
 
+    context "when a published content item is linked to content in draft" do
+      before do
+        create_link(a, b, "related")
+        create_content_item(a, "/a-published", "published")
+        create_content_item(b, "/b-draft", "draft")
+      end
+
+      context "with a fallback to published" do
+        let(:state_fallback_order) { [:published] }
+
+        it "does not expose the draft item in expanded links" do
+          expect(expanded_links[:related]).not_to match(a_hash_including(base_path: "/b-draft"))
+        end
+      end
+
+      context "with a fallback to draft" do
+        let(:state_fallback_order) { [:draft, :published] }
+
+        it "exposes the draft item in expanded links" do
+          expect(expanded_links[:related]).to match([a_hash_including(base_path: "/b-draft")])
+        end
+      end
+    end
+
     context "when one of the recursive content items does not match the provided state" do
       before do
         create_link(a, b, "parent")
@@ -346,10 +370,10 @@ RSpec.describe Presenters::Queries::ExpandedLinkSet do
     let(:state_fallback_order) { [:draft, :published] }
 
     before do
-      create_content_item(a, "/a")
-      create_content_item(b, "/b")
-      create_content_item(c, "/c")
-      create_content_item(d, "/d")
+      create_content_item(a, "/a-draft", "draft")
+      create_content_item(b, "/b-published")
+      create_content_item(c, "/c-published")
+      create_content_item(d, "/d-published")
 
       create_link(d, c, "parent")
       create_link(c, b, "parent")
@@ -359,15 +383,25 @@ RSpec.describe Presenters::Queries::ExpandedLinkSet do
     it "automatically expands reverse dependencies to one level of depth" do
       expect(expanded_links[:children]).to match([
         a_hash_including(
-          base_path: "/b",
+          base_path: "/b-published",
           expanded_links: a_hash_including(
             parent: [a_hash_including(
-              base_path: "/a",
+              base_path: "/a-draft",
               expanded_links: anything,
             )]
           )
         )
       ])
+    end
+
+    context "with a state fallback to published" do
+      let(:state_fallback_order) { [:published] }
+
+      it "excludes draft dependees" do
+        expect(expanded_links[:children]).to match([
+          a_hash_including(base_path: "/b-published", expanded_links: {})
+        ])
+      end
     end
   end
 end


### PR DESCRIPTION
https://trello.com/c/dCPy2Gyj/737-ensure-link-expansion-doesn-t-include-draft-content-in-dependency-resolution

- Adds a couple of tests to assert that link expansion, when properly configured, will not expose draft content to the live content store.
- Freezes the dependency state fallback order as this is holds the configuration for draft and live content stores.