### PR TITLE
Schema validator improvements

### DIFF
--- a/app/commands/v2/put_content.rb
+++ b/app/commands/v2/put_content.rb
@@ -287,7 +287,7 @@ module Commands
       end
 
       def validate_schema
-        SchemaValidator.new(payload.except(:content_id), type: :schema).validate
+        SchemaValidator.new(type: :schema).validate(payload.except(:content_id))
       end
     end
   end

--- a/app/validators/schema_validator.rb
+++ b/app/validators/schema_validator.rb
@@ -26,6 +26,8 @@ private
 
     return true if errors.empty?
 
+    errors = errors.map { |e| present_error e }
+
     Airbrake.notify_or_ignore(
       {
         error_class: "SchemaValidationError",
@@ -37,6 +39,20 @@ private
       }
     )
     false
+  end
+
+  def present_error(error_hash)
+    # The schema key just contains an addressable, which is not informative as
+    # the schema in use should be clear from the error class and message
+    error_hash = error_hash.reject { |k,v| k == :schema }
+
+    if error_hash.has_key? :errors
+      error_hash[:errors] = Hash[
+        error_hash[:errors].map {|k,errors| [k,errors.map { |e| present_error e }]}
+      ]
+    end
+
+    error_hash
   end
 
   def schema

--- a/app/validators/schema_validator.rb
+++ b/app/validators/schema_validator.rb
@@ -59,7 +59,7 @@ private
     Airbrake.notify_or_ignore(error, parameters: {
       explanation: "#{payload} is missing schema_name #{schema_name} or type #{type}"
     })
-    @schema = {}
+    {}
   end
 
   def schema_name

--- a/app/validators/schema_validator.rb
+++ b/app/validators/schema_validator.rb
@@ -20,7 +20,7 @@ class SchemaValidator
 
     return true if errors.empty?
 
-    errors = errors.map { |e| present_error e }
+    errors = errors.map { |e| present_error(e) }
 
     Airbrake.notify_or_ignore(
       {
@@ -44,7 +44,7 @@ private
     # the schema in use should be clear from the error class and message
     error_hash = error_hash.reject { |k, _| k == :schema }
 
-    if error_hash.has_key? :errors
+    if error_hash.has_key?(:errors)
       error_hash[:errors] = Hash[
         error_hash[:errors].map { |k, errors| [k, errors.map { |e| present_error e }] }
       ]

--- a/app/validators/schema_validator.rb
+++ b/app/validators/schema_validator.rb
@@ -1,23 +1,17 @@
 require 'json-schema'
 
 class SchemaValidator
-  def initialize(payload, type:, schema_name: nil, schema: nil)
-    @payload = payload
+  def initialize(type:, schema_name: nil, schema: nil)
     @type = type
     @schema = schema
     @schema_name = schema_name
   end
 
-  def validate
+  def validate(payload)
+    @payload = payload
+
     return true if schema_name_exception?
-    validate_schema
-  end
 
-private
-
-  attr_reader :payload, :type
-
-  def validate_schema
     errors = JSON::Validator.fully_validate(
       schema,
       payload,
@@ -40,6 +34,10 @@ private
     )
     false
   end
+
+private
+
+  attr_reader :payload, :type
 
   def present_error(error_hash)
     # The schema key just contains an addressable, which is not informative as

--- a/app/validators/schema_validator.rb
+++ b/app/validators/schema_validator.rb
@@ -42,11 +42,11 @@ private
   def present_error(error_hash)
     # The schema key just contains an addressable, which is not informative as
     # the schema in use should be clear from the error class and message
-    error_hash = error_hash.reject { |k,v| k == :schema }
+    error_hash = error_hash.reject { |k, _| k == :schema }
 
     if error_hash.has_key? :errors
       error_hash[:errors] = Hash[
-        error_hash[:errors].map {|k,errors| [k,errors.map { |e| present_error e }]}
+        error_hash[:errors].map { |k, errors| [k, errors.map { |e| present_error e }] }
       ]
     end
 

--- a/app/validators/schema_validator.rb
+++ b/app/validators/schema_validator.rb
@@ -19,7 +19,7 @@ private
 
   def validate_schema
     errors = JSON::Validator.fully_validate(
-      schema_for_validation,
+      schema,
       payload,
       errors_as_objects: true,
     )
@@ -37,12 +37,6 @@ private
       }
     )
     false
-  end
-
-  def schema_for_validation
-    return schema unless schema.has_key?("oneOf")
-    index = payload.has_key?(:format) ? 0 : 1
-    schema.merge(schema["oneOf"][index]).except("oneOf")
   end
 
   def schema

--- a/app/validators/schema_validator.rb
+++ b/app/validators/schema_validator.rb
@@ -46,7 +46,9 @@ private
 
     if error_hash.has_key?(:errors)
       error_hash[:errors] = Hash[
-        error_hash[:errors].map { |k, errors| [k, errors.map { |e| present_error e }] }
+        error_hash[:errors].map do |k, errors|
+          [k, errors.map { |e| present_error e }]
+        end
       ]
     end
 

--- a/spec/commands/v2/put_content_spec.rb
+++ b/spec/commands/v2/put_content_spec.rb
@@ -809,7 +809,7 @@ RSpec.describe Commands::V2::PutContent do
     it "validate against schema" do
       allow(SchemaValidator).to receive(:new).and_return(double('validator', validate: true))
       expect(SchemaValidator).to receive(:new)
-        .with(payload.except(:content_id), type: :schema)
+        .with(type: :schema)
 
       described_class.call(payload)
     end

--- a/spec/validators/schema_validator_spec.rb
+++ b/spec/validators/schema_validator_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe SchemaValidator do
   end
 
   subject(:validator) do
-    SchemaValidator.new(payload, type: :schema, schema: schema)
+    SchemaValidator.new(type: :schema, schema: schema)
   end
 
   context "schema" do
@@ -22,7 +22,7 @@ RSpec.describe SchemaValidator do
     it "logs to airbrake with an unknown schema_name" do
       expect(Airbrake).to receive(:notify_or_ignore)
         .with(an_instance_of(Errno::ENOENT), a_hash_including(:parameters))
-      validator.validate
+      validator.validate(payload)
     end
   end
 
@@ -31,11 +31,11 @@ RSpec.describe SchemaValidator do
 
     it "does not report to airbrake" do
       expect(Airbrake).to_not receive(:notify_or_ignore)
-      validator.validate
+      validator.validate(payload)
     end
 
     it "logs to airbrake when the payload is invalid" do
-      expect(validator.validate).to be true
+      expect(validator.validate(payload)).to be true
     end
   end
 
@@ -44,11 +44,11 @@ RSpec.describe SchemaValidator do
 
     it "reports to airbrake" do
       expect(Airbrake).to receive(:notify_or_ignore)
-      validator.validate
+      validator.validate(payload)
     end
 
     it "logs to airbrake when the payload is invalid" do
-      expect(validator.validate).to be false
+      expect(validator.validate(payload)).to be false
     end
   end
 
@@ -57,7 +57,7 @@ RSpec.describe SchemaValidator do
 
     it "does not report to airbrake" do
       expect(Airbrake).to_not receive(:notify_or_ignore)
-      validator.validate
+      validator.validate(payload)
     end
   end
 
@@ -124,7 +124,7 @@ RSpec.describe SchemaValidator do
             )
           )
         end
-        validator.validate
+        validator.validate(payload)
       end
     end
 
@@ -163,7 +163,7 @@ RSpec.describe SchemaValidator do
             )
           )
         end
-        validator.validate
+        validator.validate(payload)
       end
     end
   end

--- a/spec/validators/schema_validator_spec.rb
+++ b/spec/validators/schema_validator_spec.rb
@@ -90,10 +90,10 @@ RSpec.describe SchemaValidator do
         { schema_name: "foo" }
       }
       it "reports useful validation errors" do
-        expect(Airbrake).to receive(:notify_or_ignore) do |error, opts|
+        expect(Airbrake).to receive(:notify_or_ignore) do |_, opts|
           expect(opts[:parameters][:errors][0]).to match(
             a_hash_including(
-              message: a_string_starting_with( "The property '#/' of type Hash did not match"),
+              message: a_string_starting_with("The property '#/' of type Hash did not match"),
               failed_attribute: "OneOf",
               errors: {
                 oneof_0: [
@@ -133,10 +133,10 @@ RSpec.describe SchemaValidator do
         { format: "foo" }
       }
       it "reports useful validation errors" do
-        expect(Airbrake).to receive(:notify_or_ignore) do |error, opts|
+        expect(Airbrake).to receive(:notify_or_ignore) do |_, opts|
           expect(opts[:parameters][:errors][0]).to match(
             a_hash_including(
-              message: a_string_starting_with( "The property '#/' of type Hash did not match"),
+              message: a_string_starting_with("The property '#/' of type Hash did not match"),
               failed_attribute: "OneOf",
               errors: {
                 oneof_0: [

--- a/spec/validators/schema_validator_spec.rb
+++ b/spec/validators/schema_validator_spec.rb
@@ -90,8 +90,39 @@ RSpec.describe SchemaValidator do
         { schema_name: "foo" }
       }
       it "reports useful validation errors" do
-        expect(Airbrake).to receive(:notify_or_ignore) do |error, _|
-          expect(error.message).to match(/did not contain a required property of 'document_type'/)
+        expect(Airbrake).to receive(:notify_or_ignore) do |error, opts|
+          expect(opts[:parameters][:errors][0]).to match(
+            a_hash_including(
+              message: a_string_starting_with( "The property '#/' of type Hash did not match"),
+              failed_attribute: "OneOf",
+              errors: {
+                oneof_0: [
+                  a_hash_including(
+                    message: a_string_starting_with("The property '#/' did not contain a required property of 'title'"),
+                    failed_attribute: "Required",
+                  ),
+                  a_hash_including(
+                    message: a_string_starting_with("The property '#/' did not contain a required property of 'format'"),
+                    failed_attribute: "Required",
+                  ),
+                  a_hash_including(
+                    message: a_string_starting_with("The property '#/' contains additional properties [\"schema_name\"] outside of the schema when none are allowed"),
+                    failed_attribute: "AdditionalProperties"
+                  )
+                ],
+                oneof_1: [
+                  a_hash_including(
+                    message: a_string_starting_with("The property '#/' did not contain a required property of 'format'"),
+                    failed_attribute: "Required",
+                  ),
+                  a_hash_including(
+                    message: a_string_starting_with("The property '#/' did not contain a required property of 'document_type'"),
+                    failed_attribute: "Required",
+                  ),
+                ]
+              }
+            )
+          )
         end
         validator.validate
       end
@@ -102,8 +133,35 @@ RSpec.describe SchemaValidator do
         { format: "foo" }
       }
       it "reports useful validation errors" do
-        expect(Airbrake).to receive(:notify_or_ignore) do |error, _|
-          expect(error.message).to match(/did not contain a required property of 'title'/)
+        expect(Airbrake).to receive(:notify_or_ignore) do |error, opts|
+          expect(opts[:parameters][:errors][0]).to match(
+            a_hash_including(
+              message: a_string_starting_with( "The property '#/' of type Hash did not match"),
+              failed_attribute: "OneOf",
+              errors: {
+                oneof_0: [
+                  a_hash_including(
+                    message: a_string_starting_with("The property '#/' did not contain a required property of 'title'"),
+                    failed_attribute: "Required",
+                  ),
+                ],
+                oneof_1: [
+                  a_hash_including(
+                    message: a_string_starting_with("The property '#/' did not contain a required property of 'document_type'"),
+                    failed_attribute: "Required",
+                  ),
+                  a_hash_including(
+                    message: a_string_starting_with("The property '#/' did not contain a required property of 'schema_name'"),
+                    failed_attribute: "Required",
+                  ),
+                  a_hash_including(
+                    message: a_string_starting_with("The property '#/' contains additional properties [\"format\"] outside of the schema when none are allowed"),
+                    failed_attribute: "AdditionalProperties"
+                  ),
+                ]
+              }
+            )
+          )
         end
         validator.validate
       end


### PR DESCRIPTION
This applies the same approach I used for schema validation here [1], to the SchemaValidator class, such that it can be used for validation of message queue payloads. These changes will improve the error report usefulness for all other uses also.

1: https://github.com/alphagov/publishing-api/pull/383