### PR TITLE
Add GOVUK-Publishing-Source-Dependent-Content-Id header

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,7 @@ gem "gds-sso", "12.1.0"
 gem 'bunny', '2.5.1'
 gem 'whenever', '0.9.4', require: false
 gem "govuk_sidekiq", "~> 0.0"
+gem 'sidekiq', git: "https://github.com/alphagov/sidekiq.git", branch: "fix-testing-with-overridden-queue"
 gem "json-schema", require: false
 gem "hashdiff"
 gem "sidekiq-unique-jobs", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,14 @@
+GIT
+  remote: https://github.com/alphagov/sidekiq.git
+  revision: cadebcf4977189b8ca534e0ccb2b304d2ac70be2
+  branch: fix-testing-with-overridden-queue
+  specs:
+    sidekiq (4.1.4)
+      concurrent-ruby (~> 1.0)
+      connection_pool (~> 2.2, >= 2.2.0)
+      redis (~> 3.2, >= 3.2.1)
+      sinatra (>= 1.4.7)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -307,11 +318,6 @@ GEM
     scss_lint (0.44.0)
       rake (~> 10.0)
       sass (~> 3.4.15)
-    sidekiq (4.1.4)
-      concurrent-ruby (~> 1.0)
-      connection_pool (~> 2.2, >= 2.2.0)
-      redis (~> 3.2, >= 3.2.1)
-      sinatra (>= 1.4.7)
     sidekiq-logging-json (0.0.16)
       sidekiq (>= 3, < 5)
     sidekiq-statsd (0.1.5)
@@ -408,6 +414,7 @@ DEPENDENCIES
   rails (= 4.2.7.1)
   rspec
   rspec-rails (~> 3.3)
+  sidekiq!
   sidekiq-unique-jobs
   simplecov (= 0.10.0)
   simplecov-rcov (= 0.2.3)

--- a/app/services/downstream_service.rb
+++ b/app/services/downstream_service.rb
@@ -63,4 +63,20 @@ module DownstreamService
       state: %w(draft published unpublished),
     ).exists?
   end
+
+  # Sets the value for the GOVUK-Dependency-Resolution-Source-Content-Id header.
+  #
+  # The presence of this header should indicate that the request is a result of
+  # the process of dependency resolution within the Publishing API. The value
+  # of the header is the content id on which dependency resolution took place.
+  #
+  # Note that due to the possibility of recursive dependency resolution, there
+  # doesn't have to be a direct dependency between the source content_id
+  # (header value) and the respective content for the request.
+  def self.set_govuk_dependency_resolution_source_content_id_header(value)
+    GdsApi::GovukHeaders.set_header(
+      "govuk_dependency_resolution_source_content_id",
+      value,
+    )
+  end
 end

--- a/app/workers/dependency_resolution_worker.rb
+++ b/app/workers/dependency_resolution_worker.rb
@@ -57,6 +57,7 @@ private
       payload_version: payload_version,
       update_dependencies: false,
       alert_on_invalid_state_error: false,
+      dependency_resolution_source_content_id: content_id,
     )
   end
 
@@ -68,6 +69,7 @@ private
       payload_version: payload_version,
       update_dependencies: false,
       alert_on_invalid_state_error: false,
+      dependency_resolution_source_content_id: content_id,
     )
   end
 end

--- a/app/workers/downstream_draft_worker.rb
+++ b/app/workers/downstream_draft_worker.rb
@@ -2,7 +2,8 @@ require 'sidekiq-unique-jobs'
 
 class DownstreamDraftWorker
   attr_reader :web_content_item, :content_item_id, :payload_version,
-    :update_dependencies, :alert_on_invalid_state_error
+    :update_dependencies, :alert_on_invalid_state_error,
+    :dependency_resolution_source_content_id
 
   include DownstreamQueue
   include Sidekiq::Worker
@@ -48,6 +49,10 @@ private
     @payload_version = attributes.fetch(:payload_version)
     @update_dependencies = attributes.fetch(:update_dependencies, true)
     @alert_on_invalid_state_error = attributes.fetch(:alert_on_invalid_state_error, true)
+    @dependency_resolution_source_content_id = attributes.fetch(
+      :dependency_resolution_source_content_id,
+      nil
+    )
   end
 
   def enqueue_dependencies

--- a/app/workers/downstream_draft_worker.rb
+++ b/app/workers/downstream_draft_worker.rb
@@ -28,6 +28,12 @@ class DownstreamDraftWorker
       raise AbortWorkerError.new("The content item for id: #{content_item_id} was not found")
     end
 
+    unless dependency_resolution_source_content_id.nil?
+      DownstreamService.set_govuk_dependency_resolution_source_content_id_header(
+        dependency_resolution_source_content_id
+      )
+    end
+
     if web_content_item.base_path
       DownstreamService.update_draft_content_store(
         DownstreamPayload.new(web_content_item, payload_version, Adapters::DraftContentStore::DEPENDENCY_FALLBACK_ORDER)

--- a/app/workers/downstream_live_worker.rb
+++ b/app/workers/downstream_live_worker.rb
@@ -3,7 +3,7 @@ require 'sidekiq-unique-jobs'
 class DownstreamLiveWorker
   attr_reader :content_item_id, :web_content_item, :payload_version,
     :message_queue_update_type, :update_dependencies,
-    :alert_on_invalid_state_error
+    :alert_on_invalid_state_error, :dependency_resolution_source_content_id
 
   include DownstreamQueue
   include Sidekiq::Worker
@@ -54,6 +54,10 @@ private
     @message_queue_update_type = attributes.fetch(:message_queue_update_type, nil)
     @update_dependencies = attributes.fetch(:update_dependencies, true)
     @alert_on_invalid_state_error = attributes.fetch(:alert_on_invalid_state_error, true)
+    @dependency_resolution_source_content_id = attributes.fetch(
+      :dependency_resolution_source_content_id,
+      nil
+    )
   end
 
   def enqueue_dependencies

--- a/app/workers/downstream_live_worker.rb
+++ b/app/workers/downstream_live_worker.rb
@@ -29,6 +29,12 @@ class DownstreamLiveWorker
       raise AbortWorkerError.new("The content item for id: #{content_item_id} was not found")
     end
 
+    unless dependency_resolution_source_content_id.nil?
+      DownstreamService.set_govuk_dependency_resolution_source_content_id_header(
+        dependency_resolution_source_content_id
+      )
+    end
+
     payload = DownstreamPayload.new(web_content_item, payload_version, Adapters::ContentStore::DEPENDENCY_FALLBACK_ORDER)
 
     DownstreamService.update_live_content_store(payload) if web_content_item.base_path


### PR DESCRIPTION
This is for https://trello.com/c/04568g2y/796-view-request-path-more-easily-medium

Actually effecting the logging in the content store, and nginx will require changes there also. 