### PR TITLE
Improve uniqueness constraints

### DIFF
--- a/app/workers/downstream_draft_worker.rb
+++ b/app/workers/downstream_draft_worker.rb
@@ -14,7 +14,8 @@ class DownstreamDraftWorker
   def self.uniq_args(args)
     [
       args.first.fetch("content_item_id"),
-      'draft'
+      args.first.fetch("update_dependencies", true),
+      name,
     ]
   end
 

--- a/app/workers/downstream_live_worker.rb
+++ b/app/workers/downstream_live_worker.rb
@@ -14,7 +14,9 @@ class DownstreamLiveWorker
   def self.uniq_args(args)
     [
       args.first.fetch("content_item_id"),
-      'live'
+      args.first.fetch("message_queue_update_type", nil),
+      args.first.fetch("update_dependencies", true),
+      name,
     ]
   end
 


### PR DESCRIPTION
Adding the other arguments to the uniqueness to ensure that major
updates are not rejected, and that other dependencies are also updated
correctly.

See https://github.com/alphagov/publishing-api/pull/465 for more info