### PR TITLE
last_edited_at fixups

### DIFF
--- a/app/commands/v2/put_content.rb
+++ b/app/commands/v2/put_content.rb
@@ -31,6 +31,8 @@ module Commands
         create_supporting_objects(content_item)
         ensure_link_set_exists(content_item)
 
+        update_last_edited_at_if_needed(content_item, payload[:last_edited_at])
+
         if previously_published_item
           set_first_published_at(content_item, previously_published_item)
 

--- a/doc/semantics-of-the-publishing-api.md
+++ b/doc/semantics-of-the-publishing-api.md
@@ -348,10 +348,10 @@ The `last_edited_at` records the last time that the content received a major or
 minor update. This can be used by the publishing applications as a ordering
 parameter and shown to editors.
 
-If the `last_updated_at` is specified when PUTing content, the given value will
-be stored. If `last_updated_at` is not specified, and the update type is major
-or minor, the `last_updated_at` will be set to the current time. For any other
-update type, the `last_updated_at` will be unchanged.
+If the `last_edited_at` is specified when PUTing content, the given value will
+be stored. If `last_edited_at` is not specified, and the update type is major
+or minor, the `last_edited_at` will be set to the current time. For any other
+update type, the `last_edited_at` will be unchanged.
 
 The `last_edited_at` must use the [ISO 8601
 format](https://en.wikipedia.org/wiki/ISO_8601).

--- a/spec/commands/v2/put_content_spec.rb
+++ b/spec/commands/v2/put_content_spec.rb
@@ -865,24 +865,14 @@ RSpec.describe Commands::V2::PutContent do
           end
         end
       end
-    end
 
-    context "with no provided last_edited_at" do
-      let!(:content_item) {
-        FactoryGirl.create(:draft_content_item,
-          content_id: content_id,
-        )
-      }
+      it "stores last_edited_at as the current time" do
+        Timecop.freeze do
+          described_class.call(payload)
 
-      context "when update type is major or minor" do
-        it "stores last_edited_at as the current time" do
-          Timecop.freeze do
-            described_class.call(payload)
+          content_item.reload
 
-            content_item.reload
-
-            expect(content_item.last_edited_at.iso8601).to eq(Time.zone.now.iso8601)
-          end
+          expect(content_item.last_edited_at.iso8601).to eq(Time.zone.now.iso8601)
         end
       end
 

--- a/spec/commands/v2/put_content_spec.rb
+++ b/spec/commands/v2/put_content_spec.rb
@@ -828,6 +828,16 @@ RSpec.describe Commands::V2::PutContent do
           expect(content_item.last_edited_at.iso8601).to eq(last_edited_at.iso8601)
         end
       end
+
+      it "stores last_edited_at as the current time" do
+        Timecop.freeze do
+          described_class.call(payload)
+
+          content_item = ContentItem.last
+
+          expect(content_item.last_edited_at.iso8601).to eq(Time.zone.now.iso8601)
+        end
+      end
     end
 
     context "draft does exist" do

--- a/spec/commands/v2/put_content_spec.rb
+++ b/spec/commands/v2/put_content_spec.rb
@@ -814,7 +814,7 @@ RSpec.describe Commands::V2::PutContent do
       described_class.call(payload)
     end
 
-    context "draft does not exist" do
+    context "when the draft does not exist" do
       context "with a provided last_edited_at" do
         it "stores the provided timestamp" do
           last_edited_at = 1.year.ago
@@ -840,7 +840,7 @@ RSpec.describe Commands::V2::PutContent do
       end
     end
 
-    context "draft does exist" do
+    context "when the draft does exist" do
       let!(:content_item) {
         FactoryGirl.create(:draft_content_item,
           content_id: content_id,


### PR DESCRIPTION
Trello card: https://trello.com/c/QJPHGeQf/738-add-last-edited-at-timestamp-to-content-items-small-ish
Previous pull request: https://github.com/alphagov/publishing-api/pull/365

These commits fix some mistakes in the documentation, and fix setting `last_edited_at` for new content items (as well as fixing the test coverage for this).

@elliotcm who worked with me on the last pull request
@tuzz (as the RFC author)
@alphagov/team-publishing-platform (who need to be aware of this work)