### PR TITLE
Filter out redirects on `/lookup-by-base-path`

### DIFF
--- a/app/controllers/lookups_controller.rb
+++ b/app/controllers/lookups_controller.rb
@@ -7,7 +7,9 @@ class LookupsController < ApplicationController
 
     base_paths_and_content_ids = ContentItemFilter
       .filter(state: states, base_path: base_paths)
-      .pluck(:base_path, :content_id)
+      .pluck(:base_path, :content_id, :document_type)
+      .reject { |arr| arr[2] == 'redirect' }
+      .map { |arr| arr[0..1] }
       .uniq
 
     response = Hash[base_paths_and_content_ids]

--- a/spec/requests/lookups_spec.rb
+++ b/spec/requests/lookups_spec.rb
@@ -23,6 +23,15 @@ RSpec.describe "POST /lookup-by-base-path", type: :request do
         "/only-unpublished-page" => "cc6d416c-f369-4b7c-bac7-5e9401e79362",
       )
     end
+
+    it "ignored redirects" do
+      FactoryGirl.create(:redirect_content_item, state: "unpublished", base_path: "/published-page", content_id: "aa491126-77ed-4e81-91fa-8dc7f74e9657")
+      base_paths = ['/published-page']
+
+      post "/lookup-by-base-path", base_paths: base_paths
+
+      expect(parsed_response).to eql({})
+    end
   end
 
   def create_test_content


### PR DESCRIPTION
Some base paths have multiple redirects, which are returned as part of this lookup, but not in any particular order:

```ruby
> ContentItemFilter.filter(state: %w(published unpublished), base_path: ['/renewing-your-tax-credits-claim']).pluck(:base_path, :content_id, :document_typ    e, :updated_at)
[["/renewing-your-tax-credits-claim", "64d2120f-2396-4033-8e91-45f3e1f49ad8", "redirect", Tue, 19 Apr 2016 15:02:19 UTC +00:00],
 ["/renewing-your-tax-credits-claim", "6aecd670-0451-49d2-bce7-a4258be1adb3", "redirect", Tue, 19 Apr 2016 15:02:22 UTC +00:00],
 ["/renewing-your-tax-credits-claim", "bd88b94e-9fb0-44ea-84e8-6c3a4ef962a7", "answer", Tue, 07 Jun 2016 12:27:13 UTC +00:00],
 ["/renewing-your-tax-credits-claim", "fefde62e-a660-41eb-a222-4f711a3208da", "redirect", Wed, 04 May 2016 18:51:16 UTC +00:00]]
 ```

In the example above, the most recently published content item for this base path is `bd88b94e-9fb0-44ea-84e8-6c3a4ef962a7`. However, the existing implementation will return the bottom one which is
`fefde62e-a660-41eb-a222-4f711a3208da`, because it's the last value written to the hash for that base path key.

This commit attempts to address this by filtering out redirects.