### PR TITLE
Fix hmrc contacts with no Location

### DIFF
--- a/db/migrate/20160721120915_clean_up_pathless_contacts.rb
+++ b/db/migrate/20160721120915_clean_up_pathless_contacts.rb
@@ -1,0 +1,14 @@
+class CleanUpPathlessContacts < ActiveRecord::Migration
+  def change
+    # There are approx 800 contact ContentItems.
+    ContentItem.where(schema_name: "contact", publishing_app: "contacts").find_each do |item|
+      path = item.routes.first[:path]
+
+      # Approx 25 records have no Location supporting object.
+      unless Location.find_by(content_item: item)
+        Location.create!(base_path: path, content_item: item)
+        puts "Added location '#{path}' for content item #{item.id}"
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160715153009) do
+ActiveRecord::Schema.define(version: 20160721120915) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
https://govuk.zendesk.com/agent/tickets/1371252

The publishing-api previously had a bug which prevented contacts which have a base_path
from populating a corresponding Location record. This has now been updated so that
contacts and other formats can optionally specify a path and the relevant Location
object will be created. There are around 21 records without a Location object
which need updating.