### PR TITLE
Add contacts to pathless formats

### DIFF
--- a/app/commands/v2/publish.rb
+++ b/app/commands/v2/publish.rb
@@ -13,7 +13,7 @@ module Commands
         end
 
         translation = Translation.find_by!(content_item: content_item)
-        location = Location.find_by!(content_item: content_item)
+        location = Location.find_by(content_item: content_item)
         update_type = payload[:update_type] || content_item.update_type
 
         if update_type.blank?
@@ -87,6 +87,8 @@ module Commands
       end
 
       def clear_published_items_of_same_locale_and_base_path(content_item, translation, location)
+        return unless location
+
         SubstitutionHelper.clear!(
           new_item_document_type: content_item.document_type,
           new_item_content_id: content_item.content_id,
@@ -149,6 +151,8 @@ module Commands
         )
 
         PublishingAPI.service(:queue_publisher).send_message(queue_payload)
+
+        return if content_item.pathless?
 
         queue = update_type == 'republish' ? PresentedContentStoreWorker::LOW_QUEUE : PresentedContentStoreWorker::HIGH_QUEUE
 

--- a/app/commands/v2/put_content.rb
+++ b/app/commands/v2/put_content.rb
@@ -254,6 +254,7 @@ module Commands
 
       def send_downstream(content_item)
         return unless downstream
+        return if content_item.pathless?
 
         message = "Enqueuing PresentedContentStoreWorker job with "
         message += "{ content_store: Adapters::DraftContentStore, content_item_id: #{content_item.id} }"

--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -26,7 +26,7 @@ class ContentItem < ActiveRecord::Base
   ].freeze
 
   NON_RENDERABLE_FORMATS = %w(redirect gone).freeze
-  EMPTY_BASE_PATH_FORMATS = %w(government).freeze
+  EMPTY_BASE_PATH_FORMATS = %w(contact government).freeze
 
   scope :renderable_content, -> { where.not(document_type: NON_RENDERABLE_FORMATS) }
 
@@ -43,6 +43,10 @@ class ContentItem < ActiveRecord::Base
   }
   validates :description, well_formed_content_types: { must_include: "text/html" }
   validates :details, well_formed_content_types: { must_include: "text/html" }
+
+  def pathless?
+    EMPTY_BASE_PATH_FORMATS.include?(schema_name)
+  end
 
 private
 

--- a/spec/commands/v2/publish_spec.rb
+++ b/spec/commands/v2/publish_spec.rb
@@ -423,4 +423,30 @@ RSpec.describe Commands::V2::Publish do
 
     it_behaves_like TransactionalCommand
   end
+
+  context "for a pathless content item" do
+    let(:pathless_content_item) do
+      FactoryGirl.create(:draft_content_item, schema_name: "contact")
+    end
+
+    let(:payload) do
+      {
+        content_id: pathless_content_item.content_id,
+        update_type: "major",
+        previous_version: 1,
+      }
+    end
+
+    before do
+      location = Location.find_by(content_item: pathless_content_item)
+      location.destroy
+    end
+
+    it "publishes the item" do
+      described_class.call(payload)
+
+      state = State.find_by!(content_item: pathless_content_item)
+      expect(state.name).to eq("published")
+    end
+  end
 end

--- a/spec/commands/v2/put_content_spec.rb
+++ b/spec/commands/v2/put_content_spec.rb
@@ -890,5 +890,23 @@ RSpec.describe Commands::V2::PutContent do
         end
       end
     end
+
+    context "with a pathless content item payload" do
+      before do
+        payload.delete(:base_path)
+        payload[:schema_name] = "contact"
+      end
+
+      it "saves the content as draft" do
+        expect {
+          described_class.call(payload)
+        }.to change(ContentItem, :count).by(1)
+      end
+
+      it "doesn't send to the draft content store" do
+        described_class.call(payload)
+        expect(PresentedContentStoreWorker).not_to receive(:perform_async_in_queue)
+      end
+    end
   end
 end

--- a/spec/models/content_item_spec.rb
+++ b/spec/models/content_item_spec.rb
@@ -131,6 +131,18 @@ RSpec.describe ContentItem do
     end
   end
 
+  context 'EMPTY_BASE_PATH_FORMATS' do
+    it 'defines formats not requiring a base_path attibute' do
+      expect(ContentItem::EMPTY_BASE_PATH_FORMATS).to eq(%w(contact government))
+    end
+  end
+
+  context "pathless?" do
+    it "denotes content not requiring a base path" do
+      expect(ContentItem.new(schema_name: "contact").pathless?).to be true
+    end
+  end
+
   it_behaves_like DefaultAttributes
   it_behaves_like WellFormedContentTypesValidator
   it_behaves_like DescriptionOverrides

--- a/spec/models/content_item_spec.rb
+++ b/spec/models/content_item_spec.rb
@@ -1,4 +1,4 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe ContentItem do
   subject { FactoryGirl.build(:content_item) }
@@ -67,7 +67,7 @@ RSpec.describe ContentItem do
           expect(subject).to be_valid
         end
 
-        ['no spaces', 'puncutation!', 'mixedCASE'].each do |value|
+        ["no spaces", "puncutation!", "mixedCASE"].each do |value|
           subject.rendering_app = value
           expect(subject).to be_invalid
           expect(subject.errors[:rendering_app].size).to eq(1)
@@ -89,7 +89,7 @@ RSpec.describe ContentItem do
       end
     end
 
-    context 'content_id' do
+    context "content_id" do
       it "accepts a UUID" do
         subject.content_id = "a7c48dac-f1c6-45a8-b5c1-5c407d45826f"
         expect(subject).to be_valid
@@ -106,9 +106,9 @@ RSpec.describe ContentItem do
       end
     end
 
-    context 'phase' do
-      it 'defaults to live' do
-        expect(described_class.new.phase).to eq('live')
+    context "phase" do
+      it "defaults to live" do
+        expect(described_class.new.phase).to eq("live")
       end
 
       %w(alpha beta live).each do |phase|
@@ -118,21 +118,21 @@ RSpec.describe ContentItem do
         end
       end
 
-      it 'is invalid without a phase' do
+      it "is invalid without a phase" do
         subject.phase = nil
         expect(subject).not_to be_valid
         expect(subject.errors[:phase].size).to eq(1)
       end
 
-      it 'is invalid with any other phase' do
-        subject.phase = 'not-a-correct-phase'
+      it "is invalid with any other phase" do
+        subject.phase = "not-a-correct-phase"
         expect(subject).to_not be_valid
       end
     end
   end
 
-  context 'EMPTY_BASE_PATH_FORMATS' do
-    it 'defines formats not requiring a base_path attibute' do
+  context "EMPTY_BASE_PATH_FORMATS" do
+    it "defines formats not requiring a base_path attibute" do
       expect(ContentItem::EMPTY_BASE_PATH_FORMATS).to eq(%w(contact government))
     end
   end


### PR DESCRIPTION
Part of: https://trello.com/c/JxKRVn6c/731-export-whitehall-contacts-to-publishing-api-medium

Adds `contact` as a pathless content item format.
There was also some undesirable/missing behaviour for drafting and publishing content without a base path so this PR adds a way to draft and publish 'pathless' content without sending it to the content store(s).