### PR TITLE
Add updated_at and created_at to get_linkables payload

### DIFF
--- a/app/presenters/queries/linkable_presenter.rb
+++ b/app/presenters/queries/linkable_presenter.rb
@@ -1,12 +1,14 @@
 module Presenters
   module Queries
     class LinkablePresenter
-      def self.present(content_id, state, title, base_path, internal_name)
+      def self.present(content_id, state, title, base_path, updated_at, created_at, internal_name)
         {
           title: title,
           content_id: content_id,
           publication_state: state,
           base_path: base_path,
+          updated_at: updated_at,
+          created_at: created_at,
           internal_name: internal_name || title,
         }
       end

--- a/app/queries/get_linkables.rb
+++ b/app/queries/get_linkables.rb
@@ -8,7 +8,7 @@ module Queries
       Linkable
         .where(document_type: [document_type, "placeholder_#{document_type}"])
         .includes(:content_item)
-        .pluck(:content_id, :state, :title, :base_path, "content_items.details->>'internal_name' as internal_name")
+        .pluck(:content_id, :state, :title, :base_path, :updated_at, :created_at, "content_items.details->>'internal_name' as internal_name")
         .map { |linkable_data|
           Presenters::Queries::LinkablePresenter.present(*linkable_data)
         }

--- a/spec/presenters/queries/linkable_presenter_spec.rb
+++ b/spec/presenters/queries/linkable_presenter_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 RSpec.describe Presenters::Queries::LinkablePresenter do
   let(:internal_name) { nil }
   let(:state) { "draft" }
+  let(:date) { Time.now.utc.iso8601 }
 
   let(:args) {
     [
@@ -10,6 +11,8 @@ RSpec.describe Presenters::Queries::LinkablePresenter do
       state,
       "A title",
       "/vat-rates",
+      date,
+      date,
       internal_name,
     ]
   }
@@ -44,6 +47,20 @@ RSpec.describe Presenters::Queries::LinkablePresenter do
       it "shows as 'published'" do
         output = described_class.present(*args)
         expect(output[:publication_state]).to eq("published")
+      end
+    end
+
+    context 'when updated_at is passed' do
+      it 'shows updated_at datetime' do
+        output = described_class.present(*args)
+        expect(output[:updated_at]).to eq(date)
+      end
+    end
+
+    context 'when created_at is passed' do
+      it 'shows created_at datetime' do
+        output = described_class.present(*args)
+        expect(output[:created_at]).to eq(date)
       end
     end
   end


### PR DESCRIPTION
We would like to expose these two fields so we can see them on Content Tagger.
This will then allow us to sort the results by either of those fields.

Trello: https://trello.com/c/y9VdJshp/111-add-created-at-updated-at-ordering-to-taxons-list

## Result

```
Services.publishing_api.get_linkables(format: 'taxon').first

=> {"title"=>"Early Years Foundation Stage",
 "content_id"=>"66566163-4a0d-4ae4-8a16-13b81e67a4a0",
 "publication_state"=>"published",
 "base_path"=>
  "/alpha-taxonomy/f3ee9cf4-9212-4614-96e3-5ea15e3d4aa7-early-years-foundation-stage",
 "updated_at"=>"2016-08-05T12:54:16.398Z",
 "created_at"=>"2016-08-05T12:54:16.398Z",
 "internal_name"=>"Early Years Foundation Stage"}
```