### PR TITLE
Return error when payload schema validation fails

### DIFF
--- a/app/validators/schema_validator.rb
+++ b/app/validators/schema_validator.rb
@@ -29,7 +29,7 @@ private
   def schema
     @schema || JSON.load(File.read(schema_filepath))
   rescue Errno::ENOENT => error
-    msg = "#{payload} is missing schema_name #{schema_name} or type #{type}"
+    msg = "Unable to find schema for schema_name #{schema_name} and type #{type}"
     Airbrake.notify_or_ignore(error, parameters: { explanation: msg })
     {}
   end

--- a/app/validators/schema_validator.rb
+++ b/app/validators/schema_validator.rb
@@ -19,53 +19,29 @@ class SchemaValidator
       payload,
       errors_as_objects: true,
     )
-
-    return true if errors.empty?
-
-    Airbrake.notify_or_ignore(
-      {
-        error_class: "SchemaValidationError",
-        error_message: "Error validating payload against schema '#{schema_name}'"
-      },
-      parameters: {
-        errors: errors_for_airbrake,
-        message_data: payload
-      }
-    )
-    false
+    errors.empty?
   end
 
 private
 
   attr_reader :payload, :type
 
-  def errors_for_airbrake
-    Hash[errors.map.with_index { |e, i| [i, present_error(e)] }]
-  end
-
-  def present_error(error_hash)
-    # The schema key just contains an addressable, which is not informative as
-    # the schema in use should be clear from the error class and message
-    error_hash = error_hash.reject { |k, _| k == :schema }
-
-    if error_hash.has_key?(:errors)
-      error_hash[:errors] = Hash[
-        error_hash[:errors].map do |k, errors|
-          [k, Hash[errors.map.with_index { |e, i| [i, present_error(e)] }]]
-        end
-      ]
-    end
-
-    error_hash
-  end
-
   def schema
-    @schema || JSON.load(File.read("govuk-content-schemas/formats/#{schema_name}/publisher_v2/#{type}.json"))
+    @schema || JSON.load(File.read(schema_filepath))
   rescue Errno::ENOENT => error
-    Airbrake.notify_or_ignore(error, parameters: {
-      explanation: "#{payload} is missing schema_name #{schema_name} or type #{type}"
-    })
+    msg = "#{payload} is missing schema_name #{schema_name} or type #{type}"
+    Airbrake.notify_or_ignore(error, parameters: { explanation: msg })
     {}
+  end
+
+  def schema_filepath
+    File.join(
+      "govuk-content-schemas",
+      "formats",
+      schema_name,
+      "publisher_v2",
+      "#{type}.json"
+    )
   end
 
   def schema_name

--- a/spec/validators/schema_validator_spec.rb
+++ b/spec/validators/schema_validator_spec.rb
@@ -3,169 +3,67 @@ require "rails_helper"
 RSpec.describe SchemaValidator do
   let(:schema) do
     {
-      "type" => "object",
-      "required" => ["a"],
-      "properties" => {
-        "a" => { "type" => "integer" }
+      type: "object",
+      required: ["a"],
+      properties: {
+        a: { "type" => "integer" }
       }
-    }
+    }.deep_stringify_keys
   end
 
-  subject(:validator) do
-    SchemaValidator.new(type: :schema, schema: schema)
-  end
+  subject(:validator) { SchemaValidator.new(type: :schema, schema: schema) }
 
-  context "schema" do
-    let(:schema) { nil }
-    let(:payload) { { schema_name: 'test' } }
+  describe "#validate" do
+    context "unknown schema name" do
+      let(:schema) { nil }
+      let(:payload) { { schema_name: "test" } }
 
-    it "logs to airbrake with an unknown schema_name" do
-      expect(Airbrake).to receive(:notify_or_ignore)
-        .with(an_instance_of(Errno::ENOENT), a_hash_including(:parameters))
-      validator.validate(payload)
-    end
-  end
-
-  context "valid payload" do
-    let(:payload) { { a: 1 } }
-
-    it "does not report to airbrake" do
-      expect(Airbrake).to_not receive(:notify_or_ignore)
-      validator.validate(payload)
-    end
-
-    it "logs to airbrake when the payload is invalid" do
-      expect(validator.validate(payload)).to be true
-    end
-  end
-
-  context "invalid payload" do
-    let(:payload) { { b: 1 } }
-
-    it "reports to airbrake" do
-      expect(Airbrake).to receive(:notify_or_ignore)
-      validator.validate(payload)
-    end
-
-    it "logs to airbrake when the payload is invalid" do
-      expect(validator.validate(payload)).to be false
-    end
-  end
-
-  context "exceptions" do
-    let(:payload) { { schema_name: 'placeholder_test' } }
-
-    it "does not report to airbrake" do
-      expect(Airbrake).to_not receive(:notify_or_ignore)
-      validator.validate(payload)
-    end
-  end
-
-  context "schema with format/schema_name alternatives" do
-    let(:schema) {
-      {
-        "oneOf" => [
-          {
-            "properties" => {
-              "format" => { "type" => "string" },
-              "title" => { "type" => "string" },
-            },
-            "additionalProperties" => false,
-            "required" => %w{format title},
-          },
-          {
-            "properties" => {
-              "schema_name" => { "type" => "string" },
-              "document_type" => { "type" => "string" },
-            },
-            "additionalProperties" => false,
-            "required" => %w{schema_name document_type format}
-          }
-        ]
-      }
-    }
-
-    context "when schema_name is provided" do
-      let(:payload) {
-        { schema_name: "foo" }
-      }
-      it "reports useful validation errors" do
-        expect(Airbrake).to receive(:notify_or_ignore) do |error, opts|
-          expect(error[:error_message]).to eq("Error validating payload against schema 'foo'")
-          expect(opts[:parameters][:errors][0]).to match(
-            a_hash_including(
-              message: a_string_starting_with("The property '#/' of type Hash did not match"),
-              failed_attribute: "OneOf",
-              errors: {
-                oneof_0: {
-                  0 => a_hash_including(
-                    message: a_string_starting_with("The property '#/' did not contain a required property of 'title'"),
-                    failed_attribute: "Required",
-                  ),
-                  1 => a_hash_including(
-                    message: a_string_starting_with("The property '#/' did not contain a required property of 'format'"),
-                    failed_attribute: "Required",
-                  ),
-                  2 => a_hash_including(
-                    message: a_string_starting_with("The property '#/' contains additional properties [\"schema_name\"] outside of the schema when none are allowed"),
-                    failed_attribute: "AdditionalProperties"
-                  )
-                },
-                oneof_1: {
-                  0 => a_hash_including(
-                    message: a_string_starting_with("The property '#/' did not contain a required property of 'format'"),
-                    failed_attribute: "Required",
-                  ),
-                  1 => a_hash_including(
-                    message: a_string_starting_with("The property '#/' did not contain a required property of 'document_type'"),
-                    failed_attribute: "Required",
-                  ),
-                }
-              }
-            )
-          )
-        end
+      it "logs to airbrake with an unknown schema_name" do
+        expect(Airbrake)
+          .to receive(:notify_or_ignore)
+          .with(an_instance_of(Errno::ENOENT), a_hash_including(:parameters))
         validator.validate(payload)
       end
     end
 
-    context "when format is provided" do
-      let(:payload) {
-        { format: "foo" }
-      }
-      it "reports useful validation errors" do
-        expect(Airbrake).to receive(:notify_or_ignore) do |error, opts|
-          expect(error[:error_message]).to eq("Error validating payload against schema 'foo'")
-          expect(opts[:parameters][:errors][0]).to match(
-            a_hash_including(
-              message: a_string_starting_with("The property '#/' of type Hash did not match"),
-              failed_attribute: "OneOf",
-              errors: {
-                oneof_0: {
-                  0 => a_hash_including(
-                    message: a_string_starting_with("The property '#/' did not contain a required property of 'title'"),
-                    failed_attribute: "Required",
-                  ),
-                },
-                oneof_1: {
-                  0 => a_hash_including(
-                    message: a_string_starting_with("The property '#/' did not contain a required property of 'document_type'"),
-                    failed_attribute: "Required",
-                  ),
-                  1 => a_hash_including(
-                    message: a_string_starting_with("The property '#/' did not contain a required property of 'schema_name'"),
-                    failed_attribute: "Required",
-                  ),
-                  2 => a_hash_including(
-                    message: a_string_starting_with("The property '#/' contains additional properties [\"format\"] outside of the schema when none are allowed"),
-                    failed_attribute: "AdditionalProperties"
-                  ),
-                }
-              }
-            )
-          )
-        end
-        validator.validate(payload)
+    context "valid payload" do
+      let(:payload) { { a: 1 } }
+
+      it "returns true" do
+        expect(validator.validate(payload)).to be true
+      end
+    end
+
+    context "invalid payload" do
+      let(:payload) { { b: 1 } }
+
+      it "returns false" do
+        expect(validator.validate(payload)).to be false
+      end
+    end
+  end
+
+  describe "#errors" do
+    subject do
+      validator.validate(payload)
+      validator.errors
+    end
+
+    context "valid payload" do
+      let(:payload) { { a: 1 } }
+
+      it "is empty" do
+        expect(subject).to be_empty
+      end
+    end
+
+    context "invalid payload" do
+      let(:payload) { { b: 1 } }
+
+      it "is populated" do
+        expect(subject.count).to eq 1
+        expected = /property '#\/' did not contain a required property of 'a'/
+        expect(subject.first[:message]).to match expected
       end
     end
   end


### PR DESCRIPTION
Rather than allowing payloads that fail schema validation to be saved
and sent downstream, return a ValidationFailure instance to the
publishing app, containing details of the validation errors. This
will prompt the apps to fix any remaining validation problems.