### PR TITLE
Add a temporary task to migrate manuals

### DIFF
--- a/lib/tasks/manuals.rake
+++ b/lib/tasks/manuals.rake
@@ -1,0 +1,23 @@
+# FIXME: Remove this task once it has been run in production
+namespace :manuals do
+  desc "Temporary task to migration specialist publisher manuals to manuals publisher"
+  task migrate: :environment do
+    specialist_publisher_manuals = ContentItem.where(
+      publishing_app: "specialist-publisher", document_type: %w(manual manual_section))
+
+    specialist_publisher_manuals.each do |manual|
+      # Find the Location of each specialist publisher content item
+      location = Location.find_by(content_item: manual)
+      # Find the PathReservation for that Location
+      path_reservation = PathReservation.find_by(publishing_app: "specialist-publisher",
+                                                 base_path: location.base_path)
+      # Update the PathReservation if it exists
+      path_reservation.update_attribute(:publishing_app, "manuals-publisher") if path_reservation
+    end
+
+    # Update the publishing_app for all specialist publisher manuals
+    specialist_publisher_manuals.update_all(publishing_app: "manuals-publisher")
+
+    puts "Migrated #{specialist_publisher_manuals.count} manuals and sections from specialist-publisher to manuals-publisher"
+  end
+end


### PR DESCRIPTION
[This was previously a migration](https://github.com/alphagov/publishing-api/pull/521) which has run successfully on integration but has been moved to a temporary rake task to provide better control of when we migrate manuals (as this needs to be around the same time as manuals publisher goes live).

Manuals publishing will soon be handled by the 'Manuals Publisher'
application which is essentially the manuals-specific parts of
Specialist Publisher v1 repurposed.

Specialist Publisher will be restricted to publishing specialist
content like aaib reports. This means that content items with a
document_type of manuals or manual_sections will have an incorrect
publishing_app value as they are currently set to
'specialist-publisher'.

Update the relevant manuals content items publishing_app value
to be manuals-publisher.

Also update any relevant PathReservation records to the correct
publishing_app.