### PR TITLE
Make version check in put content clearer

### DIFF
--- a/app/commands/v2/put_content.rb
+++ b/app/commands/v2/put_content.rb
@@ -62,14 +62,14 @@ module Commands
       end
 
       def update_existing_content_item(content_item)
+        check_version_and_raise_if_conflicting(content_item, payload[:previous_version])
+
         if base_path_required?
           clear_draft_items_of_same_locale_and_base_path(content_item, locale, base_path)
 
           previous_location = Location.find_by!(content_item: content_item)
           previous_routes = content_item.routes
         end
-
-        check_version_and_raise_if_conflicting(content_item, payload[:previous_version])
 
         update_content_item(content_item)
         update_last_edited_at_if_needed(content_item, payload[:last_edited_at])


### PR DESCRIPTION
I thought I had found a bug in the code where it allowed the state of the application to be mutated on a validation error. It turns out that this is actually not the case as all the database changes are wrapped in a transaction which the exception causes a rollback.

Despite this I thought these tests and the change in the ordering of the code could make it easier to understand the intentions of the code and could help someone else not come to the conclusion I came to.

Can understand though if people agree that this isn't necessary to merge in.