### PR TITLE
Small performance improvement

### DIFF
--- a/app/commands/v2/patch_link_set.rb
+++ b/app/commands/v2/patch_link_set.rb
@@ -28,9 +28,7 @@ module Commands
             links.create!(target_content_id: content_id)
           end
 
-          content_ids_to_delete.each do |content_id|
-            links.find_by!(target_content_id: content_id).destroy
-          end
+          links.where(target_content_id: content_ids_to_delete).delete_all
         end
 
         after_transaction_commit do


### PR DESCRIPTION
[Trello](https://trello.com/c/WMvRKsAt/792-publishing-api-performance-improvements-patchlinkset-2-days)

As part of a wider task to improve performance of Publishing API, do the PatchLinkSet deletes all in one go rather than one by one. It's a very small performance improvement, but has the advantage of also being a refactoring in this case.