### PR TITLE
Remove orphaned translation `ContentItem`

### DIFF
--- a/db/migrate/20160906160955_remove_orphaned_translation.rb
+++ b/db/migrate/20160906160955_remove_orphaned_translation.rb
@@ -1,0 +1,14 @@
+require_relative "helpers/delete_content_item"
+
+class RemoveOrphanedTranslation < ActiveRecord::Migration
+  def up
+    #/guidance/equitable-life-payment-scheme.de
+    #id: 23835, content_id: "5f5890da-7631-11e4-a3cb-005056011aef"
+    #Whitehall - edition_id: 649963
+
+    content_item = ContentItem.find(23835)
+    Helpers::DeleteContentItem.destroy_supporting_objects([content_item])
+
+    content_item.destroy
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160901125346) do
+ActiveRecord::Schema.define(version: 20160906160955) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
This migration deletes a `ContentItem`, and all the supporting stuff, that is a translation of a Whitehall `DetailedGuide`. Whitehall has no knowledge of this translation and the URL currently 404s.

This is probably being caused by a known issue in Whitehall where deleted translations are not currently unpublished from Publishing API. There is a [Trello card for fixing this](https://trello.com/c/ieIgR5mN/692-deleted-translations-not-unpublished) with #core-formats