### PR TITLE
Revert "Remove unpublishing for previously published item..."

### DIFF
--- a/app/commands/v2/publish.rb
+++ b/app/commands/v2/publish.rb
@@ -37,7 +37,6 @@ module Commands
         State.supersede(previous_item) if previous_item
 
         clear_published_items_of_same_locale_and_base_path(content_item, translation, location)
-        remove_unpublishing(previous_item) if previous_item
 
         set_public_updated_at(content_item, previous_item, update_type)
         set_first_published_at(content_item)
@@ -161,11 +160,6 @@ module Commands
           content_store: Adapters::ContentStore,
           payload: { content_item_id: content_item.id, payload_version: event.id },
         )
-      end
-
-      def remove_unpublishing(content_item)
-        unpublishing = Unpublishing.find_by(content_item: content_item)
-        unpublishing.destroy if unpublishing
       end
     end
   end

--- a/spec/commands/v2/publish_spec.rb
+++ b/spec/commands/v2/publish_spec.rb
@@ -393,29 +393,6 @@ RSpec.describe Commands::V2::Publish do
       end
     end
 
-    context "for a previously unpublished item" do
-      let!(:unpublished_item) do
-        FactoryGirl.create(:content_item,
-          content_id: content_id,
-          state: "published",
-          lock_version: 2,
-          base_path: base_path,
-        )
-      end
-
-      let!(:unpublishing) do
-        FactoryGirl.create(:unpublishing, content_item: unpublished_item)
-      end
-
-      it "removes the unpublishing" do
-        expect {
-          described_class.call(payload)
-        }.to change(Unpublishing, :count).by(-1)
-
-        expect(Unpublishing.find_by(content_item: unpublished_item)).to be nil
-      end
-    end
-
     it_behaves_like TransactionalCommand
   end
 


### PR DESCRIPTION
This reverts commit 63feb0efa7e85ff522ec9201a63dfe612dd41a9f.

There's no need to remove an unpublishing when a piece of
content is unwithdrawn, the unpublished content item will
be superseded and the unpublishing will be related to this,
not the new (redrafted and published) item.