### PR TITLE
Document required fields for PUT content

### DIFF
--- a/doc/publishing-api-syntactic-usage.md
+++ b/doc/publishing-api-syntactic-usage.md
@@ -21,7 +21,9 @@ PUT and POST endpoints take an optional integer field `previous_version` in the 
  - `content_id` the primary identifier for the content being created or updated.
 Requests to create a new draft content item:
  - `base_path` must be a valid path format
+ - `document_type`
  - `publishing_app`
+ - `schema_name`
  - `title` required unless format is redirect or gone
  - `phase` must be one of alpha, beta, live
 

--- a/doc/publishing-api-syntactic-usage.md
+++ b/doc/publishing-api-syntactic-usage.md
@@ -31,6 +31,7 @@ Requests to create a new draft content item:
  - `locale` (optional, defaults to en) must be one of I18n.available_locales
 Requests to update an existing draft content item:
  - `previous_version` (optional but advised) is used to ensure the request is updating the latest lock version of this draft. ie. optimistic locking.
+ - `rendering_app` this is required if the format is renderable (ie. not a redirect or gone).
 
 ## `GET /v2/content/:content_id`
 


### PR DESCRIPTION
`schema_name` and `document_type` are required fields and `rendering_app` is nearly always required for `PUT /v2/content/:content_id`.

It looks like we're gradually removing the `format` field. Should the pact test in gds-api-adapters be updated to send `schema_name` and `document_type`?

https://github.com/alphagov/gds-api-adapters/blob/master/test/publishing_api_v2_test.rb#L14