### PR TITLE
Allow pathless formats to accept a base_path

### DIFF
--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -44,10 +44,6 @@ class ContentItem < ActiveRecord::Base
   validates :description, well_formed_content_types: { must_include: "text/html" }
   validates :details, well_formed_content_types: { must_include: "text/html" }
 
-  def pathless?
-    EMPTY_BASE_PATH_FORMATS.include?(schema_name)
-  end
-
 private
 
   def renderable_content?

--- a/spec/commands/v2/put_content_spec.rb
+++ b/spec/commands/v2/put_content_spec.rb
@@ -898,8 +898,8 @@ RSpec.describe Commands::V2::PutContent do
       end
 
       it "doesn't send to the draft content store" do
-        described_class.call(payload)
         expect(PresentedContentStoreWorker).not_to receive(:perform_async_in_queue)
+        described_class.call(payload)
       end
 
       context "for an existing draft content item" do
@@ -922,6 +922,17 @@ RSpec.describe Commands::V2::PutContent do
           expect {
             described_class.call(payload)
           }.to change(ContentItem, :count).by(1)
+        end
+      end
+
+      context "for a pathless format with a path" do
+        before do
+          payload[:base_path] = "/vat-rates"
+        end
+
+        it "sends to the content-store" do
+          expect(PresentedContentStoreWorker).to receive(:perform_async_in_queue)
+          described_class.call(payload)
         end
       end
     end

--- a/spec/models/content_item_spec.rb
+++ b/spec/models/content_item_spec.rb
@@ -137,12 +137,6 @@ RSpec.describe ContentItem do
     end
   end
 
-  context "pathless?" do
-    it "denotes content not requiring a base path" do
-      expect(ContentItem.new(schema_name: "contact").pathless?).to be true
-    end
-  end
-
   it_behaves_like DefaultAttributes
   it_behaves_like WellFormedContentTypesValidator
   it_behaves_like DescriptionOverrides


### PR DESCRIPTION
https://govuk.zendesk.com/agent/tickets/1371252

The `contact` format is ambiguous in accepting a `base_path` but not requiring it.
Contacts from whitehall do not have a path and are never sent to the content store whereas contacts-admin content does use this field and is presented to the content store as expected.
This change allows for content items of a pathless format to use the `base_path` if supplied.