### PR TITLE
Don't validate uniqueness of pathless content

### DIFF
--- a/app/validators/content_item_uniqueness_validator.rb
+++ b/app/validators/content_item_uniqueness_validator.rb
@@ -12,8 +12,7 @@ class ContentItemUniquenessValidator < ActiveModel::Validator
     state = record.is_a?(State) ? record.name : unique_fields[:state]
     user_facing_version = record.is_a?(UserFacingVersion) ? record.number : unique_fields[:user_facing_version]
 
-    required_fields = [state, locale, user_facing_version]
-    required_fields << base_path if content_item.requires_base_path?
+    required_fields = [base_path, state, locale, user_facing_version]
 
     return unless required_fields.all?
 

--- a/spec/validators/content_item_uniqueness_validator_spec.rb
+++ b/spec/validators/content_item_uniqueness_validator_spec.rb
@@ -89,12 +89,6 @@ RSpec.describe ContentItemUniquenessValidator do
 
   context "for a content item that doesn't require base_path" do
     before do
-      @existing_item = FactoryGirl.create(
-        :content_item,
-        base_path: nil,
-        document_type: "contact",
-        user_facing_version: 1,
-      )
       @content_item = FactoryGirl.create(
         :content_item,
         base_path: nil,
@@ -103,25 +97,11 @@ RSpec.describe ContentItemUniquenessValidator do
       )
     end
 
-    it "doesn't have a Location object" do
-      expect(Location.find_by(content_item: @content_item)).to be_nil
-    end
+    it "doesn't attempt to find similar items" do
+      expect(Queries::ContentItemUniqueness).not_to receive(:first_non_unique_item)
 
-    it "can have valid supporting objects" do
-      assert_valid(State.find_by!(content_item: @content_item))
-      assert_valid(Translation.find_by!(content_item: @content_item))
-      assert_valid(UserFacingVersion.find_by!(content_item: @content_item))
-    end
-
-    it "can have invalid supporting objects" do
-      user_facing_version = FactoryGirl.build(:user_facing_version,
-        content_item: @content_item,
-        number: 1,
-      )
-
-      expected_error = "conflicts with a duplicate: state=draft, locale=en, base_path=, user_version=1, "\
-                       "content_id=#{@existing_item.content_id}"
-      assert_invalid(user_facing_version, [expected_error])
+      subject.validate(State.find_by(content_item: @content_item))
+      expect(@content_item.errors).to be_empty
     end
   end
 


### PR DESCRIPTION
https://trello.com/c/b6ZrXFTX/778-contacts-validation-produces-false-positives

Content items without a `base_path` will match anything with a similar locale, version and state.
This will lead to false positives as one of the four uniqueness identifiers is missing.
Instead, we don't attempt to validate pathless items, the existing version checking in the `V2::PutContent` command protects duplicating pathless content.