### PR TITLE
Cache the signon token for applications

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ else
   gem "gds-api-adapters", "30.2.0"
 end
 
-gem "gds-sso", "11.2.1"
+gem "gds-sso", github: "alphagov/gds-sso"
 
 gem 'bunny', '2.0.0'
 gem 'whenever', '0.9.4', require: false

--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ else
   gem "gds-api-adapters", "30.2.0"
 end
 
-gem "gds-sso", github: "alphagov/gds-sso"
+gem "gds-sso", "12.1.0"
 
 gem 'bunny', '2.0.0'
 gem 'whenever', '0.9.4', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,17 +1,3 @@
-GIT
-  remote: git://github.com/alphagov/gds-sso.git
-  revision: a1a0d92564618fec10ff9855c12ab373fc8f6ba5
-  specs:
-    gds-sso (12.0.0)
-      multi_json (~> 1.0)
-      oauth2 (~> 1.0)
-      omniauth (~> 1.2)
-      omniauth-gds (~> 3.2)
-      rack-accept (~> 0.4.4)
-      rails (>= 3.0.0)
-      warden (~> 1.2)
-      warden-oauth2 (~> 0.0.1)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -118,6 +104,15 @@ GEM
       plek (>= 1.9.0)
       rack-cache
       rest-client (~> 1.8.0)
+    gds-sso (12.1.0)
+      multi_json (~> 1.0)
+      oauth2 (~> 1.0)
+      omniauth (~> 1.2)
+      omniauth-gds (~> 3.2)
+      rack-accept (~> 0.4.4)
+      rails (>= 3.0.0)
+      warden (~> 1.2)
+      warden-oauth2 (~> 0.0.1)
     globalid (0.3.6)
       activesupport (>= 4.1.0)
     govuk-lint (0.8.0)
@@ -373,7 +368,7 @@ DEPENDENCIES
   factory_girl_rails (= 4.5.0)
   faker
   gds-api-adapters (= 30.2.0)
-  gds-sso!
+  gds-sso (= 12.1.0)
   govuk-lint
   hashdiff
   json-schema

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,17 @@
+GIT
+  remote: git://github.com/alphagov/gds-sso.git
+  revision: a1a0d92564618fec10ff9855c12ab373fc8f6ba5
+  specs:
+    gds-sso (12.0.0)
+      multi_json (~> 1.0)
+      oauth2 (~> 1.0)
+      omniauth (~> 1.2)
+      omniauth-gds (~> 3.2)
+      rack-accept (~> 0.4.4)
+      rails (>= 3.0.0)
+      warden (~> 1.2)
+      warden-oauth2 (~> 0.0.1)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -104,22 +118,13 @@ GEM
       plek (>= 1.9.0)
       rack-cache
       rest-client (~> 1.8.0)
-    gds-sso (11.2.1)
-      multi_json (~> 1.0)
-      oauth2 (~> 1.0)
-      omniauth (~> 1.2)
-      omniauth-gds (~> 3.2)
-      rack-accept (~> 0.4.4)
-      rails (>= 3.0.0)
-      warden (~> 1.2)
-      warden-oauth2 (~> 0.0.1)
     globalid (0.3.6)
       activesupport (>= 4.1.0)
     govuk-lint (0.8.0)
       rubocop (~> 0.35.0)
       scss_lint (~> 0.44.0)
     hashdiff (0.3.0)
-    hashie (3.4.3)
+    hashie (3.4.4)
     hitimes (1.2.3)
     http-cookie (1.0.2)
       domain_name (~> 0.5)
@@ -130,7 +135,7 @@ GEM
     json (1.8.3)
     json-schema (2.5.2)
       addressable (~> 2.3.8)
-    jwt (1.5.2)
+    jwt (1.5.1)
     kgio (2.9.3)
     link_header (0.0.8)
     logstash-event (1.1.5)
@@ -154,15 +159,15 @@ GEM
     nokogiri (1.6.7.2)
       mini_portile2 (~> 2.0.0.rc2)
     null_logger (0.0.1)
-    oauth2 (1.0.0)
+    oauth2 (1.1.0)
       faraday (>= 0.8, < 0.10)
-      jwt (~> 1.0)
+      jwt (~> 1.0, < 1.5.2)
       multi_json (~> 1.3)
       multi_xml (~> 0.5)
-      rack (~> 1.2)
-    omniauth (1.2.2)
+      rack (>= 1.2, < 3)
+    omniauth (1.3.1)
       hashie (>= 1.2, < 4)
-      rack (~> 1.0)
+      rack (>= 1.0, < 3)
     omniauth-gds (3.2.1)
       multi_json (~> 1.10)
       omniauth-oauth2 (= 1.3.1)
@@ -341,7 +346,7 @@ GEM
       kgio (~> 2.6)
       rack
       raindrops (~> 0.7)
-    warden (1.2.4)
+    warden (1.2.6)
       rack (>= 1.0)
     warden-oauth2 (0.0.1)
       warden
@@ -368,7 +373,7 @@ DEPENDENCIES
   factory_girl_rails (= 4.5.0)
   faker
   gds-api-adapters (= 30.2.0)
-  gds-sso (= 11.2.1)
+  gds-sso!
   govuk-lint
   hashdiff
   json-schema

--- a/config/initializers/gds-sso.rb
+++ b/config/initializers/gds-sso.rb
@@ -1,6 +1,7 @@
 GDS::SSO.config do |config|
-  config.user_model   = "User"
-  config.oauth_id     = ENV['OAUTH_ID']
+  config.user_model = "User"
+  config.oauth_id = ENV['OAUTH_ID']
   config.oauth_secret = ENV['OAUTH_SECRET']
   config.oauth_root_url = Plek.find("signon")
+  config.cache = Rails.cache
 end


### PR DESCRIPTION
This bumps the gds-sso gem and configures it to use a cache, which will prevent publishing-api from making many requests to Signon for the user data associated with the bearer token.

See https://github.com/alphagov/gds-sso/pull/97 for the change.

This speeds up most calls to publishing-api by ~120ms.

https://trello.com/c/Gpc22bUW/684-speed-up-publishing-api-by-caching-the-token
