### PR TITLE
Remove redundant tax credits redirects

### DIFF
--- a/db/migrate/20160622100129_remove_redundant_tax_credits_redirects.rb
+++ b/db/migrate/20160622100129_remove_redundant_tax_credits_redirects.rb
@@ -1,0 +1,32 @@
+class RemoveRedundantTaxCreditsRedirects < ActiveRecord::Migration
+  def up
+    redirect_content_ids = [
+      "64d2120f-2396-4033-8e91-45f3e1f49ad8",
+      "6aecd670-0451-49d2-bce7-a4258be1adb3",
+      "fefde62e-a660-41eb-a222-4f711a3208da"
+    ]
+    redirect_content_ids.each do |content_id|
+      content_items = ContentItem.where(content_id: content_id)
+
+      supporting_classes = [
+        AccessLimit,
+        Linkable,
+        Location,
+        State,
+        Translation,
+        Unpublishing,
+        UserFacingVersion
+      ]
+
+      supporting_classes.each do |klass|
+        klass.where(content_item: content_items).destroy_all
+      end
+
+      LockVersion.where(target: content_items).destroy_all
+
+      content_items.destroy_all
+
+      LinkSet.where(content_id: content_id).destroy_all
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160614144815) do
+ActiveRecord::Schema.define(version: 20160622100129) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
Previous discussion: https://github.com/alphagov/publishing-api/pull/377

These are 3 redirects which are currently confusing `/lookup-by-base-path` queries for `/renewing-your-tax-credits-claim`. They redirect `/renewing-your-tax-credits-claim` to `/renew-your-tax-credits-claim`, which then redirects back to the original path, which is where the real content item for this path exists anyway. (`bd88b94e-9fb0-44ea-84e8-6c3a4ef962a7`)

While queries to the content-store seem to resolve fine by returning the final content item, `/lookup-by-base-path` lookups on publishing-api don't work well when more than one content item exists for a particular route. It returns one of these redirects, which isn't useful for dependency resolution expansion.

This commit removes the offending redirects using a data migration.