### PR TITLE
Change handling of links to preserve ordering

### DIFF
--- a/app/models/link_set.rb
+++ b/app/models/link_set.rb
@@ -1,3 +1,3 @@
 class LinkSet < ActiveRecord::Base
-  has_many :links, -> { order(id: :asc) }, dependent: :destroy
+  has_many :links, -> { order(link_type: :asc, position: :asc) }, dependent: :destroy
 end

--- a/db/migrate/20161003145646_add_position_to_links.rb
+++ b/db/migrate/20161003145646_add_position_to_links.rb
@@ -1,0 +1,5 @@
+class AddPositionToLinks < ActiveRecord::Migration
+  def change
+    add_column :links, :position, :integer
+  end
+end

--- a/db/migrate/20161006115515_add_position_to_existing_links.rb
+++ b/db/migrate/20161006115515_add_position_to_existing_links.rb
@@ -1,0 +1,5 @@
+class AddPositionToExistingLinks < ActiveRecord::Migration
+  def change
+    Link.where(position: nil).update_all(position: 0)
+  end
+end

--- a/db/migrate/20161006115850_make_position_required.rb
+++ b/db/migrate/20161006115850_make_position_required.rb
@@ -1,0 +1,5 @@
+class MakePositionRequired < ActiveRecord::Migration
+  def change
+    change_column :links, :position, :integer, null: false, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160913130622) do
+ActiveRecord::Schema.define(version: 20161006115850) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -91,9 +91,10 @@ ActiveRecord::Schema.define(version: 20160913130622) do
   create_table "links", force: :cascade do |t|
     t.integer  "link_set_id"
     t.string   "target_content_id"
-    t.string   "link_type",         null: false
-    t.datetime "created_at",        null: false
-    t.datetime "updated_at",        null: false
+    t.string   "link_type",                     null: false
+    t.datetime "created_at",                    null: false
+    t.datetime "updated_at",                    null: false
+    t.integer  "position",          default: 0, null: false
   end
 
   add_index "links", ["link_set_id", "target_content_id"], name: "index_links_on_link_set_id_and_target_content_id", using: :btree

--- a/doc/api.md
+++ b/doc/api.md
@@ -27,7 +27,7 @@ for other apps (eg email-alert-service) to consume.
 ### Optimistic locking (`previous_version`)
 
 All PUT and POST endpoints take an optional JSON attribute `previous_version`
-in the request. If given, the coresponding value should be a integer. This
+in the request. If given, the corresponding value should be a integer. This
 allows the Publishing API to check that the publishing app sending the request
 intends to update the latest lock version of the model in question.
 
@@ -349,7 +349,8 @@ included within the response.
 Creates or updates a set of links for the given `content_id`. Link sets can be
 created before or after the [PUT request](#put_v2contentcontent-id) for the
 content item. These are tied to a content item solely by matching `content_id`
-and they are not associated with a content items locale or version.
+and they are not associated with a content item's locale or version. The ordering
+of links in the request is preserved.
 
 ### Path parameters
 - [`content_id`](model.md#content_id)
@@ -385,6 +386,7 @@ and they are not associated with a content items locale or version.
 
 Retrieves the link set for the given `content_id`. Returns arrays of
 `content_id`s representing content items. These are grouped by `link_type`.
+The ordering of the returned links matches the ordering when they were created.
 
 ### Path parameters
 - [`content_id`](model.md#content_id)


### PR DESCRIPTION
**NOTE** To be reviewed by the Publishing API team.

Currently, the `PATCH link_sets` command works out the difference between the provided links payload and the links currently in the database for the link set concerned. Links are then created and/or deleted in the database to match the payload. This process does not preserve ordering, so new links are appended at the end of the link set.

This commit changes the command to delete all existing links in the database for the link set, and re-add all the links from the payload, thereby preserving the natural ordering in the payload. In addition, the ordering is also recorded in a new `position` field in the `links` table, to allow the ordering algorithm to be changed in future without affecting natural ordering.

All existing links in the database are given a `position` of zero to reflect the fact that they have no inherent order.

Trello: https://trello.com/c/LlO4fTIS/153-make-publishing-api-order-the-links-size-3-mazz

cc @kevindew 