### PR TITLE
Allow pathless content updates

### DIFF
--- a/app/commands/v2/publish.rb
+++ b/app/commands/v2/publish.rb
@@ -33,9 +33,10 @@ module Commands
 
         State.supersede(previous_item) if previous_item
 
-        publish_redirect_if_content_item_has_moved(location, previous_location, translation)
-
-        clear_published_items_of_same_locale_and_base_path(content_item, translation, location)
+        unless content_item.pathless?
+          publish_redirect_if_content_item_has_moved(location, previous_location, translation)
+          clear_published_items_of_same_locale_and_base_path(content_item, translation, location)
+        end
 
         set_public_updated_at(content_item, previous_item, update_type)
         set_first_published_at(content_item)
@@ -85,8 +86,6 @@ module Commands
       end
 
       def clear_published_items_of_same_locale_and_base_path(content_item, translation, location)
-        return unless location
-
         SubstitutionHelper.clear!(
           new_item_document_type: content_item.document_type,
           new_item_content_id: content_item.content_id,

--- a/spec/commands/v2/publish_spec.rb
+++ b/spec/commands/v2/publish_spec.rb
@@ -469,5 +469,19 @@ RSpec.describe Commands::V2::Publish do
       state = State.find_by!(content_item: pathless_content_item)
       expect(state.name).to eq("published")
     end
+
+    context "with a previously published item" do
+      let!(:live_content_item) do
+        FactoryGirl.create(:live_content_item,
+                           content_id: pathless_content_item.content_id, schema_name: "contact")
+      end
+
+      it "publishes the draft" do
+        described_class.call(payload)
+
+        state = State.find_by!(content_item: pathless_content_item)
+        expect(state.name).to eq("published")
+      end
+    end
   end
 end

--- a/spec/commands/v2/put_content_spec.rb
+++ b/spec/commands/v2/put_content_spec.rb
@@ -854,6 +854,29 @@ RSpec.describe Commands::V2::PutContent do
         described_class.call(payload)
         expect(PresentedContentStoreWorker).not_to receive(:perform_async_in_queue)
       end
+
+      context "for an existing draft content item" do
+        let!(:draft_content_item) do
+          FactoryGirl.create(:draft_content_item, content_id: content_id, title: "Old Title")
+        end
+
+        it "updates the draft" do
+          described_class.call(payload)
+          expect(draft_content_item.reload.title).to eq("Some Title")
+        end
+      end
+
+      context "for an existing live content item" do
+        let!(:live_content_item) do
+          FactoryGirl.create(:live_content_item, content_id: content_id, title: "Old Title")
+        end
+
+        it "creates a new draft" do
+          expect {
+            described_class.call(payload)
+          }.to change(ContentItem, :count).by(1)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
https://govuk.zendesk.com/agent/tickets/1371252

Updating a content item without a base path should not attempt
to perform any of the path-reliant steps in persisting the content.
The helper methods `base_path_required?` and `content_item.pathless?`
are used to identify content formats which shouldn't need to create, compare
or update any `Location` supporting objects.