### PR TITLE
Include warnings in the put content response

### DIFF
--- a/app/commands/v2/put_content.rb
+++ b/app/commands/v2/put_content.rb
@@ -26,7 +26,10 @@ module Commands
           send_downstream(content_item)
         end
 
-        response_hash = Presenters::Queries::ContentItemPresenter.present(content_item)
+        response_hash = Presenters::Queries::ContentItemPresenter.present(
+          content_item,
+          include_warnings: true,
+        )
         Success.new(response_hash)
       end
 

--- a/doc/api.md
+++ b/doc/api.md
@@ -63,6 +63,9 @@ Used to create or update a draft content item. It will restrict creation if
 there is already a draft content item with the same `base_path` and `locale`.
 Uses [optimistic-locking](#optimistic-locking-previous_version).
 
+If the request is successful, this endpoint will respond with the
+presented content item and [warnings](#warnings).
+
 ### Path parameters
 - [`content_id`](model.md#content_id)
   - Specifies the `content_id` of the content to be created or updated.

--- a/spec/requests/content_item_requests/endpoint_behaviour_spec.rb
+++ b/spec/requests/content_item_requests/endpoint_behaviour_spec.rb
@@ -220,7 +220,10 @@ RSpec.describe "Endpoint behaviour", type: :request do
       put "/v2/content/#{content_id}", content_item.to_json
 
       updated_content_item = ContentItem.find_by!(content_id: content_id)
-      presented_content_item = Presenters::Queries::ContentItemPresenter.present(updated_content_item)
+      presented_content_item = Presenters::Queries::ContentItemPresenter.present(
+        updated_content_item,
+        include_warnings: true,
+      )
 
       expect(response.body).to eq(presented_content_item.to_json)
     end


### PR DESCRIPTION
This information can then be used by publishing applications to better
inform their users.

https://trello.com/c/HW8dr2QM/810-warn-when-putting-a-draft-that-will-conflict-with-a-published-unpublished-item-occupying-a-base-path-medium