### PR TITLE
Return 422 on put-content requests without publishing_app

### DIFF
--- a/app/commands/v2/put_content.rb
+++ b/app/commands/v2/put_content.rb
@@ -5,6 +5,12 @@ module Commands
         raise_if_links_is_provided
         validate_schema
 
+        if publishing_app.blank?
+          raise_command_error(422, "publishing_app is required", fields: {
+            publishing_app: ["is required"]
+          })
+        end
+
         PathReservation.reserve_base_path!(base_path, publishing_app) if base_path_required?
         content_item = find_previously_drafted_content_item
 
@@ -219,7 +225,7 @@ module Commands
       end
 
       def publishing_app
-        payload.fetch(:publishing_app)
+        payload[:publishing_app]
       end
 
       def update_content_item(content_item)

--- a/spec/commands/v2/put_content_spec.rb
+++ b/spec/commands/v2/put_content_spec.rb
@@ -751,6 +751,18 @@ RSpec.describe Commands::V2::PutContent do
       end
     end
 
+    context 'without a publishing_app' do
+      before do
+        payload.delete(:publishing_app)
+      end
+
+      it "raises an error" do
+        expect {
+          described_class.call(payload)
+        }.to raise_error(CommandError, /publishing_app is required/)
+      end
+    end
+
     it_behaves_like TransactionalCommand
 
     it "validate against schema" do


### PR DESCRIPTION
When a request is submitted to PUT /v2/content/:content-id without a
publishing_app a 500 response is returned. These changes instead return a 422
and a descriptive message.