### PR TITLE
Specific ordering for links relation of LinkSet

### DIFF
--- a/app/models/link_set.rb
+++ b/app/models/link_set.rb
@@ -1,3 +1,3 @@
 class LinkSet < ActiveRecord::Base
-  has_many :links, dependent: :destroy
+  has_many :links, -> { order(id: :asc) }, dependent: :destroy
 end

--- a/spec/service_consumers/pact_helper.rb
+++ b/spec/service_consumers/pact_helper.rb
@@ -358,8 +358,8 @@ Pact.provider_states_for "GDS API Adapters" do
         user_facing_version: 1,
       )
 
-      link_set1 = FactoryGirl.create(:link_set, content_id: content_id2)
-      link_set2 = FactoryGirl.create(:link_set, content_id: content_id3)
+      link_set1 = FactoryGirl.create(:link_set, content_id: content_id3)
+      link_set2 = FactoryGirl.create(:link_set, content_id: content_id2)
 
       FactoryGirl.create(:link, link_set: link_set1, link_type: "topic", target_content_id: content_id1)
       FactoryGirl.create(:link, link_set: link_set2, link_type: "topic", target_content_id: content_id1)


### PR DESCRIPTION
This PR introduces ordering to the links relation of LinkSet. This introduces some additional consistency to the results and resolves an intermittent test failure: https://ci.dev.publishing.service.gov.uk/job/govuk_publishing-api_branches/2067/

Technically the ordering of the links isn't something we care about or something that can be defined by the request. Although by having no ordering specified on the relation we're leaving it up to Postgres to determine the ordering which means it may vary. Making this consistent will mean more uniformity in responses, which would be beneficial if anyone is diffing responses.