### PR TITLE
Update the publishing_app for Specialist Publisher manuals

### DIFF
--- a/db/migrate/20160920133337_update_publishing_app_of_manuals.rb
+++ b/db/migrate/20160920133337_update_publishing_app_of_manuals.rb
@@ -1,0 +1,19 @@
+class UpdatePublishingAppOfManuals < ActiveRecord::Migration
+  def change
+    specialist_publisher_manuals = ContentItem.where(
+      publishing_app: "specialist-publisher", document_type: ["manual", "manual_section"])
+
+    specialist_publisher_manuals.each do |manual|
+      # Find the Location of each specialist publisher content item
+      location = Location.find_by(content_item: manual)
+      # Find the PathReservation for that Location
+      path_reservation = PathReservation.find_by(publishing_app: "specialist-publisher",
+                                                 base_path: location.base_path)
+      # Update the PathReservation if it exists
+      path_reservation.update_attribute(:publishing_app, "manuals-publisher") if path_reservation
+    end
+
+    # Update the publishing_app for all specialist publisher manuals
+    specialist_publisher_manuals.update_all(publishing_app: "manuals-publisher")
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160913130622) do
+ActiveRecord::Schema.define(version: 20160920133337) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
https://trello.com/c/2jXtF2jl/285-task-migrate-existing-sp-manuals-v1-in-the-publishing-api-small

Reviewers welcome!

Manuals will have their own publishing application so update
the relevant content items so that `publishing_app: "manuals-publisher"`.
Also update any relevant PathReservation records to the correct `publishing_app`.