### PR TITLE
Fix call to update_column on taxonomy rake task

### DIFF
--- a/lib/tasks/taxonomy.rake
+++ b/lib/tasks/taxonomy.rake
@@ -18,7 +18,7 @@ namespace :taxonomy do
         puts "Found #{path_reservations.count} path reservations belonging to collections publisher"
         path_reservations.each do |path_reservation|
           puts "Updating #{path_reservation.base_path} to content-tagger"
-          path_reservation.update_column(publishing_app: "content-tagger")
+          path_reservation.update_column(:publishing_app, "content-tagger")
         end
       end
     end


### PR DESCRIPTION
The method `update_column` takes 2 arguments: the column name and the value,
rather than a hash. This commit fixes the method call so the rake task completes
without errors.

https://github.com/rails/rails/blob/5d1402a1011f58b405e42007d3ceed4e122d273e/activerecord/lib/active_record/persistence.rb#L272