### PR TITLE
Update documentation for deprecated format field

### DIFF
--- a/doc/semantics-of-the-publishing-api.md
+++ b/doc/semantics-of-the-publishing-api.md
@@ -57,31 +57,6 @@ a tendency to change.
 
 ---
 
-### format
-
-Examples: *manual, policy, redirect*
-
-Required: Yes
-
-The `format` specifies the data format of the content item as per the
-[GOV.UK content schemas](https://github.com/alphagov/govuk-content-schemas).
-It is used downstream to render the content item according a specific layout for
-that `format`.
-
-If the `format` is one of either *redirect* or *gone*, the content item is
-considered non-renderable and this waives the requirement for some of the other
-fields in the content item to be present, namely `title`, `rendering_app` and
-`public_updated_at`.
-
-At present, not all content goes through the publishing pipeline, but there is
-still a need to link to content items on our legacy infrastructure. There are
-some special formats that can be used in these cases. The `format` should be
-prefixed with *placeholder_* or set to *placeholder*. See
-[here](https://github.com/alphagov/content-store/blob/master/doc/placeholder_item.md)
-for more information.
-
----
-
 ### publishing_app
 
 Example: *collections-publisher*
@@ -108,19 +83,57 @@ the convention used in the Router API.
 
 ### details
 
-Example: *{ body: "Something about VAT” }*
+Example: *{ body: "Something about VAT" }*
 
 Required: Conditionally
 
 The `details` (sometimes referred to as “details hash”) contains content and
-other attributes that are specific to the `format` of the content item. The
+other attributes that are specific to the `schema_name` of the content item. The
 [GOV.UK content schemas](https://github.com/alphagov/govuk-content-schemas)
 determine which fields appear in the details and which are required. The details
 can contain arbitrary JSON that will be stored against the content item.
 
-Not all `formats` have required fields and so details is not required unless the
-`format` demands it. If it is not set, it will default to an empty JSON object
+Not all `schemas` have required fields and so details is not required unless the
+`schema` demands it. If it is not set, it will default to an empty JSON object
 as specified in the GOV.UK content schemas.
+
+---
+
+### document_type
+
+Examples: *manual, policy, redirect*
+
+Required: Conditionally
+
+The `document_type` specifies the type of content item that will be rendered.
+It is used downstream to render the content item according to a specific layout
+for that `document_type`.  
+
+This field, together with `schema_name`, replaces the `format` field. It is
+required in the absence of a `format` field.
+
+If the `document_type` is one of either *redirect* or *gone*, the content item is
+considered non-renderable and this waives the requirement for some of the other
+fields in the content item to be present, namely `title`, `rendering_app` and
+`public_updated_at`.
+
+---
+
+### format
+
+**Deprecated**
+
+Examples: *manual, policy, redirect*
+
+Required: Conditionally
+
+The `format` specifies the data format of the content item as per the
+[GOV.UK content schemas](https://github.com/alphagov/govuk-content-schemas).
+It is used downstream to render the content item according a specific layout for
+that `format`.
+
+This field has been replaced by sending both the `document_type` and
+`schema_name` fields. Both of which are required if this field is omitted.
 
 ---
 
@@ -225,6 +238,27 @@ users' requests to the appropriate front-end application.
 
 The `rendering_app` is required except in cases where the content item is
 non-renderable (see [**format**](#format)).
+
+---
+
+### schema_name
+
+Examples: *manual, policy, redirect*
+
+Required: Conditionally
+
+The `schema_name` specifies the data format of the content item as per the
+[GOV.UK content schemas](https://github.com/alphagov/govuk-content-schemas).
+It is used to validate that the request matches the specified format.
+
+This field is required when the deprecated field `format` is not provided.
+
+At present, not all content goes through the publishing pipeline, but there is
+still a need to link to content items on our legacy infrastructure. There are
+some special formats that can be used in these cases. The `schema_name` should be
+prefixed with *placeholder_* or set to *placeholder*. See
+[here](https://github.com/alphagov/content-store/blob/master/doc/placeholder_item.md)
+for more information.
 
 ---
 

--- a/doc/semantics-of-the-publishing-api.md
+++ b/doc/semantics-of-the-publishing-api.md
@@ -107,7 +107,10 @@ Required: Conditionally
 
 The `document_type` specifies the type of content item that will be rendered.
 It is used downstream to render the content item according to a specific layout
-for that `document_type`.  
+for that `document_type` and to filter a list of objects in publishing apps. 
+
+There is not a formal list of acceptable values for `document_type`. It
+should be in the form of a-z string with underscore separators. 
 
 This field, together with `schema_name`, replaces the `format` field. It is
 required in the absence of a `format` field.
@@ -247,9 +250,9 @@ Examples: *manual, policy, redirect*
 
 Required: Conditionally
 
-The `schema_name` specifies the data format of the content item as per the
+The `schema_name` specifies the schema file used to validate the request
+as per the 
 [GOV.UK content schemas](https://github.com/alphagov/govuk-content-schemas).
-It is used to validate that the request matches the specified format.
 
 This field is required when the deprecated field `format` is not provided.
 


### PR DESCRIPTION
I've attempted to update the documentation for the deprecation of the format field. I don't think this quite complete and I have a few questions to resolve to complete this:

1. How to define what a document_type should match? I understand it’s the document type that is selected when creating a document on whitehall or similar systems, but don’t know of a list.
2. Is document_type, schema_name or both used to determine which layout is used to render the item?
3. Whether key information should be on document_type field and/or schema_name field.
    1. Redirect or gone types - I’ve tied to document_type
    2. Placeholder I’ve put on the schema_name
4. The format we’d use to mark a field as deprecated - as is the case with the format field

