### PR TITLE
Remove unnecessary methods

### DIFF
--- a/app/presenters/downstream_presenter.rb
+++ b/app/presenters/downstream_presenter.rb
@@ -25,8 +25,6 @@ module Presenters
       symbolized_attributes
         .except(*%i{last_edited_at id state user_facing_version}) # only intended to be used by publishing applications
         .merge(rendered_details)
-        .merge(first_published_at)
-        .merge(public_updated_at)
         .merge(links)
         .merge(access_limited)
         .merge(format)
@@ -79,27 +77,6 @@ module Presenters
 
     def rendered_details
       { details: details_presenter.details }
-    end
-
-    def first_published_at
-      if web_content_item.first_published_at.present?
-        { first_published_at: web_content_item.first_published_at }
-      else
-        {}
-      end
-    end
-
-    def public_updated_at
-      return {} unless web_content_item.public_updated_at.present?
-      { public_updated_at: web_content_item.public_updated_at }
-    end
-
-    def base_path
-      { base_path: web_content_item.base_path }
-    end
-
-    def locale
-      { locale: web_content_item.locale }
     end
 
     def format


### PR DESCRIPTION
base_path and locale methods aren't called anywhere.

first_published_at and public_updated_at already exist in
symbolized_attributes when their methods are called, thus merging an
empty hash has no effect and the populated hash merges in data which is
already within symbolized_attributes.