### PR TITLE
Add 'state_history' to response bodies

### DIFF
--- a/bench/content_item_presenter.rb
+++ b/bench/content_item_presenter.rb
@@ -1,0 +1,23 @@
+# /usr/bin/env ruby
+
+require ::File.expand_path('../../config/environment', __FILE__)
+require 'stackprof'
+require 'benchmark'
+
+$queries = 0
+ActiveSupport::Notifications.subscribe "sql.active_record" do |name, started, finished, unique_id, data|
+  $queries += 1
+end
+
+def present(number_of_items)
+  scope = ContentItem.limit(number_of_items).order("id DESC")
+  $queries = 0
+
+  puts "Presenting #{number_of_items} content items"
+  StackProf.run(mode: :wall, out: "tmp/content_item_presenter_#{number_of_items}_wall.dump") do
+    puts Benchmark.measure { Presenters::Queries::ContentItemPresenter.present_many(scope) }
+  end
+  puts "  Queries: #{$queries}"
+end
+
+6.upto(10) { |i| present(2 ** i) }


### PR DESCRIPTION
https://trello.com/c/kyRoUV0h/756-add-a-state-history-field-to-presented-items-in-publishing-api-medium

This adds a `state_history` field to the response from ContentItemPresenter:

```javascript
"state_history": {
  "1": "superseded",
  "2": "published",
  "3": "draft"
}
```

This approach uses a correlated subquery. There are probably better ways to retrieve this data, but this seemed the simplest. I have benchmarked this change and it has a slight impact on performance. To serve 64 items, it has slowed from ~75ms to ~85ms. I don't know whether that is a reasonable slow-down in order to meet the requirement. What do people think?