### PR TITLE
Content items don't need a location any more

### DIFF
--- a/app/queries/get_grouped_content_and_links.rb
+++ b/app/queries/get_grouped_content_and_links.rb
@@ -89,7 +89,7 @@ module Queries
         FROM content_items
         JOIN translations
           ON translations.content_item_id = content_items.id
-        JOIN locations
+        LEFT JOIN locations
           ON locations.content_item_id = content_items.id
         JOIN states
           ON states.content_item_id = content_items.id
@@ -117,6 +117,8 @@ module Queries
           ON link_sets.id = links.link_set_id
         WHERE
           link_sets.content_id IN (#{sql_value_placeholders(content_ids.size)})
+        ORDER BY
+          links.target_content_id ASC
       SQL
 
       ActiveRecord::Base.connection.raw_connection.exec(query, content_ids)

--- a/spec/factories/content_item.rb
+++ b/spec/factories/content_item.rb
@@ -37,9 +37,12 @@ FactoryGirl.define do
     after(:create) do |item, evaluator|
       FactoryGirl.create(:state, name: evaluator.state, content_item: item)
       FactoryGirl.create(:translation, locale: evaluator.locale, content_item: item)
-      FactoryGirl.create(:location, base_path: evaluator.base_path, content_item: item)
       FactoryGirl.create(:lock_version, number: evaluator.lock_version, target: item)
       FactoryGirl.create(:user_facing_version, number: evaluator.user_facing_version, content_item: item)
+
+      unless evaluator.base_path.nil?
+        FactoryGirl.create(:location, base_path: evaluator.base_path, content_item: item)
+      end
     end
   end
 

--- a/spec/presenters/queries/grouped_content_and_links_spec.rb
+++ b/spec/presenters/queries/grouped_content_and_links_spec.rb
@@ -89,5 +89,41 @@ RSpec.describe Presenters::Queries::GroupedContentAndLinks do
         )
       end
     end
+
+    context "presenting a content item without a location" do
+      let(:content_id) { SecureRandom.uuid }
+      let(:topic_content_id) { SecureRandom.uuid }
+
+      before do
+        FactoryGirl.create(
+          :content_item,
+          content_id: content_id,
+          base_path: nil
+        )
+
+        FactoryGirl.create(
+          :link_set,
+          content_id: content_id,
+          links_hash: {
+            "topics" => [topic_content_id]
+          }
+        )
+      end
+
+      it "set the base path attribute to nil" do
+        results = ::Queries::GetGroupedContentAndLinks.new.call
+        presenter = Presenters::Queries::GroupedContentAndLinks.new(results)
+
+        presented = presenter.present["results"]
+
+        all_items = presented.flat_map { |group| group["content_items"] }
+        expect(all_items.size).to eq(1)
+
+        content_item = all_items.first
+
+        expect(content_item.fetch("base_path")).to be_nil
+        expect(content_item.fetch("state")).to eq("draft")
+      end
+    end
   end
 end


### PR DESCRIPTION
Some formats, like contacts, don't always have an associated page on GOV.UK.
Support this in grouped-content-and-links.