### PR TITLE
Use sidekiq middleware to log enqueuing of workers

### DIFF
--- a/app/commands/v2/put_content.rb
+++ b/app/commands/v2/put_content.rb
@@ -274,10 +274,6 @@ module Commands
       def send_downstream(content_item)
         return unless downstream
 
-        message = "Enqueuing DownstreamDraftWorker job with "
-        message += "{ content_item_id: #{content_item.id} }"
-        logger.info message
-
         queue = bulk_publishing? ? DownstreamDraftWorker::LOW_QUEUE : DownstreamDraftWorker::HIGH_QUEUE
 
         DownstreamDraftWorker.perform_async_in_queue(

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,0 +1,5 @@
+Sidekiq.configure_client do |config|
+  config.client_middleware do |chain|
+    chain.add SidekiqLoggerMiddleware
+  end
+end

--- a/lib/sidekiq_logger_middleware.rb
+++ b/lib/sidekiq_logger_middleware.rb
@@ -1,0 +1,6 @@
+class SidekiqLoggerMiddleware
+  def call(worker_class, job, queue, _redis_pool)
+    logger.info "Enqueuing #{worker_class} to queue: #{queue} with arguments: #{job['args'].try(:first)}"
+    yield
+  end
+end


### PR DESCRIPTION
This changes the logging of sidekiq workers from being an adhoc thing to being something that happens automatically when a job is queued up.