### PR TITLE
Fix migrations that exception

### DIFF
--- a/db/migrate/20160901103440_remove_content_item_with_self_redirect.rb
+++ b/db/migrate/20160901103440_remove_content_item_with_self_redirect.rb
@@ -2,7 +2,7 @@ require_relative "helpers/delete_content_item"
 
 class RemoveContentItemWithSelfRedirect < ActiveRecord::Migration
   def up
-    content_item = ContentItem.find(645143)
+    content_item = ContentItem.find_by_id(645143)
 
     if content_item
       Helpers::DeleteContentItem.destroy_supporting_objects(content_item)

--- a/db/migrate/20160906160955_remove_orphaned_translation.rb
+++ b/db/migrate/20160906160955_remove_orphaned_translation.rb
@@ -6,9 +6,10 @@ class RemoveOrphanedTranslation < ActiveRecord::Migration
     #id: 23835, content_id: "5f5890da-7631-11e4-a3cb-005056011aef"
     #Whitehall - edition_id: 649963
 
-    content_item = ContentItem.find(23835)
-    Helpers::DeleteContentItem.destroy_supporting_objects([content_item])
-
-    content_item.destroy
+    content_item = ContentItem.find_by_id(23835)
+    if content_item
+      Helpers::DeleteContentItem.destroy_supporting_objects([content_item])
+      content_item.destroy
+    end
   end
 end


### PR DESCRIPTION
Using `find_by_id` rather than `find` causes these to return nil if data
is not found.