### PR TITLE
Restrict unpublishing collisions

### DIFF
--- a/app/commands/v2/unpublish.rb
+++ b/app/commands/v2/unpublish.rb
@@ -126,7 +126,8 @@ module Commands
         end
 
         filter = ContentItemFilter.new(scope: ContentItem.where(content_id: content_id))
-        filter.filter(locale: locale, state: allowed_states).last
+        content_item = filter.filter(locale: locale, state: allowed_states).last
+        content_item if content_item && (payload[:allow_draft] || !Unpublishing.is_substitute?(content_item))
       end
 
       def lookup_previous_item(content_item)

--- a/app/models/unpublishing.rb
+++ b/app/models/unpublishing.rb
@@ -23,4 +23,8 @@ class Unpublishing < ActiveRecord::Base
   def redirect?
     type == "redirect"
   end
+
+  def self.is_substitute?(content_item)
+    where(content_item: content_item).pluck(:type).first == "substitute"
+  end
 end

--- a/spec/commands/v2/unpublish_spec.rb
+++ b/spec/commands/v2/unpublish_spec.rb
@@ -338,6 +338,23 @@ RSpec.describe Commands::V2::Unpublish do
 
         described_class.call(payload)
       end
+
+      context "when the unpublishing type is substitute" do
+        let!(:unpublished_content_item) do
+          FactoryGirl.create(:substitute_unpublished_content_item,
+            content_id: content_id,
+          )
+        end
+
+        it "rejects the request with a 404" do
+          message = "Could not find a content item to unpublish"
+          expect {
+            described_class.call(payload)
+          }.to raise_error(CommandError, message) { |error|
+            expect(error.code).to eq(404)
+          }
+        end
+      end
     end
 
     context "with the `downstream` flag set to `false`" do

--- a/spec/models/unpublishing_spec.rb
+++ b/spec/models/unpublishing_spec.rb
@@ -64,4 +64,24 @@ RSpec.describe Unpublishing do
       expect(subject).to be_valid
     end
   end
+
+  describe ".is_subtitute?" do
+    subject { described_class.is_substitute?(content_item) }
+    context "when unpublished with type 'substitute'" do
+      let(:content_item) { FactoryGirl.create(:substitute_unpublished_content_item) }
+      it { is_expected.to be true }
+    end
+    context "when unpublished with type 'gone'" do
+      let(:content_item) { FactoryGirl.create(:gone_unpublished_content_item) }
+      it { is_expected.to be false }
+    end
+    context "when content item is published" do
+      let(:content_item) { FactoryGirl.create(:live_content_item) }
+      it { is_expected.to be false }
+    end
+    context "when there isn't a content item" do
+      let(:content_item) { nil }
+      it { is_expected.to be false }
+    end
+  end
 end


### PR DESCRIPTION
This adds a condition (and unfortunately an extra query) when we
unpublish an item to check whether it is unpublished with a type of
"substitute".

It's not really ideal as it could fail if a rogue published document had
a state of published and an unpublishing entry but that seems unlikely.

Rather than getting too bogged down in another substitute exception
clause I have suggested this as an alternative:
https://trello.com/c/EMIigaJ1/306-introduce-a-state-of-substituted