### PR TITLE
Update reverse links that are recursed

### DIFF
--- a/app/queries/dependent_expansion_rules.rb
+++ b/app/queries/dependent_expansion_rules.rb
@@ -11,16 +11,11 @@ module Queries
     end
 
     def reverse_name_for(link_type)
-      {
-        parent: "children",
-        documents: "document_collections",
-        working_groups: 'policies',
-        parent_taxons: "child_taxons",
-      }[link_type.to_sym]
+      reverse_names[link_type.to_sym]
     end
 
     def recursive_link_types
-      [:parent, :parent_taxons]
+      reverse_names.keys
     end
 
   private
@@ -43,6 +38,15 @@ module Queries
         :title,
         :web_url
       ]
+    end
+
+    def reverse_names
+      {
+        parent: "children",
+        documents: "document_collections",
+        working_groups: 'policies',
+        parent_taxons: "child_taxons",
+      }
     end
   end
 end

--- a/spec/queries/dependent_expansion_rules_spec.rb
+++ b/spec/queries/dependent_expansion_rules_spec.rb
@@ -26,6 +26,8 @@ RSpec.describe Queries::DependentExpansionRules do
   describe "#recurse?" do
     specify { expect(subject.recurse?(:parent)).to eq(true) }
     specify { expect(subject.recurse?(:parent_taxons)).to eq(true) }
+    specify { expect(subject.recurse?(:working_groups)).to eq(true) }
+    specify { expect(subject.recurse?(:documents)).to eq(true) }
     specify { expect(subject.recurse?(:foo)).to eq(false) }
   end
 


### PR DESCRIPTION
Adds `working_groups` and `documents` to reverse links that are expanded.