### PR TITLE
Increase Bunny timeout

### DIFF
--- a/config/rabbitmq.yml
+++ b/config/rabbitmq.yml
@@ -1,3 +1,6 @@
+# This file is replaced as part of deployment and thus options set here won't
+# be reflected when deployed
+
 defaults: &defaults
   host: localhost
   port: 5672

--- a/lib/queue_publisher.rb
+++ b/lib/queue_publisher.rb
@@ -5,6 +5,7 @@ class QueuePublisher
 
     @exchange_name = options.fetch(:exchange)
     @options = options.except(:exchange)
+    @options[:continuation_timeout] = 30_000 unless options[:continuation_timeout]
   end
 
   def connection

--- a/spec/lib/queue_publisher_spec.rb
+++ b/spec/lib/queue_publisher_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe QueuePublisher do
         pass: "super_secret",
         recover_from_connection_close: true,
         exchange: "test_exchange",
+        continuation_timeout: 30_000,
       }
     end
     let(:queue_publisher) { QueuePublisher.new(options) }


### PR DESCRIPTION
By default Bunny has a Timeout of 15 seconds which to me seemed like a very long time but one of the suggestions in [this issue](https://github.com/ruby-amqp/bunny/issues/378) was to increase to 30 seconds, which does seem to help a bit but not get rid of them. 

I did also try going to the crazy amount of 300 seconds which cleared up nearly all of them, so it could be that we need to find a sweet spot - but those timeout amounts seem so high that it would be a bit weird. 


