### PR TITLE
Allow publishing apps to request a specific version.

### DIFF
--- a/app/controllers/v2/content_items_controller.rb
+++ b/app/controllers/v2/content_items_controller.rb
@@ -24,7 +24,11 @@ module V2
     end
 
     def show
-      render json: Queries::GetContent.call(path_params[:content_id], query_params[:locale])
+      render json: Queries::GetContent.call(
+        path_params[:content_id],
+        query_params[:locale],
+        version: query_params[:version],
+      )
     end
 
     def put_content

--- a/app/queries/get_content.rb
+++ b/app/queries/get_content.rb
@@ -1,10 +1,11 @@
 module Queries
   module GetContent
-    def self.call(content_id, locale = nil)
+    def self.call(content_id, locale = nil, version: nil)
       locale ||= ContentItem::DEFAULT_LOCALE
 
       content_items = ContentItem.where(content_id: content_id)
       content_items = Translation.filter(content_items, locale: locale)
+      content_items = UserFacingVersion.filter(content_items, number: version) if version
 
       response = Presenters::Queries::ContentItemPresenter.present_many(content_items).first
 

--- a/spec/queries/get_content_spec.rb
+++ b/spec/queries/get_content_spec.rb
@@ -108,4 +108,33 @@ RSpec.describe Queries::GetContent do
       expect(result.fetch("title")).to eq("French Title")
     end
   end
+
+  describe "requesting specific versions" do
+    before do
+      FactoryGirl.create(:content_item,
+        state: "superseded",
+        content_id: content_id,
+        user_facing_version: 1,
+      )
+
+      FactoryGirl.create(:content_item,
+        state: "published",
+        content_id: content_id,
+        user_facing_version: 2,
+      )
+    end
+
+    it "returns specific versions if provided" do
+      result = subject.call(content_id, version: 1)
+      expect(result.fetch("publication_state")).to eq("superseded")
+
+      result = subject.call(content_id, version: 2)
+      expect(result.fetch("publication_state")).to eq("live")
+    end
+
+    it "returns the most recent if version isn't given" do
+      result = subject.call(content_id)
+      expect(result.fetch("publication_state")).to eq("live")
+    end
+  end
 end

--- a/spec/service_consumers/pact_helper.rb
+++ b/spec/service_consumers/pact_helper.rb
@@ -198,6 +198,30 @@ Pact.provider_states_for "GDS API Adapters" do
     end
   end
 
+  provider_state "a content item exists in with a superseded version with content_id: bed722e6-db68-43e5-9079-063f623335a7" do
+    set_up do
+      FactoryGirl.create(:content_item,
+        content_id: "bed722e6-db68-43e5-9079-063f623335a7",
+        locale: "en",
+        document_type: "topic",
+        schema_name: "topic",
+        public_updated_at: '2015-01-03',
+        state: "superseded",
+        user_facing_version: 1,
+      )
+
+      FactoryGirl.create(:content_item,
+        content_id: "bed722e6-db68-43e5-9079-063f623335a7",
+        locale: "en",
+        document_type: "topic",
+        schema_name: "topic",
+        public_updated_at: '2015-01-03',
+        state: "published",
+        user_facing_version: 2,
+      )
+    end
+  end
+
   provider_state "the content item bed722e6-db68-43e5-9079-063f623335a7 is at lock version 3" do
     set_up do
       draft = FactoryGirl.create(


### PR DESCRIPTION
During the Specialist Publisher migration work, we found that we need to be able to retrieve the published version of content so that we can re-trigger email alerts if they fail to send (for whatever reason). Currently, you can only retrieve the latest piece of content, which is sometimes a draft if the content has been redrafted.

Additionally, existing applications provide features that allow users of those apps to view superseded content. Travel Advice Publisher, for example, allows users to view "archived" content which is not currently supported by the Publishing API.

https://trello.com/c/rPoiiBbz/762-allow-get-content-item-requests-to-specify-a-user-facing-version