### PR TITLE
Add statsd instrumentation to commands

### DIFF
--- a/app/commands/base_command.rb
+++ b/app/commands/base_command.rb
@@ -6,7 +6,9 @@ module Commands
       logger.debug "#{self} called with payload:\n#{payload}"
 
       response = EventLogger.log_command(self, payload) do |event|
-        new(payload, event: event, downstream: downstream, callbacks: callbacks).call
+        PublishingAPI.service(:statsd).time(self.name.gsub(/:+/, '.')) do
+          new(payload, event: event, downstream: downstream, callbacks: callbacks).call
+        end
       end
 
       execute_callbacks(callbacks) unless nested

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -54,6 +54,7 @@ RSpec.configure do |config|
   config.include AuthenticationHelper::ControllerMixin, type: :controller
 
   config.after do
+    Timecop.return
     GDS::SSO.test_user = nil
   end
 


### PR DESCRIPTION
Times each run of a `Command` and sends the recorded duration to Statsd. The timings will be named for their command class name, with class namespaces translated to graphite key namespaces.