### PR TITLE
Fix Unpublishing update bug

### DIFF
--- a/app/models/state.rb
+++ b/app/models/state.rb
@@ -33,6 +33,7 @@ class State < ActiveRecord::Base
         explanation: explanation,
         alternative_path: alternative_path,
       )
+      unpublishing
     else
       Unpublishing.create!(
         content_item: content_item,

--- a/spec/models/state_spec.rb
+++ b/spec/models/state_spec.rb
@@ -97,6 +97,35 @@ RSpec.describe State do
       expect(unpublishing.explanation).to eq("A test explanation")
       expect(unpublishing.alternative_path).to eq("/some-path")
     end
+
+    it "updates an existing unpublishing" do
+      unpublishing = nil
+      expect {
+        unpublishing = described_class.unpublish(live_item,
+                                  type: "gone",
+                                  explanation: "A test explanation",
+                                  alternative_path: "/some-path",
+        )
+      }.to change(Unpublishing, :count).by(1)
+
+      last_unpublishing = Unpublishing.last
+      expect(unpublishing).to eq(last_unpublishing)
+      expect(unpublishing.type).to eq("gone")
+
+      # successfully created an unpublishing, now try to modify it
+      expect {
+        unpublishing = described_class.unpublish(live_item,
+                                  type: "redirect",
+                                  explanation: "A test explanation",
+                                  alternative_path: "/redirected-some-path",
+        )
+      }.to change(Unpublishing, :count).by(0)
+
+      last_unpublishing = Unpublishing.last
+      expect(unpublishing).to eq(last_unpublishing)
+      expect(unpublishing.type).to eq("redirect")
+      expect(unpublishing.alternative_path).to eq("/redirected-some-path")
+    end
   end
 
   describe ".substitute" do


### PR DESCRIPTION
When updating an existing Unpublshing record, we erroneously returned
a boolean from `update_attributes` instead of returning the updated object.
Add a test and return the value expected by client code.

@benhyland and @davidslv