### PR TITLE
Use oj JSON parser

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,6 +31,9 @@ group :development do
   gem "web-console", "~> 2.0"
 end
 
+gem "oj", "~> 2.16.1"
+gem "oj_mimic_json", "~> 1.0.1"
+
 group :development, :test do
   gem "pry"
   gem "pry-byebug"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -160,6 +160,8 @@ GEM
       multi_json (~> 1.3)
       multi_xml (~> 0.5)
       rack (>= 1.2, < 3)
+    oj (2.16.1)
+    oj_mimic_json (1.0.1)
     omniauth (1.3.1)
       hashie (>= 1.2, < 4)
       rack (>= 1.0, < 3)
@@ -373,6 +375,8 @@ DEPENDENCIES
   hashdiff
   json-schema
   logstasher (= 0.6.2)
+  oj (~> 2.16.1)
+  oj_mimic_json (~> 1.0.1)
   pact
   pact_broker-client
   pg


### PR DESCRIPTION
Using this parser increases performance of the JSON 'receiving' endpoints involved in publishing.

```
Whitehall PublishingApiWorker
100 publications

without oj 1 - 21.390000   3.790000  25.180000 (111.563083)
without oj 2 - 19.800000   6.730000  26.530000 (104.022175)
without oj 3 - 20.230000   6.220000  26.450000 (114.058231)
without oj 4 - 22.330000   7.410000  29.740000 (105.275420)

with oj 1 - 16.200000   7.610000  23.810000 ( 87.962210)
with oj 2 - 19.560000   4.100000  23.660000 ( 89.742975)
with oj 3 - 19.970000   4.230000  24.200000 ( 89.161475)
with oj 4 - 18.770000   5.130000  23.900000 ( 89.087061)
```

It will likely improve performance at the `publishing-api -> content-store` end too but I haven't  benchmarked that.