### PR TITLE
Rake task to change ownership of Taxon content items

### DIFF
--- a/lib/tasks/taxonomy.rake
+++ b/lib/tasks/taxonomy.rake
@@ -1,0 +1,14 @@
+# TODO: After running this task, it can be deleted
+namespace :taxonomy do
+  desc 'Change ownership of taxons from collections-publisher to content-tagger'
+  task change_ownership: :environment do
+    ContentItem.transaction do
+      taxons = ContentItem.where(document_type: 'taxon')
+      puts "Found #{taxons.count} taxons"
+      taxons.each do |taxon|
+        puts "Changing #{taxon.title} from #{taxon.publishing_app} to content-tagger"
+        taxon.update!(publishing_app: 'content-tagger')
+      end
+    end
+  end
+end


### PR DESCRIPTION
Currently, most taxons have been created via `collections-publisher`. We now
moved the taxonomy tools to `content-tagger`, therefore we should change the
ownership of the Taxon content items so we can edit them on `content-tagger`.

We can delete this rake task after it runs in production.