### PR TITLE
Switch back to released Sidekiq.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,15 +12,14 @@ gem "pg"
 if ENV["API_DEV"]
   gem "gds-api-adapters", path: "../gds-api-adapters"
 else
-  gem "gds-api-adapters", "33.0.0"
+  gem "gds-api-adapters", "36.3.0"
 end
 
 gem "gds-sso", "12.1.0"
 
 gem 'bunny', '2.5.1'
 gem 'whenever', '0.9.4', require: false
-gem "govuk_sidekiq", "~> 0.0"
-gem 'sidekiq', git: "https://github.com/alphagov/sidekiq.git", branch: "fix-testing-with-overridden-queue"
+gem "govuk_sidekiq", "~> 1.0.1"
 gem "json-schema", require: false
 gem "hashdiff"
 gem "sidekiq-unique-jobs", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,14 +1,3 @@
-GIT
-  remote: https://github.com/alphagov/sidekiq.git
-  revision: cadebcf4977189b8ca534e0ccb2b304d2ac70be2
-  branch: fix-testing-with-overridden-queue
-  specs:
-    sidekiq (4.1.4)
-      concurrent-ruby (~> 1.0)
-      connection_pool (~> 2.2, >= 2.2.0)
-      redis (~> 3.2, >= 3.2.1)
-      sinatra (>= 1.4.7)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -76,7 +65,7 @@ GEM
     debug_inspector (0.0.2)
     diff-lcs (1.2.5)
     docile (1.1.5)
-    domain_name (0.5.24)
+    domain_name (0.5.20160826)
       unf (>= 0.0.5, < 1.0.0)
     erubis (2.7.0)
     factory_girl (4.5.0)
@@ -89,13 +78,13 @@ GEM
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
     find_a_port (1.0.1)
-    gds-api-adapters (33.0.0)
+    gds-api-adapters (36.3.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
       plek (>= 1.9.0)
       rack-cache
-      rest-client (~> 1.8.0)
+      rest-client (~> 2.0)
     gds-sso (12.1.0)
       multi_json (~> 1.0)
       oauth2 (~> 1.0)
@@ -122,11 +111,11 @@ GEM
     govuk_schemas (0.1.0)
       activesupport
       json-schema
-    govuk_sidekiq (0.0.4)
+    govuk_sidekiq (1.0.1)
       airbrake (>= 3.1.0)
       gds-api-adapters (>= 19.1.0)
       redis-namespace (~> 1.5.2)
-      sidekiq (~> 4.1)
+      sidekiq (~> 4.2.2)
       sidekiq-logging-json (~> 0.0)
       sidekiq-statsd (~> 0.1)
     hashdiff (0.3.0)
@@ -156,16 +145,18 @@ GEM
     mail (2.6.4)
       mime-types (>= 1.16, < 4)
     method_source (0.8.2)
-    mime-types (2.99.2)
+    mime-types (3.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2016.0521)
     mini_portile2 (2.1.0)
-    minitest (5.9.0)
+    minitest (5.9.1)
     money (6.7.1)
       i18n (>= 0.6.4, <= 0.7.0)
       sixarm_ruby_unaccent (>= 1.1.1, < 2)
-    multi_json (1.11.2)
+    multi_json (1.12.1)
     multi_xml (0.5.5)
     multipart-post (2.0.0)
-    netrc (0.10.3)
+    netrc (0.11.0)
     nokogiri (1.6.8)
       mini_portile2 (~> 2.1.0)
       pkg-config (~> 1.1.7)
@@ -226,7 +217,7 @@ GEM
       ast (~> 2.2)
     pg (0.18.3)
     pkg-config (1.1.7)
-    plek (1.11.0)
+    plek (1.12.0)
     powerpack (0.1.1)
     pry (0.10.3)
       coderay (~> 1.1.0)
@@ -274,14 +265,14 @@ GEM
     raindrops (0.15.0)
     rake (10.5.0)
     randexp (0.1.7)
-    redis (3.3.0)
+    redis (3.3.1)
     redis-namespace (1.5.2)
       redis (~> 3.0, >= 3.0.4)
     request_store (1.2.0)
-    rest-client (1.8.0)
+    rest-client (2.0.0)
       http-cookie (>= 1.0.2, < 2.0)
-      mime-types (>= 1.16, < 3.0)
-      netrc (~> 0.7)
+      mime-types (>= 1.16, < 4.0)
+      netrc (~> 0.8)
     rspec (3.3.0)
       rspec-core (~> 3.3.0)
       rspec-expectations (~> 3.3.0)
@@ -318,6 +309,11 @@ GEM
     scss_lint (0.44.0)
       rake (~> 10.0)
       sass (~> 3.4.15)
+    sidekiq (4.2.2)
+      concurrent-ruby (~> 1.0)
+      connection_pool (~> 2.2, >= 2.2.0)
+      rack-protection (~> 1.5)
+      redis (~> 3.2, >= 3.2.1)
     sidekiq-logging-json (0.0.16)
       sidekiq (>= 3, < 5)
     sidekiq-statsd (0.1.5)
@@ -334,10 +330,6 @@ GEM
     simplecov-html (0.10.0)
     simplecov-rcov (0.2.3)
       simplecov (>= 0.4.1)
-    sinatra (1.4.7)
-      rack (~> 1.5)
-      rack-protection (~> 1.4)
-      tilt (>= 1.3, < 3)
     sixarm_ruby_unaccent (1.1.1)
     slop (3.6.0)
     spring (1.7.1)
@@ -356,14 +348,13 @@ GEM
       tins (~> 1.0)
     thor (0.19.1)
     thread_safe (0.3.5)
-    tilt (2.0.5)
     timecop (0.8.0)
     tins (1.6.0)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
     unf (0.1.4)
       unf_ext
-    unf_ext (0.0.7.1)
+    unf_ext (0.0.7.2)
     unicorn (4.9.0)
       kgio (~> 2.6)
       rack
@@ -393,12 +384,12 @@ DEPENDENCIES
   database_cleaner
   factory_girl_rails (= 4.5.0)
   faker
-  gds-api-adapters (= 33.0.0)
+  gds-api-adapters (= 36.3.0)
   gds-sso (= 12.1.0)
   govspeak (~> 4.0)
   govuk-lint
   govuk_schemas (~> 0.1)
-  govuk_sidekiq (~> 0.0)
+  govuk_sidekiq (~> 1.0.1)
   hashdiff
   json-schema
   logstasher (= 0.6.2)
@@ -414,7 +405,6 @@ DEPENDENCIES
   rails (= 4.2.7.1)
   rspec
   rspec-rails (~> 3.3)
-  sidekiq!
   sidekiq-unique-jobs
   simplecov (= 0.10.0)
   simplecov-rcov (= 0.2.3)


### PR DESCRIPTION
4.2.2 includes the fix we made for testing with overridden queue.

Also upgrade gds-api-adapters to fix some deprecation warnings from
RestClient.