### PR TITLE
Update Bunny gem to 2.5.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ end
 
 gem "gds-sso", "12.1.0"
 
-gem 'bunny', '2.0.0'
+gem 'bunny', '2.5.1'
 gem 'whenever', '0.9.4', require: false
 gem "govuk_sidekiq", "~> 0.0"
 gem "deprecated_columns"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,7 +41,7 @@ GEM
     airbrake (4.2.1)
       builder
       multi_json
-    amq-protocol (1.9.2)
+    amq-protocol (2.0.1)
     arel (6.0.3)
     ast (2.2.0)
     astrolabe (1.3.1)
@@ -50,8 +50,8 @@ GEM
     binding_of_caller (0.7.2)
       debug_inspector (>= 0.0.1)
     builder (3.2.2)
-    bunny (2.0.0)
-      amq-protocol (>= 1.9.2)
+    bunny (2.5.1)
+      amq-protocol (>= 2.0.1)
     byebug (5.0.0)
       columnize (= 0.9.0)
     chronic (0.10.2)
@@ -365,7 +365,7 @@ PLATFORMS
 
 DEPENDENCIES
   airbrake (~> 4.2.1)
-  bunny (= 2.0.0)
+  bunny (= 2.5.1)
   database_cleaner
   deprecated_columns
   factory_girl_rails (= 4.5.0)


### PR DESCRIPTION
This seems to have helped with some of the errors we have been receiving in integration, we do still get the annoying Timeout::Error's but potentially less of them, it's hard to be sure though.