### PR TITLE
Add migration for removing a content item which redirects to itself

### DIFF
--- a/db/migrate/20160901103440_remove_content_item_with_self_redirect.rb
+++ b/db/migrate/20160901103440_remove_content_item_with_self_redirect.rb
@@ -1,0 +1,12 @@
+require_relative "helpers/delete_content_item"
+
+class RemoveContentItemWithSelfRedirect < ActiveRecord::Migration
+  def up
+    content_item = ContentItem.find(645143)
+
+    if content_item
+      Helpers::DeleteContentItem.destroy_supporting_objects(content_item)
+      content_item.destroy
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160830105752) do
+ActiveRecord::Schema.define(version: 20160901103440) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
This causes a redirect loop on the live site. In a different branch, I have
proposed adding validation to reject data like this.