### PR TITLE
Make rendering_app optional for contacts

### DIFF
--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -36,7 +36,7 @@ class ContentItem < ActiveRecord::Base
   validates :content_id, presence: true, uuid: true
   validates :publishing_app, presence: true
   validates :title, presence: true, if: :renderable_content?
-  validates :rendering_app, presence: true, dns_hostname: true, if: :renderable_content?
+  validates :rendering_app, presence: true, dns_hostname: true, if: :requires_rendering_app?
   validates :phase, inclusion: {
     in: %w(alpha beta live),
     message: 'must be either alpha, beta, or live'
@@ -56,5 +56,9 @@ private
 
   def renderable_content?
     NON_RENDERABLE_FORMATS.exclude?(document_type)
+  end
+
+  def requires_rendering_app?
+    renderable_content? && document_type != "contact"
   end
 end

--- a/spec/models/content_item_spec.rb
+++ b/spec/models/content_item_spec.rb
@@ -81,6 +81,15 @@ RSpec.describe ContentItem do
       end
     end
 
+    context "when the content item is optionally 'renderable'" do
+      subject { FactoryGirl.build(:content_item, document_type: "contact") }
+
+      it "does not require a rendering_app" do
+        subject.rendering_app = nil
+        expect(subject).to be_valid
+      end
+    end
+
     context "content_id" do
       it "accepts a UUID" do
         subject.content_id = "a7c48dac-f1c6-45a8-b5c1-5c407d45826f"


### PR DESCRIPTION
Whitehall contacts are currently failing model validation because they
don't specify a rendering_app. Resolved so that the rendering_app
property is optional for ContentItems with a document_type of 'contact'

[Trello](https://trello.com/c/5itDAuZ5/801-fix-publishing-of-contacts-from-whitehall-medium)