### PR TITLE
Delete links and entire content items with migration helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,19 +53,42 @@ directory.
 
 ### Deleting content items
 
-If you need to delete all traces of a content item from the system, you need to
-do the following:
+To delete all traces of a content item you will need to create a migration.
+
+If you need to delete all traces of a content item from the system:
+
 ```
 require_relative "helpers/delete_content_item"
 class RemoveYourContentItem < ActiveRecord::Migration
   # Remove /some/base-path
   def up
-    content_items = ContentItem.where(content_id: "some-content-id")
+    Helpers::DeleteContentItem.destroy_content_items_with_links("some-content-id")
+  end
+end
+```
+
+If you need to delete an instance of a particular content item:
+
+```
+require_relative "helpers/delete_content_item"
+class RemoveYourContentInstance < ActiveRecord::Migration
+  def up
+    content_items = ContentItem.where(id: 123)
 
     Helpers::DeleteContentItem.destroy_supporting_objects(content_items)
 
     content_items.destroy_all
+  end
+end
+```
 
+If you need to delete just the links for a content item:
+
+```
+require_relative "helpers/delete_content_item"
+class RemoveLinks < ActiveRecord::Migration
+  # Remove /some/base-path
+  def up
     Helpers::DeleteContentItem.destroy_links("some-content-id")
   end
 end

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ class RemoveYourContentItem < ActiveRecord::Migration
 
     content_items.destroy_all
 
-    LinkSet.where(content_id: "some-content-id").destroy_all
+    Helpers::DeleteContentItem.destroy_links("some-content-id")
   end
 end
 ```

--- a/db/migrate/helpers/delete_content_item.rb
+++ b/db/migrate/helpers/delete_content_item.rb
@@ -1,5 +1,15 @@
 module Helpers
   module DeleteContentItem
+    def self.destroy_content_items_with_links(content_ids)
+      content_ids = Array(content_ids)
+
+      content_items = ContentItem.where(content_id: content_ids)
+      destroy_supporting_objects(content_items)
+      content_items.destroy_all
+
+      destroy_links(content_ids)
+    end
+
     def self.destroy_supporting_objects(content_items)
       content_items = Array(content_items)
 

--- a/db/migrate/helpers/delete_content_item.rb
+++ b/db/migrate/helpers/delete_content_item.rb
@@ -19,5 +19,11 @@ module Helpers
 
       LockVersion.where(target: content_items).destroy_all
     end
+
+    def self.destroy_links(content_ids)
+      content_ids = Array(content_ids)
+      LinkSet.where(content_id: content_ids).destroy_all
+      Link.where(target_content_id: content_ids).destroy_all
+    end
   end
 end


### PR DESCRIPTION
This adds a helper to delete all links to and from a content item.

Also includes a new helper that can remove all instances of a content item and links for a content-id.