### PR TITLE
Support unpublishing drafts

### DIFF
--- a/app/commands/v2/unpublish.rb
+++ b/app/commands/v2/unpublish.rb
@@ -2,6 +2,11 @@ module Commands
   module V2
     class Unpublish < BaseCommand
       def call
+        if payload[:allow_draft] && payload[:discard_drafts]
+          message = "allow_draft and discard_drafts cannot be used together"
+          raise_command_error(422, message, fields: {})
+        end
+
         content_id = payload.fetch(:content_id)
         content_item = find_unpublishable_content_item(content_id)
 

--- a/app/commands/v2/unpublish.rb
+++ b/app/commands/v2/unpublish.rb
@@ -17,7 +17,7 @@ module Commands
 
         check_version_and_raise_if_conflicting(content_item, previous_version_number)
 
-        if draft_present?(content_id)
+        if draft_present?(content_id) && !payload[:allow_draft]
           if payload[:discard_drafts] == true
             DiscardDraft.call(
               {
@@ -121,6 +121,11 @@ module Commands
 
       def find_unpublishable_content_item(content_id)
         allowed_states = %w(published unpublished)
+
+        if payload[:allow_draft]
+          allowed_states << "draft"
+        end
+
         filter = ContentItemFilter.new(scope: ContentItem.where(content_id: content_id))
         filter.filter(locale: locale, state: allowed_states).first
       end

--- a/app/commands/v2/unpublish.rb
+++ b/app/commands/v2/unpublish.rb
@@ -128,7 +128,7 @@ module Commands
         allowed_states = %w(published unpublished)
 
         if payload[:allow_draft]
-          allowed_states << "draft"
+          allowed_states = %w(draft)
         end
 
         filter = ContentItemFilter.new(scope: ContentItem.where(content_id: content_id))

--- a/app/commands/v2/unpublish.rb
+++ b/app/commands/v2/unpublish.rb
@@ -120,8 +120,9 @@ module Commands
       end
 
       def find_unpublishable_content_item(content_id)
+        allowed_states = %w(published unpublished)
         filter = ContentItemFilter.new(scope: ContentItem.where(content_id: content_id))
-        filter.filter(locale: locale, state: %w(published unpublished)).first
+        filter.filter(locale: locale, state: allowed_states).first
       end
 
       def draft_present?(content_id)

--- a/doc/publishing-api-syntactic-usage.md
+++ b/doc/publishing-api-syntactic-usage.md
@@ -97,6 +97,7 @@ Requests to update an existing draft content item:
                        (ignored) if `withdrawal`.
   - `discard_drafts` (optional) anything other than `true` is considered `false`,
     including being absent.
+  - `allow_draft` (optional) specify that the intended item to unpublish is in the draft state, and enable unpublishing it.
 
 ## `GET /v2/links/:content_id`
 

--- a/doc/publishing-api-syntactic-usage.md
+++ b/doc/publishing-api-syntactic-usage.md
@@ -72,8 +72,8 @@ Requests to update an existing draft content item:
 
  [Request/Response detail](https://pact-broker.dev.publishing.service.gov.uk/pacts/provider/Publishing%20API/consumer/GDS%20API%20Adapters/latest#an_unpublish_request_given_a_published_content_item_exists_with_content_id:_bed722e6-db68-43e5-9079-063f623335a7)
 
-  - Will refuse to unpublish a lone draft.
-  - Will refuse to unpublish a redrafted document unless `discard_drafts` is `true`.
+  - Will refuse to unpublish a lone draft unless `allow_draft` is `true`.
+  - Will refuse to unpublish a redrafted document unless `discard_drafts` is `true` or `allow_draft` is `true`.
   - Validates that unpublishing `type` is one of `withdrawal`, `gone` or `redirect` and raises a 422 otherwise.
   - Retrieves the live content item with the matching content_id and locale and changes its state to `unpublished`.
   - Creates an `Unpublishing` with the provided details.

--- a/doc/publishing-api-syntactic-usage.md
+++ b/doc/publishing-api-syntactic-usage.md
@@ -73,6 +73,7 @@ Requests to update an existing draft content item:
  [Request/Response detail](https://pact-broker.dev.publishing.service.gov.uk/pacts/provider/Publishing%20API/consumer/GDS%20API%20Adapters/latest#an_unpublish_request_given_a_published_content_item_exists_with_content_id:_bed722e6-db68-43e5-9079-063f623335a7)
 
   - Will refuse to unpublish a lone draft unless `allow_draft` is `true`.
+  - If `allow_draft` is `true`, will refuse to unpublish anything other than a draft.
   - Will refuse to unpublish a redrafted document unless `discard_drafts` is `true` or `allow_draft` is `true`.
   - Validates that unpublishing `type` is one of `withdrawal`, `gone` or `redirect` and raises a 422 otherwise.
   - Retrieves the live content item with the matching content_id and locale and changes its state to `unpublished`.

--- a/doc/publishing-api-syntactic-usage.md
+++ b/doc/publishing-api-syntactic-usage.md
@@ -74,7 +74,7 @@ Requests to update an existing draft content item:
 
   - Will refuse to unpublish a lone draft unless `allow_draft` is `true`.
   - If `allow_draft` is `true`, will refuse to unpublish anything other than a draft.
-  - Will refuse to unpublish a redrafted document unless `discard_drafts` is `true` or `allow_draft` is `true`.
+  - Will refuse to unpublish a redrafted document unless `discard_drafts` is `true`.
   - Validates that unpublishing `type` is one of `withdrawal`, `gone` or `redirect` and raises a 422 otherwise.
   - Retrieves the live content item with the matching content_id and locale and changes its state to `unpublished`.
   - Creates an `Unpublishing` with the provided details.

--- a/spec/commands/v2/unpublish_spec.rb
+++ b/spec/commands/v2/unpublish_spec.rb
@@ -141,6 +141,23 @@ RSpec.describe Commands::V2::Unpublish do
 
           described_class.call(payload_with_allow_draft)
         end
+
+        context "with `discard_drafts` set to true" do
+          let(:payload_with_allow_draft_and_discard_drafts) do
+            payload_with_allow_draft.merge(
+              discard_drafts: true,
+            )
+          end
+
+          it "rejects the request with a 422" do
+            expected_message = "allow_draft and discard_drafts cannot be used together"
+            expect {
+              described_class.call(payload_with_allow_draft_and_discard_drafts)
+            }.to raise_error(CommandError, expected_message) { |error|
+              expect(error.code).to eq(422)
+            }
+          end
+        end
       end
     end
 

--- a/spec/commands/v2/unpublish_spec.rb
+++ b/spec/commands/v2/unpublish_spec.rb
@@ -78,7 +78,7 @@ RSpec.describe Commands::V2::Unpublish do
     end
 
     context "when only a draft is present" do
-      before do
+      let!(:draft_content_item) do
         FactoryGirl.create(:draft_content_item,
           content_id: content_id,
         )

--- a/spec/commands/v2/unpublish_spec.rb
+++ b/spec/commands/v2/unpublish_spec.rb
@@ -75,6 +75,22 @@ RSpec.describe Commands::V2::Unpublish do
 
         described_class.call(payload)
       end
+
+      context "and the allow_draft parameter is given" do
+        let(:payload_with_allow_draft) do
+          payload.merge(
+            allow_draft: true,
+          )
+        end
+
+        it "rejects the request with a 404" do
+          expect {
+            described_class.call(payload_with_allow_draft)
+          }.to raise_error(CommandError, "Could not find a content item to unpublish") { |error|
+            expect(error.code).to eq(404)
+          }
+        end
+      end
     end
 
     context "when only a draft is present" do


### PR DESCRIPTION
Trello: https://trello.com/c/uXUhd3oJ/757-allow-unpublishing-of-draft-items-medium

This is being done to assist in the Specialist Publisher migration @tuzz 