### PR TITLE
Don't filter content items by publishing app

### DIFF
--- a/app/controllers/v2/content_items_controller.rb
+++ b/app/controllers/v2/content_items_controller.rb
@@ -56,9 +56,7 @@ module V2
     end
 
     def publishing_app
-      unless current_user.has_permission?('view_all')
-        current_user.app_name
-      end
+      query_params[:publishing_app]
     end
 
     def filters

--- a/doc/api.md
+++ b/doc/api.md
@@ -266,10 +266,6 @@ the draft content store with the published item, if one exists. Uses
 
  [Request/Response detail](https://pact-broker.dev.publishing.service.gov.uk/pacts/provider/Publishing%20API/consumer/GDS%20API%20Adapters/latest#a_get_entries_request_given_a_content_item_exists_in_multiple_locales_with_content_id:_bed722e6-db68-43e5-9079-063f623335a7)
 
-**This endpoint will only return content for which the value of `publishing_app`
-matches the name of the application making the request, unless that app's API
-key has `view_all` permissions.**
-
 Retrieves a paginated list of content items for the provided query string
 parameters. If content items exists in both a published and a draft state, the
 draft is returned.
@@ -297,6 +293,8 @@ draft is returned.
 - `q` *(optional)*
   - Search term to match against [`title`](model.md#title) and
     [`base_path`](model.md#base_path) fields.
+- `publishing_app` *(optional)*
+  - Used to restrict content items to those for a given publishing app.
 
 ## `GET /v2/content/:content_id`
 

--- a/spec/controllers/v2/content_items_controller_spec.rb
+++ b/spec/controllers/v2/content_items_controller_spec.rb
@@ -462,20 +462,20 @@ RSpec.describe V2::ContentItemsController do
       FactoryGirl.create(:draft_content_item, publishing_app: 'specialist_publisher', base_path: '/item3')
     end
 
-    it "displays items filtered by the user's app_name" do
-      request.env['warden'].user.app_name = 'whitehall'
-      get :index, document_type: 'guide', fields: %w(base_path publishing_app)
+    it "displays items filtered by publishing_app parameter" do
+      get :index,
+        document_type: "guide",
+        fields: %w(base_path publishing_app),
+        publishing_app: "whitehall"
       items = parsed_response["results"]
       expect(items.length).to eq(2)
-      expect(items.all? { |i| i["publishing_app"] == 'whitehall' }).to be true
+      expect(items.all? { |i| i["publishing_app"] == "whitehall" }).to be true
     end
 
-    it "displays all items if user has 'view_all' permission" do
-      request.env['warden'].user.permissions << 'view_all'
+    it "displays all items by default" do
       get :index, document_type: 'guide', fields: %w(base_path publishing_app)
       items = parsed_response["results"]
       expect(items.length).to eq(4)
-      expect(items.map { |i| i["publishing_app"] }.uniq).to match_array(%w(whitehall specialist_publisher publisher))
     end
   end
 end


### PR DESCRIPTION
As per [Trello](https://trello.com/c/op0k4PYl/800-remove-permission-check-on-get-content-items-small)

This restriction is no longer required, and content-tagger in particular
needs to be able to see content items from all apps (in order to be able
to tag them to taxons).