### PR TITLE
Simplify state name presentation (live to published)

### DIFF
--- a/app/presenters/queries/content_item_presenter.rb
+++ b/app/presenters/queries/content_item_presenter.rb
@@ -86,7 +86,7 @@ module Presenters
         fields_to_select = fields.map do |field|
           case field
           when :publication_state
-            "#{PUBLICATION_STATE_SQL} AS publication_state"
+            "states.name AS publication_state"
           when :user_facing_version
             "user_facing_versions.number AS user_facing_version"
           when :lock_version
@@ -115,15 +115,6 @@ module Presenters
         return scope unless search_query.present?
         scope.where("title ilike ? OR base_path ilike ?", "%#{search_query}%", "%#{search_query}%")
       end
-
-      PUBLICATION_STATE_SQL = <<-SQL.freeze
-        CASE WHEN (states.name = 'published') THEN
-          'live'
-        ELSE
-          states.name
-        END
-      SQL
-
 
       STATE_HISTORY_SQL = <<-SQL.freeze
         (

--- a/app/presenters/queries/linkable_presenter.rb
+++ b/app/presenters/queries/linkable_presenter.rb
@@ -5,19 +5,10 @@ module Presenters
         {
           title: title,
           content_id: content_id,
-          publication_state: publication_state(state),
+          publication_state: state,
           base_path: base_path,
           internal_name: internal_name || title,
         }
-      end
-
-      def self.publication_state(state)
-        case state
-        when "published"
-          "live"
-        else
-          state
-        end
       end
     end
   end

--- a/spec/presenters/queries/content_item_presenter_spec.rb
+++ b/spec/presenters/queries/content_item_presenter_spec.rb
@@ -61,8 +61,8 @@ RSpec.describe Presenters::Queries::ContentItemPresenter do
         State.find_by!(content_item: content_item).update!(name: "published")
       end
 
-      it "has a publication state of live" do
-        expect(result.fetch("publication_state")).to eq("live")
+      it "has a publication state of published" do
+        expect(result.fetch("publication_state")).to eq("published")
       end
     end
 

--- a/spec/presenters/queries/linkable_presenter_spec.rb
+++ b/spec/presenters/queries/linkable_presenter_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Presenters::Queries::LinkablePresenter do
       end
     end
 
-    context "when state is not 'live'" do
+    context "when state is not 'published'" do
       it "uses the state" do
         output = described_class.present(*args)
         expect(output[:publication_state]).to eq("draft")
@@ -41,9 +41,9 @@ RSpec.describe Presenters::Queries::LinkablePresenter do
     context "when state is 'published'" do
       let(:state) { "published" }
 
-      it "shows as 'live'" do
+      it "shows as 'published'" do
         output = described_class.present(*args)
-        expect(output[:publication_state]).to eq("live")
+        expect(output[:publication_state]).to eq("published")
       end
     end
   end

--- a/spec/queries/get_content_collection_spec.rb
+++ b/spec/queries/get_content_collection_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe Queries::GetContentCollection do
       fields: %w(base_path publication_state),
     ).call).to match_array([
       hash_including("base_path" => "/draft", "publication_state" => "draft"),
-      hash_including("base_path" => "/live", "publication_state" => "live"),
+      hash_including("base_path" => "/live", "publication_state" => "published"),
     ])
   end
 
@@ -158,7 +158,7 @@ RSpec.describe Queries::GetContentCollection do
         fields: %w(base_path publication_state),
       ).call).to match_array([
         hash_including("base_path" => "/content.en", "publication_state" => "draft"),
-        hash_including("base_path" => "/content.en", "publication_state" => "live"),
+        hash_including("base_path" => "/content.en", "publication_state" => "published"),
       ])
     end
 
@@ -169,7 +169,7 @@ RSpec.describe Queries::GetContentCollection do
         filters: { locale: 'ar' },
       ).call).to match_array([
         hash_including("base_path" => "/content.ar", "publication_state" => "draft"),
-        hash_including("base_path" => "/content.ar", "publication_state" => "live"),
+        hash_including("base_path" => "/content.ar", "publication_state" => "published"),
       ])
     end
 
@@ -181,8 +181,8 @@ RSpec.describe Queries::GetContentCollection do
       ).call).to match_array([
         hash_including("base_path" => "/content.en", "publication_state" => "draft"),
         hash_including("base_path" => "/content.ar", "publication_state" => "draft"),
-        hash_including("base_path" => "/content.en", "publication_state" => "live"),
-        hash_including("base_path" => "/content.ar", "publication_state" => "live"),
+        hash_including("base_path" => "/content.en", "publication_state" => "published"),
+        hash_including("base_path" => "/content.ar", "publication_state" => "published"),
       ])
     end
   end

--- a/spec/queries/get_content_spec.rb
+++ b/spec/queries/get_content_spec.rb
@@ -158,12 +158,12 @@ RSpec.describe Queries::GetContent do
       expect(result.fetch("publication_state")).to eq("superseded")
 
       result = subject.call(content_id, version: 2)
-      expect(result.fetch("publication_state")).to eq("live")
+      expect(result.fetch("publication_state")).to eq("published")
     end
 
     it "returns the most recent if version isn't given" do
       result = subject.call(content_id)
-      expect(result.fetch("publication_state")).to eq("live")
+      expect(result.fetch("publication_state")).to eq("published")
     end
   end
 end

--- a/spec/queries/get_linked_spec.rb
+++ b/spec/queries/get_linked_spec.rb
@@ -154,13 +154,13 @@ RSpec.describe Queries::GetLinked do
             ).to match_array([
               {
                 "title" => "Another VATTY thing",
-                "publication_state" => "live",
+                "publication_state" => "published",
                 "base_path" => "/vatty",
                 "locale" => "en",
               },
               {
                 "title" => "VAT and VATy things",
-                "publication_state" => "live",
+                "publication_state" => "published",
                 "base_path" => "/vat-rates",
                 "locale" => "en",
               }

--- a/spec/requests/linkables_spec.rb
+++ b/spec/requests/linkables_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe "GET /v2/linkables", type: :request do
       hash_including(
         content_id: policy_2.content_id,
         title: "Policy 2",
-        publication_state: "live",
+        publication_state: "published",
         base_path: "/vat-rates",
         internal_name: "Policy 2"
       ),


### PR DESCRIPTION
ContentItemPresenter was renaming published to live for no apparent reason, so now it is
using a consistent ubiquitous language