### PR TITLE
Return the content_id of the duplicate item on error

### DIFF
--- a/app/validators/content_item_uniqueness_validator.rb
+++ b/app/validators/content_item_uniqueness_validator.rb
@@ -38,7 +38,8 @@ class ContentItemUniquenessValidator < ActiveModel::Validator
       error << "state=#{state_name}, "
       error << "locale=#{locale}, "
       error << "base_path=#{base_path}, "
-      error << "user_version=#{user_version}"
+      error << "user_version=#{user_version}, "
+      error << "content_id=#{additional_items.first.content_id}"
 
       record.errors.add(:content_item, error)
     end

--- a/spec/validators/content_item_uniqueness_validator_spec.rb
+++ b/spec/validators/content_item_uniqueness_validator_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe ContentItemUniquenessValidator do
   end
 
   context "for a content item with duplicate supporting objects" do
-    before do
+    let!(:existing_item) do
       FactoryGirl.create(:content_item,
         user_facing_version: 2,
         base_path: base_path,
@@ -49,7 +49,8 @@ RSpec.describe ContentItemUniquenessValidator do
         number: 2,
       )
 
-      expected_error = "conflicts with a duplicate: state=draft, locale=en, base_path=/vat-rates, user_version=2"
+      expected_error = "conflicts with a duplicate: state=draft, locale=en, base_path=/vat-rates, user_version=2, "\
+                       "content_id=#{existing_item.content_id}"
       assert_invalid(user_facing_version, [expected_error])
     end
   end


### PR DESCRIPTION
Allows us to recover in batch import processes like dfid-transition
without having to issue a second lookup to the publishing API to find
out what content we're colliding with. Although `additional_items.any?`
and the concomitant `additional_items.first.content_id`
might imply that there could be more than one conflicting item,
discussions with the publishing team indicate that this situation
could be described as an exotic corner case.