### PR TITLE
Refactor uniqueness validator

### DIFF
--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -44,6 +44,10 @@ class ContentItem < ActiveRecord::Base
   validates :description, well_formed_content_types: { must_include: "text/html" }
   validates :details, well_formed_content_types: { must_include: "text/html" }
 
+  def requires_base_path?
+    EMPTY_BASE_PATH_FORMATS.exclude?(document_type)
+  end
+
 private
 
   def renderable_content?

--- a/app/queries/content_item_uniqueness.rb
+++ b/app/queries/content_item_uniqueness.rb
@@ -1,0 +1,57 @@
+module Queries
+  module ContentItemUniqueness
+    extend ArelHelpers
+    extend self
+
+    def unique_fields_for_content_item(content_item)
+      scope = unique_fields_scope
+      scope
+        .where(table(:content_items)[:id].eq(content_item.id))
+        .take(1)
+      get_rows(scope).first.try(:symbolize_keys)
+    end
+
+    def first_non_unique_item(content_item, base_path:, locale:, state:, user_facing_version:)
+      scope = unique_fields_scope
+      scope
+        .where(table(:content_items)[:id].not_eq(content_item.id))
+        .where(table(:states)[:name].eq(state))
+        .where(table(:translations)[:locale].eq(locale))
+        .where(table(:locations)[:base_path].eq(base_path))
+        .where(table(:user_facing_versions)[:number].eq(user_facing_version))
+        .take(1)
+      get_rows(scope).first.try(:symbolize_keys)
+    end
+
+    def unique_fields_scope
+      content_items_table = table(:content_items)
+      states_table = table(:states)
+      translations_table = table(:translations)
+      locations_table = table(:locations)
+      user_facing_versions_table = table(:user_facing_versions)
+
+      content_items_table
+        .project(
+          content_items_table[:content_id],
+          states_table[:name].as("state"),
+          translations_table[:locale],
+          locations_table[:base_path],
+          user_facing_versions_table[:number].as("user_facing_version")
+        )
+        .outer_join(states_table).on(
+          content_items_table[:id].eq(states_table[:content_item_id])
+        )
+        .outer_join(translations_table).on(
+          content_items_table[:id].eq(translations_table[:content_item_id])
+        )
+        .outer_join(locations_table).on(
+          content_items_table[:id].eq(locations_table[:content_item_id])
+        )
+        .outer_join(user_facing_versions_table).on(
+          content_items_table[:id].eq(user_facing_versions_table[:content_item_id])
+        )
+    end
+
+    private_class_method :unique_fields_scope
+  end
+end

--- a/app/validators/content_item_uniqueness_validator.rb
+++ b/app/validators/content_item_uniqueness_validator.rb
@@ -107,11 +107,11 @@ private
   end
 
   def pillars_of_unique_scope
-    content_items_table = self.table(:content_items)
-    states_table = self.table(:states)
-    translations_table = self.table(:translations)
-    locations_table = self.table(:locations)
-    user_facing_versions_table = self.table(:user_facing_versions)
+    content_items_table = table(:content_items)
+    states_table = table(:states)
+    translations_table = table(:translations)
+    locations_table = table(:locations)
+    user_facing_versions_table = table(:user_facing_versions)
 
     content_items_table
       .project(

--- a/app/validators/content_item_uniqueness_validator.rb
+++ b/app/validators/content_item_uniqueness_validator.rb
@@ -1,5 +1,7 @@
 class ContentItemUniquenessValidator < ActiveModel::Validator
   def validate(record)
+    return unless record.content_item
+
     content_item = record.content_item
     unique_fields = Queries::ContentItemUniqueness.unique_fields_for_content_item(content_item)
 

--- a/app/validators/content_item_uniqueness_validator.rb
+++ b/app/validators/content_item_uniqueness_validator.rb
@@ -1,47 +1,133 @@
 class ContentItemUniquenessValidator < ActiveModel::Validator
+  include ::Queries::ArelHelpers
+
+  # def validate(record)
+  #   content_item = record.content_item
+  #
+  #   state = record if record.is_a?(State)
+  #   translation = record if record.is_a?(Translation)
+  #   location = record if record.is_a?(Location)
+  #   user_facing_version = record if record.is_a?(UserFacingVersion)
+  #
+  #   state ||= State.find_by(content_item: content_item)
+  #   translation ||= Translation.find_by(content_item: content_item)
+  #   location ||= Location.find_by(content_item: content_item)
+  #   user_facing_version ||= UserFacingVersion.find_by(content_item: content_item)
+  #
+  #   return unless state && translation && location && user_facing_version
+  #
+  #   # We should only have one content item at a given path (and locale) for each
+  #   # content store. Superseded content items aren't in either content store so
+  #   # we can relax this validation.
+  #   return if state.name == "superseded"
+  #
+  #   state_name = state.name
+  #   locale = translation.locale
+  #   base_path = location.base_path
+  #   user_version = user_facing_version.number
+  #
+  #   matching_items = ContentItemFilter.filter(
+  #     state: state_name,
+  #     locale: locale,
+  #     base_path: base_path,
+  #     user_version: user_version,
+  #   )
+  #
+  #   additional_items = matching_items - [content_item]
+  #
+  #   if additional_items.any?
+  #     error = "conflicts with a duplicate: "
+  #     error << "state=#{state_name}, "
+  #     error << "locale=#{locale}, "
+  #     error << "base_path=#{base_path}, "
+  #     error << "user_version=#{user_version}, "
+  #     error << "content_id=#{additional_items.first.content_id}"
+  #
+  #     record.errors.add(:content_item, error)
+  #   end
+  # end
+
   def validate(record)
     content_item = record.content_item
+    pillars = pillars_for_content_item(content_item)
 
-    state = record if record.is_a?(State)
-    translation = record if record.is_a?(Translation)
-    location = record if record.is_a?(Location)
-    user_facing_version = record if record.is_a?(UserFacingVersion)
+    return unless pillars
 
-    state ||= State.find_by(content_item: content_item)
-    translation ||= Translation.find_by(content_item: content_item)
-    location ||= Location.find_by(content_item: content_item)
-    user_facing_version ||= UserFacingVersion.find_by(content_item: content_item)
+    state_name = record.is_a?(State) ? record.name : pillars["state_name"]
+    locale = record.is_a?(Translation) ? record.locale : pillars["locale"]
+    base_path = record.is_a?(Location) ? record.base_path : pillars["base_path"]
+    user_version = record.is_a?(UserFacingVersion) ? record.number : pillars["user_version"]
 
-    return unless state && translation && location && user_facing_version
+    return unless [state_name, locale, base_path, user_version].all?
 
     # We should only have one content item at a given path (and locale) for each
     # content store. Superseded content items aren't in either content store so
     # we can relax this validation.
-    return if state.name == "superseded"
+    return if state_name == "superseded"
 
-    state_name = state.name
-    locale = translation.locale
-    base_path = location.base_path
-    user_version = user_facing_version.number
+    non_unique = pillars_for_unique_fields(content_item, state_name, locale, base_path, user_version)
 
-    matching_items = ContentItemFilter.filter(
-      state: state_name,
-      locale: locale,
-      base_path: base_path,
-      user_version: user_version,
-    )
-
-    additional_items = matching_items - [content_item]
-
-    if additional_items.any?
+    if non_unique
       error = "conflicts with a duplicate: "
       error << "state=#{state_name}, "
       error << "locale=#{locale}, "
       error << "base_path=#{base_path}, "
       error << "user_version=#{user_version}, "
-      error << "content_id=#{additional_items.first.content_id}"
+      error << "content_id=#{non_unique["content_id"]}"
 
       record.errors.add(:content_item, error)
     end
+  end
+
+private
+
+  def pillars_for_content_item(content_item)
+    content_items_table = table(:content_items)
+
+    scope = pillars_of_unique_scope
+    scope.where(content_items_table[:content_id].eq(content_item.content_id))
+    get_rows(scope).first
+  end
+
+  def pillars_for_unique_fields(content_item, state_name, locale, base_path, user_version)
+    content_items_table = table(:content_items)
+    states_table = table(:states)
+    translations_table = table(:translations)
+    locations_table = table(:locations)
+    user_facing_versions_table = table(:user_facing_versions)
+
+    scope = pillars_of_unique_scope
+    scope
+      .where(content_items_table[:id].not_eq(content_item.id))
+      .where(states_table[:name].eq(state_name))
+      .where(translations_table[:locale].eq(locale))
+      .where(locations_table[:base_path].eq(base_path))
+      .where(user_facing_versions_table[:number].eq(user_version))
+    get_rows(scope).first
+  end
+
+  def pillars_of_unique_scope
+    content_items_table = self.table(:content_items)
+    states_table = self.table(:states)
+    translations_table = self.table(:translations)
+    locations_table = self.table(:locations)
+    user_facing_versions_table = self.table(:user_facing_versions)
+
+    content_items_table
+      .project(
+        content_items_table[:content_id],
+        states_table[:name].as("state_name"),
+        translations_table[:locale],
+        locations_table[:base_path],
+        user_facing_versions_table[:number].as("user_version")
+      )
+      .outer_join(states_table)
+        .on(content_items_table[:id].eq(states_table[:content_item_id]))
+      .outer_join(translations_table)
+        .on(content_items_table[:id].eq(translations_table[:content_item_id]))
+      .outer_join(locations_table)
+        .on(content_items_table[:id].eq(locations_table[:content_item_id]))
+      .outer_join(user_facing_versions_table)
+        .on(content_items_table[:id].eq(user_facing_versions_table[:content_item_id]))
   end
 end

--- a/app/validators/content_item_uniqueness_validator.rb
+++ b/app/validators/content_item_uniqueness_validator.rb
@@ -73,7 +73,7 @@ class ContentItemUniquenessValidator < ActiveModel::Validator
       error << "locale=#{locale}, "
       error << "base_path=#{base_path}, "
       error << "user_version=#{user_version}, "
-      error << "content_id=#{non_unique["content_id"]}"
+      error << "content_id=#{non_unique['content_id']}"
 
       record.errors.add(:content_item, error)
     end
@@ -122,12 +122,12 @@ private
         user_facing_versions_table[:number].as("user_version")
       )
       .outer_join(states_table)
-        .on(content_items_table[:id].eq(states_table[:content_item_id]))
+      .on(content_items_table[:id].eq(states_table[:content_item_id]))
       .outer_join(translations_table)
-        .on(content_items_table[:id].eq(translations_table[:content_item_id]))
+      .on(content_items_table[:id].eq(translations_table[:content_item_id]))
       .outer_join(locations_table)
-        .on(content_items_table[:id].eq(locations_table[:content_item_id]))
+      .on(content_items_table[:id].eq(locations_table[:content_item_id]))
       .outer_join(user_facing_versions_table)
-        .on(content_items_table[:id].eq(user_facing_versions_table[:content_item_id]))
+      .on(content_items_table[:id].eq(user_facing_versions_table[:content_item_id]))
   end
 end

--- a/app/validators/content_item_uniqueness_validator.rb
+++ b/app/validators/content_item_uniqueness_validator.rb
@@ -1,133 +1,42 @@
 class ContentItemUniquenessValidator < ActiveModel::Validator
-  include ::Queries::ArelHelpers
-
-  # def validate(record)
-  #   content_item = record.content_item
-  #
-  #   state = record if record.is_a?(State)
-  #   translation = record if record.is_a?(Translation)
-  #   location = record if record.is_a?(Location)
-  #   user_facing_version = record if record.is_a?(UserFacingVersion)
-  #
-  #   state ||= State.find_by(content_item: content_item)
-  #   translation ||= Translation.find_by(content_item: content_item)
-  #   location ||= Location.find_by(content_item: content_item)
-  #   user_facing_version ||= UserFacingVersion.find_by(content_item: content_item)
-  #
-  #   return unless state && translation && location && user_facing_version
-  #
-  #   # We should only have one content item at a given path (and locale) for each
-  #   # content store. Superseded content items aren't in either content store so
-  #   # we can relax this validation.
-  #   return if state.name == "superseded"
-  #
-  #   state_name = state.name
-  #   locale = translation.locale
-  #   base_path = location.base_path
-  #   user_version = user_facing_version.number
-  #
-  #   matching_items = ContentItemFilter.filter(
-  #     state: state_name,
-  #     locale: locale,
-  #     base_path: base_path,
-  #     user_version: user_version,
-  #   )
-  #
-  #   additional_items = matching_items - [content_item]
-  #
-  #   if additional_items.any?
-  #     error = "conflicts with a duplicate: "
-  #     error << "state=#{state_name}, "
-  #     error << "locale=#{locale}, "
-  #     error << "base_path=#{base_path}, "
-  #     error << "user_version=#{user_version}, "
-  #     error << "content_id=#{additional_items.first.content_id}"
-  #
-  #     record.errors.add(:content_item, error)
-  #   end
-  # end
-
   def validate(record)
     content_item = record.content_item
-    pillars = pillars_for_content_item(content_item)
+    unique_fields = Queries::ContentItemUniqueness.unique_fields_for_content_item(content_item)
 
-    return unless pillars
+    return unless unique_fields
 
-    state_name = record.is_a?(State) ? record.name : pillars["state_name"]
-    locale = record.is_a?(Translation) ? record.locale : pillars["locale"]
-    base_path = record.is_a?(Location) ? record.base_path : pillars["base_path"]
-    user_version = record.is_a?(UserFacingVersion) ? record.number : pillars["user_version"]
+    base_path = record.is_a?(Location) ? record.base_path : unique_fields[:base_path]
+    locale = record.is_a?(Translation) ? record.locale : unique_fields[:locale]
+    state = record.is_a?(State) ? record.name : unique_fields[:state]
+    user_facing_version = record.is_a?(UserFacingVersion) ? record.number : unique_fields[:user_facing_version]
 
-    return unless [state_name, locale, base_path, user_version].all?
+    required_fields = [state, locale, user_facing_version]
+    required_fields << base_path if content_item.requires_base_path?
+
+    return unless required_fields.all?
 
     # We should only have one content item at a given path (and locale) for each
     # content store. Superseded content items aren't in either content store so
     # we can relax this validation.
-    return if state_name == "superseded"
+    return if state == "superseded"
 
-    non_unique = pillars_for_unique_fields(content_item, state_name, locale, base_path, user_version)
+    non_unique = Queries::ContentItemUniqueness.first_non_unique_item(
+      content_item,
+      base_path: base_path,
+      locale: locale,
+      state: state,
+      user_facing_version: user_facing_version,
+    )
 
     if non_unique
       error = "conflicts with a duplicate: "
-      error << "state=#{state_name}, "
+      error << "state=#{state}, "
       error << "locale=#{locale}, "
       error << "base_path=#{base_path}, "
-      error << "user_version=#{user_version}, "
-      error << "content_id=#{non_unique['content_id']}"
+      error << "user_version=#{user_facing_version}, "
+      error << "content_id=#{non_unique[:content_id]}"
 
       record.errors.add(:content_item, error)
     end
-  end
-
-private
-
-  def pillars_for_content_item(content_item)
-    content_items_table = table(:content_items)
-
-    scope = pillars_of_unique_scope
-    scope.where(content_items_table[:content_id].eq(content_item.content_id))
-    get_rows(scope).first
-  end
-
-  def pillars_for_unique_fields(content_item, state_name, locale, base_path, user_version)
-    content_items_table = table(:content_items)
-    states_table = table(:states)
-    translations_table = table(:translations)
-    locations_table = table(:locations)
-    user_facing_versions_table = table(:user_facing_versions)
-
-    scope = pillars_of_unique_scope
-    scope
-      .where(content_items_table[:id].not_eq(content_item.id))
-      .where(states_table[:name].eq(state_name))
-      .where(translations_table[:locale].eq(locale))
-      .where(locations_table[:base_path].eq(base_path))
-      .where(user_facing_versions_table[:number].eq(user_version))
-    get_rows(scope).first
-  end
-
-  def pillars_of_unique_scope
-    content_items_table = table(:content_items)
-    states_table = table(:states)
-    translations_table = table(:translations)
-    locations_table = table(:locations)
-    user_facing_versions_table = table(:user_facing_versions)
-
-    content_items_table
-      .project(
-        content_items_table[:content_id],
-        states_table[:name].as("state_name"),
-        translations_table[:locale],
-        locations_table[:base_path],
-        user_facing_versions_table[:number].as("user_version")
-      )
-      .outer_join(states_table)
-      .on(content_items_table[:id].eq(states_table[:content_item_id]))
-      .outer_join(translations_table)
-      .on(content_items_table[:id].eq(translations_table[:content_item_id]))
-      .outer_join(locations_table)
-      .on(content_items_table[:id].eq(locations_table[:content_item_id]))
-      .outer_join(user_facing_versions_table)
-      .on(content_items_table[:id].eq(user_facing_versions_table[:content_item_id]))
   end
 end

--- a/spec/models/content_item_spec.rb
+++ b/spec/models/content_item_spec.rb
@@ -137,6 +137,23 @@ RSpec.describe ContentItem do
     end
   end
 
+  describe "#requires_base_path?" do
+    it "doesn't require a base path for 'contact' document_type" do
+      subject.document_type = "contact"
+      expect(subject.requires_base_path?).to be false
+    end
+
+    it "doesn't require a base path for 'government' document_type" do
+      subject.document_type = "government"
+      expect(subject.requires_base_path?).to be false
+    end
+
+    it "requires a base path for other document_types" do
+      subject.document_type = "different document type"
+      expect(subject.requires_base_path?).to be true
+    end
+  end
+
   it_behaves_like DefaultAttributes
   it_behaves_like WellFormedContentTypesValidator
   it_behaves_like DescriptionOverrides

--- a/spec/queries/content_item_uniqueness_spec.rb
+++ b/spec/queries/content_item_uniqueness_spec.rb
@@ -1,0 +1,180 @@
+require "rails_helper"
+
+RSpec.describe Queries::ContentItemUniqueness do
+  let(:base_path) { "/unique-content-item" }
+  let(:user_facing_version) { "2" }
+  let(:locale) { "en" }
+  let(:state) { "draft" }
+
+  describe "#unique_fields_for_content_item" do
+    context "content item exists" do
+      it "returns a hash of the unique fields" do
+        content_item = FactoryGirl.create(
+          :content_item,
+          base_path: base_path,
+          locale: locale,
+          state: state,
+          user_facing_version: user_facing_version,
+        )
+
+        result = Queries::ContentItemUniqueness.unique_fields_for_content_item(content_item)
+        expect(result).to eq(
+          content_id: content_item.content_id,
+          base_path: base_path,
+          locale: locale,
+          state: state,
+          user_facing_version: user_facing_version,
+        )
+      end
+    end
+
+    context "content item does not exist" do
+      it "returns nil" do
+        content_item = FactoryGirl.build(:content_item)
+        result = Queries::ContentItemUniqueness.unique_fields_for_content_item(content_item)
+        expect(result).to be_nil
+      end
+    end
+  end
+
+  describe "#first_non_unique_item" do
+    before do
+      @existing_content_item = FactoryGirl.create(
+        :content_item,
+        base_path: base_path,
+        locale: locale,
+        state: state,
+        user_facing_version: user_facing_version,
+      )
+      @different_content_item = FactoryGirl.create(:content_item)
+    end
+
+    context "content item conflicts" do
+      it "returns a hash of the conflict" do
+        result = Queries::ContentItemUniqueness.first_non_unique_item(
+          @different_content_item,
+          base_path: base_path,
+          locale: locale,
+          state: state,
+          user_facing_version: user_facing_version,
+        )
+        expect(result).to eq(
+          content_id: @existing_content_item.content_id,
+          base_path: base_path,
+          locale: locale,
+          state: state,
+          user_facing_version: user_facing_version,
+        )
+      end
+    end
+
+    context "content item does not conflict" do
+      context "different base_path" do
+        it "returns nil" do
+          result = Queries::ContentItemUniqueness.first_non_unique_item(
+            @different_content_item,
+            base_path: "/new-base-path",
+            locale: locale,
+            state: state,
+            user_facing_version: user_facing_version,
+          )
+
+          expect(result).to be_nil
+        end
+      end
+      context "different locale" do
+        it "returns nil" do
+          result = Queries::ContentItemUniqueness.first_non_unique_item(
+            @different_content_item,
+            base_path: base_path,
+            locale: "fr",
+            state: state,
+            user_facing_version: user_facing_version,
+          )
+
+          expect(result).to be_nil
+        end
+      end
+
+      context "different state" do
+        it "returns nil" do
+          result = Queries::ContentItemUniqueness.first_non_unique_item(
+            @different_content_item,
+            base_path: base_path,
+            locale: locale,
+            state: "published",
+            user_facing_version: user_facing_version,
+          )
+
+          expect(result).to be_nil
+        end
+      end
+
+      context "different user facing version" do
+        it "returns nil" do
+          result = Queries::ContentItemUniqueness.first_non_unique_item(
+            @different_content_item,
+            base_path: base_path,
+            locale: locale,
+            state: state,
+            user_facing_version: "4",
+          )
+
+          expect(result).to be_nil
+        end
+      end
+    end
+
+    context "content item has an empty base_path" do
+      before do
+        @existing_content_item = FactoryGirl.create(
+          :content_item,
+          base_path: nil,
+          document_type: "contact",
+          locale: locale,
+          state: state,
+          user_facing_version: user_facing_version,
+        )
+        @different_content_item = FactoryGirl.create(
+          :content_item,
+          base_path: nil,
+          document_type: "contact",
+        )
+      end
+
+      context "does not conflict" do
+        it "returns nil" do
+          result = Queries::ContentItemUniqueness.first_non_unique_item(
+            @different_content_item,
+            base_path: nil,
+            locale: "fr",
+            state: state,
+            user_facing_version: user_facing_version,
+          )
+
+          expect(result).to be_nil
+        end
+      end
+
+      context "does conflict" do
+        it "returns a hash of the conflict" do
+          result = Queries::ContentItemUniqueness.first_non_unique_item(
+            @different_content_item,
+            base_path: nil,
+            locale: locale,
+            state: state,
+            user_facing_version: user_facing_version,
+          )
+
+          expect(result).to eq(
+            content_id: @existing_content_item.content_id,
+            base_path: nil,
+            locale: locale,
+            state: state,
+            user_facing_version: user_facing_version,
+          )
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
The ContentItemUniqueness validator has been identified as one of our performance bottlenecks. We've found we can improve performance modestly by refactoring this to use less queries and of those be specific ones that don't instantiate ActiveRecord models.

Against the `bench/publish.rb` script I get the following results on my machine with this branch:
```
vagrant publishing-api git:(refactor_uniqueness_validator) ruby bench/publish.rb
Creating drafts...
Publishing...
....................................................................................................
  3.110000   0.560000   3.670000 (  5.347455)
3003 SQL queries
Creating new drafts...
Superseding...
....................................................................................................
  3.140000   0.680000   3.820000 (  5.487163)
3300 SQL queries
```
On the master branch (@5e7597f) I get: 
```
vagrant publishing-api git:(master) ruby bench/publish.rb
Creating drafts...
Publishing...
....................................................................................................
  3.140000   0.690000   3.830000 (  5.404747)
3203 SQL queries
Creating new drafts...
Superseding...
....................................................................................................
  2.840000   1.440000   4.280000 (  5.911925)
3700 SQL queries
```