### PR TITLE
Remove lock version specifying

### DIFF
--- a/spec/requests/content_item_requests/endpoint_behaviour_spec.rb
+++ b/spec/requests/content_item_requests/endpoint_behaviour_spec.rb
@@ -300,10 +300,6 @@ RSpec.describe "Endpoint behaviour", type: :request do
         )
       }
 
-      before do
-        FactoryGirl.create(:lock_version, target: content_item, number: 2)
-      end
-
       it "responds with 200" do
         get "/v2/content/#{content_id}"
         expect(response.status).to eq(200)


### PR DESCRIPTION
This block appears to make the tests behave in a non-deterministic
manner as it creates a seconds entry in the lock version table which may
or may not get accessed to present the content item.

It also doesn't seem to add anything to the test or be part of what is
tested.