### PR TITLE
Represent

### DIFF
--- a/app/commands/v2/represent_downstream.rb
+++ b/app/commands/v2/represent_downstream.rb
@@ -5,14 +5,17 @@ module Commands
         self.to_s
       end
 
-      def call(scope)
+      def call(scope, draft = false)
         filter = ContentItemFilter.new(scope: scope)
 
-        items_for_draft_store(filter).pluck(:id, :content_id).each do |(content_item_id, content_id)|
-          send_to_content_store(content_item_id, content_id, Adapters::DraftContentStore)
+        if draft
+          items_for_draft_store(filter).pluck(:id, :content_id).each do |(content_item_id, content_id)|
+            send_to_content_store(content_item_id, content_id, Adapters::DraftContentStore)
+          end
         end
 
-        items_for_live_store(filter).pluck(:id, :content_id).each do |(content_item_id, content_id)|
+        items_for_live_store(filter).pluck(:id, :content_id).each_with_index do |(content_item_id, content_id), index|
+          sleep 60 if (index + 1) % 10_000 == 0
           send_to_content_store(content_item_id, content_id, Adapters::ContentStore)
         end
       end

--- a/app/commands/v2/represent_downstream.rb
+++ b/app/commands/v2/represent_downstream.rb
@@ -43,6 +43,7 @@ module Commands
             PresentedContentStoreWorker::LOW_QUEUE,
             content_store: content_store,
             payload: { content_item_id: content_item_id, payload_version: event.id },
+            enqueue_dependency_check: false,
           )
         end
       end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,6 +1,5 @@
 ---
 :verbose: true
-:concurrency:  2
 :logfile: ./log/sidekiq.json.log
 :queues:
   - content_store # Deprecated, will be removed once all jobs are worked


### PR DESCRIPTION
Sleep every 10000 items so that sidekiq can process the queues and
memory can be kept under control

Increase concurrency level to default (25 threads)