### PR TITLE
Stop skipping uniqueness validation for "superseded" content items

### DIFF
--- a/app/validators/content_item_uniqueness_validator.rb
+++ b/app/validators/content_item_uniqueness_validator.rb
@@ -16,11 +16,6 @@ class ContentItemUniquenessValidator < ActiveModel::Validator
 
     return unless required_fields.all?
 
-    # We should only have one content item at a given path (and locale) for each
-    # content store. Superseded content items aren't in either content store so
-    # we can relax this validation.
-    return if state == "superseded"
-
     non_unique = Queries::ContentItemUniqueness.first_non_unique_item(
       content_item,
       base_path: base_path,

--- a/spec/validators/content_item_uniqueness_validator_spec.rb
+++ b/spec/validators/content_item_uniqueness_validator_spec.rb
@@ -104,24 +104,4 @@ RSpec.describe ContentItemUniquenessValidator do
       expect(@content_item.errors).to be_empty
     end
   end
-
-  context "when a duplicate content item exists in a superseded state" do
-    let!(:content_item) do
-      FactoryGirl.create(:content_item,
-        state: "superseded",
-        base_path: base_path,
-      )
-    end
-
-    it "allows duplicates and does not raise an error" do
-      expect {
-        FactoryGirl.create(:content_item,
-          state: "superseded",
-          base_path: base_path,
-        )
-      }.not_to raise_error
-
-      expect(ContentItem.count).to eq(2)
-    end
-  end
 end


### PR DESCRIPTION
This is unnecessary, as there can only be one superseded content item per user
facing version.