### PR TITLE
Optimise put_content endpoint.

### DIFF
--- a/app/commands/base_command.rb
+++ b/app/commands/base_command.rb
@@ -73,6 +73,7 @@ module Commands
 
         raise_command_error(409, "Conflict", fields, friendly_message: friendly_message)
       end
+      current_version
     end
 
     def raise_command_error(code, message, fields, friendly_message: nil)

--- a/app/commands/v2/put_content.rb
+++ b/app/commands/v2/put_content.rb
@@ -66,7 +66,7 @@ module Commands
       end
 
       def update_existing_content_item(content_item)
-        check_version_and_raise_if_conflicting(content_item, payload[:previous_version])
+        version = check_version_and_raise_if_conflicting(content_item, payload[:previous_version])
 
         if content_with_base_path?
           clear_draft_items_of_same_locale_and_base_path(content_item, locale, base_path)
@@ -77,7 +77,8 @@ module Commands
 
         update_content_item(content_item)
         update_last_edited_at_if_needed(content_item, payload[:last_edited_at])
-        increment_lock_version(content_item)
+
+        increment_lock_version(version)
 
         if path_has_changed?(previous_location)
           from_path = previous_location.base_path
@@ -252,8 +253,7 @@ module Commands
         content_item.update_attributes(last_edited_at: last_edited_at) if last_edited_at
       end
 
-      def increment_lock_version(content_item)
-        lock_version = LockVersion.find_by!(target: content_item)
+      def increment_lock_version(lock_version)
         lock_version.increment
         lock_version.save!
       end

--- a/app/models/lock_version.rb
+++ b/app/models/lock_version.rb
@@ -30,6 +30,6 @@ class LockVersion < ActiveRecord::Base
 private
 
   def content_item_target?
-    target.is_a?(ContentItem)
+    target_type == 'ContentItem'
   end
 end

--- a/app/models/lock_version.rb
+++ b/app/models/lock_version.rb
@@ -32,19 +32,4 @@ private
   def content_item_target?
     target.is_a?(ContentItem)
   end
-
-  def draft_and_live_versions
-    draft = ContentItemFilter.similar_to(target, state: "draft", user_version: nil).first
-    live = ContentItemFilter.similar_to(target, state: "published", user_version: nil).first
-
-    if draft == target
-      draft_version = self
-      live_version = self.class.find_by(target: live)
-    elsif live == target
-      draft_version = self.class.find_by(target: draft)
-      live_version = self
-    end
-
-    [draft_version, live_version]
-  end
 end

--- a/app/models/user_facing_version.rb
+++ b/app/models/user_facing_version.rb
@@ -28,18 +28,7 @@ private
     true
   end
 
-  def draft_and_live_versions
-    draft = ContentItemFilter.similar_to(content_item, state: "draft", user_version: nil).first
-    live = ContentItemFilter.similar_to(content_item, state: "published", user_version: nil).first
-
-    if draft == content_item
-      draft_version = self
-      live_version = self.class.find_by(content_item: live)
-    elsif live == content_item
-      draft_version = self.class.find_by(content_item: draft)
-      live_version = self
-    end
-
-    [draft_version, live_version]
+  def target
+    content_item
   end
 end

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -21,11 +21,11 @@ private
   end
 
   def draft_and_live_versions
-    result = Queries::DraftAndLiveVersions.call(target, self.class.name.tableize)
+    result = Queries::DraftAndLiveVersions.call(target, self.class.table_name)
     if result["draft"] == self.number
       draft_version = self.number
-      live_version = result["published"]
-    elsif result["published"] == self.number
+      live_version = result["live"]
+    elsif result["live"] == self.number
       draft_version = result["draft"]
       live_version = self.number
     end

--- a/app/models/version.rb
+++ b/app/models/version.rb
@@ -20,13 +20,26 @@ private
     errors.add(:number, message)
   end
 
+  def draft_and_live_versions
+    result = Queries::DraftAndLiveVersions.call(target, self.class.name.tableize)
+    if result["draft"] == self.number
+      draft_version = self.number
+      live_version = result["published"]
+    elsif result["published"] == self.number
+      draft_version = result["draft"]
+      live_version = self.number
+    end
+
+    [draft_version, live_version]
+  end
+
   def draft_cannot_be_behind_live
     draft_version, live_version = draft_and_live_versions
 
     return unless draft_version && live_version
 
-    if draft_version.number < live_version.number
-      mismatch = "(#{draft_version.number} < #{live_version.number})"
+    if draft_version < live_version
+      mismatch = "(#{draft_version} < #{live_version})"
       message = "draft #{self.class.name} cannot be behind the live #{self.class.name} #{mismatch}"
       errors.add(:number, message)
     end

--- a/app/queries/arel_helpers.rb
+++ b/app/queries/arel_helpers.rb
@@ -28,7 +28,8 @@ module Queries
     end
 
     def get_rows(scope)
-      result = ActiveRecord::Base.connection.exec_query(scope.to_sql)
+      scope = scope.to_sql unless scope.is_a? String
+      result = ActiveRecord::Base.connection.exec_query(scope)
 
       result.to_hash.map do |r|
         r.each do |k, v|

--- a/app/queries/draft_and_live_versions.rb
+++ b/app/queries/draft_and_live_versions.rb
@@ -1,0 +1,56 @@
+module Queries
+  module DraftAndLiveVersions
+    extend ArelHelpers
+    def self.call(content_item, target_class, locale = nil, base_path = nil)
+      content_items_table = table(:content_items)
+      states_table = table(:states)
+      translations_table = table(:translations)
+      locations_table = table(:locations)
+      versions_table = table(target_class)
+      versions_fk = target_class == "lock_versions" ? :target_id : :content_item_id
+
+      if base_path.nil?
+        base_path = locations_table.project(locations_table[:base_path])
+          .where(locations_table[:content_item_id].eq(content_item.id))
+      end
+      if locale.nil?
+        locale = translations_table.project(translations_table[:locale])
+          .where(translations_table[:content_item_id].eq(content_item.id))
+      end
+
+      scope = content_items_table
+        .project(
+          Arel::Nodes::NamedFunction.new("row_number", [])
+            .over(Arel::Nodes::Window.new
+              .partition(states_table[:name])
+              .order(versions_table[:number])
+            ).as("r"),
+          states_table[:name].as("state"),
+          versions_table[:number].as("version_number")
+        )
+        .outer_join(states_table).on(
+          content_items_table[:id].eq(states_table[:content_item_id])
+        )
+        .outer_join(translations_table).on(
+          content_items_table[:id].eq(translations_table[:content_item_id])
+        )
+        .outer_join(locations_table).on(
+          content_items_table[:id].eq(locations_table[:content_item_id])
+        )
+        .outer_join(versions_table).on(
+          content_items_table[:id].eq(versions_table[versions_fk])
+        )
+        .where(content_items_table[:content_id].eq(content_item.content_id))
+        .where(locations_table[:base_path].eq(base_path))
+        .where(translations_table[:locale].eq(locale))
+        .where(states_table[:name].in(%w(draft published)))
+
+      partitioned = cte(scope, as: :partitioned)
+      query = partitioned.table.project(Arel.star)
+        .with(partitioned.compiled_scope)
+        .where(partitioned.table[:r].eq(1))
+
+      Hash[get_rows(query).map { |i| [i["state"], i["version_number"].to_i] }]
+    end
+  end
+end

--- a/app/queries/draft_and_live_versions.rb
+++ b/app/queries/draft_and_live_versions.rb
@@ -1,18 +1,13 @@
 module Queries
   module DraftAndLiveVersions
     extend ArelHelpers
-    def self.call(content_item, target_class, locale = nil, base_path = nil)
+    def self.call(content_item, target_table_name, locale = nil)
       content_items_table = table(:content_items)
       states_table = table(:states)
       translations_table = table(:translations)
-      locations_table = table(:locations)
-      versions_table = table(target_class)
-      versions_fk = target_class == "lock_versions" ? :target_id : :content_item_id
+      versions_table = table(target_table_name)
+      versions_fk = target_table_name == "lock_versions" ? :target_id : :content_item_id
 
-      if base_path.nil?
-        base_path = locations_table.project(locations_table[:base_path])
-          .where(locations_table[:content_item_id].eq(content_item.id))
-      end
       if locale.nil?
         locale = translations_table.project(translations_table[:locale])
           .where(translations_table[:content_item_id].eq(content_item.id))
@@ -20,35 +15,49 @@ module Queries
 
       scope = content_items_table
         .project(
-          Arel::Nodes::NamedFunction.new("row_number", [])
-            .over(Arel::Nodes::Window.new
-              .partition(states_table[:name])
-              .order(versions_table[:number])
-            ).as("r"),
-          states_table[:name].as("state"),
+          Arel::Nodes::SqlLiteral.new(
+            "CASE WHEN states.name IN ('published', 'unpublished') THEN 'live' " +
+            "WHEN states.name = 'draft' THEN 'draft' END"
+          ).as("state"),
           versions_table[:number].as("version_number")
         )
-        .outer_join(states_table).on(
+        .join(states_table).on(
           content_items_table[:id].eq(states_table[:content_item_id])
         )
-        .outer_join(translations_table).on(
+        .join(translations_table).on(
           content_items_table[:id].eq(translations_table[:content_item_id])
         )
-        .outer_join(locations_table).on(
-          content_items_table[:id].eq(locations_table[:content_item_id])
-        )
-        .outer_join(versions_table).on(
+        .join(versions_table).on(
           content_items_table[:id].eq(versions_table[versions_fk])
         )
         .where(content_items_table[:content_id].eq(content_item.content_id))
-        .where(locations_table[:base_path].eq(base_path))
         .where(translations_table[:locale].eq(locale))
-        .where(states_table[:name].in(%w(draft published)))
+        .where(states_table[:name].in(%w(draft published unpublished)))
+      if target_table_name == "lock_versions"
+        scope.where(versions_table[:target_type].eq("ContentItem"))
+      end
 
-      partitioned = cte(scope, as: :partitioned)
-      query = partitioned.table.project(Arel.star)
-        .with(partitioned.compiled_scope)
-        .where(partitioned.table[:r].eq(1))
+      cte = Arel::Table.new("cte")
+      left = cte
+        .project(
+          cte[:state],
+          cte[:version_number]
+        )
+        .where(cte[:state].eq("draft"))
+        .order(cte[:version_number].desc)
+        .take(1)
+      right = cte
+        .project(
+          cte[:state],
+          cte[:version_number]
+        )
+        .where(cte[:state].eq("live"))
+        .order(cte[:version_number].desc)
+        .take(1)
+
+      # Arel doesn't correctly add parens around complex UNION clauses, which
+      # Postgres requires, so we need to build up the SQL query manually.
+      query = "WITH cte AS (#{scope.to_sql}) (#{left.to_sql}) UNION (#{right.to_sql})"
 
       Hash[get_rows(query).map { |i| [i["state"], i["version_number"].to_i] }]
     end

--- a/bench/put_content.rb
+++ b/bench/put_content.rb
@@ -15,6 +15,7 @@ ActiveSupport::Notifications.subscribe "sql.active_record" do |name, started, fi
 end
 
 new_item = (ARGV.first == '--new-item')
+redraft = (ARGV.first == '--redraft')
 
 content_id = SecureRandom.uuid
 title = Faker::Company.catch_phrase
@@ -47,14 +48,34 @@ content_items = 100.times.map do
 end
 
 begin
-  StackProf.run(mode: :wall, out: "tmp/put_content_wall.dump") do
-    puts Benchmark.measure {
-      content_items.each do |item|
-        Commands::V2::PutContent.call(item)
-        print "."
-      end
-      puts ""
-    }
+  if redraft
+    puts "Creating published items..."
+    content_items.each do |item|
+      Commands::V2::PutContent.call(item)
+      Commands::V2::Publish.call(content_id: item[:content_id], update_type: 'major')
+    end
+    $queries = 0
+
+    puts "Publishing..."
+    StackProf.run(mode: :wall, out: "tmp/put_content_wall.dump") do
+      puts Benchmark.measure {
+        content_items.each do |item|
+          Commands::V2::PutContent.call(item.merge(title: Faker::Company.catch_phrase))
+          print "."
+        end
+        puts ""
+      }
+    end
+  else
+    StackProf.run(mode: :wall, out: "tmp/put_content_wall.dump") do
+      puts Benchmark.measure {
+        content_items.each do |item|
+          Commands::V2::PutContent.call(item)
+          print "."
+        end
+        puts ""
+      }
+    end
   end
 
   puts "#{$queries} SQL queries"

--- a/bench/put_content.rb
+++ b/bench/put_content.rb
@@ -14,10 +14,14 @@ ActiveSupport::Notifications.subscribe "sql.active_record" do |name, started, fi
   $queries += 1
 end
 
+new_item = (ARGV.first == '--new-item')
+
 content_id = SecureRandom.uuid
 title = Faker::Company.catch_phrase
 
 content_items = 100.times.map do
+  title = Faker::Company.catch_phrase if new_item
+  content_id = SecureRandom.uuid if new_item
   {
     content_id: content_id,
     format: "placeholder",

--- a/spec/factories/live_content_item.rb
+++ b/spec/factories/live_content_item.rb
@@ -12,6 +12,7 @@ FactoryGirl.define do
             locale: evaluator.locale,
             base_path: evaluator.base_path,
             lock_version: evaluator.lock_version,
+            user_facing_version: evaluator.draft_version_number,
           )
         )
 

--- a/spec/queries/draft_and_live_versions_spec.rb
+++ b/spec/queries/draft_and_live_versions_spec.rb
@@ -1,0 +1,51 @@
+require "rails_helper"
+
+RSpec.describe Queries::DraftAndLiveVersions do
+  let(:content_id) { SecureRandom.uuid }
+  let(:base_path) { "/vat-rates" }
+
+  let(:payload) {
+    {
+      content_id: content_id,
+      base_path: base_path,
+      update_type: "major",
+      title: "Some Title",
+      publishing_app: "publisher",
+      rendering_app: "frontend",
+      document_type: "guide",
+      schema_name: "guide",
+      locale: "en",
+      routes: [{ path: base_path, type: "exact" }],
+      redirects: [],
+      phase: "beta",
+    }
+  }
+
+  before do
+    3.times do |i|
+      FactoryGirl.create(:content_item,
+        state: 'superseded',
+        content_id: content_id,
+        user_facing_version: i,
+        base_path: base_path
+      )
+    end
+    @item = FactoryGirl.create(:live_content_item, :with_draft,
+      content_id: content_id,
+      user_facing_version: 4,
+      draft_version_number: 5,
+      base_path: base_path
+    )
+    FactoryGirl.create(:live_content_item, :with_draft,
+      content_id: content_id,
+      lock_version: 2,
+      user_facing_version: 5,
+    )
+  end
+
+  it "finds the right draft and live versions" do
+    result = Queries::DraftAndLiveVersions.call(@item, :user_facing_versions, 'en', base_path)
+    expect(result["draft"]).to eq(5)
+    expect(result["published"]).to eq(4)
+  end
+end


### PR DESCRIPTION
A series of optimisations to put_content.

There can be various different paths through this code, so this PR also adds command-line parameters to the benchmark script (`bench/put_content.rb`) to test those paths.  Results from each run:


```
New item each time: master
  7.140000   0.780000   7.920000 ( 10.570383)
4324 SQL queries

now
  5.660000   0.460000   6.120000 (  8.595015)
2928 SQL queries

Update same item each time: master
  4.640000   0.450000   5.090000 (  6.907528)
2249 SQL queries

now
  3.330000   0.590000   3.920000 (  5.665207)
1543 SQL queries

Redrafting: master
  4.090000   0.320000   4.410000 (  6.650513)
2218 SQL queries

now
  3.120000   0.260000   3.380000 (  5.184676)
1513 SQL queries
```

The main win is in doing the draft vs live validation for LockVersion and UserFacingVersion in a single query, and there are a few other minor changes to reduce the number of unnecessary queries more generally. There's still a lot to gain in the uniqueness validations, but that would conflict with other work going on around those so it's best to leave that for a separate PR.