### PR TITLE
Migrate links

### DIFF
--- a/app/commands/v2/represent_downstream.rb
+++ b/app/commands/v2/represent_downstream.rb
@@ -2,27 +2,39 @@ module Commands
   module V2
     class RepresentDownstream
       def self.name
-        "Commands::V2::RepresentDownstream"
+        self.to_s
       end
 
       def call(scope)
         filter = ContentItemFilter.new(scope: scope)
 
-        draft_content_items = Queries::GetLatest.call(
-          filter.filter(state: %w{draft published}))
-        live_content_items = filter.filter(state: "published")
-
-        draft_content_items.each do |draft_content_item|
-          send_to_content_store(draft_content_item, Adapters::DraftContentStore)
+        items_for_draft_store(filter).find_each do |draft_store_item|
+          send_to_content_store(draft_store_item, Adapters::DraftContentStore)
         end
 
-        live_content_items.each do |live_content_item|
-          send_to_content_store(live_content_item, Adapters::ContentStore)
+        items_for_live_store(filter).find_each do |live_store_item|
+          send_to_content_store(live_store_item, Adapters::ContentStore)
         end
       end
 
+    private
+
+      def items_for_draft_store(filter)
+        Queries::GetLatest.call(
+          filter.filter(state: %w{draft published})
+        )
+      end
+
+      def items_for_live_store(filter)
+        filter.filter(state: "published")
+      end
+
       def send_to_content_store(content_item, content_store)
-        payload = { content_id: content_item.content_id, message: "Representing to #{content_store}" }
+        payload = {
+          content_id: content_item.content_id,
+          message: "Representing to #{content_store}"
+        }
+
         EventLogger.log_command(self.class, payload) do |event|
           PresentedContentStoreWorker.perform_async_in_queue(
             PresentedContentStoreWorker::LOW_QUEUE,

--- a/app/commands/v2/represent_downstream.rb
+++ b/app/commands/v2/represent_downstream.rb
@@ -1,0 +1,37 @@
+module Commands
+  module V2
+    class RepresentDownstream
+      def self.name
+        "Commands::V2::RepresentDownstream"
+      end
+
+      def call(scope)
+        filter = ContentItemFilter.new(scope: scope)
+
+        draft_content_items = Queries::GetLatest.call(
+          filter.filter(state: %w{draft published}))
+        live_content_items = filter.filter(state: "published")
+
+        draft_content_items.each do |draft_content_item|
+          send_to_content_store(draft_content_item, Adapters::DraftContentStore)
+        end
+
+        live_content_items.each do |live_content_item|
+          send_to_content_store(live_content_item, Adapters::ContentStore)
+        end
+      end
+
+      def send_to_content_store(content_item, content_store)
+        payload = { content_id: content_item.content_id, message: "Representing to #{content_store}" }
+        EventLogger.log_command(self.class, payload) do |event|
+          PresentedContentStoreWorker.perform_async_in_queue(
+            PresentedContentStoreWorker::LOW_QUEUE,
+            content_store: content_store,
+            payload: { content_item_id: content_item.id, payload_version: event.id },
+            request_uuid: nil
+          )
+        end
+      end
+    end
+  end
+end

--- a/app/models/web_content_item.rb
+++ b/app/models/web_content_item.rb
@@ -12,7 +12,13 @@ class WebContentItem
   end
 
   CONTENT_ITEM_METHODS = [
-    :content_id, :description, :analytics_identifier, :title, :public_updated_at, :schema_name
+    :analytics_identifier,
+    :content_id,
+    :description,
+    :details,
+    :public_updated_at,
+    :schema_name,
+    :title,
   ]
 
   def_delegators :@content_item, *CONTENT_ITEM_METHODS

--- a/app/presenters/downstream_presenter.rb
+++ b/app/presenters/downstream_presenter.rb
@@ -35,10 +35,16 @@ module Presenters
 
     def links
       return {} unless link_set
-      {
-        links: link_set_presenter.links,
-        expanded_links: expanded_link_set_presenter.links
-      }
+      if MigrateExpandedLinks.document_types.include?(content_item.document_type)
+        {
+          links: expanded_link_set_presenter.links
+        }
+      else
+        {
+          links: link_set_presenter.links,
+          expanded_links: expanded_link_set_presenter.links
+        }
+      end
     end
 
     def access_limited

--- a/app/presenters/downstream_presenter.rb
+++ b/app/presenters/downstream_presenter.rb
@@ -35,14 +35,15 @@ module Presenters
 
     def links
       return {} unless link_set
-      if MigrateExpandedLinks.document_types.include?(content_item.document_type)
+
+      if MigrateExpandedLinks.schema_names.include?(content_item.schema_name)
         {
-          links: expanded_link_set_presenter.links
+          links: expanded_link_set_presenter.links,
         }
       else
         {
           links: link_set_presenter.links,
-          expanded_links: expanded_link_set_presenter.links
+          expanded_links: expanded_link_set_presenter.links,
         }
       end
     end

--- a/app/presenters/migrate_expanded_links.rb
+++ b/app/presenters/migrate_expanded_links.rb
@@ -1,0 +1,9 @@
+module Presenters
+  module MigrateExpandedLinks
+    extend self
+
+    def document_types
+      %w(service_manual_topic service_manual_guide)
+    end
+  end
+end

--- a/app/presenters/migrate_expanded_links.rb
+++ b/app/presenters/migrate_expanded_links.rb
@@ -2,8 +2,25 @@ module Presenters
   module MigrateExpandedLinks
     extend self
 
-    def document_types
-      %w(service_manual_topic service_manual_guide)
+    def schema_names
+      %w(service_manual_guide service_manual_topic service_manual_service_standard)
+    end
+
+  private
+
+    def todo
+      %w(
+        case_study coming_soon contact detailed_guide
+        email_alert_signup financial_release
+        financial_releases_campaign financial_releases_geoblocker
+        financial_releases_index financial_releases_success finder
+        finder_email_signup gone hmrc_manual hmrc_manual_section
+        html_publication mainstream_browse_page manual
+        manual_section policy publication redirect special_route
+        specialist_document statistics_announcement take_part taxon
+        topic topical_event_about_page travel_advice
+        travel_advice_index unpublishing working_group
+       )
     end
   end
 end

--- a/app/presenters/queries/expanded_link_set.rb
+++ b/app/presenters/queries/expanded_link_set.rb
@@ -41,7 +41,7 @@ module Presenters
           end
 
           expanded_links.merge(
-            expanded_links: next_level,
+            links: next_level,
           )
         end
       end

--- a/app/queries/dependee_expansion_rules.rb
+++ b/app/queries/dependee_expansion_rules.rb
@@ -6,7 +6,10 @@ module Queries
   private
 
     def custom(link_type)
-      {}[link_type]
+      {
+        organisations: default_fields + [:details],
+        html_publication: default_fields + [:schema_name, :document_type],
+      }[link_type]
     end
   end
 end

--- a/app/queries/dependent_expansion_rules.rb
+++ b/app/queries/dependent_expansion_rules.rb
@@ -16,11 +16,11 @@ module Queries
       }[link_type.to_sym]
     end
 
-  private
-
     def recursive_link_types
       [:parent]
     end
+
+  private
 
     def custom(link_type)
       {

--- a/lib/tasks/migrate_links.rake
+++ b/lib/tasks/migrate_links.rake
@@ -1,0 +1,23 @@
+namespace :migrate_links do
+  desc "Migrate links for a all formats"
+  task all: :environment do
+    Commands::V2::RepresentDownstream.new.call(
+      ContentItem.where(schema_name: Presenters::MigrateExpandedLinks.document_types)
+    )
+  end
+
+  desc """
+  Migrate links for a specific schema_name
+  Usage
+  rake 'migrate_links:schema[:schema_name]'
+  """
+  task :schema, [:schema_name] => :environment do |_t, args|
+    schema_name = args[:schema_name]
+
+    raise "Schema name needs to be in MigrateExpandedLinks" unless Presenters::MigrateExpandedLinks.schema_names.include?(schema_name)
+
+    Commands::V2::RepresentDownstream.new.call(
+      ContentItem.where(schema_name: schema_name)
+    )
+  end
+end

--- a/spec/presenters/downstream_presenter_spec.rb
+++ b/spec/presenters/downstream_presenter_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe Presenters::DownstreamPresenter do
             api_url: "http://www.dev.gov.uk/api/content/b",
             web_url: "http://www.dev.gov.uk/b",
             analytics_identifier: "GDS01",
-            expanded_links: {},
+            links: {},
           }],
           available_translations: [{
             analytics_identifier: "GDS01",

--- a/spec/presenters/queries/expanded_link_set_spec.rb
+++ b/spec/presenters/queries/expanded_link_set_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe Presenters::Queries::ExpandedLinkSet do
         create_link(a, b, "related")
         create_link(b, c, "related")
 
-        expect(expanded_links[:related]).to match([a_hash_including(base_path: "/b", expanded_links: {})])
+        expect(expanded_links[:related]).to match([a_hash_including(base_path: "/b", links: {})])
       end
     end
 
@@ -68,12 +68,12 @@ RSpec.describe Presenters::Queries::ExpandedLinkSet do
         expect(expanded_links[:parent]).to match([
           a_hash_including(
             base_path: "/b",
-            expanded_links: {
+            links: {
             parent: [a_hash_including(
               base_path: "/c",
-              expanded_links: {
+              links: {
                 parent: [
-                  a_hash_including(base_path: "/d", expanded_links: {})
+                  a_hash_including(base_path: "/d", links: {})
                 ]
               })]
             })
@@ -87,7 +87,7 @@ RSpec.describe Presenters::Queries::ExpandedLinkSet do
         create_link(b, c, "related")
 
         expect(expanded_links[:parent]).to match([
-          a_hash_including(base_path: "/b", expanded_links: {})
+          a_hash_including(base_path: "/b", links: {})
         ])
       end
     end
@@ -98,7 +98,7 @@ RSpec.describe Presenters::Queries::ExpandedLinkSet do
         create_link(b, c, "parent")
 
         expect(expanded_links[:related]).to match([
-          a_hash_including(base_path: "/b", expanded_links: {})
+          a_hash_including(base_path: "/b", links: {})
         ])
       end
     end
@@ -109,8 +109,8 @@ RSpec.describe Presenters::Queries::ExpandedLinkSet do
         create_link(b, a, "parent")
 
         expect(expanded_links[:parent]).to match([
-          a_hash_including(base_path: "/b", expanded_links: {
-            parent: [a_hash_including(base_path: "/a", expanded_links: {})]
+          a_hash_including(base_path: "/b", links: {
+            parent: [a_hash_including(base_path: "/a", links: {})]
           })
         ])
       end
@@ -122,11 +122,11 @@ RSpec.describe Presenters::Queries::ExpandedLinkSet do
         create_link(a, c, "related")
 
         expect(expanded_links[:parent]).to match([
-          a_hash_including(base_path: "/b", expanded_links: {})
+          a_hash_including(base_path: "/b", links: {})
         ])
 
         expect(expanded_links[:related]).to match([
-          a_hash_including(base_path: "/c", expanded_links: {})
+          a_hash_including(base_path: "/c", links: {})
         ])
       end
     end
@@ -137,8 +137,8 @@ RSpec.describe Presenters::Queries::ExpandedLinkSet do
         create_link(a, c, "related")
 
         expect(expanded_links[:related]).to match([
-          a_hash_including(base_path: "/b", expanded_links: {}),
-          a_hash_including(base_path: "/c", expanded_links: {}),
+          a_hash_including(base_path: "/b", links: {}),
+          a_hash_including(base_path: "/c", links: {}),
         ])
       end
     end
@@ -186,7 +186,7 @@ RSpec.describe Presenters::Queries::ExpandedLinkSet do
 
         it "expands the links for node a correctly" do
           expect(expanded_links[:related]).to match([
-            a_hash_including(base_path: "/b", expanded_links: {})
+            a_hash_including(base_path: "/b", links: {})
           ])
         end
       end
@@ -196,7 +196,7 @@ RSpec.describe Presenters::Queries::ExpandedLinkSet do
 
         it "expands the links for node a correctly" do
           expect(expanded_links[:related]).to match([
-            a_hash_including(base_path: "/c", expanded_links: {})
+            a_hash_including(base_path: "/c", links: {})
           ])
         end
       end
@@ -245,7 +245,7 @@ RSpec.describe Presenters::Queries::ExpandedLinkSet do
 
         it "expands the links for node a correctly" do
           expect(expanded_links[:parent]).to match([
-            a_hash_including(base_path: "/b-draft", expanded_links: {})
+            a_hash_including(base_path: "/b-draft", links: {})
           ])
         end
       end
@@ -255,8 +255,8 @@ RSpec.describe Presenters::Queries::ExpandedLinkSet do
 
         it "expands the links for node a correctly" do
           expect(expanded_links[:parent]).to match([
-            a_hash_including(base_path: "/b-published", expanded_links: {
-              parent: [a_hash_including(base_path: "/c-published", expanded_links: {})]
+            a_hash_including(base_path: "/b-published", links: {
+              parent: [a_hash_including(base_path: "/c-published", links: {})]
             })
           ])
         end
@@ -284,9 +284,9 @@ RSpec.describe Presenters::Queries::ExpandedLinkSet do
 
       it "expands for the content item of the first state that matches" do
         expect(expanded_links[:parent]).to match([
-          a_hash_including(base_path: "/b-published", expanded_links: {
-            parent: [a_hash_including(base_path: "/c-draft", expanded_links: {
-              parent: [a_hash_including(base_path: "/d-published", expanded_links: {})]
+          a_hash_including(base_path: "/b-published", links: {
+            parent: [a_hash_including(base_path: "/c-draft", links: {
+              parent: [a_hash_including(base_path: "/d-published", links: {})]
             })]
           })
         ])
@@ -312,7 +312,7 @@ RSpec.describe Presenters::Queries::ExpandedLinkSet do
 
     it "does not expand the fields for those links" do
       expect(expanded_links[:parent]).to match([
-        a_hash_including(base_path: "/b", expanded_links: {})
+        a_hash_including(base_path: "/b", links: {})
       ])
     end
   end
@@ -384,10 +384,10 @@ RSpec.describe Presenters::Queries::ExpandedLinkSet do
       expect(expanded_links[:children]).to match([
         a_hash_including(
           base_path: "/b-published",
-          expanded_links: a_hash_including(
+          links: a_hash_including(
             parent: [a_hash_including(
               base_path: "/a-draft",
-              expanded_links: anything,
+              links: anything,
             )]
           )
         )
@@ -399,7 +399,7 @@ RSpec.describe Presenters::Queries::ExpandedLinkSet do
 
       it "excludes draft dependees" do
         expect(expanded_links[:children]).to match([
-          a_hash_including(base_path: "/b-published", expanded_links: {})
+          a_hash_including(base_path: "/b-published", links: {})
         ])
       end
     end

--- a/spec/requests/expanded_links_endpoint_spec.rb
+++ b/spec/requests/expanded_links_endpoint_spec.rb
@@ -57,6 +57,7 @@ RSpec.describe "GET /v2/expanded-links/:id", type: :request do
             "base_path" => "/my-super-org",
             "content_id" => "9b5ae6f5-f127-4843-9333-c157a404dd2d",
             "description" => "VAT rates for goods and services",
+            "details" => { "body" => "<p>Something about VAT</p>\n" },
             "locale" => "en",
             "public_updated_at" => "2014-05-14T13:00:06.000Z",
             "title" => "VAT rates",

--- a/spec/requests/expanded_links_endpoint_spec.rb
+++ b/spec/requests/expanded_links_endpoint_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe "GET /v2/expanded-links/:id", type: :request do
             "public_updated_at" => "2014-05-14T13:00:06.000Z",
             "title" => "VAT rates",
             "web_url" => "http://www.dev.gov.uk/my-super-org",
-            "expanded_links" => {},
+            "links" => {},
           }
         ],
         "available_translations" => translations,


### PR DESCRIPTION
Rake task to Represent the content item downstream without state changes.

Use the expanded link set presenter for links that are ready to migrate. (currently service_manual)

Use `links` for and second level expansion instead of `expanded_links` so that there are no changes to frontend apps. 

https://trello.com/c/yNL1Lziv/727-prepare-formats-to-switch-to-expanded-links