### PR TITLE
Use WebContentItem for downstream presenter

### DIFF
--- a/app/models/web_content_item.rb
+++ b/app/models/web_content_item.rb
@@ -28,10 +28,6 @@ WebContentItem = Struct.new(*fields) do
     new(*hash.symbolize_keys.values_at(*members))
   end
 
-  def self.from_scope(scope)
-    ActiveRecord::Base.connection.exec_query(scope.to_sql).to_hash.map { |r| from_hash(r) }
-  end
-
   def api_url
     return unless base_path
     Plek.current.website_root + "/api/content" + base_path
@@ -43,6 +39,6 @@ WebContentItem = Struct.new(*fields) do
   end
 
   def description
-    JSON.parse(self[:description])["value"]
+    self[:description]["value"]
   end
 end

--- a/app/presenters/downstream_presenter.rb
+++ b/app/presenters/downstream_presenter.rb
@@ -60,7 +60,7 @@ module Presenters
 
     def expanded_link_set_presenter
       Presenters::Queries::ExpandedLinkSet.new(
-        link_set: link_set,
+        content_id: web_content_item.content_id,
         state_fallback_order: state_fallback_order,
         locale_fallback_order: locale_fallback_order
       )

--- a/app/presenters/downstream_presenter.rb
+++ b/app/presenters/downstream_presenter.rb
@@ -1,6 +1,14 @@
+require 'queries/get_web_content_items'
+
 module Presenters
   class DownstreamPresenter
     def self.present(web_content_item, state_fallback_order:)
+      if web_content_item.is_a?(ContentItem)
+        # TODO: Add deprecation notice here once we start to migrate other parts of
+        # the app to use WebContentItem. Adding a notice now would be too noisy
+        web_content_item = ::Queries::GetWebContentItems.(web_content_item.id).first
+      end
+
       link_set = LinkSet.find_by(content_id: web_content_item.content_id)
       new(web_content_item, link_set, state_fallback_order: state_fallback_order).present
     end

--- a/app/presenters/queries/available_translations.rb
+++ b/app/presenters/queries/available_translations.rb
@@ -22,7 +22,7 @@ module Presenters
         scope = ContentItem.where(content_id: content_id)
         scope = State.join_content_items(scope)
         scope = Translation.join_content_items(scope)
-        scope.select(*(WebContentItem::CONTENT_ITEM_METHODS + %w(id locale name)))
+        scope.select(*%w(id locale name))
       end
 
       def filter_states
@@ -37,7 +37,7 @@ module Presenters
 
       def expand_translation(item)
         expansion_rules = ::Queries::DependentExpansionRules
-        web_item = WebContentItem.new(item, locale: item.locale)
+        web_item = ::Queries::GetWebContentItems.call(item.id).first
         ExpandLink.new(web_item, :available_translations, expansion_rules).expand_link
       end
 

--- a/app/presenters/queries/expanded_link_set.rb
+++ b/app/presenters/queries/expanded_link_set.rb
@@ -100,7 +100,7 @@ module Presenters
 
       def valid_web_content_items(target_content_ids)
         target_content_ids = without_passsthrough_hashes(target_content_ids)
-        web_content_items(target_content_ids).select(&:content_item)
+        web_content_items(target_content_ids)
       end
 
       def without_passsthrough_hashes(target_content_ids)
@@ -108,32 +108,13 @@ module Presenters
       end
 
       def web_content_items(target_content_ids)
-        target_content_ids.map do |target_content_id|
-          web_content_item(target_content_id)
-        end
-      end
-
-      def web_content_item(target_content_id)
-        @web_content_item ||= {}
-        @web_content_item[target_content_id] ||=
-          ::WebContentItem.new(content_item(target_content_id))
-      end
-
-      def content_item(target_content_id)
-        content_item_filter = ContentItemFilter.new(
-          scope: ContentItem.where(content_id: target_content_id)
+        ::Queries::GetWebContentItems.(
+          ::Queries::GetContentItemIdsWithFallbacks.(
+            target_content_ids,
+            locale_fallback_order: locale_fallback_order,
+            state_fallback_order: state_fallback_order
+          )
         )
-
-        @content_item ||= {}
-
-        locale_fallback_order.each do |locale|
-          state_fallback_order.each do |state|
-            @content_item[target_content_id] ||=
-              content_item_filter.filter(state: state, locale: locale).first
-          end
-        end
-
-        @content_item[target_content_id]
       end
 
       def translations

--- a/app/queries/arel_helpers.rb
+++ b/app/queries/arel_helpers.rb
@@ -1,0 +1,45 @@
+module Queries
+  module ArelHelpers
+    CTE = Struct.new(:table, :compiled_scope)
+
+    def table(table)
+      Arel::Table.new(table, ActiveRecord::Base)
+    end
+
+    # Creates a CTE (common table expression, or `WITH` query)
+    # from an Arel scope and returns a `CTE` struct wrapping two references to the CTE.
+    # A CTE is an alternative to a subquery, it defines a temporary virtual table
+    # for just a single query. See:
+    # https://www.postgresql.org/docs/9.3/static/queries-with.html
+    # https://github.com/rails/arel#complex-joins
+    #
+    # `CTE#table` is a reference to a virtual Arel::Table that has
+    # column accessors and can be used in `.join()` statements
+    # `CTE#compiled_scope` should be passed to the `with` statement
+    # when you want to use the CTE.
+    def cte(scope, as:)
+      table = Arel::Table.new(as.to_s)
+      compiled_scope = Arel::Nodes::As.new(table, scope)
+      CTE.new(table, compiled_scope)
+    end
+
+    def get_column(scope)
+      ActiveRecord::Base.connection.exec_query(scope).map(&:values).flatten
+    end
+
+    def get_rows(scope)
+      result = ActiveRecord::Base.connection.exec_query(scope.to_sql)
+
+      result.to_hash.map do |r|
+        r.each do |k, v|
+          case result.column_types[k]
+          when ActiveRecord::ConnectionAdapters::PostgreSQL::OID::Json
+            r[k] = Oj.load(v) if v
+          when ActiveRecord::ConnectionAdapters::PostgreSQL::OID::DateTime
+            r[k] = Time.zone.parse(v).iso8601 if v
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/queries/get_content_item_ids_with_fallbacks.rb
+++ b/app/queries/get_content_item_ids_with_fallbacks.rb
@@ -1,0 +1,55 @@
+module Queries
+  class GetContentItemIdsWithFallbacks
+    extend ArelHelpers
+
+    def self.call(content_ids, locale_fallback_order: ContentItem::DEFAULT_LOCALE, state_fallback_order:)
+      state_fallback_order = Array(state_fallback_order).map(&:to_s)
+      locale_fallback_order = Array(locale_fallback_order).map(&:to_s)
+
+      content_items = table(:content_items)
+      states = table(:states)
+      translations = table(:translations)
+
+      fallbacks = cte(
+        content_items.project(
+          content_items[:id],
+            content_items[:content_id],
+          )
+          .join(states).on(states[:content_item_id].eq(content_items[:id]))
+          .join(translations).on(translations[:content_item_id].eq(content_items[:id]))
+          .where(content_items[:content_id].in(content_ids))
+          .where(states[:name].in(state_fallback_order))
+          .where(translations[:locale].in(locale_fallback_order))
+          .order(
+            order_by_clause(:states, :name, state_fallback_order),
+            order_by_clause(:translations, :locale, locale_fallback_order)
+          ),
+        as: "fallbacks"
+      )
+
+      aggregates = cte(
+        fallbacks.table
+          .project(Arel::Nodes::NamedFunction.new("array_agg", [fallbacks.table[:id]], "ids"))
+          .group(fallbacks.table[:content_id])
+          .with(fallbacks.compiled_scope),
+        as: "aggregates"
+      )
+
+      get_column(
+        aggregates.table
+          .project(Arel::Nodes::SqlLiteral.new('aggregates.ids[1] AS id'))
+          .with(aggregates.compiled_scope)
+          .to_sql
+      )
+    end
+
+    # Arel::Nodes::Case is coming in arel master
+    def self.order_by_clause(table, attribute, values)
+      sql = %{CASE "#{table}"."#{attribute}" }
+      sql << values.map.with_index { |v, i| "WHEN '#{v}' THEN #{i}" }.join(" ")
+      sql << " ELSE #{values.size} END"
+      Arel::Nodes::SqlLiteral.new(sql)
+    end
+    private_class_method :order_by_clause
+  end
+end

--- a/app/queries/get_expanded_links.rb
+++ b/app/queries/get_expanded_links.rb
@@ -4,7 +4,7 @@ module Queries
       link_set = find_link_set(content_id)
       lock_version = LockVersion.find_by(target: link_set)
       expanded_link_set = Presenters::Queries::ExpandedLinkSet.new(
-        link_set: link_set,
+        content_id: content_id,
         state_fallback_order: [:draft, :published],
         locale_fallback_order: [locale, ContentItem::DEFAULT_LOCALE].compact
       )

--- a/app/queries/get_web_content_items.rb
+++ b/app/queries/get_web_content_items.rb
@@ -1,0 +1,51 @@
+module Queries
+  class GetWebContentItems
+    extend ArelHelpers
+
+    def self.call(content_item_ids)
+      content_items = table(:content_items)
+
+      get_rows(scope.where(content_items[:id].in(content_item_ids))).map do |row|
+        WebContentItem.from_hash(row)
+      end
+    end
+
+    def self.scope
+      content_items = table(:content_items)
+      locations = table(:locations)
+      states = table(:states)
+      translations = table(:translations)
+      user_facing_versions = table(:user_facing_versions)
+
+      content_items
+        .project(
+          content_items[:id],
+          content_items[:analytics_identifier],
+          content_items[:content_id],
+          content_items[:description],
+          content_items[:details],
+          content_items[:document_type],
+          content_items[:first_published_at],
+          content_items[:last_edited_at],
+          content_items[:need_ids],
+          content_items[:phase],
+          content_items[:public_updated_at],
+          content_items[:publishing_app],
+          content_items[:redirects],
+          content_items[:rendering_app],
+          content_items[:routes],
+          content_items[:schema_name],
+          content_items[:title],
+          content_items[:update_type],
+          locations[:base_path],
+          states[:name].as("state"),
+          translations[:locale],
+          user_facing_versions[:number].as("user_facing_version")
+        )
+        .outer_join(locations).on(content_items[:id].eq(locations[:content_item_id]))
+        .join(states).on(content_items[:id].eq(states[:content_item_id]))
+        .join(translations).on(content_items[:id].eq(translations[:content_item_id]))
+        .join(user_facing_versions).on(content_items[:id].eq(user_facing_versions[:content_item_id]))
+    end
+  end
+end

--- a/spec/commands/v2/patch_link_set_spec.rb
+++ b/spec/commands/v2/patch_link_set_spec.rb
@@ -244,7 +244,7 @@ RSpec.describe Commands::V2::PatchLinkSet do
               "content_store_high",
               content_store: Adapters::DraftContentStore,
               payload: {
-                content_item_id: ci.id,
+                content_item_id: ci.id.to_s,
                 payload_version: an_instance_of(Fixnum)
               },
               request_uuid: "12345-67890"
@@ -341,7 +341,7 @@ RSpec.describe Commands::V2::PatchLinkSet do
               "content_store_high",
               content_store: Adapters::ContentStore,
               payload: {
-                content_item_id: ci.id,
+                content_item_id: ci.id.to_s,
                 payload_version: an_instance_of(Fixnum)
               },
               request_uuid: "12345-67890"

--- a/spec/factories/web_content_item.rb
+++ b/spec/factories/web_content_item.rb
@@ -1,0 +1,46 @@
+FactoryGirl.define do
+  factory :draft_web_content_item, class: WebContentItem do
+    content_id { SecureRandom.uuid }
+    title "VAT rates"
+    description "VAT rates for goods and services"
+    schema_name "guide"
+    document_type "guide"
+    public_updated_at "2014-05-14T13:00:06Z"
+    first_published_at "2014-01-02T03:04:05Z"
+    last_edited_at "2014-05-14T13:00:06Z"
+    publishing_app "publisher"
+    rendering_app "frontend"
+    details {
+      { body: "<p>Something about VAT</p>\n", }
+    }
+    need_ids %w(100123 100124)
+    phase "beta"
+    update_type "minor"
+    analytics_identifier "GDS01"
+    routes {
+      [
+        {
+          path: base_path,
+          type: "exact",
+        }
+      ]
+    }
+    redirects []
+    state "draft"
+    locale "en"
+    sequence(:base_path) { |n| "/vat-rates-#{n}" }
+    user_facing_version 1
+  end
+
+  trait :live do
+    state "published"
+  end
+
+  factory :live_web_content_item, parent: :draft_web_content_item, traits: [:live]
+
+  factory :gone_draft_web_content_item, parent: :draft_web_content_item do
+    sequence(:base_path) { |n| "/dodo-sanctuary-#{n}" }
+    schema_name "gone"
+    document_type "gone"
+  end
+end

--- a/spec/presenters/downstream_presenter_spec.rb
+++ b/spec/presenters/downstream_presenter_spec.rb
@@ -1,9 +1,14 @@
 require 'rails_helper'
 
 RSpec.describe Presenters::DownstreamPresenter do
-  let(:state_fallback_order) { [] }
+  def web_content_item_for(content_item)
+    Queries::GetWebContentItems.(content_item.id).first
+  end
 
-  subject(:result) { described_class.present(content_item, state_fallback_order: state_fallback_order) }
+  let(:state_fallback_order) { [] }
+  let(:web_content_item) { web_content_item_for(content_item) }
+
+  subject(:result) { described_class.present(web_content_item, state_fallback_order: state_fallback_order) }
 
   describe "V2" do
     let(:base_path) { "/vat-rates" }
@@ -81,7 +86,7 @@ RSpec.describe Presenters::DownstreamPresenter do
       end
 
       it "expands the links for the content item" do
-        result = described_class.present(a, state_fallback_order: [:draft])
+        result = described_class.present(web_content_item_for(a), state_fallback_order: [:draft])
 
         expect(result[:expanded_links]).to eq(
           related: [{

--- a/spec/presenters/queries/expanded_link_set_spec.rb
+++ b/spec/presenters/queries/expanded_link_set_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Presenters::Queries::ExpandedLinkSet do
 
   subject(:expanded_links) {
     described_class.new(
-      link_set: LinkSet.find_by(content_id: a),
+      content_id: a,
       state_fallback_order: state_fallback_order,
       locale_fallback_order: locale_fallback_order
     ).links

--- a/spec/requests/content_item_requests/downstream_requests_spec.rb
+++ b/spec/requests/content_item_requests/downstream_requests_spec.rb
@@ -100,7 +100,7 @@ RSpec.describe "Downstream requests", type: :request do
         v2_content_item.except(:update_type).merge(
           links: Presenters::Queries::LinkSetPresenter.new(link_set).links
         ).merge(
-          expanded_links: Presenters::Queries::ExpandedLinkSet.new(link_set: link_set, state_fallback_order: [:draft, :published]).links
+          expanded_links: Presenters::Queries::ExpandedLinkSet.new(content_id: link_set.content_id, state_fallback_order: [:draft, :published]).links
         )
       end
 

--- a/spec/requests/expanded_links_endpoint_spec.rb
+++ b/spec/requests/expanded_links_endpoint_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "GET /v2/expanded-links/:id", type: :request do
         "content_id" => "10529c0d-f4b3-4c7d-9589-35ba6a6d1a12",
         "description" => "Some description",
         "locale" => "en",
-        "public_updated_at" => "2014-05-14T13:00:06.000Z",
+        "public_updated_at" => "2014-05-14T13:00:06Z",
         "title" => "Some title",
         "web_url" => "http://www.dev.gov.uk/some-path"
       }
@@ -59,7 +59,7 @@ RSpec.describe "GET /v2/expanded-links/:id", type: :request do
             "description" => "VAT rates for goods and services",
             "details" => { "body" => "<p>Something about VAT</p>\n" },
             "locale" => "en",
-            "public_updated_at" => "2014-05-14T13:00:06.000Z",
+            "public_updated_at" => "2014-05-14T13:00:06Z",
             "title" => "VAT rates",
             "web_url" => "http://www.dev.gov.uk/my-super-org",
             "links" => {},


### PR DESCRIPTION
Offers a sizeable speed improvement when presenting content items with
multiple links. This builds on a spike to simplify `WebContentItem` as a (currently)
read-only struct with all data fetched in a single query.

Also slims down the `ExpandedLinkSet` presenter to work solely on a `content_id` 
instead of an entire `LinkSet` object. This massively reduces both number of queries
and amount of ActiveRecord instantiation required.

This outcome of the spike can be merged as a standalone performance improvement
and built upon for other improvements to `PutContent`, `Publish` and `PatchLinkSet`.

/cc @danielroseman @elliotcm 

Before:
```
Many reverse dependencies: 6667cce2-e809-4e21-ae09-cb0bdc1ddda3
..........
  1.960000   0.160000   2.120000 (  3.817923)
Many forward dependencies: 5eb84e7c-7631-11e4-a3cb-005056011aef
..........
 25.760000   1.680000  27.440000 ( 34.142420)
No dependencies: 23e13323-874f-4210-aad3-ca6ade9206f8
..........
  0.080000   0.000000   0.080000 (  0.103394)
Single link each way: 000227a8-f0d2-417d-8ce4-27a18d62d442
..........
  0.100000   0.020000   0.120000 (  0.150513)
Import export topic: 4bda0be5-3e65-4cc1-850c-0541e95a40ca
..........
113.480000  22.710000 136.190000 (166.417259)
```

After:
```
Many reverse dependencies: 6667cce2-e809-4e21-ae09-cb0bdc1ddda3
..........
  2.490000   0.290000   2.780000 (  5.016019)
Many forward dependencies: 5eb84e7c-7631-11e4-a3cb-005056011aef
..........
  1.670000   0.100000   1.770000 (  3.174643)
No dependencies: 23e13323-874f-4210-aad3-ca6ade9206f8
..........
  0.050000   0.010000   0.060000 (  0.083467)
Single link each way: 000227a8-f0d2-417d-8ce4-27a18d62d442
..........
  0.060000   0.020000   0.080000 (  0.119172)
Import export topic: 4bda0be5-3e65-4cc1-850c-0541e95a40ca
..........
 42.300000   7.000000  49.300000 ( 75.734204)
```