### PR TITLE
Change semantics of ContentItemPresenter.present

### DIFF
--- a/app/presenters/queries/content_item_presenter.rb
+++ b/app/presenters/queries/content_item_presenter.rb
@@ -22,10 +22,7 @@ module Presenters
       end
 
       def self.present(content_item)
-        translation = Translation.find_by!(content_item: content_item)
-
-        scope = ContentItem.where(content_id: content_item.content_id)
-        scope = Translation.filter(scope, locale: translation.locale)
+        scope = ContentItem.where(id: content_item.id)
 
         present_many(scope).first
       end


### PR DESCRIPTION
Previously, a query would be performed to lookup the locale of the
provided content item, then the scope would have been restricted to use
that locale. This means that the present method will actually present
the latest content item where the content_id and locale match that of
the provided content item.

I think this is confusing, and redundant, as the only current use of
this method is in the PutContent command, which means that the latest
content item will be the content item that is provided in the method
arguments.

This also saves a database query to determine the locale of the content
item to present.