### PR TITLE
Add last_edited_at to content item

### DIFF
--- a/app/commands/v2/put_content.rb
+++ b/app/commands/v2/put_content.rb
@@ -62,6 +62,7 @@ module Commands
         check_version_and_raise_if_conflicting(content_item, payload[:previous_version])
 
         update_content_item(content_item)
+        update_last_edited_at_if_needed(content_item, payload[:last_edited_at])
         increment_lock_version(content_item)
 
         if path_has_changed?(previous_location)
@@ -219,6 +220,14 @@ module Commands
       def update_content_item(content_item)
         content_item.assign_attributes_with_defaults(content_item_attributes_from_payload)
         content_item.save!
+      end
+
+      def update_last_edited_at_if_needed(content_item, last_edited_at = nil)
+        if last_edited_at.nil? && ["major", "minor"].include?(payload[:update_type])
+          last_edited_at = Time.zone.now
+        end
+
+        content_item.update_attributes(last_edited_at: last_edited_at) if last_edited_at
       end
 
       def increment_lock_version(content_item)

--- a/app/commands/v2/put_content.rb
+++ b/app/commands/v2/put_content.rb
@@ -223,7 +223,7 @@ module Commands
       end
 
       def update_last_edited_at_if_needed(content_item, last_edited_at = nil)
-        if last_edited_at.nil? && ["major", "minor"].include?(payload[:update_type])
+        if last_edited_at.nil? && %w(major minor).include?(payload[:update_type])
           last_edited_at = Time.zone.now
         end
 

--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -12,6 +12,7 @@ class ContentItem < ActiveRecord::Base
     :details,
     :document_type,
     :first_published_at,
+    :last_edited_at,
     :need_ids,
     :phase,
     :public_updated_at,

--- a/app/models/default_attributes.rb
+++ b/app/models/default_attributes.rb
@@ -6,6 +6,7 @@ module DefaultAttributes
     :created_at,
     :updated_at,
     :first_published_at,
+    :last_edited_at,
   ].freeze
 
   included do

--- a/app/pagination.rb
+++ b/app/pagination.rb
@@ -71,6 +71,7 @@ private
       :content_id,
       :document_type,
       :format,
+      :last_edited_at,
       :locale,
       :public_updated_at,
       :publishing_app,

--- a/app/pagination.rb
+++ b/app/pagination.rb
@@ -67,14 +67,14 @@ private
   # will be hampered.
   def valid_order_fields
     [
+      :base_path,
       :content_id,
       :document_type,
       :format,
+      :locale,
       :public_updated_at,
       :publishing_app,
       :rendering_app,
-      :base_path,
-      :locale,
       :updated_at,
     ]
   end

--- a/app/presenters/downstream_presenter.rb
+++ b/app/presenters/downstream_presenter.rb
@@ -14,6 +14,7 @@ module Presenters
     def present
       symbolized_attributes
         .slice(*content_item.class::TOP_LEVEL_FIELDS)
+        .except(:last_edited_at) # only intended to be used by publishing applications
         .merge(first_published_at)
         .merge(public_updated_at)
         .merge(links)

--- a/app/presenters/queries/content_item_presenter.rb
+++ b/app/presenters/queries/content_item_presenter.rb
@@ -94,6 +94,8 @@ module Presenters
             "description->>'value' AS description"
           when :internal_name
             "#{internal_name_sql} AS internal_name"
+          when :last_edited_at
+            "to_char(last_edited_at, '#{iso8601_sql}') as last_edited_at"
           when :public_updated_at
             "to_char(public_updated_at, '#{iso8601_sql}') as public_updated_at"
           when :first_published_at

--- a/db/migrate/20160614144815_add_last_edited_at_to_content_item.rb
+++ b/db/migrate/20160614144815_add_last_edited_at_to_content_item.rb
@@ -1,0 +1,6 @@
+class AddLastEditedAtToContentItem < ActiveRecord::Migration
+  def change
+    add_column :content_items, :last_edited_at, :datetime
+    add_index :content_items, :last_edited_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160607153243) do
+ActiveRecord::Schema.define(version: 20160614144815) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -42,10 +42,12 @@ ActiveRecord::Schema.define(version: 20160607153243) do
     t.string   "document_type"
     t.string   "schema_name"
     t.datetime "first_published_at"
+    t.datetime "last_edited_at"
   end
 
   add_index "content_items", ["content_id"], name: "index_content_items_on_content_id", using: :btree
   add_index "content_items", ["document_type"], name: "index_content_items_on_document_type", using: :btree
+  add_index "content_items", ["last_edited_at"], name: "index_content_items_on_last_edited_at", using: :btree
   add_index "content_items", ["public_updated_at"], name: "index_content_items_on_public_updated_at", using: :btree
   add_index "content_items", ["publishing_app"], name: "index_content_items_on_publishing_app", using: :btree
   add_index "content_items", ["rendering_app"], name: "index_content_items_on_rendering_app", using: :btree

--- a/doc/semantics-of-the-publishing-api.md
+++ b/doc/semantics-of-the-publishing-api.md
@@ -338,6 +338,26 @@ front-end application, when the content item is rendered.
 
 ---
 
+### last_edited_at
+
+Example: *2015-01-01T12:00:00Z*
+
+Required: No
+
+The `last_edited_at` records the last time that the content received a major or
+minor update. This can be used by the publishing applications as a ordering
+parameter and shown to editors.
+
+If the `last_updated_at` is specified when PUTing content, the given value will
+be stored. If `last_updated_at` is not specified, and the update type is major
+or minor, the `last_updated_at` will be set to the current time. For any other
+update type, the `last_updated_at` will be unchanged.
+
+The `last_edited_at` must use the [ISO 8601
+format](https://en.wikipedia.org/wiki/ISO_8601).
+
+---
+
 ### links
 
 Example: *{ “related”: [“8242a29f-8ad1-4fbe-9f71-f9e57ea5f1ea”] }*

--- a/lib/tasks/set_last_edited_at.rake
+++ b/lib/tasks/set_last_edited_at.rake
@@ -1,0 +1,6 @@
+desc "Sets last_edited_at for each content item with the value from public_updated_at"
+task set_last_edited_at: :environment do
+  sql = "UPDATE content_items SET last_edited_at = public_updated_at;"
+
+  ActiveRecord::Base.connection.execute(sql)
+end

--- a/spec/commands/v2/put_content_spec.rb
+++ b/spec/commands/v2/put_content_spec.rb
@@ -849,6 +849,21 @@ RSpec.describe Commands::V2::PutContent do
 
           expect(content_item.last_edited_at.iso8601).to eq(last_edited_at.iso8601)
         end
+
+        context "with update_type not major or minor" do
+          it "stores the provided timestamp" do
+            last_edited_at = 1.year.ago
+
+            described_class.call(payload.merge(
+                                   update_type: "republish",
+                                   last_edited_at: last_edited_at
+                                 ))
+
+            content_item.reload
+
+            expect(content_item.last_edited_at.iso8601).to eq(last_edited_at.iso8601)
+          end
+        end
       end
     end
 

--- a/spec/commands/v2/put_content_spec.rb
+++ b/spec/commands/v2/put_content_spec.rb
@@ -820,8 +820,8 @@ RSpec.describe Commands::V2::PutContent do
           last_edited_at = 1.year.ago
 
           described_class.call(payload.merge(
-            last_edited_at: last_edited_at
-          ))
+                                 last_edited_at: last_edited_at
+                              ))
 
           content_item = ContentItem.last
 
@@ -842,8 +842,8 @@ RSpec.describe Commands::V2::PutContent do
           last_edited_at = 1.year.ago
 
           described_class.call(payload.merge(
-            last_edited_at: last_edited_at
-          ))
+                                 last_edited_at: last_edited_at
+                               ))
 
           content_item.reload
 
@@ -876,8 +876,8 @@ RSpec.describe Commands::V2::PutContent do
           old_last_edited_at = content_item.last_edited_at
 
           described_class.call(payload.merge(
-            update_type: "republish"
-          ))
+                                 update_type: "republish"
+                               ))
 
           content_item.reload
 

--- a/spec/commands/v2/put_content_spec.rb
+++ b/spec/commands/v2/put_content_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe Commands::V2::PutContent do
       {
         content_id: content_id,
         base_path: base_path,
+        update_type: "major",
         title: "Some Title",
         publishing_app: "publisher",
         rendering_app: "frontend",

--- a/spec/commands/v2/put_content_spec.rb
+++ b/spec/commands/v2/put_content_spec.rb
@@ -838,30 +838,20 @@ RSpec.describe Commands::V2::PutContent do
       }
 
       context "with a provided last_edited_at" do
-        it "stores the provided timestamp" do
-          last_edited_at = 1.year.ago
+        %w(minor major republish).each do |update_type|
+          context "with update_type of #{update_type}" do
+            it "stores the provided timestamp" do
+              last_edited_at = 1.year.ago
 
-          described_class.call(payload.merge(
-                                 last_edited_at: last_edited_at
-                               ))
+              described_class.call(payload.merge(
+                                     update_type: update_type,
+                                     last_edited_at: last_edited_at
+                                   ))
 
-          content_item.reload
+              content_item.reload
 
-          expect(content_item.last_edited_at.iso8601).to eq(last_edited_at.iso8601)
-        end
-
-        context "with update_type not major or minor" do
-          it "stores the provided timestamp" do
-            last_edited_at = 1.year.ago
-
-            described_class.call(payload.merge(
-                                   update_type: "republish",
-                                   last_edited_at: last_edited_at
-                                 ))
-
-            content_item.reload
-
-            expect(content_item.last_edited_at.iso8601).to eq(last_edited_at.iso8601)
+              expect(content_item.last_edited_at.iso8601).to eq(last_edited_at.iso8601)
+            end
           end
         end
       end

--- a/spec/commands/v2/put_content_spec.rb
+++ b/spec/commands/v2/put_content_spec.rb
@@ -813,5 +813,77 @@ RSpec.describe Commands::V2::PutContent do
 
       described_class.call(payload)
     end
+
+    context "draft does not exist" do
+      context "with a provided last_edited_at" do
+        it "stores the provided timestamp" do
+          last_edited_at = 1.year.ago
+
+          described_class.call(payload.merge(
+            last_edited_at: last_edited_at
+          ))
+
+          content_item = ContentItem.last
+
+          expect(content_item.last_edited_at.iso8601).to eq(last_edited_at.iso8601)
+        end
+      end
+    end
+
+    context "draft does exist" do
+      let!(:content_item) {
+        FactoryGirl.create(:draft_content_item,
+          content_id: content_id,
+        )
+      }
+
+      context "with a provided last_edited_at" do
+        it "stores the provided timestamp" do
+          last_edited_at = 1.year.ago
+
+          described_class.call(payload.merge(
+            last_edited_at: last_edited_at
+          ))
+
+          content_item.reload
+
+          expect(content_item.last_edited_at.iso8601).to eq(last_edited_at.iso8601)
+        end
+      end
+    end
+
+    context "with no provided last_edited_at" do
+      let!(:content_item) {
+        FactoryGirl.create(:draft_content_item,
+          content_id: content_id,
+        )
+      }
+
+      context "when update type is major or minor" do
+        it "stores last_edited_at as the current time" do
+          Timecop.freeze do
+            described_class.call(payload)
+
+            content_item.reload
+
+            expect(content_item.last_edited_at.iso8601).to eq(Time.zone.now.iso8601)
+          end
+        end
+      end
+
+      context "when other update type" do
+        it "dosen't change last_edited_at" do
+          old_last_edited_at = content_item.last_edited_at
+
+          described_class.call(payload.merge(
+            update_type: "republish"
+          ))
+
+          content_item.reload
+
+          expect(content_item.last_edited_at).to eq(old_last_edited_at)
+        end
+      end
+    end
   end
 end

--- a/spec/controllers/v2/content_items_controller_spec.rb
+++ b/spec/controllers/v2/content_items_controller_spec.rb
@@ -235,8 +235,8 @@ RSpec.describe V2::ContentItemsController do
           expect(response.status).to eq(200), response.body
 
           expect(results).to eq([
-            { "last_edited_at" => "2016-01-01 00:00:00" },
-            { "last_edited_at" => "2016-02-02 00:00:00" },
+            { "last_edited_at" => "2016-01-01T00:00:00Z" },
+            { "last_edited_at" => "2016-02-02T00:00:00Z" },
           ])
         end
       end
@@ -251,8 +251,8 @@ RSpec.describe V2::ContentItemsController do
           expect(response.status).to eq(200), response.body
 
           expect(results).to eq([
-            { "last_edited_at" => "2016-02-02 00:00:00" },
-            { "last_edited_at" => "2016-01-01 00:00:00" },
+            { "last_edited_at" => "2016-02-02T00:00:00Z" },
+            { "last_edited_at" => "2016-01-01T00:00:00Z" },
           ])
         end
       end

--- a/spec/controllers/v2/content_items_controller_spec.rb
+++ b/spec/controllers/v2/content_items_controller_spec.rb
@@ -185,8 +185,14 @@ RSpec.describe V2::ContentItemsController do
 
     context "with an order param" do
       before do
-        @en_draft_content.update!(updated_at: Date.new(2016, 1, 1))
-        @ar_draft_content.update!(updated_at: Date.new(2016, 2, 2))
+        @en_draft_content.update!(
+          updated_at: Date.new(2016, 1, 1),
+          last_edited_at: Date.new(2016, 1, 1),
+        )
+        @ar_draft_content.update!(
+          updated_at: Date.new(2016, 2, 2),
+          last_edited_at: Date.new(2016, 2, 2),
+        )
 
         get :index, document_type: "topic", locale: "all", order: order, fields: fields
       end
@@ -215,6 +221,38 @@ RSpec.describe V2::ContentItemsController do
           expect(results).to eq([
             { "updated_at" => "2016-02-02 00:00:00" },
             { "updated_at" => "2016-01-01 00:00:00" },
+          ])
+        end
+      end
+
+      context "when ordering by last_edited_at ascending" do
+        let(:order) { "last_edited_at" }
+        let(:fields) { ["last_edited_at"] }
+
+        it "returns the ordered results" do
+          results = parsed_response["results"]
+
+          expect(response.status).to eq(200), response.body
+
+          expect(results).to eq([
+            { "last_edited_at" => "2016-01-01 00:00:00" },
+            { "last_edited_at" => "2016-02-02 00:00:00" },
+          ])
+        end
+      end
+
+      context "when ordering by last_edited_at descending" do
+        let(:order) { "-last_edited_at" }
+        let(:fields) { ["last_edited_at"] }
+
+        it "returns the ordered results" do
+          results = parsed_response["results"]
+
+          expect(response.status).to eq(200), response.body
+
+          expect(results).to eq([
+            { "last_edited_at" => "2016-02-02 00:00:00" },
+            { "last_edited_at" => "2016-01-01 00:00:00" },
           ])
         end
       end

--- a/spec/factories/content_item.rb
+++ b/spec/factories/content_item.rb
@@ -7,6 +7,7 @@ FactoryGirl.define do
     document_type "guide"
     public_updated_at "2014-05-14T13:00:06Z"
     first_published_at "2014-01-02T03:04:05Z"
+    last_edited_at "2014-05-14T13:00:06Z"
     publishing_app "publisher"
     rendering_app "frontend"
     details {

--- a/spec/presenters/queries/content_item_presenter_spec.rb
+++ b/spec/presenters/queries/content_item_presenter_spec.rb
@@ -30,6 +30,7 @@ RSpec.describe Presenters::Queries::ContentItemPresenter do
         "document_type" => "guide",
         "schema_name" => "guide",
         "public_updated_at" => "2014-05-14T13:00:06Z",
+        "last_edited_at" => "2014-05-14T13:00:06Z",
         "first_published_at" => "2014-01-02T03:04:05Z",
         "details" => { "body" => "<p>Something about VAT</p>\n" },
         "routes" => [{ "path" => base_path, "type" => "exact" }],

--- a/spec/requests/content_item_requests/downstream_requests_spec.rb
+++ b/spec/requests/content_item_requests/downstream_requests_spec.rb
@@ -337,6 +337,7 @@ RSpec.describe "Downstream requests", type: :request do
           :updated_at,
           :draft_content_item_id,
           :live_content_item_id,
+          :last_edited_at,
         )
     }
 


### PR DESCRIPTION
Trello card: https://trello.com/c/QJPHGeQf/738-add-last-edited-at-timestamp-to-content-items-small-ish

These commits add a new "last_edited_at" field to the content item model, along with the corresponding schema changes and add tests to cover this new behaviour. Existing tests are also changed to pass given this new functionality. 

@tuzz (as the RFC author)
@alphagov/team-publishing-platform (who need to be aware of this work)