### PR TITLE
Add data migration to move alpha_taxons links to taxons link type

### DIFF
--- a/db/migrate/20160729091936_rename_alpha_taxon_link_type.rb
+++ b/db/migrate/20160729091936_rename_alpha_taxon_link_type.rb
@@ -1,0 +1,18 @@
+class RenameAlphaTaxonLinkType < ActiveRecord::Migration
+  def up
+    alpha_taxon_links = Link.where(link_type: "alpha_taxons")
+    link_sets = LinkSet.where(id: alpha_taxon_links.pluck(:link_set_id).uniq)
+    link_sets.each do |link_set|
+      target_content_ids = link_set.links.where(link_type: "alpha_taxons").pluck(:target_content_id)
+      Commands::V2::PatchLinkSet.call(
+        {
+          content_id: link_set.content_id,
+          links: {
+            alpha_taxons: [],
+            taxons: target_content_ids,
+          }
+        }
+      )
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160715153009) do
+ActiveRecord::Schema.define(version: 20160729091936) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
We've renamed the alpha_taxons link type to taxons. This updates the
links for content currently tagged to alpha_taxons.

trello https://trello.com/c/oekIxXMI/50-data-migration-alpha-taxons-to-taxons
