### PR TITLE
Do not expand links that are non-renderable 

### DIFF
--- a/app/presenters/queries/expanded_link_set.rb
+++ b/app/presenters/queries/expanded_link_set.rb
@@ -39,9 +39,9 @@ module Presenters
             next_level = {}
           end
 
-          expanded_links.merge(
-            links: next_level,
-          )
+          expanded_links.tap do |el|
+            el[:links] = next_level unless expanded_links.empty?
+          end
         end
       end
 
@@ -77,7 +77,7 @@ module Presenters
 
           expanded_links = expand_links(links, type.to_sym, expansion_rules)
 
-          hash[type.to_sym] = expanded_links if expanded_links.any?
+          hash[type.to_sym] = expanded_links.reject(&:empty?) if expanded_links.any?
         end
       end
 
@@ -96,7 +96,7 @@ module Presenters
 
           expanded_links = expand_links(links, type.to_sym, expansion_rules)
 
-          hash[inverted_type_name.to_sym] = expanded_links if expanded_links.any?
+          hash[inverted_type_name.to_sym] = expanded_links.reject(&:empty?) if expanded_links.any?
         end
       end
 

--- a/app/queries/dependee_expansion_rules.rb
+++ b/app/queries/dependee_expansion_rules.rb
@@ -7,6 +7,7 @@ module Queries
 
     def custom(link_type)
       {
+        redirect: [],
         topical_event: default_fields + [:details],
         placeholder_topical_event: default_fields + [:details],
         organisation: default_fields + [:details],

--- a/app/queries/dependee_expansion_rules.rb
+++ b/app/queries/dependee_expansion_rules.rb
@@ -8,6 +8,7 @@ module Queries
     def custom(link_type)
       {
         redirect: [],
+        gone: [],
         topical_event: default_fields + [:details],
         placeholder_topical_event: default_fields + [:details],
         organisation: default_fields + [:details],

--- a/spec/presenters/queries/expanded_link_set_spec.rb
+++ b/spec/presenters/queries/expanded_link_set_spec.rb
@@ -18,6 +18,21 @@ RSpec.describe Presenters::Queries::ExpandedLinkSet do
     ).links
   }
 
+  context "with content items that are redirects" do
+    let!(:draft_a) { create_content_item(a, "/a", "draft") }
+    let!(:redirect) { FactoryGirl.create(:redirect_draft_content_item, content_id: b, base_path: '/b') }
+
+    let(:state_fallback_order) { [:draft] }
+
+    context "a simple non-recursive graph" do
+      it "expands the links for node a correctly" do
+        create_link(a, b, "related")
+
+        expect(expanded_links[:related]).to match([])
+      end
+    end
+  end
+
   context "with content items in a draft state" do
     let!(:draft_a) { create_content_item(a, "/a", "draft") }
     let!(:draft_b) { create_content_item(b, "/b", "draft") }

--- a/spec/presenters/queries/expanded_link_set_spec.rb
+++ b/spec/presenters/queries/expanded_link_set_spec.rb
@@ -18,15 +18,17 @@ RSpec.describe Presenters::Queries::ExpandedLinkSet do
     ).links
   }
 
-  context "with content items that are redirects" do
+  context "with content items that are non-renderable" do
     let!(:draft_a) { create_content_item(a, "/a", "draft") }
     let!(:redirect) { FactoryGirl.create(:redirect_draft_content_item, content_id: b, base_path: '/b') }
+    let!(:gone) { FactoryGirl.create(:gone_content_item, content_id: c, base_path: '/c') }
 
     let(:state_fallback_order) { [:draft] }
 
     context "a simple non-recursive graph" do
       it "expands the links for node a correctly" do
         create_link(a, b, "related")
+        create_link(a, c, "related")
 
         expect(expanded_links[:related]).to match([])
       end


### PR DESCRIPTION
Document types of redirect/gone should not be expanded since they are not
displayable on the frontend so no need to expand them here.

Prevents any page from potentially breaking for asking the link for one
of its attributes that are not there.