### PR TITLE
Make 20160816141116 migration robust in absence of data

### DIFF
--- a/db/migrate/20160816141116_remove_path_reservation_for_find_local_council.rb
+++ b/db/migrate/20160816141116_remove_path_reservation_for_find_local_council.rb
@@ -1,0 +1,11 @@
+class RemovePathReservationForFindLocalCouncil < ActiveRecord::Migration
+  def change
+    # Actually fully delete this path reservation.
+    # It was created to reserve a path for an artefact that was created in
+    # error on launch day and immediately archived without publishing (or
+    # even completing the creation of the associated edition in publisher).
+    # We want to reuse the route without leaving something lying around
+    # that could accidently be used to alter that route from panopticon.
+    PathReservation.where(base_path: '/find-local-council', publishing_app: 'publisher').destroy_all
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160801112448) do
+ActiveRecord::Schema.define(version: 20160816141116) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
It's possible that the find_by call in this migration could fail so to
avoid breaking the migration in this situation we use

    where(...).destroy_all

instead which won't break if the data is already missing.

This is a follow up to #461 - I was having a discussion about this with @dougdroper but it was merged before I could push up this change.