### PR TITLE
Command benchmarks

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,4 +46,6 @@ group :development, :test do
   gem "factory_girl_rails", "4.5.0"
   gem "pact_broker-client"
   gem "govuk-lint"
+  gem "faker"
+  gem "stackprof", require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -92,6 +92,8 @@ GEM
     factory_girl_rails (4.5.0)
       factory_girl (~> 4.5.0)
       railties (>= 3.0.0)
+    faker (1.6.3)
+      i18n (~> 0.5)
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
     find_a_port (1.0.1)
@@ -320,6 +322,7 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
+    stackprof (0.2.9)
     statsd-ruby (1.2.1)
     term-ansicolor (1.3.2)
       tins (~> 1.0)
@@ -363,6 +366,7 @@ DEPENDENCIES
   database_cleaner
   deprecated_columns
   factory_girl_rails (= 4.5.0)
+  faker
   gds-api-adapters (= 30.2.0)
   gds-sso (= 11.2.1)
   govuk-lint
@@ -384,6 +388,7 @@ DEPENDENCIES
   sidekiq-statsd (= 0.1.5)
   simplecov (= 0.10.0)
   simplecov-rcov (= 0.2.3)
+  stackprof
   timecop
   unicorn (~> 4.9.0)
   web-console (~> 2.0)

--- a/bench/patch_link_set.rb
+++ b/bench/patch_link_set.rb
@@ -1,0 +1,82 @@
+# /usr/bin/env ruby
+
+require ::File.expand_path('../../config/environment', __FILE__)
+require 'benchmark'
+require 'securerandom'
+
+require 'faker'
+require 'stackprof'
+
+abort "Refusing to run outside of development" unless Rails.env.development?
+
+$queries = 0
+ActiveSupport::Notifications.subscribe "sql.active_record" do |name, started, finished, unique_id, data|
+  $queries += 1
+end
+
+content_items = 100.times.map do
+  title = Faker::Company.catch_phrase
+  {
+    content_id: SecureRandom.uuid,
+    format: "placeholder",
+    schema_name: "placeholder",
+    document_type: "placeholder",
+    title: title,
+    base_path: "/performance-testing/#{title.parameterize}",
+    description: Faker::Lorem.paragraph,
+    public_updated_at: Time.now.iso8601,
+    locale: "en",
+    routes: [
+      {path: "/performance-testing/#{title.parameterize}", type: "exact"}
+    ],
+    redirects: [],
+    publishing_app: "performance-testing",
+    rendering_app: "performance-testing",
+    details: {
+      body: "<p>#{Faker::Lorem.paragraphs(10)}</p>"
+    },
+    phase: 'live',
+    need_ids: []
+  }
+end
+
+begin
+  puts "Publishing content items..."
+  content_items.each do |item|
+    Commands::V2::PutContent.call(item)
+    Commands::V2::Publish.call(content_id: item[:content_id], update_type: 'major')
+  end
+
+  $queries = 0
+
+  puts "Patching links..."
+
+  content_ids = content_items.map { |ci| ci[:content_id] }
+  payloads = content_items.map do |ci|
+    links = content_ids.sample(10).reject { |id| id == ci[:content_id] }
+    {content_id: ci[:content_id], links: {foos: links}}
+  end
+
+  StackProf.run(mode: :wall, out: "tmp/patch_link_set_wall.dump") do
+    puts Benchmark.measure {
+      payloads.each do |payload|
+        Commands::V2::PatchLinkSet.call(payload)
+        print "."
+      end
+      puts
+    }
+  end
+
+  puts "#{$queries} SQL queries"
+
+ensure
+  scope = ContentItem.where(publishing_app: 'performance-testing')
+  LinkSet.includes(:links).where(content_id: scope.pluck(:content_id)).destroy_all
+  Location.where(content_item: scope).delete_all
+  State.where(content_item: scope).delete_all
+  Translation.where(content_item: scope).delete_all
+  UserFacingVersion.where(content_item: scope).delete_all
+  LockVersion.where(target: scope).delete_all
+  PathReservation.where(publishing_app: 'performance-testing').delete_all
+  scope.delete_all
+end

--- a/bench/publish.rb
+++ b/bench/publish.rb
@@ -1,0 +1,90 @@
+# /usr/bin/env ruby
+
+require ::File.expand_path('../../config/environment', __FILE__)
+require 'benchmark'
+require 'securerandom'
+
+require 'faker'
+require 'stackprof'
+
+abort "Refusing to run outside of development" unless Rails.env.development?
+
+def publish(content_items)
+  puts Benchmark.measure {
+    content_items.each do |item|
+      Commands::V2::Publish.call(content_id: item[:content_id], update_type: 'major')
+      print "."
+    end
+    puts ""
+  }
+end
+
+$queries = 0
+ActiveSupport::Notifications.subscribe "sql.active_record" do |name, started, finished, unique_id, data|
+  $queries += 1
+end
+
+content_items = 100.times.map do
+  title = Faker::Company.catch_phrase
+  {
+    content_id: SecureRandom.uuid,
+    format: "placeholder",
+    schema_name: "placeholder",
+    document_type: "placeholder",
+    title: title,
+    base_path: "/performance-testing/#{title.parameterize}",
+    description: Faker::Lorem.paragraph,
+    public_updated_at: Time.now.iso8601,
+    locale: "en",
+    routes: [
+      {path: "/performance-testing/#{title.parameterize}", type: "exact"}
+    ],
+    redirects: [],
+    publishing_app: "performance-testing",
+    rendering_app: "performance-testing",
+    details: {
+      body: "<p>#{Faker::Lorem.paragraphs(10)}</p>"
+    },
+    phase: 'live',
+    need_ids: []
+  }
+end
+
+begin
+  puts "Creating drafts..."
+  content_items.each do |item|
+    Commands::V2::PutContent.call(item)
+  end
+
+  $queries = 0
+
+  puts "Publishing..."
+
+  StackProf.run(mode: :wall, out: "tmp/publish_wall.dump") { publish(content_items) }
+
+  puts "#{$queries} SQL queries"
+
+  puts "Creating new drafts..."
+  content_items.each do |item|
+    Commands::V2::PutContent.call(item.merge(title: Faker::Company.catch_phrase))
+  end
+
+  $queries = 0
+
+  puts "Superseding..."
+
+  StackProf.run(mode: :wall, out: "tmp/supersede_wall.dump") { publish(content_items) }
+
+  puts "#{$queries} SQL queries"
+
+ensure
+  scope = ContentItem.where(publishing_app: 'performance-testing')
+  LinkSet.includes(:links).where(content_id: scope.pluck(:content_id)).destroy_all
+  Location.where(content_item: scope).delete_all
+  State.where(content_item: scope).delete_all
+  Translation.where(content_item: scope).delete_all
+  UserFacingVersion.where(content_item: scope).delete_all
+  LockVersion.where(target: scope).delete_all
+  PathReservation.where(publishing_app: 'performance-testing').delete_all
+  scope.delete_all
+end

--- a/bench/put_content.rb
+++ b/bench/put_content.rb
@@ -1,0 +1,67 @@
+# /usr/bin/env ruby
+
+require ::File.expand_path('../../config/environment', __FILE__)
+require 'benchmark'
+require 'securerandom'
+
+require 'faker'
+require 'stackprof'
+
+abort "Refusing to run outside of development" unless Rails.env.development?
+
+$queries = 0
+ActiveSupport::Notifications.subscribe "sql.active_record" do |name, started, finished, unique_id, data|
+  $queries += 1
+end
+
+content_id = SecureRandom.uuid
+title = Faker::Company.catch_phrase
+
+content_items = 100.times.map do
+  {
+    content_id: content_id,
+    format: "placeholder",
+    schema_name: "placeholder",
+    document_type: "placeholder",
+    title: title,
+    base_path: "/performance-testing/#{title.parameterize}",
+    description: Faker::Lorem.paragraph,
+    public_updated_at: Time.now.iso8601,
+    locale: "en",
+    routes: [
+      {path: "/performance-testing/#{title.parameterize}", type: "exact"}
+    ],
+    redirects: [],
+    publishing_app: "performance-testing",
+    rendering_app: "performance-testing",
+    details: {
+      body: "<p>#{Faker::Lorem.paragraphs(10)}</p>"
+    },
+    phase: 'live',
+    need_ids: []
+  }
+end
+
+begin
+  StackProf.run(mode: :wall, out: "tmp/put_content_wall.dump") do
+    puts Benchmark.measure {
+      content_items.each do |item|
+        Commands::V2::PutContent.call(item)
+        print "."
+      end
+      puts ""
+    }
+  end
+
+  puts "#{$queries} SQL queries"
+
+ensure
+  scope = ContentItem.where(publishing_app: 'performance-testing')
+  LinkSet.includes(:links).where(content_id: scope.pluck(:content_id)).destroy_all
+  Location.where(content_item: scope).delete_all
+  State.where(content_item: scope).delete_all
+  Translation.where(content_item: scope).delete_all
+  UserFacingVersion.where(content_item: scope).delete_all
+  LockVersion.where(target: scope).delete_all
+  scope.delete_all
+end


### PR DESCRIPTION
Adds benchmarks for the 3 key commands. Wraps the benchmarks in StackProf, which generates useful output like this:

```
$ bundle exec stackprof tmp/put_content_wall.dump --method 'Commands::V2::PutContent#update_existing_content_item'
Commands::V2::PutContent#update_existing_content_item (/var/govuk/publishing-api/app/commands/v2/put_content.rb:56)
  samples:     0 self (0.0%)  /   3061 total (51.0%)
  callers:
    3061  (  100.0%)  Commands::V2::PutContent#call
  callees (3061 total):
    1775  (   58.0%)  Commands::V2::PutContent#increment_lock_version
     510  (   16.7%)  Commands::V2::PutContent#update_content_item
     261  (    8.5%)  Commands::V2::PutContent#clear_draft_items_of_same_locale_and_base_path
     172  (    5.6%)  ActiveRecord::Core::ClassMethods#find_by
     170  (    5.6%)  ActiveRecord::Core::ClassMethods#find_by!
     165  (    5.4%)  Commands::BaseCommand#check_version_and_raise_if_conflicting
       5  (    0.2%)  ActiveSupport::Dependencies::ModuleConstMissing#const_missing
       2  (    0.1%)  block (2 levels) in #<Module:0x007f4b31adcae0>.included
       1  (    0.0%)  Commands::V2::PutContent#path_has_changed?
  code:
                                  |    56  |       def update_existing_content_item(content_item)
  261    (4.3%)                   |    57  |         clear_draft_items_of_same_locale_and_base_path(content_item, locale, base_path)
                                  |    58  |
  170    (2.8%)                   |    59  |         previous_location = Location.find_by!(content_item: content_item)
    2    (0.0%)                   |    60  |         previous_routes = content_item.routes
                                  |    61  |
  165    (2.7%)                   |    62  |         check_version_and_raise_if_conflicting(content_item, payload[:previous_version])
                                  |    63  |
  510    (8.5%)                   |    64  |         update_content_item(content_item)
 1775   (29.5%)                   |    65  |         increment_lock_version(content_item)
                                  |    66  |
    1    (0.0%)                   |    67  |         if path_has_changed?(previous_location)
                                  |    68  |           from_path = previous_location.base_path
                                  |    69  |           update_path(previous_location, new_path: base_path)
                                  |    70  |
                                  |    71  |           create_redirect(
                                  |    72  |             from_path: from_path,
                                  |    73  |             to_path: base_path,
                                  |    74  |             routes: previous_routes,
                                  |    75  |           )
                                  |    76  |         end
                                  |    77  |
                                  |    78  |         if payload[:access_limited] && (users = payload[:access_limited][:users])
                                  |    79  |           create_or_update_access_limit(content_item, users: users)
                                  |    80  |         else
  177    (2.9%)                   |    81  |           AccessLimit.find_by(content_item: content_item).try(:destroy)
                                  |    82  |         end
```

/cc @gpeng @elliotcm 

Trello: https://trello.com/c/hm73Iru3/422-spike-investigate-performance-of-bulk-publishing