### PR TITLE
Allow full deletion of content including URL.

### DIFF
--- a/app/adapters/content_store.rb
+++ b/app/adapters/content_store.rb
@@ -21,5 +21,11 @@ module Adapters
         )
       end
     end
+
+    def self.delete_content_item(base_path)
+      CommandError.with_error_handling(ignore_404s: true) do
+        PublishingAPI.service(:live_content_store).delete_content_item(base_path)
+      end
+    end
   end
 end

--- a/app/commands/v2/unpublish.rb
+++ b/app/commands/v2/unpublish.rb
@@ -46,6 +46,8 @@ module Commands
           redirect(content_item)
         when "gone"
           gone(content_item)
+        when "vanish"
+          vanish(content_item)
         else
           message = "#{type} is not a valid unpublishing type"
           raise_command_error(422, message, fields: {})
@@ -102,6 +104,12 @@ module Commands
         send_downstream(gone)
       end
 
+      def vanish(content_item)
+        State.unpublish(content_item, type: "vanish")
+
+        delete_from_downstream(Location.find_by(content_item: content_item).base_path)
+      end
+
       def delete_linkable(content_item)
         Linkable.find_by(content_item: content_item).try(:destroy)
       end
@@ -113,6 +121,16 @@ module Commands
           content_store: Adapters::ContentStore,
           payload: downstream_payload.merge(payload_version: event.id),
           request_uuid: GdsApi::GovukHeaders.headers[:govuk_request_id],
+        )
+      end
+
+      def delete_from_downstream(base_path)
+        return unless downstream
+
+        PresentedContentStoreWorker.perform_async(
+          content_store: Adapters::ContentStore,
+          base_path: base_path,
+          delete: true,
         )
       end
 

--- a/app/models/unpublishing.rb
+++ b/app/models/unpublishing.rb
@@ -5,9 +5,10 @@ class Unpublishing < ActiveRecord::Base
 
   VALID_TYPES = %w(
     gone
-    withdrawal
+    vanish
     redirect
     substitute
+    withdrawal
   ).freeze
 
   validates :content_item, presence: true, uniqueness: true

--- a/doc/publishing-api-syntactic-usage.md
+++ b/doc/publishing-api-syntactic-usage.md
@@ -75,11 +75,12 @@ Requests to update an existing draft content item:
   - Will refuse to unpublish a lone draft unless `allow_draft` is `true`.
   - If `allow_draft` is `true`, will refuse to unpublish anything other than a draft.
   - Will refuse to unpublish a redrafted document unless `discard_drafts` is `true`.
-  - Validates that unpublishing `type` is one of `withdrawal`, `gone` or `redirect` and raises a 422 otherwise.
+  - Validates that unpublishing `type` is one of `withdrawal`, `gone`, `vanish` or `redirect` and raises a 422 otherwise.
   - Retrieves the live content item with the matching content_id and locale and changes its state to `unpublished`.
   - Creates an `Unpublishing` with the provided details.
   - Will update the `Unpublishing` if the document is already unpublished.
   - Sends the gone/redirect/withdrawal to the live content store.
+  - If `vanish` then fully deletes the item from the live content store.
   - Does not send to the draft content store (unless a draft was discarded).
   - Does not send to the message queue.
   - Returns 200 along with the content_id of the unpublished item.

--- a/spec/commands/v2/unpublish_spec.rb
+++ b/spec/commands/v2/unpublish_spec.rb
@@ -70,6 +70,7 @@ RSpec.describe Commands::V2::Unpublish do
 
       it "does not send to any other downstream system" do
         allow(PublishingAPI.service(:live_content_store)).to receive(:put_content_item)
+        expect(PublishingAPI.service(:live_content_store)).not_to receive(:delete_content_item)
         expect(PublishingAPI.service(:draft_content_store)).not_to receive(:put_content_item)
         expect(PublishingAPI.service(:queue_publisher)).not_to receive(:send_message)
 
@@ -152,6 +153,7 @@ RSpec.describe Commands::V2::Unpublish do
 
         it "does not send to any other downstream system" do
           allow(PublishingAPI.service(:live_content_store)).to receive(:put_content_item)
+          expect(PublishingAPI.service(:live_content_store)).not_to receive(:delete_content_item)
           expect(PublishingAPI.service(:draft_content_store)).not_to receive(:put_content_item)
           expect(PublishingAPI.service(:queue_publisher)).not_to receive(:send_message)
 
@@ -273,6 +275,7 @@ RSpec.describe Commands::V2::Unpublish do
 
       it "does not send to any other downstream system" do
         allow(PublishingAPI.service(:live_content_store)).to receive(:put_content_item)
+        expect(PublishingAPI.service(:live_content_store)).not_to receive(:delete_content_item)
         expect(PublishingAPI.service(:draft_content_store)).not_to receive(:put_content_item)
         expect(PublishingAPI.service(:queue_publisher)).not_to receive(:send_message)
 
@@ -289,6 +292,7 @@ RSpec.describe Commands::V2::Unpublish do
 
       it "does not send to any downstream system for a 'gone'" do
         expect(PublishingAPI.service(:live_content_store)).not_to receive(:put_content_item)
+        expect(PublishingAPI.service(:live_content_store)).not_to receive(:delete_content_item)
         expect(PublishingAPI.service(:draft_content_store)).not_to receive(:put_content_item)
         expect(PublishingAPI.service(:queue_publisher)).not_to receive(:send_message)
 
@@ -301,6 +305,7 @@ RSpec.describe Commands::V2::Unpublish do
 
       it "does not send to any downstream system for a 'redirect'" do
         expect(PublishingAPI.service(:live_content_store)).not_to receive(:put_content_item)
+        expect(PublishingAPI.service(:live_content_store)).not_to receive(:delete_content_item)
         expect(PublishingAPI.service(:draft_content_store)).not_to receive(:put_content_item)
         expect(PublishingAPI.service(:queue_publisher)).not_to receive(:send_message)
 
@@ -313,6 +318,20 @@ RSpec.describe Commands::V2::Unpublish do
 
       it "does not send to any downstream system for a 'withdrawal'" do
         expect(PublishingAPI.service(:live_content_store)).not_to receive(:put_content_item)
+        expect(PublishingAPI.service(:live_content_store)).not_to receive(:delete_content_item)
+        expect(PublishingAPI.service(:draft_content_store)).not_to receive(:put_content_item)
+        expect(PublishingAPI.service(:queue_publisher)).not_to receive(:send_message)
+
+        redraft_payload = payload.merge(
+          type: "withdrawal",
+          discard_drafts: true,
+        )
+        described_class.call(redraft_payload, downstream: false)
+      end
+
+      it "does not send to any downstream system for 'vanish'" do
+        expect(PublishingAPI.service(:live_content_store)).not_to receive(:put_content_item)
+        expect(PublishingAPI.service(:live_content_store)).not_to receive(:delete_content_item)
         expect(PublishingAPI.service(:draft_content_store)).not_to receive(:put_content_item)
         expect(PublishingAPI.service(:queue_publisher)).not_to receive(:send_message)
 

--- a/spec/models/unpublishing_spec.rb
+++ b/spec/models/unpublishing_spec.rb
@@ -11,9 +11,10 @@ RSpec.describe Unpublishing do
     it "requires a valid type" do
       valid_types = %w(
         gone
-        withdrawal
+        vanish
         redirect
         substitute
+        withdrawal
       )
 
       valid_types.each do |type|
@@ -54,6 +55,13 @@ RSpec.describe Unpublishing do
       subject.alternative_path = nil
       expect(subject).to be_invalid
       expect(subject.errors[:alternative_path].size).to eq(1)
+    end
+
+    it "does not require anything for 'vanish'" do
+      subject.type = "vanish"
+      subject.alternative_path = nil
+      subject.explanation = nil
+      expect(subject).to be_valid
     end
   end
 end

--- a/spec/support/content_store.rb
+++ b/spec/support/content_store.rb
@@ -2,6 +2,7 @@ RSpec.configure do |c|
   c.before :each, type: :request do
     stub_request(:put, Plek.find('content-store') + "/content#{base_path}")
     stub_request(:put, Plek.find('draft-content-store') + "/content#{base_path}")
+    stub_request(:delete, Plek.find('content-store') + "/content#{base_path}")
     stub_request(:delete, Plek.find('draft-content-store') + "/content#{base_path}")
   end
 end


### PR DESCRIPTION
Content which should never have been on the site
and needs to be fully removed including existence
of its URL (for example, early release of a document
which references a company or stock in its URL)
can send an unpublishing of type "vanish" to
indicate that it was published in error.

This is similar to a "gone" unpublishing except
the URL will 404 instead of 410.