### PR TITLE
Include parameters in Airbrake notifications

### DIFF
--- a/app/workers/downstream_discard_draft_worker.rb
+++ b/app/workers/downstream_discard_draft_worker.rb
@@ -24,9 +24,9 @@ class DownstreamDiscardDraftWorker
 
     enqueue_dependencies if update_dependencies
   rescue DiscardDraftBasePathConflictError => e
-    Airbrake.notify_or_ignore(e) unless ignore_base_path_conflict
+    Airbrake.notify_or_ignore(e, parameters: args) unless ignore_base_path_conflict
   rescue AbortWorkerError, DownstreamInvariantError => e
-    Airbrake.notify_or_ignore(e)
+    Airbrake.notify_or_ignore(e, parameters: args)
   end
 
 private

--- a/app/workers/downstream_draft_worker.rb
+++ b/app/workers/downstream_draft_worker.rb
@@ -22,7 +22,7 @@ class DownstreamDraftWorker
 
     enqueue_dependencies if update_dependencies
   rescue AbortWorkerError, DownstreamInvariantError => e
-    Airbrake.notify_or_ignore(e)
+    Airbrake.notify_or_ignore(e, parameters: args)
   end
 
 private

--- a/app/workers/downstream_live_worker.rb
+++ b/app/workers/downstream_live_worker.rb
@@ -25,7 +25,7 @@ class DownstreamLiveWorker
 
     enqueue_dependencies if update_dependencies
   rescue AbortWorkerError, DownstreamInvariantError => e
-    Airbrake.notify_or_ignore(e)
+    Airbrake.notify_or_ignore(e, parameters: args)
   end
 
 private

--- a/spec/workers/downstream_discard_draft_worker_spec.rb
+++ b/spec/workers/downstream_discard_draft_worker_spec.rb
@@ -187,7 +187,7 @@ RSpec.describe DownstreamDiscardDraftWorker do
 
       it "notifies airbrake" do
         expect(Airbrake).to receive(:notify_or_ignore)
-          .with(an_instance_of(DiscardDraftBasePathConflictError))
+          .with(an_instance_of(DiscardDraftBasePathConflictError), a_hash_including(:parameters))
         subject.perform(conflict_arguments)
       end
     end

--- a/spec/workers/downstream_live_worker_spec.rb
+++ b/spec/workers/downstream_live_worker_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe DownstreamLiveWorker do
 
       it "absorbs an error" do
         expect(Airbrake).to receive(:notify_or_ignore)
-          .with(an_instance_of(DownstreamInvariantError))
+          .with(an_instance_of(DownstreamInvariantError), a_hash_including(:parameters))
         subject.perform(superseded_arguments)
       end
     end
@@ -123,7 +123,7 @@ RSpec.describe DownstreamLiveWorker do
       draft = FactoryGirl.create(:draft_content_item)
 
       expect(Airbrake).to receive(:notify_or_ignore)
-        .with(an_instance_of(DownstreamInvariantError))
+        .with(an_instance_of(DownstreamInvariantError), a_hash_including(:parameters))
       subject.perform(arguments.merge("content_item_id" => draft.id))
     end
 
@@ -138,7 +138,7 @@ RSpec.describe DownstreamLiveWorker do
   describe "no content item" do
     it "swallows the error" do
       expect(Airbrake).to receive(:notify_or_ignore)
-        .with(an_instance_of(AbortWorkerError))
+        .with(an_instance_of(AbortWorkerError), a_hash_including(:parameters))
       subject.perform(arguments.merge("content_item_id" => "made-up-id"))
     end
   end


### PR DESCRIPTION
This will give us a bit more context to understand the cause of any errors as they currently have very little information.

This update will include the arguments passed to the worker so that we can trace the cause of the failure.