### PR TITLE
Don't delete links for V1 endpoint

### DIFF
--- a/app/commands/put_content_with_links.rb
+++ b/app/commands/put_content_with_links.rb
@@ -2,8 +2,6 @@ module Commands
   class PutContentWithLinks < BaseCommand
     def call
       if payload[:content_id]
-        delete_existing_links
-
         V2::PutContent.call(v2_put_content_payload, downstream: downstream, callbacks: callbacks, nested: true)
         V2::PatchLinkSet.call(v2_put_link_set_payload, downstream: downstream, callbacks: callbacks, nested: true)
         V2::Publish.call(v2_publish_payload, downstream: downstream, callbacks: callbacks, nested: true)
@@ -48,31 +46,6 @@ module Commands
       payload
         .except(:access_limited)
         .merge(update_type: payload[:update_type] || "major")
-    end
-
-    def delete_existing_links
-      return if protected_apps.include?(payload[:publishing_app])
-
-      link_set = LinkSet.find_by(content_id: payload[:content_id])
-      return unless link_set
-
-      links = link_set.links.where.not(link_type: protected_link_types)
-      links.destroy_all
-    end
-
-    def protected_link_types
-      ["taxons"]
-    end
-
-    def protected_apps
-      # specialist-publisher is being converted to a "standard" Rails app
-      # that will use the publishing-api V2 endpoints.
-      # We don't know when conversion will be completed and we need
-      # specialist-publisher documents link data in content-store ASAP, hence
-      # this quick hack.
-      # Remove this exception once specialist-publisher is fully migrated to use
-      # the publishing-api V2 endpoints.
-      ["specialist-publisher"]
     end
   end
 end

--- a/app/commands/put_draft_content_with_links.rb
+++ b/app/commands/put_draft_content_with_links.rb
@@ -2,8 +2,6 @@ module Commands
   class PutDraftContentWithLinks < BaseCommand
     def call
       if payload[:content_id]
-        delete_existing_links
-
         V2::PutContent.call(v2_put_content_payload, downstream: downstream, callbacks: callbacks, nested: true)
         V2::PatchLinkSet.call(v2_put_link_set_payload, downstream: downstream, callbacks: callbacks, nested: true)
       else
@@ -49,31 +47,6 @@ module Commands
       payload
         .slice(:content_id, :links)
         .merge(links: payload[:links] || {})
-    end
-
-    def delete_existing_links
-      return if protected_apps.include?(payload[:publishing_app])
-
-      link_set = LinkSet.find_by(content_id: payload[:content_id])
-      return unless link_set
-
-      links = link_set.links.where.not(link_type: protected_link_types)
-      links.destroy_all
-    end
-
-    def protected_link_types
-      ["taxons"]
-    end
-
-    def protected_apps
-      # specialist-publisher is being converted to a "standard" Rails app
-      # that will use the publishing-api V2 endpoints.
-      # We don't know when conversion will be completed and we need
-      # specialist-publisher documents link data in content-store ASAP, hence
-      # this quick hack.
-      # Remove this exception once specialist-publisher is fully migrated to use
-      # the publishing-api V2 endpoints.
-      ["specialist-publisher"]
     end
   end
 end

--- a/spec/commands/put_content_with_links_spec.rb
+++ b/spec/commands/put_content_with_links_spec.rb
@@ -70,60 +70,6 @@ RSpec.describe Commands::PutContentWithLinks do
     }.to change(ContentItem, :count).by(1)
   end
 
-  it "protects certain links from being overwritten" do
-    stub_request(:put, "http://draft-content-store.dev.gov.uk/content/foo")
-    stub_request(:put, "http://content-store.dev.gov.uk/content/foo")
-
-    content_item = FactoryGirl.create(:content_item)
-    link_set = FactoryGirl.create(:link_set, content_id: content_item.content_id)
-    protected_link = FactoryGirl.create(:link, link_set: link_set, link_type: 'taxons')
-    normal_link = FactoryGirl.create(:link, link_set: link_set, link_type: 'topics')
-    FactoryGirl.create(:lock_version, target: link_set)
-
-    described_class.call(
-      title: 'Test Title',
-      format: 'placeholder',
-      content_id: content_item.content_id,
-      base_path: '/foo',
-      publishing_app: 'whitehall',
-      rendering_app: 'whitehall',
-      public_updated_at: Time.now,
-      routes: [{ path: '/foo', type: "exact" }],
-      update_type: "minor",
-      links: {},
-    )
-
-    expect { normal_link.reload }.to raise_error(ActiveRecord::RecordNotFound)
-    expect { protected_link.reload }.not_to raise_error
-  end
-
-  it "protects links of certains apps from being overwritten" do
-    stub_request(:put, "http://draft-content-store.dev.gov.uk/content/foo")
-    stub_request(:put, "http://content-store.dev.gov.uk/content/foo")
-
-    link_set = FactoryGirl.create(:link_set, content_id: 'dc3643c0-ac02-43b8-a1c2-b93513878685')
-    link_1 = FactoryGirl.create(:link, link_set: link_set, link_type: 'organisations')
-    link_2 = FactoryGirl.create(:link, link_set: link_set, link_type: 'topics')
-
-    FactoryGirl.create(:lock_version, target: link_set)
-
-    described_class.call(
-      title: 'Test Title',
-      format: 'placeholder',
-      content_id: 'dc3643c0-ac02-43b8-a1c2-b93513878685',
-      base_path: '/foo',
-      publishing_app: 'specialist-publisher',
-      rendering_app: 'finder-frontend',
-      public_updated_at: Time.now,
-      routes: [{ path: '/foo', type: "exact" }],
-      update_type: "minor",
-      links: {},
-    )
-
-    expect { link_1.reload }.not_to raise_error
-    expect { link_2.reload }.not_to raise_error
-  end
-
   context "when the downstream flag is set to false" do
     it "does not send any downstream requests" do
       expect(DownstreamDraftWorker).not_to receive(:perform_async)
@@ -152,10 +98,10 @@ RSpec.describe Commands::PutContentWithLinks do
       FactoryGirl.create(:lock_version, target: link_set)
     end
 
-    it "destroys the existing links before making new ones" do
+    it "preserves links" do
       expect {
         described_class.call(payload)
-      }.to change(Link, :count).by(-1)
+      }.not_to change(Link, :count)
     end
   end
 end


### PR DESCRIPTION
https://github.com/alphagov/publishing-api/pull/278 introduced a "protection" for the links of specialist-publisher. This means that the V1 endpoint worked exactly the same as V2 for this application.

Unfortunately, "specialist-publisher" was recently renamed to "manuals-publisher" so our little hack here has stopped working. This causes the links of manuals to be wiped out on each publishing.

Because manuals-publisher is the only thing sending to the V1 endpoints anyway, this commit removes all the link-destroying code altogether.

https://trello.com/c/c9oxR8vl/210-fix-tagging-to-manuals