### PR TITLE
[WIP][Feedback Needed] - Add endpoint to allow changing the ownership of content items

### DIFF
--- a/app/commands/v2/change_ownership.rb
+++ b/app/commands/v2/change_ownership.rb
@@ -1,0 +1,67 @@
+module Commands
+  module V2
+    class ChangeOwnership < BaseCommand
+      def call
+        if publishing_app.blank?
+          raise_command_error(422, "publishing_app is required", fields: {
+            publishing_app: ["is required"]
+          })
+        end
+
+        content_item = find_content_item
+
+        raise_command_error(
+          404,
+          "Item with content_id #{content_id} does not exist",
+          fields: {}
+        ) if content_item.nil?
+
+        update_publishing_app(content_item)
+
+        after_transaction_commit do
+          send_downstream(content_item)
+        end
+
+        response_hash = Presenters::Queries::ContentItemPresenter.present(content_item)
+        Success.new(response_hash)
+      end
+
+    private
+
+      def content_id
+        payload[:content_id]
+      end
+
+      def send_downstream(content_item)
+        return unless downstream
+
+        message = "Enqueuing PresentedContentStoreWorker job with "
+        message += "{ content_store: Adapters::DraftContentStore, content_item_id: #{content_item.id} }"
+        logger.info message
+
+        PresentedContentStoreWorker.perform_async_in_queue(
+          content_store_queue,
+          content_store: Adapters::DraftContentStore,
+          payload: { content_item_id: content_item.id, payload_version: event.id },
+        )
+      end
+
+      def update_publishing_app(content_item)
+        content_item.publishing_app = payload[:publishing_app]
+        content_item.save!
+      end
+
+      def find_content_item
+        ContentItem.where(content_id: content_id).lock.first
+      end
+
+      def publishing_app
+        payload[:publishing_app]
+      end
+
+      def content_store_queue
+        PresentedContentStoreWorker::LOW_QUEUE
+      end
+    end
+  end
+end

--- a/app/controllers/v2/content_items_controller.rb
+++ b/app/controllers/v2/content_items_controller.rb
@@ -51,6 +51,11 @@ module V2
       render status: response.code, json: response
     end
 
+    def change_ownership
+      response = Commands::V2::ChangeOwnership.call(content_item)
+      render status: response.code, json: response
+    end
+
   private
 
     def content_item

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,7 @@ Rails.application.routes.draw do
       post "/content/:content_id/publish", to: "content_items#publish"
       post "/content/:content_id/unpublish", to: "content_items#unpublish"
       post "/content/:content_id/discard-draft", to: "content_items#discard_draft"
+      put "/content/:content_id/change-ownership", to: "content_items#change_ownership"
 
       get "/links/:content_id", to: "link_sets#get_links"
       get "/expanded-links/:content_id", to: "link_sets#expanded_links"


### PR DESCRIPTION
We have recently migrated some taxonomy-related tools from `collections-publisher` into `content-tagger`. Since some of the Taxons have been created on `collections-publisher`, we now need to update their ownership in order to be able to update those content items from `content-tagger`.

As things stand, we cannot update the `publishing_app` attribute of content items via the API. There is a [validator](https://github.com/alphagov/publishing-api/blob/2481abe74fd0aa3b7fb948eade84bb60c74c9bd9/app/validators/publishing_app_validator.rb) that prevents us from doing that.

This could be done via a rake task (I wrote that in a separate branch [here](https://github.com/alphagov/publishing-api/compare/change-ownership-of-taxons?expand=1) ).

However, my suggestion is to add an endpoint that allows us to change the ownership of content items without adding more logic to the validator, leaving the `put_content` flow intact.

Would this be useful and/or does it make sense?

If that's not the case, I will close this PR and open the one with the rake task.

Note: this was a very rough version to see if it would work, it's lacking tests and robustness.