### PR TITLE
Accept `override_existing` on /paths endpoint.

### DIFF
--- a/app/commands/reserve_path.rb
+++ b/app/commands/reserve_path.rb
@@ -1,7 +1,11 @@
 module Commands
   class ReservePath < BaseCommand
     def call
-      PathReservation.reserve_base_path!(base_path, payload[:publishing_app])
+      PathReservation.reserve_base_path!(
+        base_path,
+        payload[:publishing_app],
+        override_existing: payload.fetch(:override_existing, false)
+      )
       Success.new(payload)
     end
 

--- a/app/models/path_reservation.rb
+++ b/app/models/path_reservation.rb
@@ -2,9 +2,11 @@ class PathReservation < ActiveRecord::Base
   validates :base_path, absolute_path: true
   validates :publishing_app, presence: true
 
-  def self.reserve_base_path!(base_path, publishing_app)
+  def self.reserve_base_path!(base_path, publishing_app, override_existing: false)
     existing = find_by(base_path: base_path)
-    if existing.nil?
+    if existing.present? && override_existing
+      existing.update!(publishing_app: publishing_app)
+    elsif existing.nil?
       create_path_reservation(base_path, publishing_app)
     else
       existing.ensure_unique(publishing_app)

--- a/doc/api.md
+++ b/doc/api.md
@@ -22,6 +22,7 @@ for other apps (eg email-alert-service) to consume.
 - [`GET /v2/linkables`](#get-v2linkables)
 - [`POST /lookup-by-base-path`](#post-lookup-by-base-path)
 - [`GET /debug/:content_id`](#get-debugcontent_id)
+- [`PUT /paths/:base_path`](#put-pathsbase_path)
 
 ### Optimistic locking (`previous_version`)
 
@@ -439,3 +440,29 @@ Alternatively add the following host to your hosts file:
 
 And then open
 http://publishing-api.integration.publishing.service.gov.uk:8888/debug/f141fa95-0d79-4aed-8429-ed223a8f106a
+
+## `PUT /paths/:base_path`
+
+ [Request/response detail](https://pact-broker.dev.publishing.service.gov.uk/pacts/provider/Publishing%20API/consumer/GDS%20API%20Adapters/latest#a_request_to_put_a_path_given_no_content_exists)
+
+Reserves a path for a publishing application. Returns success or failure only.
+
+### Path parameters
+- [`base_path`](model.md#base_path)
+  - Identifies the path that will be reserved
+
+### JSON parameters:
+- [`publishing_app`](model.md#publishing_app) *(required)*
+  - The name of the application making this request, words separated with hyphens.
+- `override_existing` (optional)
+  - Explicitly claim a path that has already been reserved by a different
+    publishing_app. If not true, attempting to do this will fail.
+
+### State changes
+- If no path reservation for the supplied base_path is present, one will be
+  created for the supplied publishing_app.
+- If a path reservation exists for the supplied base_path but a different
+  publishing_app, and `override_existing` is not true, the command will fail.
+- If a path reservation exists for the supplied base_path and a different a
+  publishing_app, and `override_existing` is true, the existing reservation will
+  be updated to the supplied publishing_app.

--- a/spec/commands/reserve_path_spec.rb
+++ b/spec/commands/reserve_path_spec.rb
@@ -8,7 +8,8 @@ RSpec.describe Commands::ReservePath do
 
     context "with a new base_path" do
       it "successfully reserves the path" do
-        expect(PathReservation).to receive(:reserve_base_path!).with("/foo", "Foo")
+        expect(PathReservation).to receive(:reserve_base_path!)
+          .with("/foo", "Foo", override_existing: false)
         expect(described_class.call(payload)).to be_a Commands::Success
       end
     end
@@ -18,6 +19,17 @@ RSpec.describe Commands::ReservePath do
         expect {
           described_class.call(base_path: "///")
         }.to raise_error CommandError
+      end
+    end
+
+    context "with override_existing set" do
+      let(:payload) {
+        { base_path: "/foo", publishing_app: "Foo", override_existing: true }
+      }
+      it "passes on the flag" do
+        expect(PathReservation).to receive(:reserve_base_path!)
+          .with("/foo", "Foo", override_existing: true)
+        expect(described_class.call(payload)).to be_a Commands::Success
       end
     end
   end

--- a/spec/models/path_reservation_spec.rb
+++ b/spec/models/path_reservation_spec.rb
@@ -60,6 +60,20 @@ RSpec.describe PathReservation, type: :model do
           ActiveRecord::RecordInvalid, /already reserved/
         )
       end
+
+      context "when override_existing is true" do
+        it "updates the existing reservation" do
+          expect {
+            described_class.reserve_base_path!(
+              "/vat-rates", "publisher", override_existing: true
+            )
+          }.not_to raise_error
+          path_reservation = PathReservation.last
+
+          expect(path_reservation.base_path).to eq("/vat-rates")
+          expect(path_reservation.publishing_app).to eq("publisher")
+        end
+      end
     end
 
     context "when the path reservation does not exist" do

--- a/spec/requests/reserve_path_requests_spec.rb
+++ b/spec/requests/reserve_path_requests_spec.rb
@@ -26,5 +26,20 @@ RSpec.describe "PUT /paths", type: :request do
         do_request
       }.to change(PathReservation, :count).by(1)
     end
+
+    context "with override_existing set" do
+      before do
+        FactoryGirl.create(:path_reservation, base_path: base_path, publishing_app: "another")
+        payload.merge!(override_existing: true)
+      end
+
+      it "updates an existing path" do
+        expect {
+          do_request
+        }.not_to change(PathReservation, :count)
+
+        expect(PathReservation.last.publishing_app).to eq("publisher")
+      end
+    end
   end
 end


### PR DESCRIPTION
This will allow an app to explicitly claim a path that has already been
registered by a different app. Note that this is only supported on this
endpoint; the implicit path reservation that is called as part of the
put_content command will not accept this flag, to make it clear that
this must result from a specific action.