### PR TITLE
Update govuk_schemas gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,6 +52,6 @@ group :development, :test do
   gem "stackprof", require: false
   gem "spring"
   gem "spring-commands-rspec"
-  gem "govuk_schemas", "~> 0.1"
+  gem "govuk_schemas", "~> 1.0"
   gem "diffy", "~> 3.1", require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -112,9 +112,8 @@ GEM
     govuk-lint (0.8.0)
       rubocop (~> 0.35.0)
       scss_lint (~> 0.44.0)
-    govuk_schemas (0.1.0)
-      activesupport
-      json-schema
+    govuk_schemas (1.0.0)
+      json-schema (~> 2.5.0)
     govuk_sidekiq (1.0.1)
       airbrake (>= 3.1.0)
       gds-api-adapters (>= 19.1.0)
@@ -394,7 +393,7 @@ DEPENDENCIES
   gds-sso (= 12.1.0)
   govspeak (~> 5.0)
   govuk-lint
-  govuk_schemas (~> 0.1)
+  govuk_schemas (~> 1.0)
   govuk_sidekiq (~> 1.0.1)
   hashdiff
   json-schema


### PR DESCRIPTION
Changelog:

# 1.0.0

* Add regex for GOV.UK campaign URLs
* Improve error messages

# 0.2.0

* Add a new regex for the new application validation in the schema
* Fixes a problem with an infinite loop in a certain schema
* Now tests all available schema (a problem with specialist docs has
been solved)
* Drops active-support dependency, pins json-schema dependency