### PR TITLE
Use correct permissions for pact test user.

### DIFF
--- a/spec/service_consumers/pact_helper.rb
+++ b/spec/service_consumers/pact_helper.rb
@@ -28,7 +28,9 @@ Pact.provider_states_for "GDS API Adapters" do
     WebMock.enable!
     WebMock.reset!
     DatabaseCleaner.clean_with :truncation
-    FactoryGirl.create(:user)
+    GDS::SSO.test_user = FactoryGirl.create(:user,
+      permissions: %w(signin view_all),
+    )
   end
 
   tear_down do


### PR DESCRIPTION
Now we're sending correct Accept headers during
pact tests, we need to make sure that the user
we locate has the `view_all` permission required
during the /v2/content GET requests.