### PR TITLE
Periodically check for the presence of duplicate content items

### DIFF
--- a/lib/data_hygiene/duplicate_content_item.rb
+++ b/lib/data_hygiene/duplicate_content_item.rb
@@ -1,0 +1,47 @@
+module DataHygiene
+  class DuplicateContentItem
+    def check
+      log if duplicates.any?
+    end
+
+  private
+
+    def log
+      Airbrake.notify_or_ignore(
+        DuplicateContentItemError.new("Duplicate content items"),
+        parameters: parameters
+      )
+    end
+
+    def duplicates
+      @results ||= ActiveRecord::Base.connection.execute(sql)
+    end
+
+    def parameters
+      { duplicates: duplicates.map(&:to_json) }
+    end
+
+    def sql
+      <<-SQL
+        SELECT array_agg(content_items.id),
+        states.name, translations.locale, user_facing_versions.number,
+        locations.base_path
+        FROM content_items
+        INNER JOIN states
+        ON content_items.id = states.content_item_id
+        INNER JOIN translations
+        ON content_items.id = translations.content_item_id
+        INNER JOIN locations
+        ON content_items.id = locations.content_item_id
+        INNER JOIN user_facing_versions
+        ON content_items.id = user_facing_versions.content_item_id
+        WHERE states.name NOT IN ('superseded', 'unpublished')
+        GROUP BY states.name, translations.locale,
+        user_facing_versions.number, locations.base_path
+        HAVING COUNT(content_items.id) > 1;
+      SQL
+    end
+
+    class DuplicateContentItemError < StandardError; end;
+  end
+end

--- a/lib/tasks/duplicate_content_items.rake
+++ b/lib/tasks/duplicate_content_items.rake
@@ -1,0 +1,6 @@
+namespace :duplicate_content_items do
+  desc "Checks for the presence of dupicate content_items"
+  task check: :environment do
+    DataHygiene::DuplicateContentItem.new.check
+  end
+end

--- a/spec/lib/data_hygiene/duplicate_content_item_spec.rb
+++ b/spec/lib/data_hygiene/duplicate_content_item_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.describe DataHygiene::DuplicateContentItem do
+  subject(:duplicate_checker) { described_class.new }
+  let(:content_id) { SecureRandom.uuid }
+
+  before do
+    FactoryGirl.create(:content_item, content_id: content_id, base_path: '/test')
+    duplicate = FactoryGirl.build(:content_item, content_id: content_id, base_path: '/test')
+    duplicate.save(validate: false)
+    s = State.new(content_item_id: duplicate.id, name: 'draft')
+    s.save(validate: false)
+    l = Location.new(content_item_id: duplicate.id, base_path: '/test')
+    l.save(validate: false)
+    u = UserFacingVersion.new(content_item_id: duplicate.id, number: 1)
+    u.save(validate: false)
+    u = Translation.new(content_item_id: duplicate.id, locale: 'en')
+    u.save(validate: false)
+  end
+
+  it 'logs to errbit when there are duplicate content items' do
+    expect(Airbrake).to receive(:notify_or_ignore)
+    duplicate_checker.check
+  end
+end


### PR DESCRIPTION
Verify frequency of duplicate content items that are created and log to
errbit if any exist.

Duplicate being defined as a content_item that has the same state name,
locale, user facing version number and base path, and state name not in
superseded or unpublished