### PR TITLE
Create migration to copy passthrough hash content id

### DIFF
--- a/db/migrate/20160913130622_copy_passthrough_hashes.rb
+++ b/db/migrate/20160913130622_copy_passthrough_hashes.rb
@@ -1,0 +1,7 @@
+class CopyPassthroughHashes < ActiveRecord::Migration
+  def change
+    Link.where("passthrough_hash IS NOT NULL").each do |link|
+      link.update_attributes!(target_content_id: link.passthrough_hash[:content_id])
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160906160955) do
+ActiveRecord::Schema.define(version: 20160913130622) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
We are removing the passthrough hash column, this will ensure no data is
lost.

https://trello.com/c/0deqcUAh/791-remove-passthrough-hash-medium