### PR TITLE
Revert "Don't wrap all non-primitive values in an Array"

### DIFF
--- a/app/presenters/details_presenter.rb
+++ b/app/presenters/details_presenter.rb
@@ -20,13 +20,14 @@ module Presenters
   private
 
     def append_transformed_govspeak(value)
-      wrapped_value = Array.wrap(value)
-      return value unless requires_govspeak_html_transform?(wrapped_value)
+      return value if value.is_a?(String) || value.is_a?(Integer)
+      value = Array.wrap(value)
+      return value unless requires_govspeak_html_transform?(value)
       govspeak = {
         content_type: "text/html",
-        content: rendered_govspeak(wrapped_value),
+        content: rendered_govspeak(value),
       }
-      wrapped_value + [govspeak]
+      value + [govspeak]
     end
 
     def raw_govspeak(value)

--- a/spec/presenters/details_presenter_spec.rb
+++ b/spec/presenters/details_presenter_spec.rb
@@ -108,16 +108,6 @@ RSpec.describe Presenters::DetailsPresenter do
       it { is_expected.to match(expected_result) }
     end
 
-    context "when we're passed an image hash" do
-      let(:content_item_details) do
-        { image: { content_type: "image/png", content: "some content" } }
-      end
-
-      it "doesn't wrap the hash in an array" do
-        expect(subject).to eq content_item_details
-      end
-    end
-
     context "value contains nested array" do
       let(:content_item_details) { { other: %w(an array of strings) } }
       it "doesn't try to convert to govspeak" do


### PR DESCRIPTION
Reverts alphagov/publishing-api#518