### PR TITLE
Add parent_taxons / child_taxons fields to dependent expansion rules

### DIFF
--- a/app/queries/dependent_expansion_rules.rb
+++ b/app/queries/dependent_expansion_rules.rb
@@ -14,12 +14,13 @@ module Queries
       {
         parent: "children",
         documents: "document_collections",
-        working_groups: 'policies'
+        working_groups: 'policies',
+        parent_taxons: "child_taxons",
       }[link_type.to_sym]
     end
 
     def recursive_link_types
-      [:parent]
+      [:parent, :parent_taxons]
     end
 
   private

--- a/doc/api.md
+++ b/doc/api.md
@@ -268,7 +268,7 @@ the draft content store with the published item, if one exists. Uses
 
 **This endpoint will only return content for which the value of `publishing_app`
 matches the name of the application making the request, unless that app's API
-key has `view_all` permissions.** 
+key has `view_all` permissions.**
 
 Retrieves a paginated list of content items for the provided query string
 parameters. If content items exists in both a published and a draft state, the
@@ -367,7 +367,7 @@ Retrieves the link set for the given `content_id`. Returns arrays of
 
 ## `GET /v2/expanded-links/:content_id`
 
-TODO: Request/Response detail
+[Request/Response detail](https://pact-broker.dev.publishing.service.gov.uk/pacts/provider/Publishing%20API/consumer/GDS%20API%20Adapters/latest#a_get-expanded-links_request_given_empty_links_exist_for_content_id_bed722e6-db68-43e5-9079-063f623335a7)
 
 Retrieves the expanded link set for the given `content_id`. Returns arrays of
 details for each linked content item in groupings of `link_type`.

--- a/spec/queries/dependent_expansion_rules_spec.rb
+++ b/spec/queries/dependent_expansion_rules_spec.rb
@@ -25,6 +25,7 @@ RSpec.describe Queries::DependentExpansionRules do
 
   describe "#recurse?" do
     specify { expect(subject.recurse?(:parent)).to eq(true) }
+    specify { expect(subject.recurse?(:parent_taxons)).to eq(true) }
     specify { expect(subject.recurse?(:foo)).to eq(false) }
   end
 
@@ -32,5 +33,6 @@ RSpec.describe Queries::DependentExpansionRules do
     specify { expect(subject.reverse_name_for(:parent)).to eq("children") }
     specify { expect(subject.reverse_name_for(:documents)).to eq("document_collections") }
     specify { expect(subject.reverse_name_for(:working_groups)).to eq("policies") }
+    specify { expect(subject.reverse_name_for(:parent_taxons)).to eq("child_taxons") }
   end
 end


### PR DESCRIPTION
Finding Things are building tools for editing and navigating taxonomies.
To support this, we need to be able to retrieve parts of the taxonomical
hierarchy from the publishing api.

Adding these additional fields to the expansion rules allows us to do
this efficiently, without making multiple network requests to construct
the hierarchy from the client application.