### PR TITLE
[WIP] Enable use of gov.uk external campaign urls

### DIFF
--- a/spec/support/routes_and_redirects_validator.rb
+++ b/spec/support/routes_and_redirects_validator.rb
@@ -149,6 +149,35 @@ RSpec.shared_examples_for RoutesAndRedirectsValidator do
       expect { subject.valid? }.to_not raise_error
     end
 
+    context "when destination is external url" do
+      it "is invalid if it is not an external gov.uk campaign url" do
+        ["https://www.example.com/foo/bar", "https://www.gov.uk/foo/bar"].each do |destination|
+          content_item.redirects = [{ path: "#{subject.base_path}/foo", type: "exact", destination: destination }]
+
+          expect(subject).to be_invalid
+          expect(subject.errors[:redirects]).to eq(["is not a valid redirect destination"])
+        end
+      end
+
+      it "is invalid if the url is a malformed gov.uk campaign external url" do
+        ["://new-vat-rates.campaign.gov.uk/", "http:new-vat-rates.campaign.gov.uk/", "httpsnew-vat-rates.campaign.gov.uk/", "https://new_vat-rates.campaign.gov.uk/", "http://.campaign.gov.uk/", "http://new-vat-rates.campaignjservicepgov.uk/path/to/your/new/vat-rates", "https://fakesite.net/.new-vat-rates.campaign.gov.uk/path/to/your/new/vat-rates", "ftp://new-vat-rates.campaign.gov.uk/"].each do |destination|
+          content_item.redirects = [{ path: "#{subject.base_path}/foo", type: "exact", destination: destination }]
+
+          expect(subject).to be_invalid
+          expect(subject.errors[:redirects]).to eq(["is not a valid redirect destination"])
+        end
+      end
+
+      it "is valid if the url is a wellformed gov.uk campaign external url" do
+        ["http://new-vat-rates.campaign.gov.uk/", "https://new-vat-rates.campaign.gov.uk/path/to/your/new/vat-rates"].each do |destination|
+          content_item.redirects = [{ path: "#{subject.base_path}/new", type: "exact", destination: destination }]
+
+          expect(subject).to be_valid
+          expect(subject.errors[:redirects]).to eq([])
+        end
+      end
+    end
+
     context "when the type is 'prefix'" do
       it "must contain valid absolute paths for destinations" do
         content_item.redirects = [{ path: "#{subject.base_path}/foo", type: "prefix", destination: "not valid" }]
@@ -168,15 +197,6 @@ RSpec.shared_examples_for RoutesAndRedirectsValidator do
 
       it "is invalid with an non-absolute url" do
         ["foo/bar", "/url with spaces", "fdjkdfjkljsdaf"].each do |destination|
-          content_item.redirects = [{ path: "#{subject.base_path}/foo", type: "exact", destination: destination }]
-
-          expect(subject).to be_invalid
-          expect(subject.errors[:redirects]).to eq(["is not a valid redirect destination"])
-        end
-      end
-
-      it "is invalid with an external url" do
-        ["https://www.example.com/foo/bar", "https://www.gov.uk/foo/bar"].each do |destination|
           content_item.redirects = [{ path: "#{subject.base_path}/foo", type: "exact", destination: destination }]
 
           expect(subject).to be_invalid


### PR DESCRIPTION
Related to changes in this PR https://github.com/alphagov/short-url-manager/pull/62
[Trello card](https://trello.com/c/YNWyi4dd/342-enable-campaign-redirects-in-publishing-api)

# Description 

Prior to this PR, external urls were not supported and validation
were put in place to negate them.

This PR enables the use of only gov.uk external campaign urls[1].

Within, external gov.uk campaign urls[1] have been validated with regex:

* possible campaign.service.gov.uk sub domain.
* scheme must either http or https.
* cannot start a hyphen.
* can be alphanumeric (or hyphen).
* number of characters range from 1-63. Refer to [2]

In theory [2], it is believed that DNS itself can have up to 127 levels
of label, each label can be up to 63 characters and the maximum length of
the whole record is limited to approximately 255 characters.

[1] Example: https://new-vat-rates.campaign.service.gov.uk/path/to/your/new/vat-rates
[2] https://en.wikipedia.org/wiki/Subdomain