### PR TITLE
Send validation errors to Errbit as hashes.

### DIFF
--- a/app/validators/schema_validator.rb
+++ b/app/validators/schema_validator.rb
@@ -20,7 +20,7 @@ class SchemaValidator
 
     return true if errors.empty?
 
-    errors = errors.map { |e| present_error(e) }
+    errors = Hash[errors.map.with_index { |e, i| [i, present_error(e)] }]
 
     Airbrake.notify_or_ignore(
       {
@@ -47,7 +47,7 @@ private
     if error_hash.has_key?(:errors)
       error_hash[:errors] = Hash[
         error_hash[:errors].map do |k, errors|
-          [k, errors.map { |e| present_error e }]
+          [k, Hash[errors.map.with_index { |e, i| [i, present_error(e)] }]]
         end
       ]
     end

--- a/spec/validators/schema_validator_spec.rb
+++ b/spec/validators/schema_validator_spec.rb
@@ -96,30 +96,30 @@ RSpec.describe SchemaValidator do
               message: a_string_starting_with("The property '#/' of type Hash did not match"),
               failed_attribute: "OneOf",
               errors: {
-                oneof_0: [
-                  a_hash_including(
+                oneof_0: {
+                  0 => a_hash_including(
                     message: a_string_starting_with("The property '#/' did not contain a required property of 'title'"),
                     failed_attribute: "Required",
                   ),
-                  a_hash_including(
+                  1 => a_hash_including(
                     message: a_string_starting_with("The property '#/' did not contain a required property of 'format'"),
                     failed_attribute: "Required",
                   ),
-                  a_hash_including(
+                  2 => a_hash_including(
                     message: a_string_starting_with("The property '#/' contains additional properties [\"schema_name\"] outside of the schema when none are allowed"),
                     failed_attribute: "AdditionalProperties"
                   )
-                ],
-                oneof_1: [
-                  a_hash_including(
+                },
+                oneof_1: {
+                  0 => a_hash_including(
                     message: a_string_starting_with("The property '#/' did not contain a required property of 'format'"),
                     failed_attribute: "Required",
                   ),
-                  a_hash_including(
+                  1 => a_hash_including(
                     message: a_string_starting_with("The property '#/' did not contain a required property of 'document_type'"),
                     failed_attribute: "Required",
                   ),
-                ]
+                }
               }
             )
           )
@@ -139,26 +139,26 @@ RSpec.describe SchemaValidator do
               message: a_string_starting_with("The property '#/' of type Hash did not match"),
               failed_attribute: "OneOf",
               errors: {
-                oneof_0: [
-                  a_hash_including(
+                oneof_0: {
+                  0 => a_hash_including(
                     message: a_string_starting_with("The property '#/' did not contain a required property of 'title'"),
                     failed_attribute: "Required",
                   ),
-                ],
-                oneof_1: [
-                  a_hash_including(
+                },
+                oneof_1: {
+                  0 => a_hash_including(
                     message: a_string_starting_with("The property '#/' did not contain a required property of 'document_type'"),
                     failed_attribute: "Required",
                   ),
-                  a_hash_including(
+                  1 => a_hash_including(
                     message: a_string_starting_with("The property '#/' did not contain a required property of 'schema_name'"),
                     failed_attribute: "Required",
                   ),
-                  a_hash_including(
+                  2 => a_hash_including(
                     message: a_string_starting_with("The property '#/' contains additional properties [\"format\"] outside of the schema when none are allowed"),
                     failed_attribute: "AdditionalProperties"
                   ),
-                ]
+                }
               }
             )
           )


### PR DESCRIPTION
The Airbrake/Errbit protocol does not support arrays; anything that is
not a hash is sent as a string. This makes it hard to read the detailed
schema validation errors which are rendered as a single long string.

This extends the pre-processing to convert arrays to hashes keyed by
the array index.