### PR TITLE
Rename link type: alpha_taxons to taxons

### DIFF
--- a/app/commands/put_content_with_links.rb
+++ b/app/commands/put_content_with_links.rb
@@ -61,7 +61,7 @@ module Commands
     end
 
     def protected_link_types
-      ["alpha_taxons"]
+      ["taxons"]
     end
 
     def protected_apps

--- a/app/commands/put_draft_content_with_links.rb
+++ b/app/commands/put_draft_content_with_links.rb
@@ -67,7 +67,7 @@ module Commands
     end
 
     def protected_link_types
-      ["alpha_taxons"]
+      ["taxons"]
     end
 
     def protected_apps

--- a/spec/commands/put_content_with_links_spec.rb
+++ b/spec/commands/put_content_with_links_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe Commands::PutContentWithLinks do
 
     content_item = FactoryGirl.create(:content_item)
     link_set = FactoryGirl.create(:link_set, content_id: content_item.content_id)
-    protected_link = FactoryGirl.create(:link, link_set: link_set, link_type: 'alpha_taxons')
+    protected_link = FactoryGirl.create(:link, link_set: link_set, link_type: 'taxons')
     normal_link = FactoryGirl.create(:link, link_set: link_set, link_type: 'topics')
     FactoryGirl.create(:lock_version, target: link_set)
 

--- a/spec/commands/put_draft_content_with_links_spec.rb
+++ b/spec/commands/put_draft_content_with_links_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe Commands::PutDraftContentWithLinks do
     stub_request(:put, "http://content-store.dev.gov.uk/content/foo")
 
     link_set = FactoryGirl.create(:link_set, content_id: '60d81299-6ae7-4bab-b4fe-4235d518d50a')
-    protected_link = FactoryGirl.create(:link, link_set: link_set, link_type: 'alpha_taxons')
+    protected_link = FactoryGirl.create(:link, link_set: link_set, link_type: 'taxons')
     normal_link = FactoryGirl.create(:link, link_set: link_set, link_type: 'topics')
     FactoryGirl.create(:lock_version, target: link_set)
 


### PR DESCRIPTION
When we started experimenting with new taxonomy we used `alpha_taxons` as the link type.
Now that we're no longer in alpha we'd like to be consistent in using the link type.

Trello: https://trello.com/c/tt0UdAV3/35-use-taxons-as-link-type-everywhere