### PR TITLE
Remove incorrect placeholder `Publication`s

### DIFF
--- a/db/migrate/20160705121730_remove_placeholder_publications_with_incorrect_content_id.rb
+++ b/db/migrate/20160705121730_remove_placeholder_publications_with_incorrect_content_id.rb
@@ -1,0 +1,27 @@
+class RemovePlaceholderPublicationsWithIncorrectContentId < ActiveRecord::Migration
+  def up
+    content_items = ContentItem.where(content_id: [
+      "d44e0185-1dd6-42e9-ba79-7eb4d589284b", #/government/publications/defence-information-strategy/defence-information-strategy
+      "53fed749-53ca-476f-9243-da67ea0e8ad7", #/government/publications/equality-information-report-2015
+    ])
+    supporting_classes = [
+      AccessLimit,
+      Linkable,
+      Location,
+      State,
+      Translation,
+      Unpublishing,
+      UserFacingVersion,
+    ]
+
+    supporting_classes.each do |klass|
+      klass.where(content_item: content_items).destroy_all
+    end
+
+    LockVersion.where(target: content_items).destroy_all
+
+    content_items.destroy_all
+
+    LinkSet.where(content_id: "some-content-id").destroy_all
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160627100338) do
+ActiveRecord::Schema.define(version: 20160705121730) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
This PR is a migration to remove two `Publication` content items that are causing their `HtmlAttachment`
republishing sync checks to fail as their content ids don't match with the `HtmlAttachment`. 

There is a [corresponding PR on Whitehall](https://github.com/alphagov/whitehall/pull/2649)