### PR TITLE
Allow the lookup-by-base-path endpoint to work for 'unpublished' content

### DIFF
--- a/app/controllers/lookups_controller.rb
+++ b/app/controllers/lookups_controller.rb
@@ -1,7 +1,12 @@
 class LookupsController < ApplicationController
   def by_base_path
+    # return content_ids for content that is visible on the live site
+    # withdrawn items are still visible
+    states = %w(published unpublished)
+    base_paths = params.fetch(:base_paths)
+
     base_paths_and_content_ids = ContentItemFilter
-      .filter(state: "published", base_path: params.fetch(:base_paths))
+      .filter(state: states, base_path: base_paths)
       .pluck(:base_path, :content_id)
       .uniq
 

--- a/spec/requests/lookups_spec.rb
+++ b/spec/requests/lookups_spec.rb
@@ -1,24 +1,40 @@
 require "rails_helper"
 
 RSpec.describe "POST /lookup-by-base-path", type: :request do
-  it "returns content_ids for base_paths" do
-    FactoryGirl.create(:content_item, state: "published", base_path: "/my-page", content_id: "b9b2da0a-ec50-4b0e-b29c-b7cbc8195307")
-    FactoryGirl.create(:content_item, state: "draft", base_path: "/my-page", content_id: "f7cdb359-c8ab-4d6d-b1f0-5c5640b24c09")
-    FactoryGirl.create(:content_item, state: "published", base_path: "/other-page", content_id: "b879bcdb-6160-4bfd-b758-f546bbb408c4")
+  context "validating" do
+    it "requires a base_paths param" do
+      expected_error_response = { "error" => { "code" => 422, "message" => "param is missing or the value is empty: base_paths" } }
 
-    post "/lookup-by-base-path", base_paths: ["/my-page", "/other-page", "/does-not-exist"]
+      post "/lookup-by-base-path"
 
-    expect(parsed_response).to eql(
-      "/my-page" => "b9b2da0a-ec50-4b0e-b29c-b7cbc8195307",
-      "/other-page" => "b879bcdb-6160-4bfd-b758-f546bbb408c4",
-    )
+      expect(parsed_response).to eql(expected_error_response)
+    end
   end
 
-  it "requires a base_paths param" do
-    post "/lookup-by-base-path"
+  context "returning content_ids" do
+    it "returns content_ids for user-visible states (published, unpublished)" do
+      create_test_content
 
-    expect(parsed_response).to eql(
-      "error" => { "code" => 422, "message" => "param is missing or the value is empty: base_paths" }
-    )
+      post "/lookup-by-base-path", base_paths: test_base_paths
+
+      expect(parsed_response).to eql(
+        "/published-and-draft-page" => "aa491126-77ed-4e81-91fa-8dc7f74e9657",
+        "/only-published-page" => "bbabcd3c-7c45-4403-8490-db51e4bfc4f6",
+        "/only-unpublished-page" => "cc6d416c-f369-4b7c-bac7-5e9401e79362",
+      )
+    end
+  end
+
+  def create_test_content
+    FactoryGirl.create(:content_item, state: "published", base_path: "/published-and-draft-page", content_id: "aa491126-77ed-4e81-91fa-8dc7f74e9657")
+    FactoryGirl.create(:content_item, state: "draft", base_path: "/published-and-draft-page", content_id: "aa491126-77ed-4e81-91fa-8dc7f74e9657")
+    FactoryGirl.create(:content_item, state: "published", base_path: "/only-published-page", content_id: "bbabcd3c-7c45-4403-8490-db51e4bfc4f6")
+    FactoryGirl.create(:content_item, state: "unpublished", base_path: "/only-unpublished-page", content_id: "cc6d416c-f369-4b7c-bac7-5e9401e79362")
+    FactoryGirl.create(:content_item, state: "draft", base_path: "/draft-and-superseded-page", content_id: "dd1bf833-f91c-4e45-9f97-87b165808176")
+    FactoryGirl.create(:content_item, state: "superseded", base_path: "/draft-and-superseded-page", content_id: "dd1bf833-f91c-4e45-9f97-87b165808176")
+  end
+
+  def test_base_paths
+    ["/published-and-draft-page", "/only-published-page", "/only-unpublished-page", "/draft-and-superseded-page", "/does-not-exist"]
   end
 end


### PR DESCRIPTION
The endpoint was created when there were fewer states.
The main client is currently content-tagger, which is concerned
with tagging all user-visible content. This includes 'unpublished' items,
since items that have been withdrawn are still user-visible.