### PR TITLE
Remove passthrough

### DIFF
--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -6,19 +6,6 @@ class Link < ActiveRecord::Base
   validate :link_type_is_valid
   validate :content_id_is_valid
 
-  def target_content_id
-    passthrough_hash || super
-  end
-
-  def target_content_id=(string_or_hash)
-    case string_or_hash
-    when String
-      super
-    when Hash
-      self.passthrough_hash = string_or_hash
-    end
-  end
-
   def self.filter_content_items(scope, filters)
     join_sql = <<-SQL.strip_heredoc
       INNER JOIN link_sets ON link_sets.content_id = content_items.content_id

--- a/app/presenters/downstream_presenter.rb
+++ b/app/presenters/downstream_presenter.rb
@@ -40,7 +40,6 @@ module Presenters
     def links
       return {} unless link_set
       {
-        links: link_set_presenter.links,
         expanded_links: expanded_link_set_presenter.links,
       }
     end
@@ -52,10 +51,6 @@ module Presenters
           users: access_limit.users
         }
       }
-    end
-
-    def link_set_presenter
-      @link_set_presenter ||= Presenters::Queries::LinkSetPresenter.new(link_set)
     end
 
     def expanded_link_set_presenter

--- a/app/presenters/queries/expanded_link_set.rb
+++ b/app/presenters/queries/expanded_link_set.rb
@@ -28,7 +28,7 @@ module Presenters
       def expand_links(target_content_ids, type, rules)
         return {} unless expanding_this_type?(type)
 
-        content_items = valid_web_content_items(target_content_ids)
+        content_items = web_content_items(target_content_ids)
 
         content_items.map do |item|
           expanded_links = ExpandLink.new(item, item.document_type.to_sym, rules).expand_link
@@ -66,7 +66,7 @@ module Presenters
         grouped_links = LinkSet
           .eager_load(:links)
           .where(content_id: content_id)
-          .pluck(:link_type, :target_content_id, :passthrough_hash)
+          .pluck(:link_type, :target_content_id)
           .group_by(&:first)
 
         return {} if grouped_links.keys.compact.empty?
@@ -98,15 +98,6 @@ module Presenters
 
           hash[inverted_type_name.to_sym] = expanded_links.reject(&:empty?) if expanded_links.any?
         end
-      end
-
-      def valid_web_content_items(target_content_ids)
-        target_content_ids = without_passsthrough_hashes(target_content_ids)
-        web_content_items(target_content_ids)
-      end
-
-      def without_passsthrough_hashes(target_content_ids)
-        target_content_ids.reject { |content_id| content_id.is_a?(Hash) }
       end
 
       def web_content_items(target_content_ids)

--- a/app/presenters/queries/link_set_presenter.rb
+++ b/app/presenters/queries/link_set_presenter.rb
@@ -33,11 +33,11 @@ module Presenters
         #   organisations: [ UUID ],
         # }
 
-        @links ||= link_set.links.pluck(:link_type, :target_content_id, :passthrough_hash).map.with_object({}) do |link, hash|
+        @links ||= link_set.links.pluck(:link_type, :target_content_id).map.with_object({}) do |link, hash|
           type = link[0].to_sym
 
           hash[type] ||= []
-          hash[type] << (link[1] || link[2].deep_symbolize_keys)
+          hash[type] << link[1]
         end
       end
 

--- a/db/migrate/20160825141026_add_links_to_travel_advice.rb
+++ b/db/migrate/20160825141026_add_links_to_travel_advice.rb
@@ -1,0 +1,7 @@
+class AddLinksToTravelAdvice < ActiveRecord::Migration
+  def change
+    Link.find_each("passthrough_hash IS NOT NULL") do |link|
+      link.update_attributes!(target_content_id: link.passthrough_hash[:content_id])
+    end
+  end
+end

--- a/spec/presenters/downstream_presenter_spec.rb
+++ b/spec/presenters/downstream_presenter_spec.rb
@@ -22,7 +22,6 @@ RSpec.describe Presenters::DownstreamPresenter do
         details: { body: "<p>Something about VAT</p>\n" },
         format: "guide",
         document_type: "guide",
-        links: {},
         expanded_links: {},
         locale: "en",
         need_ids: %w(100123 100124),

--- a/spec/presenters/queries/expanded_link_set_spec.rb
+++ b/spec/presenters/queries/expanded_link_set_spec.rb
@@ -287,29 +287,6 @@ RSpec.describe Presenters::Queries::ExpandedLinkSet do
     end
   end
 
-  context "when a link has a 'passthrough_hash'" do
-    let(:state_fallback_order) { [:draft, :published] }
-
-    before do
-      create_link(a, b, "parent")
-      create_link(b, c, "parent")
-
-      create_content_item(a, "/a", "draft")
-      create_content_item(b, "/b", "draft")
-      create_content_item(c, "/c", "draft")
-
-      bc_link = Link.last
-      bc_link.target_content_id = { foo: "bar" }
-      bc_link.save!
-    end
-
-    it "does not expand the fields for those links" do
-      expect(expanded_links[:parent]).to match([
-        a_hash_including(base_path: "/b", links: {})
-      ])
-    end
-  end
-
   describe "multiple translations" do
     let(:state_fallback_order) { [:published] }
     let(:locale_fallback_order) { %w(ar en) }

--- a/spec/requests/content_item_requests/downstream_timeouts_spec.rb
+++ b/spec/requests/content_item_requests/downstream_timeouts_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe "Downstream timeouts", type: :request do
   end
 
   context "/v2/links" do
-    let(:request_body) { links_attributes.to_json }
+    let(:request_body) { patch_links_attributes.to_json }
     let(:request_path) { "/v2/links/#{content_id}" }
     let(:request_method) { :patch }
     let(:base_path) { "/vat-rates" }
@@ -110,7 +110,7 @@ RSpec.describe "Downstream timeouts", type: :request do
       end
 
       it "returns an error" do
-        put "/v2/links/#{content_id}", links_attributes.to_json
+        put "/v2/links/#{content_id}", patch_links_attributes.to_json
 
         expect(response.status).to eq(500)
         expect(parsed_response).to eq(
@@ -128,7 +128,7 @@ RSpec.describe "Downstream timeouts", type: :request do
       end
 
       it "returns an error" do
-        put "/v2/links/#{content_id}", links_attributes.to_json
+        put "/v2/links/#{content_id}", patch_links_attributes.to_json
 
         expect(response.status).to eq(500)
         expect(parsed_response).to eq(

--- a/spec/requests/content_item_requests/message_bus_spec.rb
+++ b/spec/requests/content_item_requests/message_bus_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe "Message bus", type: :request do
   end
 
   context "/v2/links" do
-    let(:request_body) { links_attributes.to_json }
+    let(:request_body) { patch_links_attributes.to_json }
     let(:request_path) { "/v2/links/#{content_id}" }
 
     context "with a live content item" do

--- a/spec/support/request_helpers/mocks.rb
+++ b/spec/support/request_helpers/mocks.rb
@@ -38,7 +38,10 @@ module RequestHelpers
         redirects: [],
         update_type: "major",
         analytics_identifier: "GDS01",
-      }.merge(links_attributes)
+        expanded_links: {
+          available_translations: available_translations
+        }
+      }
     end
 
     def access_limit_params
@@ -50,14 +53,11 @@ module RequestHelpers
       }
     end
 
-    def links_attributes
+    def patch_links_attributes
       {
         content_id: content_id,
         links: {
           organisations: ["30986e26-f504-4e14-a93f-a9593c34a8d9"]
-        },
-        expanded_links: {
-          available_translations: available_translations
         }
       }
     end


### PR DESCRIPTION
Passthrough hashes are not required any more since dependency resolution
does it now. The only thing that was using them was travel advice
documents types, and they have now been fixed in multipage frontend.

also there is no need to send links to content-store
Content-store uses expanded-links to display its links, and no longer
expands them. This removes the links from the payload.