### PR TITLE
Fix describing instance methods with class method convention

### DIFF
--- a/spec/lib/data_hygiene/duplicate_content_item/base_path_for_state_spec.rb
+++ b/spec/lib/data_hygiene/duplicate_content_item/base_path_for_state_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe DataHygiene::DuplicateContentItem::BasePathForState do
     }
   end
 
-  describe ".has_duplicates?" do
+  describe "#has_duplicates?" do
     subject { described_class.new.has_duplicates? }
 
     context "when there are no duplicates" do
@@ -63,7 +63,7 @@ RSpec.describe DataHygiene::DuplicateContentItem::BasePathForState do
     end
   end
 
-  describe ".number_of_duplicates" do
+  describe "#number_of_duplicates" do
     subject { described_class.new.number_of_duplicates }
     context "when there are no duplicates" do
       it { is_expected.to be 0 }
@@ -78,7 +78,7 @@ RSpec.describe DataHygiene::DuplicateContentItem::BasePathForState do
     end
   end
 
-  describe ".results" do
+  describe "#results" do
     subject { described_class.new.results }
     let(:no_matches) do
       {
@@ -194,7 +194,7 @@ RSpec.describe DataHygiene::DuplicateContentItem::BasePathForState do
     end
   end
 
-  describe ".log" do
+  describe "#log" do
     subject(:instance) { described_class.new }
     context "when there are no duplicates" do
       it "doesn't log to airbrake" do

--- a/spec/lib/data_hygiene/duplicate_content_item/state_for_locale_spec.rb
+++ b/spec/lib/data_hygiene/duplicate_content_item/state_for_locale_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe DataHygiene::DuplicateContentItem::StateForLocale do
     }
   end
 
-  describe ".has_duplicates?" do
+  describe "#has_duplicates?" do
     subject { described_class.new.has_duplicates? }
 
     context "when there are no duplicates" do
@@ -63,7 +63,7 @@ RSpec.describe DataHygiene::DuplicateContentItem::StateForLocale do
     end
   end
 
-  describe ".number_of_duplicates" do
+  describe "#number_of_duplicates" do
     subject { described_class.new.number_of_duplicates }
 
     context "when there are no duplicates" do
@@ -79,7 +79,7 @@ RSpec.describe DataHygiene::DuplicateContentItem::StateForLocale do
     end
   end
 
-  describe ".results" do
+  describe "#results" do
     subject { described_class.new.results }
 
     let(:no_matches) do
@@ -223,7 +223,7 @@ RSpec.describe DataHygiene::DuplicateContentItem::StateForLocale do
     end
   end
 
-  describe ".log" do
+  describe "#log" do
     subject(:instance) { described_class.new }
     context "when there are no duplicates" do
       it "doesn't log to airbrake" do

--- a/spec/lib/data_hygiene/duplicate_content_item/version_for_locale_spec.rb
+++ b/spec/lib/data_hygiene/duplicate_content_item/version_for_locale_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe DataHygiene::DuplicateContentItem::VersionForLocale do
     }
   end
 
-  describe ".has_duplicates?" do
+  describe "#has_duplicates?" do
     subject { described_class.new.has_duplicates? }
 
     context "when there are no duplicates" do
@@ -77,7 +77,7 @@ RSpec.describe DataHygiene::DuplicateContentItem::VersionForLocale do
     end
   end
 
-  describe ".results" do
+  describe "#results" do
     subject { described_class.new.results }
     let(:no_matches) do
       {
@@ -160,7 +160,7 @@ RSpec.describe DataHygiene::DuplicateContentItem::VersionForLocale do
     end
   end
 
-  describe ".log" do
+  describe "#log" do
     subject(:instance) { described_class.new }
 
     context "when there are no duplicates" do


### PR DESCRIPTION
I used this convention incorrectly: http://betterspecs.org/#describe