### PR TITLE
Update linkable on publish.

### DIFF
--- a/spec/commands/v2/publish_spec.rb
+++ b/spec/commands/v2/publish_spec.rb
@@ -80,18 +80,53 @@ RSpec.describe Commands::V2::Publish do
     end
 
     context "when the content item was previously published" do
+      let(:existing_base_path) { base_path }
+
       let!(:live_item) do
         FactoryGirl.create(:live_content_item,
           content_id: draft_item.content_id,
-          base_path: base_path,
+          base_path: existing_base_path,
         )
       end
+
+      let!(:linkable) {
+        FactoryGirl.create(:linkable,
+          content_item: live_item,
+          base_path: existing_base_path,
+          state: "published",
+        )
+      }
 
       it "marks the previously published item as 'superseded'" do
         described_class.call(payload)
 
         state = State.find_by!(content_item: live_item)
         expect(state.name).to eq("superseded")
+      end
+
+      context "when the base path did not change" do
+        it "updates the linkable to point to the new published item" do
+          described_class.call(payload)
+          expect(Linkable.first.content_item).to eq(draft_item)
+        end
+      end
+
+      context "when the base path changed" do
+        let(:existing_base_path) { '/old-vat-rates' }
+
+        let!(:new_linkable) {
+          FactoryGirl.create(:linkable,
+            content_item: draft_item,
+            base_path: base_path,
+            state: "draft",
+          )
+        }
+
+        it "updates the linkable to point to the new published item" do
+          described_class.call(payload)
+          expect(Linkable.count).to eq(1)
+          expect(Linkable.first.content_item).to eq(draft_item)
+        end
       end
 
       context "when the system is in an inconsistent state" do


### PR DESCRIPTION
Currently we only update the Linkable in put_content when a new draft
is created with a different base path. This means that if the base
path does not change, the Linkable still refers to the old content
item, so if the title changes the get_linkable endpoint will return
the old data.

This change ensures that on publish any linkable pointing at the old
content_item is deleted and the new one updated. There are three cases:

* if the base_path changed, we have a published linkable pointing at
the old content_item and a draft linkable pointing at the new item;
delete the old one and update the draft one to published.
* if the base_path did not change, we have one linkable but it is
pointing at the old content_item; the delete is a no-op but we update
the linkable to point to the new content_item.
* if there is no previously published item, just update the linkable
state to published.