### PR TITLE
[DO NOT MERGE] Downstream publish worker

### DIFF
--- a/app/commands/v2/patch_link_set.rb
+++ b/app/commands/v2/patch_link_set.rb
@@ -102,7 +102,6 @@ module Commands
         DownstreamPublishWorker.perform_async_in_queue(
           queue,
           content_item_id: content_item.id,
-          send_to_content_store: true,
           message_queue_update_type: "links",
           payload_version: event.id,
         )

--- a/app/commands/v2/publish.rb
+++ b/app/commands/v2/publish.rb
@@ -156,7 +156,6 @@ module Commands
         DownstreamPublishWorker.perform_async_in_queue(
           queue,
           content_item_id: content_item.id,
-          send_to_content_store: !pathless?(content_item),
           message_queue_update_type: update_type,
           payload_version: event.id,
         )

--- a/app/commands/v2/represent_downstream.rb
+++ b/app/commands/v2/represent_downstream.rb
@@ -60,7 +60,6 @@ module Commands
             content_item_id: content_item_id,
             payload_version: event.id,
             message_queue_update_type: "links",
-            send_to_content_store: true,
             update_dependencies: false,
           )
         end

--- a/app/errors/abort_worker_error.rb
+++ b/app/errors/abort_worker_error.rb
@@ -1,0 +1,2 @@
+class AbortWorkerError < RuntimeError
+end

--- a/app/queries/get_web_content_items.rb
+++ b/app/queries/get_web_content_items.rb
@@ -10,6 +10,10 @@ module Queries
       end
     end
 
+    def self.find(content_item_id)
+      call(content_item_id).first
+    end
+
     def self.scope
       content_items = table(:content_items)
       locations = table(:locations)

--- a/app/workers/dependency_resolution_worker.rb
+++ b/app/workers/dependency_resolution_worker.rb
@@ -8,7 +8,7 @@ class DependencyResolutionWorker
     assign_attributes(args.deep_symbolize_keys)
 
     content_item_dependees.each do |dependent_content_id|
-      present_content_store(dependent_content_id)
+      downstream_content_item(dependent_content_id)
     end
   end
 
@@ -29,24 +29,43 @@ private
                                      dependent_lookup: Queries::GetDependees.new).call
   end
 
-  def present_content_store(dependent_content_id)
+  def downstream_content_item(dependent_content_id)
     scope = ContentItem.where(content_id: dependent_content_id)
-
-    if content_store == Adapters::DraftContentStore
+    if draft?
       latest_content_item = Queries::GetLatest.call(scope).last
     else
-      latest_content_item = ContentItemFilter.new(scope: scope).filter(
-        state: "published",
-      ).last
+      latest_content_item = ContentItemFilter.new(scope: scope).filter(state: "published").last
     end
 
     return unless latest_content_item
 
+    if draft?
+      present_content_store(latest_content_item)
+    else
+      downstream_publish(latest_content_item)
+    end
+  end
+
+  def draft?
+    content_store == Adapters::DraftContentStore
+  end
+
+  def present_content_store(latest_content_item)
     PresentedContentStoreWorker.perform_async_in_queue(
       PresentedContentStoreWorker::LOW_QUEUE,
-      content_store: content_store,
+      content_store: Adapters::DraftContentStore,
       payload: { content_item_id: latest_content_item.id, payload_version: payload_version },
       enqueue_dependency_check: false,
+    )
+  end
+
+  def downstream_publish(latest_content_item)
+    DownstreamPublishWorker.perform_async_in_queue(
+      DownstreamPublishWorker::LOW_QUEUE,
+      content_item_id: latest_content_item.id,
+      message_queue_update_type: "links",
+      payload_version: payload_version,
+      update_dependencies: false,
     )
   end
 end

--- a/app/workers/downstream_publish_worker.rb
+++ b/app/workers/downstream_publish_worker.rb
@@ -44,8 +44,6 @@ private
     payload = presented_content_store_payload
     base_path = payload.fetch(:base_path)
     live_content_store.put_content_item(base_path, payload)
-  rescue => e
-    handle_content_store_error(e)
   end
 
   def broadcast_to_message_queue
@@ -55,18 +53,6 @@ private
 
   def live_content_store
     Adapters::ContentStore
-  end
-
-  def handle_content_store_error(error)
-    if !error.is_a?(CommandError) || error.code >= 500
-      raise error
-    else
-      # @TODO
-      # I'm not sure this is the correct explanation - feels like it was written
-      # for 409s which are swallowed
-      explanation = "The message is a duplicate and does not need to be retried"
-      Airbrake.notify_or_ignore(error, parameters: { explanation: explanation })
-    end
   end
 
   def web_content_item

--- a/app/workers/downstream_publish_worker.rb
+++ b/app/workers/downstream_publish_worker.rb
@@ -1,0 +1,93 @@
+class DownstreamPublishWorker
+  attr_reader :content_item_id, :send_to_content_store, :payload_version, :message_queue_update_type
+  include Sidekiq::Worker
+  include PerformAsyncInQueue
+
+  HIGH_QUEUE = "downstream_high".freeze
+  LOW_QUEUE = "downstream_low".freeze
+
+  sidekiq_options queue: HIGH_QUEUE
+
+  def perform(args = {})
+    assign_attributes(args.symbolize_keys)
+
+    unless web_content_item
+      raise CommandError.new(
+        code: 404,
+        message: "The content item for id: #{content_item_id} was not found",
+      )
+    end
+
+    unless content_item_state?(:published)
+      raise CommandError.new(
+        code: 500,
+        message: "Will not downstream publish a content item that isn't published",
+      )
+    end
+
+    send_to_live_content_store if send_to_content_store
+    broadcast_to_message_queue
+  end
+
+private
+
+  def assign_attributes(attributes)
+    @content_item_id = attributes.fetch(:content_item_id)
+    @payload_version = attributes.fetch(:payload_version)
+    @message_queue_update_type = attributes.fetch(:message_queue_update_type)
+    @send_to_content_store = attributes[:send_to_content_store]
+  end
+
+  def send_to_live_content_store
+    payload = presented_content_store
+    base_path = payload.fetch(:base_path)
+    live_content_store.put_content_item(base_path, payload)
+  rescue => e
+    handle_content_store_error(e)
+  end
+
+  def broadcast_to_message_queue
+    payload = presented_message_queue
+    PublishingAPI.service(:queue_publisher).send_message(payload)
+  end
+
+  def live_content_store
+    Adapters::ContentStore
+  end
+
+  def handle_content_store_error(error)
+    if !error.is_a?(CommandError) || error.code >= 500
+      raise error
+    else
+      # @TODO
+      # I'm not sure this is the correct explanation - feels like it was written
+      # for 409s which are swallowed
+      explanation = "The message is a duplicate and does not need to be retried"
+      Airbrake.notify_or_ignore(error, parameters: { explanation: explanation })
+    end
+  end
+
+  def web_content_item
+    @web_content_item ||= Queries::GetWebContentItems.(content_item_id).first
+  end
+
+  def content_item_state?(allowed_state)
+    State.where(content_item_id: content_item_id).pluck(:name) == [allowed_state.to_s]
+  end
+
+  def presented_content_store
+    Presenters::ContentStorePresenter.present(
+      web_content_item,
+      payload_version,
+      state_fallback_order: live_content_store::DEPENDENCY_FALLBACK_ORDER
+    )
+  end
+
+  def presented_message_queue
+    Presenters::MessageQueuePresenter.present(
+      web_content_item,
+      state_fallback_order: [:published],
+      update_type: message_queue_update_type,
+    )
+  end
+end

--- a/app/workers/downstream_publish_worker.rb
+++ b/app/workers/downstream_publish_worker.rb
@@ -1,11 +1,9 @@
 class DownstreamPublishWorker
   attr_reader :content_item_id, :web_content_item, :payload_version, :message_queue_update_type, :update_dependencies
 
+  include DownstreamQueue
   include Sidekiq::Worker
   include PerformAsyncInQueue
-
-  HIGH_QUEUE = "downstream_high".freeze
-  LOW_QUEUE = "downstream_low".freeze
 
   sidekiq_options queue: HIGH_QUEUE
 

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -3,8 +3,10 @@
 :concurrency:  2
 :logfile: ./log/sidekiq.json.log
 :queues:
-  - content_store_high
-  - content_store_low
+  - content_store_high # Deprecated, to be removed once jobs completed
+  - content_store_low # Deprecated, to be removed once jobs completed
+  - downstream_high
+  - downstream_low
   - dependency_resolution
   - experiments
   - default

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -3,7 +3,6 @@
 :concurrency:  2
 :logfile: ./log/sidekiq.json.log
 :queues:
-  - content_store # Deprecated, will be removed once all jobs are worked
   - content_store_high
   - content_store_low
   - dependency_resolution

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -3,8 +3,8 @@
 :concurrency:  2
 :logfile: ./log/sidekiq.json.log
 :queues:
-  - content_store_high # Deprecated, to be removed once jobs completed
-  - content_store_low # Deprecated, to be removed once jobs completed
+  - content_store_high
+  - content_store_low
   - downstream_high
   - downstream_low
   - dependency_resolution

--- a/lib/downstream_queue.rb
+++ b/lib/downstream_queue.rb
@@ -1,0 +1,4 @@
+module DownstreamQueue
+  HIGH_QUEUE = "downstream_high".freeze
+  LOW_QUEUE = "downstream_low".freeze
+end

--- a/spec/commands/v2/patch_link_set_spec.rb
+++ b/spec/commands/v2/patch_link_set_spec.rb
@@ -280,7 +280,6 @@ RSpec.describe Commands::V2::PatchLinkSet do
           a_hash_including(
             :content_item_id,
             :payload_version,
-            send_to_content_store: true,
             message_queue_update_type: "links",
           ),
         )
@@ -296,7 +295,6 @@ RSpec.describe Commands::V2::PatchLinkSet do
           a_hash_including(
             :content_item_id,
             :payload_version,
-            send_to_content_store: true,
             message_queue_update_type: "links",
           ),
         )
@@ -322,7 +320,6 @@ RSpec.describe Commands::V2::PatchLinkSet do
               "downstream_high",
               content_item_id: ci.id.to_s,
               payload_version: an_instance_of(Fixnum),
-              send_to_content_store: true,
               message_queue_update_type: "links",
             )
         end

--- a/spec/commands/v2/publish_spec.rb
+++ b/spec/commands/v2/publish_spec.rb
@@ -200,7 +200,7 @@ RSpec.describe Commands::V2::Publish do
           .to receive(:perform_async_in_queue)
           .with(
             "downstream_high",
-            a_hash_including(send_to_content_store: true),
+            a_hash_including(:content_item_id, :payload_version),
           )
 
         described_class.call(payload)
@@ -439,16 +439,6 @@ RSpec.describe Commands::V2::Publish do
         expect(state.name).to eq("published")
       end
 
-      it "does not send to content store" do
-        expect(DownstreamPublishWorker)
-          .to receive(:perform_async_in_queue)
-          .with(
-            "downstream_high",
-            a_hash_including(send_to_content_store: false),
-          )
-        described_class.call(payload)
-      end
-
       context "with a previously published item" do
         let!(:live_content_item) do
           FactoryGirl.create(:live_content_item,
@@ -461,18 +451,6 @@ RSpec.describe Commands::V2::Publish do
           state = State.find_by!(content_item: pathless_content_item)
           expect(state.name).to eq("published")
         end
-      end
-    end
-
-    context "with a Location" do
-      it "sends to content store" do
-        expect(DownstreamPublishWorker)
-          .to receive(:perform_async_in_queue)
-          .with(
-            "downstream_high",
-            a_hash_including(send_to_content_store: true),
-          )
-        described_class.call(payload)
       end
     end
   end

--- a/spec/commands/v2/represent_downstream_spec.rb
+++ b/spec/commands/v2/represent_downstream_spec.rb
@@ -1,0 +1,67 @@
+require "rails_helper"
+
+RSpec.describe Commands::V2::RepresentDownstream do
+  before do
+    stub_request(:put, %r{.*content-store.*/content/.*})
+  end
+
+  describe "call" do
+    before do
+      2.times { FactoryGirl.create(:draft_content_item) }
+      2.times { FactoryGirl.create(:live_content_item, document_type: "guidance") }
+      FactoryGirl.create(:live_content_item, document_type: "press_release")
+    end
+
+    context "downstream publish" do
+      it "sends to downstream publish worker" do
+        expect(DownstreamPublishWorker).to receive(:perform_async_in_queue)
+          .exactly(3).times
+        subject.call(ContentItem.all, false)
+      end
+
+      it "uses 'downstream_low' queue" do
+        expect(DownstreamPublishWorker).to receive(:perform_async_in_queue)
+          .with("downstream_low", anything)
+          .at_least(1).times
+        subject.call(ContentItem.all, false)
+      end
+
+      it "doesn't update dependencies" do
+        expect(DownstreamPublishWorker).to receive(:perform_async_in_queue)
+          .with(anything, a_hash_including(update_dependencies: false))
+          .at_least(1).times
+        subject.call(ContentItem.all, false)
+      end
+
+      it "has a message_queue_update_type of 'links'" do
+        expect(DownstreamPublishWorker).to receive(:perform_async_in_queue)
+          .with(anything, a_hash_including(message_queue_update_type: "links"))
+          .at_least(1).times
+        subject.call(ContentItem.all, false)
+      end
+    end
+
+    context "scope" do
+      it "can specify a scope" do
+        expect(DownstreamPublishWorker).to receive(:perform_async_in_queue)
+          .with("downstream_low", a_hash_including(:content_item_id, :payload_version))
+          .exactly(2).times
+        subject.call(ContentItem.where(document_type: "guidance"), false)
+      end
+    end
+
+    context "drafts optional" do
+      it "can send to draft content store" do
+        expect(PresentedContentStoreWorker).to receive(:perform_async_in_queue)
+          .with("content_store_low", a_hash_including(content_store: Adapters::DraftContentStore))
+          .exactly(5).times
+        subject.call(ContentItem.all, true)
+      end
+
+      it "can not send to draft content store" do
+        expect(PresentedContentStoreWorker).to_not receive(:perform_async_in_queue)
+        subject.call(ContentItem.all, false)
+      end
+    end
+  end
+end

--- a/spec/workers/downstream_publish_worker_spec.rb
+++ b/spec/workers/downstream_publish_worker_spec.rb
@@ -100,53 +100,6 @@ RSpec.describe DownstreamPublishWorker do
     end
   end
 
-  describe "raised errors" do
-    before do
-      stub_request(:put, "http://content-store.dev.gov.uk/content/foo").
-        to_return(status: status, body: {}.to_json)
-    end
-
-    def do_request
-      subject.perform(arguments)
-    end
-
-    expectations = {
-      200 => { raises_error: false, logs_to_airbrake: false },
-      202 => { raises_error: false, logs_to_airbrake: false },
-      400 => { raises_error: false, logs_to_airbrake: true },
-      409 => { raises_error: false, logs_to_airbrake: false },
-      500 => { raises_error: true, logs_to_airbrake: false },
-    }
-
-    expectations.each do |status, expectation|
-      context "when the content store responds with a #{status}" do
-        let(:status) { status }
-
-        if expectation.fetch(:raises_error)
-          it "raises an error" do
-            expect { do_request }.to raise_error(CommandError)
-          end
-        else
-          it "does not raise an error" do
-            expect { do_request }.to_not raise_error
-          end
-        end
-
-        if expectation.fetch(:logs_to_airbrake)
-          it "logs the response to airbrake" do
-            expect(Airbrake).to receive(:notify_or_ignore)
-            do_request rescue CommandError
-          end
-        else
-          it "does not log the response to airbrake" do
-            expect(Airbrake).to_not receive(:notify_or_ignore)
-            do_request rescue CommandError
-          end
-        end
-      end
-    end
-  end
-
   describe "draft-to-live protection" do
     it "rejects draft content items" do
       draft = FactoryGirl.create(:draft_content_item)

--- a/spec/workers/downstream_publish_worker_spec.rb
+++ b/spec/workers/downstream_publish_worker_spec.rb
@@ -1,0 +1,144 @@
+require "rails_helper"
+
+RSpec.describe DownstreamPublishWorker do
+  let(:content_item) { FactoryGirl.create(:live_content_item, base_path: "/foo") }
+  let(:arguments) {
+    {
+      "content_item_id" => content_item.id,
+      "payload_version" => 1,
+      "message_queue_update_type" => "major",
+      "send_to_content_store" => "true",
+    }
+  }
+
+  before do
+    stub_request(:put, %r{.*content-store.*/content/.*})
+  end
+
+  describe "arguments" do
+    it "requires content_item_id" do
+      expect {
+        subject.perform(arguments.except("content_item_id"))
+      }.to raise_error(KeyError)
+    end
+
+    it "requires payload_version" do
+      expect {
+        subject.perform(arguments.except("payload_version"))
+      }.to raise_error(KeyError)
+    end
+
+    it "requires message_queue_update_type" do
+      expect {
+        subject.perform(arguments.except("message_queue_update_type"))
+      }.to raise_error(KeyError)
+    end
+
+    it "doesn't require send_to_content_store" do
+      expect {
+        subject.perform(arguments.except("send_to_content_store"))
+      }.not_to raise_error
+    end
+  end
+
+  describe "optional send to live content store" do
+    context "can send to content store" do
+      it "sends put content to live content store" do
+        expect(Adapters::ContentStore).to receive(:put_content_item)
+        subject.perform(arguments)
+      end
+
+      it "receives the base path" do
+        base_path = Location.where(content_item: content_item).pluck(:base_path).first
+        expect(Adapters::ContentStore).to receive(:put_content_item)
+          .with(base_path, anything)
+        subject.perform(arguments)
+      end
+    end
+
+    it "can not send to the content store" do
+      expect(Adapters::ContentStore).to_not receive(:put_content_item)
+      subject.perform(arguments.merge("send_to_content_store" => false))
+    end
+  end
+
+  describe "broadcast to message queue" do
+    it "sends a message" do
+      expect(PublishingAPI.service(:queue_publisher)).to receive(:send_message)
+
+      subject.perform(arguments)
+    end
+
+    it "uses the `message_queue_update_type`" do
+      expect(PublishingAPI.service(:queue_publisher)).to receive(:send_message)
+        .with(hash_including(update_type: "minor"))
+
+      subject.perform(arguments.merge("message_queue_update_type" => "minor"))
+    end
+  end
+
+  describe "raised errors" do
+    before do
+      stub_request(:put, "http://content-store.dev.gov.uk/content/foo").
+        to_return(status: status, body: {}.to_json)
+    end
+
+    def do_request
+      subject.perform(arguments)
+    end
+
+    expectations = {
+      200 => { raises_error: false, logs_to_airbrake: false },
+      202 => { raises_error: false, logs_to_airbrake: false },
+      400 => { raises_error: false, logs_to_airbrake: true },
+      409 => { raises_error: false, logs_to_airbrake: false },
+      500 => { raises_error: true, logs_to_airbrake: false },
+    }
+
+    expectations.each do |status, expectation|
+      context "when the content store responds with a #{status}" do
+        let(:status) { status }
+
+        if expectation.fetch(:raises_error)
+          it "raises an error" do
+            expect { do_request }.to raise_error(CommandError)
+          end
+        else
+          it "does not raise an error" do
+            expect { do_request }.to_not raise_error
+          end
+        end
+
+        if expectation.fetch(:logs_to_airbrake)
+          it "logs the response to airbrake" do
+            expect(Airbrake).to receive(:notify_or_ignore)
+            do_request rescue CommandError
+          end
+        else
+          it "does not log the response to airbrake" do
+            expect(Airbrake).to_not receive(:notify_or_ignore)
+            do_request rescue CommandError
+          end
+        end
+      end
+    end
+  end
+
+  describe "draft-to-live protection" do
+    it "rejects draft content items" do
+      draft = FactoryGirl.create(:draft_content_item)
+
+      expect {
+        subject.perform(arguments.merge("content_item_id" => draft.id))
+      }.to raise_error(CommandError)
+    end
+
+    it "allows live content items" do
+      live = FactoryGirl.create(:live_content_item)
+
+      expect {
+        subject.perform(arguments.merge("content_item_id" => live.id))
+      }.not_to raise_error
+    end
+  end
+end


### PR DESCRIPTION
This is the first of a selection of classes to replace the PresentedContentStoreWorker with workers that are more specialised and thus require less configuration and their use is more apparent from their name.

The impetus for this work was to increase the speed of publishing by pushing the message queue into an asynchronous task, this however meant repurposing the worker.

This has different queue names for sidekiq and I am not sure if we need to set them up in advance of a merge/deployment. We would also have to maintain the PresentedContentStoreWorker until the queue for that is clear.

The performance difference with `ruby bench/publish.rb` is as such:
**This branch:**
```
Creating drafts...
Publishing...
....................................................................................................
  2.610000   0.400000   3.010000 (  3.883270)
2301 SQL queries
Creating new drafts...
Superseding...
....................................................................................................
  3.050000   0.320000   3.370000 (  4.306301)
2800 SQL queries
````
**Master branch:**
```
Creating drafts...
Publishing...
....................................................................................................
  3.460000   0.700000   4.160000 (  6.069500)
3203 SQL queries
Creating new drafts...
Superseding...
....................................................................................................
  4.200000   0.560000   4.760000 (  6.731551)
3700 SQL queries
```