### PR TITLE
Include warnings when presenting content

### DIFF
--- a/app/controllers/v2/content_items_controller.rb
+++ b/app/controllers/v2/content_items_controller.rb
@@ -26,6 +26,7 @@ module V2
         path_params[:content_id],
         query_params[:locale],
         version: query_params[:version],
+        include_warnings: true,
       )
     end
 

--- a/app/presenters/queries/content_item_presenter.rb
+++ b/app/presenters/queries/content_item_presenter.rb
@@ -3,7 +3,8 @@
 module Presenters
   module Queries
     class ContentItemPresenter
-      attr_accessor :scope, :fields, :order, :limit, :offset, :search_query
+      attr_accessor :scope, :fields, :order, :limit, :offset, :search_query,
+                    :include_warnings
 
       DEFAULT_FIELDS = [
         *ContentItem::TOP_LEVEL_FIELDS,
@@ -34,6 +35,7 @@ module Presenters
         self.limit = params[:limit]
         self.offset = params[:offset]
         self.search_query = params[:search_query]
+        self.include_warnings = params[:include_warnings] || false
       end
 
       def present_many
@@ -140,6 +142,8 @@ module Presenters
             int_columns.each { |c| parse_int_column(result, c) }
             parse_state_history(result)
 
+            result["warnings"] = get_warnings(result) if include_warnings
+
             yielder.yield result
           end
         end
@@ -159,6 +163,29 @@ module Presenters
         column = "state_history"
         return unless result.key?(column)
         result[column] = result[column].map(&:values).to_h
+      end
+
+      def get_warnings(result)
+        required_fields = %i{
+          content_id
+          state_history
+          user_facing_version
+          base_path
+          document_type
+        }
+
+        missing_fields = required_fields - fields
+
+        unless missing_fields.empty?
+          raise "#{missing_fields} must be included if the include_warnings parameter is true"
+        end
+
+        Presenters::Queries::ContentItemWarnings.call(
+          result["content_id"],
+          result["state_history"][result["user_facing_version"]],
+          result["base_path"],
+          result["document_type"],
+        )
       end
 
       # It is substantially faster to evaluate in this way rather than calling

--- a/app/presenters/queries/content_item_presenter.rb
+++ b/app/presenters/queries/content_item_presenter.rb
@@ -22,10 +22,10 @@ module Presenters
         new(scope, params).present_many
       end
 
-      def self.present(content_item)
+      def self.present(content_item, params = {})
         scope = ContentItem.where(id: content_item.id)
 
-        present_many(scope).first
+        present_many(scope, params).first
       end
 
       def initialize(scope, params = {})

--- a/app/presenters/queries/content_item_warnings.rb
+++ b/app/presenters/queries/content_item_warnings.rb
@@ -1,0 +1,23 @@
+module Presenters
+  module Queries
+    module ContentItemWarnings
+      def self.call(content_id, state, base_path, document_type)
+        return unless state == "draft"
+
+        blocking_content_item_id = ::Queries::CheckForContentItemPreventingDraftFromBeingPublished.call(
+          content_id,
+          base_path,
+          document_type,
+        )
+
+        warnings = {}
+
+        if blocking_content_item_id
+          warnings["content_item_blocking_publish"] = "There is an item of content that prevents this draft from being published"
+        end
+
+        warnings
+      end
+    end
+  end
+end

--- a/app/queries/check_for_content_item_preventing_draft_from_being_published.rb
+++ b/app/queries/check_for_content_item_preventing_draft_from_being_published.rb
@@ -1,0 +1,51 @@
+module Queries
+  module CheckForContentItemPreventingDraftFromBeingPublished
+    extend ArelHelpers
+
+    # Checks for any content item which would prevent a content item with the
+    # specified content_id and base_path from being published (from the draft
+    # state).
+    def self.call(content_id, base_path, document_type)
+      if SubstitutionHelper::SUBSTITUTABLE_DOCUMENT_TYPES.include?(document_type)
+        return # The SubstitionHelper will unpublish any item that is in the way
+      end
+
+      content_items_table = table(:content_items)
+      states_table = table(:states)
+      locations_table = table(:locations)
+      unpublishings_table = table(:unpublishings)
+
+      scope = content_items_table
+        .project(
+          content_items_table[:id]
+        )
+        .join(states_table).on(
+          content_items_table[:id].eq(states_table[:content_item_id])
+        )
+        .join(locations_table).on(
+          content_items_table[:id].eq(locations_table[:content_item_id])
+        )
+        .outer_join(unpublishings_table).on( # LEFT OUTER JOIN
+          content_items_table[:id].eq(unpublishings_table[:content_item_id])
+        )
+        .where(content_items_table[:content_id].not_eq(content_id))
+        .where(states_table[:name].in(%w(published unpublished)))
+        .where(content_items_table[:document_type].not_in(
+                 SubstitutionHelper::SUBSTITUTABLE_DOCUMENT_TYPES
+        ))
+        .where(locations_table[:base_path].eq(base_path))
+        .where(
+          unpublishings_table[:type].not_eq("substitute")
+          .or(unpublishings_table[:type].eq(nil))
+        )
+
+      rows = get_rows(scope)
+
+      if rows.length > 1
+        raise "Multiple rows returned in CheckForContentItemPreventingDraftFromBeingPublished"
+      end
+
+      rows.first["id"].to_i if rows.first
+    end
+  end
+end

--- a/app/queries/get_content.rb
+++ b/app/queries/get_content.rb
@@ -1,13 +1,16 @@
 module Queries
   module GetContent
-    def self.call(content_id, locale = nil, version: nil)
+    def self.call(content_id, locale = nil, version: nil, include_warnings: false)
       locale_to_use = locale || ContentItem::DEFAULT_LOCALE
 
       content_items = ContentItem.where(content_id: content_id)
       content_items = Translation.filter(content_items, locale: locale_to_use)
       content_items = UserFacingVersion.filter(content_items, number: version) if version
 
-      response = Presenters::Queries::ContentItemPresenter.present_many(content_items).first
+      response = Presenters::Queries::ContentItemPresenter.present_many(
+        content_items,
+        include_warnings: include_warnings
+      ).first
 
       if response.present?
         response

--- a/app/substitution_helper.rb
+++ b/app/substitution_helper.rb
@@ -1,4 +1,12 @@
 module SubstitutionHelper
+  SUBSTITUTABLE_DOCUMENT_TYPES = %w(
+    coming_soon
+    gone
+    redirect
+    unpublishing
+    special_route
+  ).freeze
+
   class << self
     def clear!(
       new_item_document_type:,
@@ -39,7 +47,7 @@ module SubstitutionHelper
   private
 
     def substitute?(document_type)
-      %w(coming_soon gone redirect unpublishing special_route).include?(document_type)
+      SUBSTITUTABLE_DOCUMENT_TYPES.include?(document_type)
     end
   end
 

--- a/bench/content_item_presenter.rb
+++ b/bench/content_item_presenter.rb
@@ -15,7 +15,7 @@ def present(number_of_items)
 
   puts "Presenting #{number_of_items} content items"
   StackProf.run(mode: :wall, out: "tmp/content_item_presenter_#{number_of_items}_wall.dump") do
-    puts Benchmark.measure { Presenters::Queries::ContentItemPresenter.present_many(scope) }
+    puts Benchmark.measure { Presenters::Queries::ContentItemPresenter.present_many(scope).to_a }
   end
   puts "  Queries: #{$queries}"
 end

--- a/doc/api.md
+++ b/doc/api.md
@@ -35,6 +35,26 @@ If `previous_version` is provided, the Publishing API will confirm that the
 provided value matches that of the content item in the Publishing API. If it
 does not, a 409 Conflict response will be given.
 
+### Warnings
+
+Some endpoints may return warnings along with the content items. For
+those that do, in the top level object for the content item, there
+will be a value named "warnings". This will be an object, where the
+names are the warnings that are applicable, and the coresponding
+values are a human readable description of the warning.
+
+#### Content Item Blocking Publish
+
+This warning is only applicable for content items in the draft state, and
+indicates that the draft cannot be published due to the presence of another
+content item.
+
+This will occur when the draft has a different content id from an existing item
+of content, published (or unpublished) at the same base path. Some document
+types are exempt from this restriction, and if either the draft, or the blocking
+content item are of a "substitutable" document type, upon the publish of the
+draft, the blocking item will be unpublished.
+
 ## `PUT /v2/content/:content_id`
 
 [Request/Response detail](https://pact-broker.dev.publishing.service.gov.uk/pacts/provider/Publishing%20API/consumer/GDS%20API%20Adapters/latest#a_request_from_the_Whitehall_application_to_create_a_content_item_at_/test-item_given_/test-item_has_been_reserved_by_the_Publisher_application)
@@ -303,6 +323,9 @@ draft is returned.
 
 Retrieves a single content item for a `content_id` and `locale`. By default the
 most recent version is returned, which may be a draft.
+
+If the returned item is in the draft state, [warnings](#warnings) may be
+included within the response.
 
 ### Path parameters
 - [`content_id`](model.md#content_id)

--- a/spec/queries/check_for_content_item_preventing_draft_from_being_published_spec.rb
+++ b/spec/queries/check_for_content_item_preventing_draft_from_being_published_spec.rb
@@ -1,0 +1,173 @@
+require "rails_helper"
+
+RSpec.describe Queries::CheckForContentItemPreventingDraftFromBeingPublished do
+  let(:content_id) { SecureRandom.uuid }
+  let(:base_path) { "/vat-rates" }
+  let(:document_type) { "guide" }
+
+  describe ".call" do
+    subject { described_class.call(content_id, base_path, document_type) }
+
+    shared_examples "check succeeds" do
+      it "returns nil" do
+        expect(subject).to eq(nil)
+      end
+    end
+
+    context "with a single content item" do
+      before do
+        FactoryGirl.create(:content_item,
+          content_id: content_id,
+          base_path: base_path,
+          document_type: document_type,
+          user_facing_version: 1,
+          locale: "en",
+        )
+      end
+
+      include_examples "check succeeds"
+    end
+
+    context "with two content items of different locales" do
+      before do
+        FactoryGirl.create(:content_item,
+          content_id: content_id,
+          base_path: base_path + ".en",
+          document_type: document_type,
+          user_facing_version: 1,
+          locale: "en",
+        )
+
+        FactoryGirl.create(:content_item,
+          content_id: content_id,
+          base_path: base_path + ".es",
+          document_type: document_type,
+          user_facing_version: 1,
+          locale: "es",
+        )
+      end
+
+      include_examples "check succeeds"
+    end
+
+    context "with a unpublished item, of type \"substitute\", and a draft at the same base path" do
+      before do
+        FactoryGirl.create(:unpublished_content_item,
+          content_id: SecureRandom.uuid,
+          base_path: base_path,
+          document_type: document_type,
+          unpublishing_type: "substitute",
+          user_facing_version: 1,
+          locale: "en",
+        )
+
+        FactoryGirl.create(:content_item,
+          content_id: content_id,
+          base_path: base_path,
+          document_type: document_type,
+          user_facing_version: 1,
+          locale: "en",
+        )
+      end
+
+      include_examples "check succeeds"
+    end
+
+    context "with a published item, with a substitutable document_type, and a draft at the same base path" do
+      before do
+        FactoryGirl.create(:content_item,
+          content_id: SecureRandom.uuid,
+          base_path: base_path,
+          document_type: "unpublishing",
+          state: "published",
+          user_facing_version: 1,
+          locale: "en",
+        )
+
+        FactoryGirl.create(:content_item,
+          content_id: content_id,
+          base_path: base_path,
+          document_type: document_type,
+          user_facing_version: 1,
+          locale: "en",
+        )
+      end
+
+      include_examples "check succeeds"
+    end
+
+    context "with a draft with a substitutable document_type, and a published item at the same base path" do
+      let(:document_type) { "unpublishing" }
+
+      before do
+        FactoryGirl.create(:content_item,
+          content_id: SecureRandom.uuid,
+          base_path: base_path,
+          document_type: "guide",
+          state: "published",
+          user_facing_version: 1,
+          locale: "en",
+        )
+
+        FactoryGirl.create(:content_item,
+          content_id: content_id,
+          base_path: base_path,
+          document_type: document_type,
+          user_facing_version: 1,
+          locale: "en",
+        )
+      end
+
+      include_examples "check succeeds"
+    end
+
+    context "with a unpublished item, and a draft at the same base path" do
+      before do
+        @blocking_content_item = FactoryGirl.create(:gone_unpublished_content_item,
+          content_id: SecureRandom.uuid,
+          base_path: base_path,
+          document_type: document_type,
+          user_facing_version: 1,
+          locale: "en",
+        )
+
+        FactoryGirl.create(:content_item,
+          content_id: content_id,
+          base_path: base_path,
+          document_type: document_type,
+          user_facing_version: 1,
+          locale: "en",
+        )
+      end
+
+      it "fails, returning the id of the content item" do
+        expect(subject).to eq(@blocking_content_item.id)
+      end
+    end
+
+    context "with a published item, and a draft at the same base path" do
+      before do
+        @blocking_content_item = FactoryGirl.create(:content_item,
+          content_id: SecureRandom.uuid,
+          base_path: base_path,
+          document_type: document_type,
+          state: "published",
+          user_facing_version: 1,
+          locale: "en",
+        )
+
+        FactoryGirl.create(:content_item,
+          content_id: content_id,
+          base_path: base_path,
+          document_type: document_type,
+          user_facing_version: 1,
+          locale: "en",
+        )
+      end
+
+      it "fails, returning the id of the content item" do
+        expect(subject).to eq(@blocking_content_item.id)
+      end
+    end
+  end
+end

--- a/spec/requests/content_item_requests/endpoint_behaviour_spec.rb
+++ b/spec/requests/content_item_requests/endpoint_behaviour_spec.rb
@@ -310,14 +310,20 @@ RSpec.describe "Endpoint behaviour", type: :request do
         get "/v2/content/#{content_id}"
 
         updated_content_item = ContentItem.find_by!(content_id: content_id)
-        presented_content_item = Presenters::Queries::ContentItemPresenter.present(updated_content_item)
+        presented_content_item = Presenters::Queries::ContentItemPresenter.present(
+          updated_content_item,
+          include_warnings: true,
+        )
 
         expect(response.body).to eq(presented_content_item.to_json)
       end
 
       it "responds with the presented content item for the correct locale" do
         FactoryGirl.create(:draft_content_item, content_id: content_id, locale: "ar")
-        presented_content_item = Presenters::Queries::ContentItemPresenter.present(content_item)
+        presented_content_item = Presenters::Queries::ContentItemPresenter.present(
+          content_item,
+          include_warnings: true,
+        )
 
         get "/v2/content/#{content_id}"
 


### PR DESCRIPTION
This branch is for most of https://trello.com/c/CePxu8NA/809-include-warnings-in-payload-retrieved-from-publishing-api except the pact tests which I haven't looked in to yet.