### PR TITLE
Add the reverse names for documents and working_groups

### DIFF
--- a/app/queries/dependent_expansion_rules.rb
+++ b/app/queries/dependent_expansion_rules.rb
@@ -13,6 +13,8 @@ module Queries
     def reverse_name_for(link_type)
       {
         parent: "children",
+        documents: "document_collections",
+        working_groups: 'policies'
       }[link_type.to_sym]
     end
 

--- a/spec/queries/dependent_expansion_rules_spec.rb
+++ b/spec/queries/dependent_expansion_rules_spec.rb
@@ -30,5 +30,7 @@ RSpec.describe Queries::DependentExpansionRules do
 
   describe "#reverse_name_for(link_type)" do
     specify { expect(subject.reverse_name_for(:parent)).to eq("children") }
+    specify { expect(subject.reverse_name_for(:documents)).to eq("document_collections") }
+    specify { expect(subject.reverse_name_for(:working_groups)).to eq("policies") }
   end
 end


### PR DESCRIPTION
Document collections have links to documents. (Whitehall) Documents
need to know which collections they belong to. See 7a5b6e9 in
content_store.

To render a working_group, you need the list of policies which link to that
working_group. See 5292b6e in content_store