### PR TITLE
Use normal ruby recursion for link traversal

### DIFF
--- a/app/queries/dependent_expansion_rules.rb
+++ b/app/queries/dependent_expansion_rules.rb
@@ -6,6 +6,11 @@ module Queries
       custom(link_type) || default_fields
     end
 
+    def expand_field(web_content_item)
+      return unless web_content_item
+      web_content_item.to_h.slice(*expansion_fields(web_content_item.document_type.to_sym))
+    end
+
     def recurse?(link_type)
       recursive_link_types.include?(link_type.to_sym)
     end
@@ -15,6 +20,10 @@ module Queries
     end
 
     def recursive_link_types
+      reverse_names.keys - [:documents, :working_groups]
+    end
+
+    def reverse_recursive_types
       reverse_names.keys
     end
 

--- a/spec/queries/dependent_expansion_rules_spec.rb
+++ b/spec/queries/dependent_expansion_rules_spec.rb
@@ -25,8 +25,8 @@ RSpec.describe Queries::DependentExpansionRules do
   describe "#recurse?" do
     specify { expect(subject.recurse?(:parent)).to eq(true) }
     specify { expect(subject.recurse?(:parent_taxons)).to eq(true) }
-    specify { expect(subject.recurse?(:working_groups)).to eq(true) }
-    specify { expect(subject.recurse?(:documents)).to eq(true) }
+    specify { expect(subject.recurse?(:working_groups)).to eq(false) }
+    specify { expect(subject.recurse?(:documents)).to eq(false) }
     specify { expect(subject.recurse?(:foo)).to eq(false) }
   end
 


### PR DESCRIPTION
The speed gains of using the recursive SQL doesn't out way the cost of
understanding the query, there are a few more queries to the DB, but it
is easier to reason about in the code, and is still calculated in roughly
the same time.

We also need to split the rules for going down the chain, and going up
the chain. For instance documents we want document_collections, but we
don't want to recurse on those document documents.

before:
Many reverse dependencies: 4bda0be5-3e65-4cc1-850c-0541e95a40ca
..........  3.920000   0.150000   4.070000 (  7.515828)
queries: 165

Many forward dependencies: 5f4f1e91-7631-11e4-a3cb-005056011aef
..........  2.200000   0.060000   2.260000 (  3.754221)
queries: 120

No dependencies: 23e13323-874f-4210-aad3-ca6ade9206f8
..........  0.080000   0.010000   0.090000 (  0.113228)
queries: 100

Single link each way: 00012147-49f6-4e90-be1f-e50bb719f53d
..........  0.160000   0.010000   0.170000 (  0.302323)
queries: 160

after:
Many reverse dependencies: 4bda0be5-3e65-4cc1-850c-0541e95a40ca
..........  3.920000   0.160000   4.080000 (  8.682721)
queries: 175

Many forward dependencies: 5f4f1e91-7631-11e4-a3cb-005056011aef
..........  2.730000   0.110000   2.840000 (  3.641704)
queries: 160

No dependencies: 23e13323-874f-4210-aad3-ca6ade9206f8
..........  0.070000   0.000000   0.070000 (  0.106539)
queries: 100

Single link each way: 00012147-49f6-4e90-be1f-e50bb719f53d
..........  0.140000   0.020000   0.160000 (  0.274945)
queries: 160