### PR TITLE
Remove PathReservation for '/find-local-council'

### DIFF
--- a/db/migrate/20160816141116_remove_path_reservation_for_find_local_council.rb
+++ b/db/migrate/20160816141116_remove_path_reservation_for_find_local_council.rb
@@ -1,0 +1,11 @@
+class RemovePathReservationForFindLocalCouncil < ActiveRecord::Migration
+  def change
+    # Actually fully delete this path reservation.
+    # It was created to reserve a path for an artefact that was created in
+    # error on launch day and immediately archived without publishing (or
+    # even completing the creation of the associated edition in publisher).
+    # We want to reuse the route without leaving something lying around
+    # that could accidently be used to alter that route from panopticon.
+    PathReservation.find_by(base_path: '/find-local-council').destroy
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160801112448) do
+ActiveRecord::Schema.define(version: 20160816141116) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
This path reservation is a placeholder for the find-local-council
panopticon artefact.  This artefact was created in error and immediately
withdrawn without being published, and without completing the creation of
the associated edition.  There's no workflow for changing a path
reservation to have a different publishing app, so we delete it to make
room for the new one that will come from frontend when it published the
new find-local-council special route.

For: https://trello.com/c/RXWWvAZk/461-use-publishing-api-to-manage-routes-and-tagging-for-find-local-council

See alphagov/frontend#986 for extra context on the new find-local-council route and alphagov/panopticon#390 for other cleanup on the old owner of the route.