### PR TITLE
Dependency integration tests

### DIFF
--- a/spec/presenters/queries/expanded_link_set_spec.rb
+++ b/spec/presenters/queries/expanded_link_set_spec.rb
@@ -1,33 +1,7 @@
 require "rails_helper"
 
 RSpec.describe Presenters::Queries::ExpandedLinkSet do
-  def create_link_set
-    link_set = FactoryGirl.create(:link_set, content_id: SecureRandom.uuid)
-    link_set.content_id
-  end
-
-  def create_content_item(content_id, base_path, state = "published", locale = "en")
-    FactoryGirl.create(
-      :content_item,
-      content_id: content_id,
-      base_path: base_path,
-      state: state,
-      locale: locale,
-      document_type: 'topical_event',
-      details: {},
-    )
-  end
-
-  def create_link(from, to, link_type)
-    link_set = LinkSet.find_by(content_id: from)
-
-    FactoryGirl.create(
-      :link,
-      link_set: link_set,
-      target_content_id: to,
-      link_type: link_type,
-    )
-  end
+  include DependencyResolutionHelper
 
   let(:a) { create_link_set }
   let(:b) { create_link_set }

--- a/spec/support/dependency_resolution_helper.rb
+++ b/spec/support/dependency_resolution_helper.rb
@@ -1,0 +1,29 @@
+module DependencyResolutionHelper
+  def create_link_set
+    link_set = FactoryGirl.create(:link_set, content_id: SecureRandom.uuid)
+    link_set.content_id
+  end
+
+  def create_content_item(content_id, base_path, state = "published", locale = "en")
+    FactoryGirl.create(
+      :content_item,
+      content_id: content_id,
+      base_path: base_path,
+      state: state,
+      locale: locale,
+      document_type: 'topical_event',
+      details: {},
+    )
+  end
+
+  def create_link(from, to, link_type)
+    link_set = LinkSet.find_by(content_id: from)
+
+    FactoryGirl.create(
+      :link,
+      link_set: link_set,
+      target_content_id: to,
+      link_type: link_type,
+    )
+  end
+end


### PR DESCRIPTION
Insure draft dependencies do not get sent to the
live content store or to the message queue

https://trello.com/c/gGal51EL/760-dependency-resolution-downstream-integration-tests-medium