### PR TITLE
Split command arguments into 2 hashes

### DIFF
--- a/app/substitution_helper.rb
+++ b/app/substitution_helper.rb
@@ -20,8 +20,9 @@ module SubstitutionHelper
 
         if mismatch && allowed_to_substitute
           if state == "draft"
-            Commands::V2::DiscardDraft.call(
-              content_id: blocking_item.content_id,
+            Commands::V2::DiscardDraft.call({
+                content_id: blocking_item.content_id,
+              },
               downstream: downstream,
               nested: nested,
               callbacks: callbacks,


### PR DESCRIPTION
Fixes accidentally combining the items into a single hash which was
causing the arguments (unsurprisingly) to be ignored.