### PR TITLE
Deprecated columns is no longer needed

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,6 @@ gem "gds-sso", "12.1.0"
 gem 'bunny', '2.5.1'
 gem 'whenever', '0.9.4', require: false
 gem "govuk_sidekiq", "~> 0.0"
-gem "deprecated_columns"
 gem "json-schema", require: false
 gem "hashdiff"
 gem "sidekiq-unique-jobs", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -63,8 +63,6 @@ GEM
       safe_yaml (~> 1.0.0)
     database_cleaner (1.3.0)
     debug_inspector (0.0.2)
-    deprecated_columns (0.1.0)
-      rails (>= 4.0)
     diff-lcs (1.2.5)
     docile (1.1.5)
     domain_name (0.5.24)
@@ -367,7 +365,6 @@ DEPENDENCIES
   airbrake (~> 4.2.1)
   bunny (= 2.5.1)
   database_cleaner
-  deprecated_columns
   factory_girl_rails (= 4.5.0)
   faker
   gds-api-adapters (= 33.0.0)

--- a/app/models/access_limit.rb
+++ b/app/models/access_limit.rb
@@ -1,9 +1,4 @@
 class AccessLimit < ActiveRecord::Base
-  # These are to be removed after deploy
-  belongs_to :target, polymorphic: true
-  deprecated_columns :target_id, :target_type
-  # These are to be removed after deploy
-
   belongs_to :content_item
 
   validate :user_uids_are_strings


### PR DESCRIPTION
Completely removes the target dependency on AccessLimit and removes the
gem.