### PR TITLE
Do not add duplicate jobs to Sidekiq queues

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,7 @@ gem "govuk_sidekiq", "~> 0.0"
 gem "deprecated_columns"
 gem "json-schema", require: false
 gem "hashdiff"
+gem "sidekiq-unique-jobs", require: false
 
 group :development do
   # Access an IRB console on exception pages or by using <%= console %> in views

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -301,6 +301,9 @@ GEM
       activesupport
       sidekiq (>= 2.6)
       statsd-ruby (>= 1.1.0)
+    sidekiq-unique-jobs (4.0.18)
+      sidekiq (>= 2.6)
+      thor
     simplecov (0.10.0)
       docile (~> 1.1.0)
       json (~> 1.8)
@@ -386,6 +389,7 @@ DEPENDENCIES
   rails (= 4.2.7.1)
   rspec
   rspec-rails (~> 3.3)
+  sidekiq-unique-jobs
   simplecov (= 0.10.0)
   simplecov-rcov (= 0.2.3)
   spring

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -6,7 +6,7 @@
   - content_store_high # Deprecated, to be removed with PresentedContentStoreWorker
   - content_store_low # Deprecated, to be removed with PresentedContentStoreWorker
   - downstream_high
-  - downstream_low
   - dependency_resolution
+  - downstream_low
   - experiments
   - default

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -38,6 +38,13 @@ end
 #
 Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
 
+require 'sidekiq-unique-jobs'
+Sidekiq.configure_client do |config|
+  config.client_middleware do |chain|
+    chain.remove SidekiqUniqueJobs::Client::Middleware
+  end
+end
+
 RSpec.configure do |config|
   # RSpec Rails can automatically mix in different behaviours to your tests
   # based on their file location, for example enabling you to call `get` and


### PR DESCRIPTION
This uses Sidekiq unique jobs `until executing` to enforce uniqueness,
which means the job will only be scheduled into redis once per content
item based off its content_item_id and which store it is
going to (live/draft).

Any jobs added until the first one of the same arguments has been
unlocked will just be dropped.

For a content item that has 751 links, these are the Sidekiq::Stats

Before:
{:processed=>5269, :failed=>12,
:scheduled_size=>0, :retry_size=>0, :dead_size=>0, :processes_size=>1,
:default_queue_latency=>0, :workers_size=>0, :enqueued=>0}

After:
{:processed=>751, :failed=>0,
:scheduled_size=>0, :retry_size=>0, :dead_size=>0, :processes_size=>1,
:default_queue_latency=>0, :workers_size=>0, :enqueued=>0}