### PR TITLE
Less errors from Downstream Workers

### DIFF
--- a/app/commands/v2/discard_draft.rb
+++ b/app/commands/v2/discard_draft.rb
@@ -44,7 +44,7 @@ module Commands
           live_content_item_id: live_content_item_id,
           payload_version: event.id,
           update_dependencies: true,
-          ignore_base_path_conflict: nested
+          alert_on_base_path_conflict: !nested
         )
       end
 

--- a/app/errors/discard_draft_base_path_conflict_error.rb
+++ b/app/errors/discard_draft_base_path_conflict_error.rb
@@ -1,2 +1,2 @@
-class DiscardDraftBasePathConflictError < DownstreamInvariantError
+class DiscardDraftBasePathConflictError < RuntimeError
 end

--- a/app/errors/downstream_invariant_error.rb
+++ b/app/errors/downstream_invariant_error.rb
@@ -1,2 +1,2 @@
-class DownstreamInvariantError < RuntimeError
+class DownstreamInvalidStateError < RuntimeError
 end

--- a/app/services/downstream_service.rb
+++ b/app/services/downstream_service.rb
@@ -2,7 +2,7 @@ module DownstreamService
   def self.update_live_content_store(downstream_payload)
     if %w(published unpublished).exclude?(downstream_payload.state)
       message = "Can only send published and unpublished items to live content store"
-      raise DownstreamInvariantError.new(message)
+      raise DownstreamInvalidStateError.new(message)
     end
 
     case downstream_payload.content_store_action
@@ -16,7 +16,7 @@ module DownstreamService
   def self.update_draft_content_store(downstream_payload)
     if %w(draft published unpublished).exclude?(downstream_payload.state)
       message = "Can only send draft, published and unpublished items to draft content store"
-      raise DownstreamInvariantError.new(message)
+      raise DownstreamInvalidStateError.new(message)
     end
 
     case downstream_payload.content_store_action
@@ -30,7 +30,7 @@ module DownstreamService
   def self.broadcast_to_message_queue(downstream_payload, update_type)
     if downstream_payload.state != "published"
       message = "Can only send published items to the message queue"
-      raise DownstreamInvariantError.new(message)
+      raise DownstreamInvalidStateError.new(message)
     end
 
     payload = downstream_payload.message_queue_payload(update_type)

--- a/app/workers/dependency_resolution_worker.rb
+++ b/app/workers/dependency_resolution_worker.rb
@@ -56,6 +56,7 @@ private
       content_item_id: latest_content_item.id,
       payload_version: payload_version,
       update_dependencies: false,
+      alert_on_invalid_state_error: false,
     )
   end
 
@@ -66,6 +67,7 @@ private
       message_queue_update_type: "links",
       payload_version: payload_version,
       update_dependencies: false,
+      alert_on_invalid_state_error: false,
     )
   end
 end

--- a/app/workers/downstream_discard_draft_worker.rb
+++ b/app/workers/downstream_discard_draft_worker.rb
@@ -27,7 +27,7 @@ class DownstreamDiscardDraftWorker
     enqueue_dependencies if update_dependencies
   rescue DiscardDraftBasePathConflictError => e
     alert_on_base_path_conflict ? notify_airbrake(e, args) : logger.warn(e.message)
-  rescue AbortWorkerError, DownstreamInvariantError => e
+  rescue AbortWorkerError, DownstreamInvalidStateError => e
     notify_airbrake(e, args)
   end
 

--- a/app/workers/downstream_live_worker.rb
+++ b/app/workers/downstream_live_worker.rb
@@ -3,7 +3,7 @@ require 'sidekiq-unique-jobs'
 class DownstreamLiveWorker
   attr_reader :content_item_id, :web_content_item, :payload_version,
     :message_queue_update_type, :update_dependencies,
-    :alert_on_invariant_error
+    :alert_on_invalid_state_error
 
   include DownstreamQueue
   include Sidekiq::Worker
@@ -37,8 +37,8 @@ class DownstreamLiveWorker
     end
 
     enqueue_dependencies if update_dependencies
-  rescue DownstreamInvariantError => e
-    alert_on_invariant_error ? notify_airbrake(e, args) : logger.warn(e.message)
+  rescue DownstreamInvalidStateError => e
+    alert_on_invalid_state_error ? notify_airbrake(e, args) : logger.warn(e.message)
   rescue AbortWorkerError => e
     notify_airbrake(e, args)
   end
@@ -51,7 +51,7 @@ private
     @payload_version = attributes.fetch(:payload_version)
     @message_queue_update_type = attributes.fetch(:message_queue_update_type, nil)
     @update_dependencies = attributes.fetch(:update_dependencies, true)
-    @alert_on_invariant_error = attributes.fetch(:alert_on_invariant_error, true)
+    @alert_on_invalid_state_error = attributes.fetch(:alert_on_invalid_state_error, true)
   end
 
   def enqueue_dependencies

--- a/spec/services/downstream_service_spec.rb
+++ b/spec/services/downstream_service_spec.rb
@@ -21,10 +21,10 @@ RSpec.describe DownstreamService do
     context "draft item" do
       let(:state) { "draft" }
 
-      it "raises a DownstreamInvariantError" do
+      it "raises a DownstreamInvalidStateError" do
         expect {
           DownstreamService.update_live_content_store(downstream_payload)
-        }.to raise_error(DownstreamInvariantError)
+        }.to raise_error(DownstreamInvalidStateError)
       end
     end
 
@@ -153,10 +153,10 @@ RSpec.describe DownstreamService do
         let(:state) { state }
 
         if should_error
-          it "should raise a DownstreamInvariantError" do
+          it "should raise a DownstreamInvalidStateError" do
             expect {
               DownstreamService.broadcast_to_message_queue(downstream_payload, update_type)
-            }.to raise_error(DownstreamInvariantError)
+            }.to raise_error(DownstreamInvalidStateError)
           end
         else
           it "should not raise an error" do

--- a/spec/workers/dependency_resolution_worker_spec.rb
+++ b/spec/workers/dependency_resolution_worker_spec.rb
@@ -34,7 +34,8 @@ RSpec.describe DependencyResolutionWorker, :perform do
         :content_item_id,
         :payload_version,
         message_queue_update_type: "links",
-        update_dependencies: false
+        update_dependencies: false,
+        alert_on_invalid_state_error: false,
       ),
     )
     worker_perform

--- a/spec/workers/downstream_draft_worker_spec.rb
+++ b/spec/workers/downstream_draft_worker_spec.rb
@@ -2,13 +2,15 @@ require "rails_helper"
 
 RSpec.describe DownstreamDraftWorker do
   let(:content_item) { FactoryGirl.create(:draft_content_item, base_path: "/foo") }
-  let(:arguments) {
+  let(:base_arguments) {
     {
       "content_item_id" => content_item.id,
       "payload_version" => 1,
       "update_dependencies" => true,
+      "alert_on_invariant_error" => true,
     }
   }
+  let(:arguments) { base_arguments }
 
   before do
     stub_request(:put, %r{.*content-store.*/content/.*})
@@ -30,6 +32,12 @@ RSpec.describe DownstreamDraftWorker do
     it "doesn't require update_dependencies" do
       expect {
         subject.perform(arguments.except("update_dependencies"))
+      }.not_to raise_error
+    end
+
+    it "doesn't require alert_on_invariant_error" do
+      expect {
+        subject.perform(arguments.except("alert_on_invariant_error"))
       }.not_to raise_error
     end
   end
@@ -66,16 +74,55 @@ RSpec.describe DownstreamDraftWorker do
 
   describe "update dependencies" do
     context "can update dependencies" do
+      let(:arguments) { base_arguments.merge("update_dependencies" => true) }
       it "enqueues dependencies" do
         expect(DependencyResolutionWorker).to receive(:perform_async)
-        subject.perform(arguments.merge("update_dependencies" => true))
+        subject.perform(arguments)
       end
     end
 
     context "can not update dependencies" do
+      let(:arguments) { base_arguments.merge("update_dependencies" => false) }
       it "doesn't enqueue dependencies" do
         expect(DependencyResolutionWorker).to_not receive(:perform_async)
-        subject.perform(arguments.merge("update_dependencies" => false))
+        subject.perform(arguments)
+      end
+    end
+  end
+
+  describe "error alerting" do
+    let(:message) { "Can only send draft, published and unpublished items to the draft content store" }
+    let(:logger) { Sidekiq::Logging.logger }
+
+    before do
+      allow(DownstreamService).to receive(:update_draft_content_store)
+        .and_raise(DownstreamInvariantError, message)
+    end
+
+    context "when alert_on_invariant_error is true" do
+      let(:arguments) { base_arguments.merge("alert_on_invariant_error" => true) }
+      it "notifies airbrake" do
+        expect(Airbrake).to receive(:notify_or_ignore)
+        subject.perform(arguments)
+      end
+
+      it "doesn't log the message" do
+        expect(logger).to_not receive(:warn).with(message)
+        subject.perform(arguments)
+      end
+    end
+
+    context "when alert_on_invariant_error is false" do
+      let(:arguments) { base_arguments.merge("alert_on_invariant_error" => false) }
+
+      it "doesn't notify airbrake" do
+        expect(Airbrake).to_not receive(:notify_or_ignore)
+        subject.perform(arguments)
+      end
+
+      it "logs the message" do
+        expect(logger).to receive(:warn).with(message)
+        subject.perform(arguments)
       end
     end
   end

--- a/spec/workers/downstream_draft_worker_spec.rb
+++ b/spec/workers/downstream_draft_worker_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe DownstreamDraftWorker do
       "content_item_id" => content_item.id,
       "payload_version" => 1,
       "update_dependencies" => true,
-      "alert_on_invariant_error" => true,
+      "alert_on_invalid_state_error" => true,
     }
   }
   let(:arguments) { base_arguments }
@@ -35,9 +35,9 @@ RSpec.describe DownstreamDraftWorker do
       }.not_to raise_error
     end
 
-    it "doesn't require alert_on_invariant_error" do
+    it "doesn't require alert_on_invalid_state_error" do
       expect {
-        subject.perform(arguments.except("alert_on_invariant_error"))
+        subject.perform(arguments.except("alert_on_invalid_state_error"))
       }.not_to raise_error
     end
   end
@@ -96,11 +96,11 @@ RSpec.describe DownstreamDraftWorker do
 
     before do
       allow(DownstreamService).to receive(:update_draft_content_store)
-        .and_raise(DownstreamInvariantError, message)
+        .and_raise(DownstreamInvalidStateError, message)
     end
 
-    context "when alert_on_invariant_error is true" do
-      let(:arguments) { base_arguments.merge("alert_on_invariant_error" => true) }
+    context "when alert_on_invalid_state_error is true" do
+      let(:arguments) { base_arguments.merge("alert_on_invalid_state_error" => true) }
       it "notifies airbrake" do
         expect(Airbrake).to receive(:notify_or_ignore)
         subject.perform(arguments)
@@ -112,8 +112,8 @@ RSpec.describe DownstreamDraftWorker do
       end
     end
 
-    context "when alert_on_invariant_error is false" do
-      let(:arguments) { base_arguments.merge("alert_on_invariant_error" => false) }
+    context "when alert_on_invalid_state_error is false" do
+      let(:arguments) { base_arguments.merge("alert_on_invalid_state_error" => false) }
 
       it "doesn't notify airbrake" do
         expect(Airbrake).to_not receive(:notify_or_ignore)

--- a/spec/workers/downstream_live_worker_spec.rb
+++ b/spec/workers/downstream_live_worker_spec.rb
@@ -2,14 +2,16 @@ require "rails_helper"
 
 RSpec.describe DownstreamLiveWorker do
   let(:content_item) { FactoryGirl.create(:live_content_item, base_path: "/foo") }
-  let(:arguments) {
+  let(:base_arguments) {
     {
       "content_item_id" => content_item.id,
       "payload_version" => 1,
       "message_queue_update_type" => "major",
       "update_dependencies" => true,
+      "alert_on_invariant_error" => true,
     }
   }
+  let(:arguments) { base_arguments }
 
   before do
     stub_request(:put, %r{.*content-store.*/content/.*})
@@ -37,6 +39,12 @@ RSpec.describe DownstreamLiveWorker do
     it "doesn't require update_dependencies" do
       expect {
         subject.perform(arguments.except("update_dependencies"))
+      }.not_to raise_error
+    end
+
+    it "doesn't require alert_on_invariant_error" do
+      expect {
+        subject.perform(arguments.except("alert_on_invariant_error"))
       }.not_to raise_error
     end
   end
@@ -140,6 +148,43 @@ RSpec.describe DownstreamLiveWorker do
       expect(Airbrake).to receive(:notify_or_ignore)
         .with(an_instance_of(AbortWorkerError), a_hash_including(:parameters))
       subject.perform(arguments.merge("content_item_id" => "made-up-id"))
+    end
+  end
+
+  describe "error alerting" do
+    let(:message) { "Can only send published and unpublished items to the live content store" }
+    let(:logger) { Sidekiq::Logging.logger }
+
+    before do
+      allow(DownstreamService).to receive(:update_live_content_store)
+        .and_raise(DownstreamInvariantError, message)
+    end
+
+    context "when alert_on_invariant_error is true" do
+      let(:arguments) { base_arguments.merge("alert_on_invariant_error" => true) }
+      it "notifies airbrake" do
+        expect(Airbrake).to receive(:notify_or_ignore)
+        subject.perform(arguments)
+      end
+
+      it "doesn't log the message" do
+        expect(logger).to_not receive(:warn).with(message)
+        subject.perform(arguments)
+      end
+    end
+
+    context "when alert_on_invariant_error is false" do
+      let(:arguments) { base_arguments.merge("alert_on_invariant_error" => false) }
+
+      it "doesn't notify airbrake" do
+        expect(Airbrake).to_not receive(:notify_or_ignore)
+        subject.perform(arguments)
+      end
+
+      it "logs the message" do
+        expect(logger).to receive(:warn).with(message)
+        subject.perform(arguments)
+      end
     end
   end
 end

--- a/spec/workers/downstream_live_worker_spec.rb
+++ b/spec/workers/downstream_live_worker_spec.rb
@@ -42,9 +42,9 @@ RSpec.describe DownstreamLiveWorker do
       }.not_to raise_error
     end
 
-    it "doesn't require alert_on_invariant_error" do
+    it "doesn't require alert_on_invalid_state_error" do
       expect {
-        subject.perform(arguments.except("alert_on_invariant_error"))
+        subject.perform(arguments.except("alert_on_invalid_state_error"))
       }.not_to raise_error
     end
   end
@@ -78,7 +78,7 @@ RSpec.describe DownstreamLiveWorker do
 
       it "absorbs an error" do
         expect(Airbrake).to receive(:notify_or_ignore)
-          .with(an_instance_of(DownstreamInvariantError), a_hash_including(:parameters))
+          .with(an_instance_of(DownstreamInvalidStateError), a_hash_including(:parameters))
         subject.perform(superseded_arguments)
       end
     end
@@ -131,7 +131,7 @@ RSpec.describe DownstreamLiveWorker do
       draft = FactoryGirl.create(:draft_content_item)
 
       expect(Airbrake).to receive(:notify_or_ignore)
-        .with(an_instance_of(DownstreamInvariantError), a_hash_including(:parameters))
+        .with(an_instance_of(DownstreamInvalidStateError), a_hash_including(:parameters))
       subject.perform(arguments.merge("content_item_id" => draft.id))
     end
 
@@ -157,11 +157,11 @@ RSpec.describe DownstreamLiveWorker do
 
     before do
       allow(DownstreamService).to receive(:update_live_content_store)
-        .and_raise(DownstreamInvariantError, message)
+        .and_raise(DownstreamInvalidStateError, message)
     end
 
-    context "when alert_on_invariant_error is true" do
-      let(:arguments) { base_arguments.merge("alert_on_invariant_error" => true) }
+    context "when alert_on_invalid_state_error is true" do
+      let(:arguments) { base_arguments.merge("alert_on_invalid_state_error" => true) }
       it "notifies airbrake" do
         expect(Airbrake).to receive(:notify_or_ignore)
         subject.perform(arguments)
@@ -173,8 +173,8 @@ RSpec.describe DownstreamLiveWorker do
       end
     end
 
-    context "when alert_on_invariant_error is false" do
-      let(:arguments) { base_arguments.merge("alert_on_invariant_error" => false) }
+    context "when alert_on_invalid_state_error is false" do
+      let(:arguments) { base_arguments.merge("alert_on_invalid_state_error" => false) }
 
       it "doesn't notify airbrake" do
         expect(Airbrake).to_not receive(:notify_or_ignore)


### PR DESCRIPTION
On integration we've seen a bunch of errors that occur when bulk publishing occurs. The general cause of those is:

Consider Item A v1 that links to Item B v2
- Item A is updated from version 1 to version 2 -> Item A v2 is enqueued to content store, Item B v1 is enqueued to the content store
- Item B is updated from version 1 to version 2 -> Item B v2 is enqueued to the content store
- When the worker tries to send Item B v1 to the content store it errors because v1 has been superseded.

This changes makes it so that errors aren't alerted to Airbrake when an error occurs from dependency resolution by adding an attribute of `:alert_on_invalid_state_error`. The hardest part of this task was deciding on what to name that attribute and I'm not sure alert is great either. I considered `ignore_on_invalid_state_error` but this felt wrong as it's good to log the message, also considered `raise_on_invalid_state_error` or `error_on_invalid_state_error` but I didn't feel they appropriately represented the consequences.

This change will also completely remove `DownstreamInvariantError` from our logs - mainly because it has been renamed to `DownstreamInvalidStateError` 😉 - which hopefully will make this error easier to understand.