### PR TITLE
Fix bug when no schema validation errors

### DIFF
--- a/app/commands/v2/put_content.rb
+++ b/app/commands/v2/put_content.rb
@@ -305,7 +305,7 @@ module Commands
       end
 
       def raise_if_payload_fails_schema_validation
-        return unless schema_validation_errors.any?
+        return if schema_validation_errors.blank?
         message = "The payload did not conform to the schema"
         raise CommandError.new(
           code: 422,

--- a/spec/commands/v2/put_content_spec.rb
+++ b/spec/commands/v2/put_content_spec.rb
@@ -922,7 +922,7 @@ RSpec.describe Commands::V2::PutContent do
 
     context "schema validation passes" do
       let(:validator) do
-        instance_double(SchemaValidator, validate: true, errors: [])
+        instance_double(SchemaValidator, validate: true, errors: nil)
       end
       before do
         allow(SchemaValidator).to receive(:new) { validator }


### PR DESCRIPTION
The errors property on the SchemaValidator is nil if there are no
errors, so handle with `blank?` rather than `any?` (which assumes that
`errors` is Enumerable)

Fixes this: https://errbit.integration.publishing.service.gov.uk/apps/552637940da1157bfa000399/problems/57df9b136578630639110b00