### PR TITLE
Don't send web_url and api_url to content store

### DIFF
--- a/app/models/web_content_item.rb
+++ b/app/models/web_content_item.rb
@@ -30,15 +30,21 @@ WebContentItem = Struct.new(*fields) do
 
   def to_h
     super.merge(
+      api_path: api_path,
       api_url: api_url,
       web_url: web_url,
       description: description
      )
   end
 
-  def api_url
+  def api_path
     return unless base_path
-    Plek.current.website_root + "/api/content" + base_path
+    "/api/content" + base_path
+  end
+
+  def api_url
+    return unless api_path
+    Plek.current.website_root + api_path
   end
 
   def web_url

--- a/app/presenters/downstream_presenter.rb
+++ b/app/presenters/downstream_presenter.rb
@@ -23,7 +23,7 @@ module Presenters
 
     def present
       symbolized_attributes
-        .except(*%i{last_edited_at id state user_facing_version}) # only intended to be used by publishing applications
+        .except(*%i{last_edited_at id state user_facing_version api_url web_url}) # only intended to be used by publishing applications
         .merge(rendered_details)
         .merge(first_published_at)
         .merge(public_updated_at)

--- a/app/presenters/queries/content_item_presenter.rb
+++ b/app/presenters/queries/content_item_presenter.rb
@@ -16,7 +16,7 @@ module Presenters
         :internal_name,
         :updated_at,
         :state_history,
-      ]
+      ].freeze
 
       def self.present_many(scope, params = {})
         new(scope, params).present_many

--- a/app/queries/dependent_expansion_rules.rb
+++ b/app/queries/dependent_expansion_rules.rb
@@ -27,7 +27,7 @@ module Queries
     def default_fields
       [
         :analytics_identifier,
-        :api_url,
+        :api_path,
         :base_path,
         :content_id,
         :description,
@@ -36,7 +36,6 @@ module Queries
         :public_updated_at,
         :schema_name,
         :title,
-        :web_url
       ]
     end
 

--- a/doc/api.md
+++ b/doc/api.md
@@ -298,9 +298,9 @@ draft is returned.
 - [`document_type`](model.md#document_type) *(required)*
   - The type of content item to return.
 - `fields[]` *(optional)*
-  - Accepts an array of: "analytics_identifier", "api_url", "base_path",
+  - Accepts an array of: "analytics_identifier", "base_path",
     "content_id", "description", "document_type", "locale",
-    "public_updated_at", "schema_name", "title", "web_urls"
+    "public_updated_at", "schema_name", "title"
   - Determines which fields will be returned in the response, if omitted all
     fields will be returned.
 - [`locale`](model.md#locale) *(optional, default "en")*
@@ -416,9 +416,9 @@ Retrieves all content items that link to the given `content_id` for some
 - `link_type` *(required)*
   - The type of link between the documents.
 - `fields[]` *(required)*
-  - Accepts an array of: "analytics_identifier", "api_url", "base_path",
+  - Accepts an array of: "analytics_identifier", "base_path",
     "content_id", "description", "document_type", "locale",
-    "public_updated_at", "schema_name", "title", "web_urls"
+    "public_updated_at", "schema_name", "title"
   - Determines which fields will be returned in the response.
 
 ## `GET /v2/linkables`

--- a/spec/presenters/downstream_presenter_spec.rb
+++ b/spec/presenters/downstream_presenter_spec.rb
@@ -90,6 +90,7 @@ RSpec.describe Presenters::DownstreamPresenter do
         expect(result[:expanded_links]).to eq(
           related: [{
             content_id: b.content_id,
+            api_path: "/api/content/b",
             base_path: "/b",
             title: "VAT rates",
             description: "VAT rates for goods and services",
@@ -97,14 +98,12 @@ RSpec.describe Presenters::DownstreamPresenter do
             document_type: 'guide',
             locale: "en",
             public_updated_at: "2014-05-14T13:00:06Z",
-            api_url: "http://www.dev.gov.uk/api/content/b",
-            web_url: "http://www.dev.gov.uk/b",
             analytics_identifier: "GDS01",
             links: {},
           }],
           available_translations: [{
             analytics_identifier: "GDS01",
-            api_url: "http://www.dev.gov.uk/api/content/a",
+            api_path: "/api/content/a",
             base_path: "/a",
             content_id: a.content_id,
             description: "VAT rates for goods and services",
@@ -113,7 +112,6 @@ RSpec.describe Presenters::DownstreamPresenter do
             locale: "en",
             public_updated_at: "2014-05-14T13:00:06Z",
             title: "VAT rates",
-            web_url: "http://www.dev.gov.uk/a",
           }],
         )
       end

--- a/spec/queries/dependee_rules_spec.rb
+++ b/spec/queries/dependee_rules_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Queries::DependeeExpansionRules do
       it "returns the default fields" do
         expect(subject.expansion_fields(link_type)).to eq([
           :analytics_identifier,
-          :api_url,
+          :api_path,
           :base_path,
           :content_id,
           :description,
@@ -25,7 +25,6 @@ RSpec.describe Queries::DependeeExpansionRules do
           :public_updated_at,
           :schema_name,
           :title,
-          :web_url,
         ])
       end
     end

--- a/spec/queries/dependeee_expansion_rules_spec.rb
+++ b/spec/queries/dependeee_expansion_rules_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Queries::DependeeExpansionRules do
       it "returns the default fields" do
         expect(subject.expansion_fields(link_type)).to eq([
           :analytics_identifier,
-          :api_url,
+          :api_path,
           :base_path,
           :content_id,
           :description,
@@ -25,7 +25,6 @@ RSpec.describe Queries::DependeeExpansionRules do
           :public_updated_at,
           :schema_name,
           :title,
-          :web_url,
         ])
       end
     end

--- a/spec/queries/dependent_expansion_rules_spec.rb
+++ b/spec/queries/dependent_expansion_rules_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Queries::DependentExpansionRules do
       it "returns the default fields" do
         expect(subject.expansion_fields(link_type)).to eq([
           :analytics_identifier,
-          :api_url,
+          :api_path,
           :base_path,
           :content_id,
           :description,
@@ -17,7 +17,6 @@ RSpec.describe Queries::DependentExpansionRules do
           :public_updated_at,
           :schema_name,
           :title,
-          :web_url,
         ])
       end
     end

--- a/spec/requests/expanded_links_endpoint_spec.rb
+++ b/spec/requests/expanded_links_endpoint_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe "GET /v2/expanded-links/:id", type: :request do
     [
       {
         "analytics_identifier" => "GDS01",
-        "api_url" => "http://www.dev.gov.uk/api/content/some-path",
+        "api_path" => "/api/content/some-path",
         "base_path" => "/some-path",
         "content_id" => "10529c0d-f4b3-4c7d-9589-35ba6a6d1a12",
         "description" => "Some description",
@@ -14,7 +14,6 @@ RSpec.describe "GET /v2/expanded-links/:id", type: :request do
         "schema_name" => "placeholder",
         "public_updated_at" => "2014-05-14T13:00:06Z",
         "title" => "Some title",
-        "web_url" => "http://www.dev.gov.uk/some-path"
       }
     ]
   }
@@ -55,7 +54,7 @@ RSpec.describe "GET /v2/expanded-links/:id", type: :request do
         "organisations" => [
           {
             "analytics_identifier" => "GDS01",
-            "api_url" => "http://www.dev.gov.uk/api/content/my-super-org",
+            "api_path" => "/api/content/my-super-org",
             "base_path" => "/my-super-org",
             "content_id" => "9b5ae6f5-f127-4843-9333-c157a404dd2d",
             "schema_name" => "organisation",
@@ -64,7 +63,6 @@ RSpec.describe "GET /v2/expanded-links/:id", type: :request do
             "locale" => "en",
             "public_updated_at" => "2014-05-14T13:00:06Z",
             "title" => "VAT rates",
-            "web_url" => "http://www.dev.gov.uk/my-super-org",
             "links" => {},
             "details" => { "body" => "<p>Something about VAT</p>\n" },
           }

--- a/spec/support/request_helpers/mocks.rb
+++ b/spec/support/request_helpers/mocks.rb
@@ -2,6 +2,10 @@ module RequestHelpers
   module Mocks
     extend self
 
+    def api_path
+      "/api/content" + base_path
+    end
+
     def base_path
       "/vat-rates"
     end
@@ -66,7 +70,7 @@ module RequestHelpers
       [
         {
           analytics_identifier: "GDS01",
-          api_url: "http://www.dev.gov.uk/api/content/vat-rates",
+          api_path: "/api/content/vat-rates",
           base_path: "/vat-rates",
           content_id: content_id,
           description: "VAT rates for goods and services",
@@ -75,7 +79,6 @@ module RequestHelpers
           locale: "en",
           public_updated_at: DateTime.parse("2014-05-14T13:00:06Z"),
           title: "VAT rates",
-          web_url: "http://www.dev.gov.uk/vat-rates"
         }
       ]
     end


### PR DESCRIPTION
Storing URLs in the content store causes problems when the content store data is synced with different environments.

Instead we will continue sending base_path and in addition to this we are sending api_path which can be used to generate the API URL.