### PR TITLE
Task and methods to aide Govspeak migration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -53,4 +53,5 @@ group :development, :test do
   gem "spring"
   gem "spring-commands-rspec"
   gem "govuk_schemas", "~> 0.1"
+  gem "diffy", "~> 3.1", require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -66,6 +66,7 @@ GEM
     database_cleaner (1.3.0)
     debug_inspector (0.0.2)
     diff-lcs (1.2.5)
+    diffy (3.1.0)
     docile (1.1.5)
     domain_name (0.5.20160826)
       unf (>= 0.0.5, < 1.0.0)
@@ -386,6 +387,7 @@ DEPENDENCIES
   airbrake (~> 4.2.1)
   bunny (= 2.5.1)
   database_cleaner
+  diffy (~> 3.1)
   factory_girl_rails (= 4.5.0)
   faker
   gds-api-adapters (= 36.3.0)

--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -63,7 +63,11 @@ class ContentItem < ActiveRecord::Base
       wrapped = Array.wrap(value)
       html = wrapped.find { |item| item.is_a?(Hash) && item[:content_type] == "text/html" }
       govspeak = wrapped.find { |item| item.is_a?(Hash) && item[:content_type] == "text/govspeak" }
-      html && govspeak ? wrapped - [html] : value
+      if html.present? && govspeak.present?
+        wrapped - [html]
+      else
+        value
+      end
     end
 
     details.deep_dup.each_with_object({}) do |(key, value), memo|

--- a/lib/data_hygiene/govspeak_compare.rb
+++ b/lib/data_hygiene/govspeak_compare.rb
@@ -1,0 +1,96 @@
+require "diffy"
+
+module DataHygiene
+  class GovspeakCompare
+    attr_reader :content_item
+
+    def initialize(content_item)
+      @content_item = content_item
+    end
+
+    def published_html
+      @published_html ||= format_published_html
+    end
+
+    def generated_html
+      @generated_html ||= html_from_details(
+        Presenters::DetailsPresenter.new(content_item.details_for_govspeak_conversion).details
+      )
+    end
+
+    def diffs
+      @diffs ||= calculate_diffs
+    end
+
+    def same_html?
+      HashDiff.diff(published_html, generated_html) == []
+    end
+
+    def pretty_much_same_html?
+      return true if same_html?
+      diffs.all? { |_, diff| diff == [] }
+    end
+
+  private
+
+    def calculate_diffs
+      keys = (published_html.keys + generated_html.keys).uniq.sort
+      keys.each_with_object({}) do |key, memo|
+        memo[key] = html_diff(published_html[key], generated_html[key])
+      end
+    end
+
+    def html_diff(old_html, new_html)
+      old_html = apply_old_html_common_changes(old_html)
+      diff = Diffy::Diff.new(old_html, new_html, context: 1)
+
+      diff = diff.reject { |s| s.match(/^ /) || s.match(/^(\+|-)$/) }
+
+      diff.reject do |s|
+        check = (s[0] == "+" ? "-" : "+") + s[1..-1]
+        diff.any? { |elem| basically_match(elem) == basically_match(check) }
+      end
+    end
+
+    def apply_old_html_common_changes(html)
+      return unless html
+      # In specialist publisher we have a lot of new lines in inline attachments
+      # which causes us trouble as we only allow inline attachments to be on a single line
+      regex = %r{<a (rel="external" )?href="https:\/\/assets.digital.cabinet-office.gov.uk\/.*?">((?:.|\n)*?)<\/a>}
+      html.gsub(regex) { |inner_content| inner_content.tr("\n", " ") }
+    end
+
+    # This method strips out a lot of the common differences that are the result
+    # of different versions of govspeak rendering.
+    # It was wrote when testing Specialist Publisher documents and may need
+    # additional items when comparing content items published from different apps
+    def basically_match(s)
+      s = s.dup
+      # strip span surrounding an inline-attachment as this element
+      s.gsub!(/<span\s+class=\"attachment\-inline\">(.+?)<\/span>/, '\1')
+      # a number of past inline attachments are incorrectly marked as rel="external"
+      # the last p element in a blockquote is given a class of last-child
+      s.gsub!(/(rel="external"|class="last-child")/, "")
+      # it's very common for extra whitespace to be present.
+      s.gsub!(/\s+/, "") #whitespace
+    end
+
+    def format_published_html
+      html_details = html_from_details(content_item.details)
+      html_details.each_with_object({}) do |(key, value), memo|
+        # pushed through nokogiri to catch minor html differences (<br /> -> <br>, unicode characters)
+        memo[key] = Nokogiri::HTML.fragment(value).to_html
+      end
+    end
+
+    def html_from_details(details)
+      details.each_with_object({}) do |(key, value), memo|
+        wrapped = Array.wrap(value)
+        html = wrapped.find do |item|
+          item.is_a?(Hash) && item[:content_type] == "text/html"
+        end
+        memo[key] = html[:content] if html && html[:content]
+      end
+    end
+  end
+end

--- a/lib/tasks/govspeak.rake
+++ b/lib/tasks/govspeak.rake
@@ -1,0 +1,35 @@
+namespace :govspeak do
+  task :compare, [:publishing_app, :limit, :offset, :order] => :environment do |_, args|
+    args.with_defaults(order: "content_items.id ASC")
+    scope = State.joins(:content_item)
+    scope = scope.where(content_items: { publishing_app: args[:publishing_app] }) if args[:publishing_app].present?
+    scope = scope.where(name: %w(published unpublished draft))
+    scope = scope.limit(args[:limit]) if args[:limit].present?
+    scope = scope.offset(args[:offset]) if args[:offset].present?
+    scope = scope.order(args[:order])
+    total = scope.count
+    same_html = 0
+    trivial_differences = 0
+    scope.each do |state|
+      content_item = state.content_item
+      comparer = DataHygiene::GovspeakCompare.new(content_item)
+      same_html += 1 if comparer.same_html?
+      trivial_differences += 1 if !comparer.same_html? && comparer.pretty_much_same_html?
+      next if comparer.pretty_much_same_html?
+      state = State.where(content_item_id: content_item.id).pluck(:name).first
+      base_path = Location.where(content_item_id: content_item.id).pluck(:base_path).first
+      puts "Content Item #{content_item.id} #{content_item.content_id} #{state} #{base_path}"
+      comparer.diffs.each do |field, diff|
+        next if diff == []
+        puts field
+        diff.each do |item|
+          print item.red if item[0] == "-"
+          print item.green if item[0] == "+"
+        end
+      end
+    end
+    puts "Same HTML: #{same_html}/#{total}"
+    puts "Trivial Differences: #{trivial_differences}/#{total}"
+    puts "Other differences: #{total - (same_html + trivial_differences)}/#{total}"
+  end
+end

--- a/spec/lib/data_hygiene/govspeak_compare_spec.rb
+++ b/spec/lib/data_hygiene/govspeak_compare_spec.rb
@@ -1,0 +1,195 @@
+require 'rails_helper'
+
+RSpec.describe DataHygiene::GovspeakCompare do
+  let(:content_item) { FactoryGirl.create(:content_item, details: details) }
+  let(:details) do
+    { body: [
+        { content_type: "text/html", content: body_html },
+        { content_type: "text/govspeak", content: body_govspeak },
+      ],
+      other: [
+        { content_type: "text/html", content: other_html },
+        { content_type: "text/govspeak", content: other_govspeak },
+      ],
+    }
+  end
+
+  let(:body_html) { "<h1>Foo</h1>" }
+  let(:body_govspeak) { "#Foo" }
+  let(:other_html) { body_html }
+  let(:other_govspeak) { body_govspeak }
+
+  describe '.published_html' do
+    subject { described_class.new(content_item).published_html }
+
+    context "when details is an empty hash" do
+      let(:details) { {} }
+      it { is_expected.to be_a Hash }
+      it { is_expected.to be_empty }
+    end
+
+    context "when there are two fields with content_type HTML and one with only govspeak" do
+      let(:details) do
+        { field_1: { content_type: "text/html", content: "<h1>Hi</h1>" },
+          field_2: [
+            { content_type: "text/html", content: "<h1>Hello</h1>" },
+            { content_type: "text/govspeak", content: "#Hi" },
+          ],
+          field_3: [{ content_type: "text/govspeak", content: "#Erm" }],
+        }
+      end
+      it { is_expected.to include(:field_1, :field_2) }
+    end
+
+    context "when the HTML includes aspects that Nokogiri changes" do
+      let(:body_html) do
+        "<p>HTML entities: &pound; <br /> Unicode characters: &#x1f355;"
+      end
+      let(:expected_html) do
+        "<p>HTML entities: £ <br> Unicode characters: 🍕</p>"
+      end
+      it { is_expected.to include(body: expected_html) }
+    end
+  end
+
+  describe '.generated_html' do
+    subject { described_class.new(content_item).generated_html }
+
+    context "when details is an empty hash" do
+      let(:details) { {} }
+      it { is_expected.to be_a Hash }
+      it { is_expected.to be_empty }
+    end
+
+    context "when details contains govspeak fields" do
+      let(:details) do
+        { field_1: { content_type: "text/html", content: "<h1>Hi</h1>" },
+          field_2: [
+            { content_type: "text/html", content: "<h1>Hello</h1>" },
+            { content_type: "text/govspeak", content: "#Hi" },
+          ],
+          field_3: [{ content_type: "text/govspeak", content: "Erm" }],
+        }
+      end
+
+      it { is_expected.to include(:field_2, :field_3) }
+      it { is_expected.to include(field_2: %{<h1 id="hi">Hi</h1>\n}) }
+      it { is_expected.to include(field_3: "<p>Erm</p>\n") }
+    end
+  end
+
+  describe '.diffs' do
+    subject { described_class.new(content_item).diffs }
+
+    context "when published_html is the same as generated_html" do
+      let(:body_html) { "<p>Hello World</p>\n" }
+      let(:body_govspeak) { "Hello World" }
+      let(:expected) { { body: [], other: [] } }
+
+      it "has an empty array for each html field" do
+        is_expected.to eq expected
+      end
+    end
+
+    context "when a HTML field is missing" do
+      let(:html) { "<p>Hi</p>\n" }
+      let(:details) do
+        { field_1: { content_type: "text/govspeak", content: "Hi" } }
+      end
+
+      it { is_expected.to include(field_1: ["+#{html}"]) }
+    end
+
+    context "when the HTML is different" do
+      let(:body_html) { "<p>Hi</p>\n" }
+      let(:body_govspeak) { "Hello\n" }
+
+      it { is_expected.to include(body: ["-#{body_html}", "+<p>Hello</p>\n"]) }
+    end
+
+    context "when there is extra white space in the HTML" do
+      let(:body_html) { "<p>  Whitespace   </p>\n" }
+      let(:body_govspeak) { "Whitespace\n" }
+
+      it { is_expected.to include(body: []) }
+    end
+
+    context "when there are extra new lines in the HTML" do
+      let(:body_html) { "<p>Foo</p>\n\n\n\n\n<p>Bar</p>\n" }
+      let(:body_govspeak) { "Foo\n\nBar\n" }
+
+      it { is_expected.to include(body: []) }
+    end
+
+    context "when the govspeak wraps inline attachments in spans" do
+      let(:body_html) { %{<p><a href="url">Inline Attachment</a></p>\n} }
+      let(:body_govspeak) do
+        %{<span class="attachment-inline"><a href="url">Inline Attachment</a></span>\n}
+      end
+
+      it { is_expected.to include(body: []) }
+    end
+
+    context "when the govspeak contains rel=\"external\"" do
+      let(:body_html) { %{<p><a href="url" rel="external">My File</a></p>\n} }
+      let(:body_govspeak) do
+        %{<a href="url">My File</a>\n}
+      end
+
+      it { is_expected.to include(body: []) }
+    end
+  end
+
+  describe 'same_html?' do
+    subject { described_class.new(content_item).same_html? }
+
+    context "when govspeak will render to the same HTML" do
+      let(:body_html) { "<p>Foo</p>\n" }
+      let(:body_govspeak) { "Foo\n" }
+
+      it { is_expected.to be true }
+    end
+
+    context "when the govspeak will render to a diff we'd ignore" do
+      let(:body_html) { "<p> Foo </p>\n" }
+      let(:body_govspeak) { "Foo\n" }
+
+      it { is_expected.to be false }
+    end
+
+    context "when there is no HTML to compare" do
+      let(:details) { {} }
+      it { is_expected.to be true }
+    end
+  end
+
+  describe 'pretty_much_same_html?' do
+    subject { described_class.new(content_item).pretty_much_same_html? }
+
+    context "when govspeak will render to the same HTML" do
+      let(:body_html) { "<p>Foo</p>\n" }
+      let(:body_govspeak) { "Foo\n" }
+
+      it { is_expected.to be true }
+    end
+
+    context "when the govspeak will render to a diff we'd ignore" do
+      let(:body_html) { "<p> Foo </p>\n" }
+      let(:body_govspeak) { "Foo\n" }
+
+      it { is_expected.to be true }
+    end
+
+    context "when the govspeak will render to a diff we'd acknowledge" do
+      let(:body_html) { "<p>Foo</p>\n" }
+      let(:body_govspeak) { "Bar\n" }
+
+      it { is_expected.to be false }
+    end
+
+    context "when there is no HTML to compare" do
+      let(:details) { {} }
+      it { is_expected.to be true }
+    end
+  end
+end

--- a/spec/models/content_item_spec.rb
+++ b/spec/models/content_item_spec.rb
@@ -155,6 +155,54 @@ RSpec.describe ContentItem do
     end
   end
 
+  describe "#details_for_govspeak_conversion" do
+    subject do
+      FactoryGirl.build(:content_item, details: details)
+        .details_for_govspeak_conversion
+    end
+
+    let(:html_content) { { content_type: "text/html", content: "<b>Hello</b>" } }
+    let(:govspeak_content) { { content_type: "text/govspeak", content: "**Hello**" } }
+
+    context "details has no body" do
+      let(:details) { { field: "value" } }
+      it { is_expected.to match(details) }
+    end
+
+    context "details doesn't have a text/govspeak content type" do
+      let(:details) { { body: [html_content] } }
+      it { is_expected.to match(details) }
+    end
+
+    context "details doesn't have a text/html content type" do
+      let(:details) { { body: [govspeak_content] } }
+      it { is_expected.to match(details) }
+    end
+
+    context "details has text/html and text/govspeak content types" do
+      let(:details) { { body: [html_content, govspeak_content] } }
+      it { is_expected.to match(body: [govspeak_content]) }
+    end
+
+    context "details has govspeak in multiple keys" do
+      let(:details) do
+        {
+          key_1: [html_content, govspeak_content],
+          key_2: [govspeak_content, html_content],
+          key_3: html_content,
+        }
+      end
+      let(:expected_result) do
+        {
+          key_1: [govspeak_content],
+          key_2: [govspeak_content],
+          key_3: html_content,
+        }
+      end
+      it { is_expected.to match(expected_result) }
+    end
+  end
+
   it_behaves_like DefaultAttributes
   it_behaves_like WellFormedContentTypesValidator
   it_behaves_like DescriptionOverrides


### PR DESCRIPTION
This provides a rake task so that we can check how the govspeak we store will be rendered and how it will compare to the HTML variations that are stored.

The task will output differences like so: 
```
vm  publishing-api git:(govspeak-checking) rake "govspeak:compare[specialist-publisher]"

Content Item 409907 bd18a79c-78fd-4983-aaf4-90f24e1f9c98 draft /guidance/family-procedure-rules/part-34-reciprocal-enforcement-of-maintenance-orders
body
-<h2 id="footnotes">Footnotes</h2><div class="footnotes">
+<div class="footnotes">
Content Item 412472 3a29e364-2ca7-4246-837c-0220112e7f33 draft /cma-cases/co-op-psw
body
-<p>Download <a rel="external" href="https://assets.digital.cabinet-office.gov.uk/media/555de36140f0b669c4000099/Coop-Plymouth.pdf">Anticipated acquisition by Co-operative Group Limited of Plymouth &amp; South West Co-operative Society Limited</a> (pdf 129kb)</p>
+<p>Download [InlineAttachment:OFTwork-mergers-Mergers_Cases-2009-Co-operative2/Coop-Plymouth.pdf] (pdf 129kb)</p>
-<p>Download the <a rel="external" href="https://assets.digital.cabinet-office.gov.uk/media/555de360e5274a7084000096/Co-op-PSW.pdf">full text of the decision</a>
+<p>Download the [InlineAttachment:OFTwork-mergers-Mergers_Cases-2009-Co-operative2/Co-op-PSW.pdf]
```

As there can be lots of minor differences caused by different versions of govspeak we try and strip those changes out prior to comparison. These may be tied somewhat to Specialist Publisher - which we will likely find out when we check the next publishing_app.