### PR TITLE
Allow base_path lookups for a single given state

### DIFF
--- a/app/controllers/lookups_controller.rb
+++ b/app/controllers/lookups_controller.rb
@@ -2,7 +2,7 @@ class LookupsController < ApplicationController
   def by_base_path
     # return content_ids for content that is visible on the live site
     # withdrawn items are still visible
-    states = %w(published unpublished)
+    states = params[:state] || %w(published unpublished)
     base_paths = params.fetch(:base_paths)
 
     base_paths_and_content_ids = ContentItemFilter

--- a/app/controllers/lookups_controller.rb
+++ b/app/controllers/lookups_controller.rb
@@ -1,8 +1,11 @@
 class LookupsController < ApplicationController
+  # return content_ids for content that is visible on the live site
+  # withdrawn items are still visible
+  DEFAULT_STATES_FILTER = %w(published unpublished).freeze
+
   def by_base_path
-    # return content_ids for content that is visible on the live site
-    # withdrawn items are still visible
-    states = params[:state] || %w(published unpublished)
+    states = params[:state] ? valid_state_params : DEFAULT_STATES_FILTER
+
     base_paths = params.fetch(:base_paths)
 
     base_paths_and_content_ids = ContentItemFilter
@@ -12,5 +15,17 @@ class LookupsController < ApplicationController
 
     response = Hash[base_paths_and_content_ids]
     render json: response
+  end
+
+private
+
+  def valid_state_params
+    unless State.allowed_values.include?(params[:state])
+      raise CommandError.new(
+        code: 422,
+        message: "state: '#{params[:state]}' not one of #{State.allowed_values}"
+      )
+    end
+    params[:state]
   end
 end

--- a/app/models/state.rb
+++ b/app/models/state.rb
@@ -3,6 +3,10 @@ class State < ActiveRecord::Base
 
   validates_with ContentItemUniquenessValidator
 
+  def self.allowed_values
+    %w(draft published superseded unpublished)
+  end
+
   def self.filter(content_item_scope, name:)
     join_content_items(content_item_scope)
       .where("states.name" => name)

--- a/spec/models/state_spec.rb
+++ b/spec/models/state_spec.rb
@@ -152,4 +152,11 @@ RSpec.describe State do
       )
     end
   end
+
+  describe ".allowed_values" do
+    it "has four allowed values" do
+      expect(described_class.allowed_values).to match_array(
+        %w(draft published unpublished superseded))
+    end
+  end
 end

--- a/spec/requests/lookups_spec.rb
+++ b/spec/requests/lookups_spec.rb
@@ -25,15 +25,32 @@ RSpec.describe "POST /lookup-by-base-path", type: :request do
     end
 
     context "a state is given in addition to base_paths" do
-      it "returns content_ids for the given state, even if not user-visible" do
-        create_test_content
+      context "that is in the list of valid states" do
+        it "returns content_ids for the given state, even if not user-visible" do
+          create_test_content
 
-        post "/lookup-by-base-path", base_paths: test_base_paths, state: 'draft'
+          post "/lookup-by-base-path", base_paths: test_base_paths, state: 'draft'
 
-        expect(parsed_response).to eql(
-          "/published-and-draft-page" => "aa491126-77ed-4e81-91fa-8dc7f74e9657",
-          "/draft-and-superseded-page" => "dd1bf833-f91c-4e45-9f97-87b165808176"
-        )
+          expect(parsed_response).to eql(
+            "/published-and-draft-page" => "aa491126-77ed-4e81-91fa-8dc7f74e9657",
+            "/draft-and-superseded-page" => "dd1bf833-f91c-4e45-9f97-87b165808176"
+          )
+        end
+      end
+
+      context "that is not in the list of valid states" do
+        it "raises a useful error" do
+          create_test_content
+
+          post "/lookup-by-base-path", base_paths: test_base_paths, state: 'xianhua'
+
+          expect(parsed_response).to eql(
+            "error" => {
+              "code" => 422,
+              "message" => %(state: 'xianhua' not one of ["draft", "published", "superseded", "unpublished"])
+            }
+          )
+        end
       end
     end
   end

--- a/spec/requests/lookups_spec.rb
+++ b/spec/requests/lookups_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "POST /lookup-by-base-path", type: :request do
     end
   end
 
-  context "returning content_ids" do
+  describe "returning content_ids" do
     it "returns content_ids for user-visible states (published, unpublished)" do
       create_test_content
 
@@ -22,6 +22,19 @@ RSpec.describe "POST /lookup-by-base-path", type: :request do
         "/only-published-page" => "bbabcd3c-7c45-4403-8490-db51e4bfc4f6",
         "/only-unpublished-page" => "cc6d416c-f369-4b7c-bac7-5e9401e79362",
       )
+    end
+
+    context "a state is given in addition to base_paths" do
+      it "returns content_ids for the given state, even if not user-visible" do
+        create_test_content
+
+        post "/lookup-by-base-path", base_paths: test_base_paths, state: 'draft'
+
+        expect(parsed_response).to eql(
+          "/published-and-draft-page" => "aa491126-77ed-4e81-91fa-8dc7f74e9657",
+          "/draft-and-superseded-page" => "dd1bf833-f91c-4e45-9f97-87b165808176"
+        )
+      end
     end
   end
 


### PR DESCRIPTION
* Gives us a way to see what existing item is causing a collision in
  dfid-transition
* Don't allow multiple state query, as some combinations (e.g.
  live/draft) are inadvisable