### PR TITLE
Loosen coupling between queues and particular Content Items

### DIFF
--- a/app/commands/v2/discard_draft.rb
+++ b/app/commands/v2/discard_draft.rb
@@ -13,7 +13,7 @@ module Commands
         increment_live_lock_version if live
 
         after_transaction_commit do
-          downstream_discard_draft(draft_path, draft.content_id, live.try(:id))
+          downstream_discard_draft(draft_path, draft.content_id, locale)
         end
 
         Success.new(content_id: content_id)
@@ -34,14 +34,14 @@ module Commands
         draft.destroy
       end
 
-      def downstream_discard_draft(path_used, content_id, live_content_item_id)
+      def downstream_discard_draft(path_used, content_id, locale)
         return unless downstream
 
         DownstreamDiscardDraftWorker.perform_async_in_queue(
           DownstreamDiscardDraftWorker::HIGH_QUEUE,
           base_path: path_used,
           content_id: content_id,
-          live_content_item_id: live_content_item_id,
+          locale: locale,
           payload_version: event.id,
           update_dependencies: true,
           alert_on_base_path_conflict: !nested

--- a/app/commands/v2/discard_draft.rb
+++ b/app/commands/v2/discard_draft.rb
@@ -44,7 +44,6 @@ module Commands
           locale: locale,
           payload_version: event.id,
           update_dependencies: true,
-          alert_on_base_path_conflict: !nested
         )
       end
 

--- a/app/commands/v2/put_content.rb
+++ b/app/commands/v2/put_content.rb
@@ -23,7 +23,7 @@ module Commands
         end
 
         after_transaction_commit do
-          send_downstream(content_item)
+          send_downstream(content_item.content_id, locale)
         end
 
         response_hash = Presenters::Queries::ContentItemPresenter.present(
@@ -266,14 +266,15 @@ module Commands
         payload.fetch(:bulk_publishing, false)
       end
 
-      def send_downstream(content_item)
+      def send_downstream(content_id, locale)
         return unless downstream
 
         queue = bulk_publishing? ? DownstreamDraftWorker::LOW_QUEUE : DownstreamDraftWorker::HIGH_QUEUE
 
         DownstreamDraftWorker.perform_async_in_queue(
           queue,
-          content_item_id: content_item.id,
+          content_id: content_id,
+          locale: locale,
           payload_version: event.id,
           update_dependencies: true,
         )

--- a/app/commands/v2/unpublish.rb
+++ b/app/commands/v2/unpublish.rb
@@ -92,14 +92,16 @@ module Commands
 
         DownstreamDraftWorker.perform_async_in_queue(
           DownstreamDraftWorker::HIGH_QUEUE,
-          content_item_id: content_item.id,
+          content_id: content_item.content_id,
+          locale: locale,
           payload_version: event.id,
           update_dependencies: true,
         )
 
         DownstreamLiveWorker.perform_async_in_queue(
           DownstreamLiveWorker::HIGH_QUEUE,
-          content_item_id: content_item.id,
+          content_id: content_item.content_id,
+          locale: locale,
           payload_version: event.id,
           update_dependencies: true,
         )

--- a/app/queries/locales_for_content_item.rb
+++ b/app/queries/locales_for_content_item.rb
@@ -1,0 +1,42 @@
+module Queries
+  module LocalesForContentItem
+    extend ArelHelpers
+
+    def self.call(
+      content_id,
+      states = %w[draft published unpublished],
+      include_substitutes = false
+    )
+      content_items_table = ContentItem.arel_table
+      translations_table = Translation.arel_table
+      states_table = State.arel_table
+
+      scope = translations_table
+        .project(translations_table[:locale]).distinct
+        .join(content_items_table).on(
+          content_items_table[:id].eq(translations_table[:content_item_id])
+        )
+        .join(states_table).on(
+          content_items_table[:id].eq(states_table[:content_item_id])
+        )
+        .where(content_items_table[:content_id].eq(content_id))
+        .where(states_table[:name].in(states))
+
+      unless include_substitutes
+        unpublishings_table = Unpublishing.arel_table
+
+        scope = scope.outer_join(unpublishings_table).on(
+          content_items_table[:id].eq(unpublishings_table[:content_item_id])
+            .and(states_table[:name].eq("unpublished"))
+          )
+          .where(
+            unpublishings_table[:type].eq(nil).or(
+              unpublishings_table[:type].not_eq("substitute")
+            )
+          )
+      end
+
+      get_rows(scope).map { |row| row["locale"] }
+    end
+  end
+end

--- a/app/workers/downstream_discard_draft_worker.rb
+++ b/app/workers/downstream_discard_draft_worker.rb
@@ -22,13 +22,13 @@ class DownstreamDiscardDraftWorker
 
     enqueue_dependencies if update_dependencies
   rescue DiscardDraftBasePathConflictError => e
-    alert_on_base_path_conflict ? notify_airbrake(e, args) : logger.warn(e.message)
+    logger.warn(e.message)
   end
 
 private
 
   attr_reader :base_path, :content_id, :locale, :web_content_item,
-    :payload_version, :update_dependencies, :alert_on_base_path_conflict
+    :payload_version, :update_dependencies
 
   def assign_attributes(attributes)
     @base_path = attributes.fetch(:base_path)
@@ -36,7 +36,6 @@ private
     assign_backwards_compatible_content_item(attributes)
     @payload_version = attributes.fetch(:payload_version)
     @update_dependencies = attributes.fetch(:update_dependencies, true)
-    @alert_on_base_path_conflict = attributes.fetch(:alert_on_base_path_conflict, true)
   end
 
   def assign_backwards_compatible_content_item(attributes)
@@ -57,9 +56,5 @@ private
       content_id: content_id,
       payload_version: payload_version,
     )
-  end
-
-  def notify_airbrake(error, parameters)
-    Airbrake.notify(error, parameters: parameters)
   end
 end

--- a/app/workers/downstream_discard_draft_worker.rb
+++ b/app/workers/downstream_discard_draft_worker.rb
@@ -5,6 +5,11 @@ class DownstreamDiscardDraftWorker
 
   sidekiq_options queue: HIGH_QUEUE
 
+  # FIXME: This worker can be initialised using a legacy interface with
+  # "live_content_item_id" and the updated interface which uses "locale".
+  # Both interfaces are supported until we are confident there are no longer
+  # items in the sidekiq queue. They should all be long gone by
+  # December 2016 and probably sooner.
   def perform(args = {})
     assign_attributes(args.symbolize_keys)
 

--- a/app/workers/downstream_discard_draft_worker.rb
+++ b/app/workers/downstream_discard_draft_worker.rb
@@ -1,8 +1,4 @@
 class DownstreamDiscardDraftWorker
-  attr_reader :base_path, :content_id, :live_content_item_id,
-    :live_web_content_item, :payload_version, :update_dependencies,
-    :alert_on_base_path_conflict
-
   include DownstreamQueue
   include Sidekiq::Worker
   include PerformAsyncInQueue
@@ -12,12 +8,12 @@ class DownstreamDiscardDraftWorker
   def perform(args = {})
     assign_attributes(args.symbolize_keys)
 
-    live_path = live_web_content_item.try(:base_path)
-    if live_path
+    current_path = web_content_item.try(:base_path)
+    if current_path
       DownstreamService.update_draft_content_store(
-        DownstreamPayload.new(live_web_content_item, payload_version, Adapters::ContentStore::DEPENDENCY_FALLBACK_ORDER)
+        DownstreamPayload.new(web_content_item, payload_version, Adapters::ContentStore::DEPENDENCY_FALLBACK_ORDER)
       )
-      if base_path && live_path != base_path
+      if base_path && current_path != base_path
         DownstreamService.discard_from_draft_content_store(base_path)
       end
     elsif base_path
@@ -27,22 +23,31 @@ class DownstreamDiscardDraftWorker
     enqueue_dependencies if update_dependencies
   rescue DiscardDraftBasePathConflictError => e
     alert_on_base_path_conflict ? notify_airbrake(e, args) : logger.warn(e.message)
-  rescue AbortWorkerError, DownstreamInvalidStateError => e
-    notify_airbrake(e, args)
   end
 
 private
 
+  attr_reader :base_path, :content_id, :locale, :web_content_item,
+    :payload_version, :update_dependencies, :alert_on_base_path_conflict
+
   def assign_attributes(attributes)
     @base_path = attributes.fetch(:base_path)
     @content_id = attributes.fetch(:content_id)
-    @live_content_item_id = attributes[:live_content_item_id]
-    if live_content_item_id
-      @live_web_content_item = Queries::GetWebContentItems.find(live_content_item_id)
-    end
+    assign_backwards_compatible_content_item(attributes)
     @payload_version = attributes.fetch(:payload_version)
     @update_dependencies = attributes.fetch(:update_dependencies, true)
     @alert_on_base_path_conflict = attributes.fetch(:alert_on_base_path_conflict, true)
+  end
+
+  def assign_backwards_compatible_content_item(attributes)
+    if attributes[:locale]
+      @locale = attributes[:locale]
+      @web_content_item = Queries::GetWebContentItems.for_content_store(content_id, locale, true)
+    else
+      content_item_id = attributes[:live_content_item_id]
+      @web_content_item = content_item_id ? Queries::GetWebContentItems.find(content_item_id) : nil
+      @locale = web_content_item.try(:locale)
+    end
   end
 
   def enqueue_dependencies

--- a/app/workers/downstream_draft_worker.rb
+++ b/app/workers/downstream_draft_worker.rb
@@ -1,10 +1,6 @@
 require 'sidekiq-unique-jobs'
 
 class DownstreamDraftWorker
-  attr_reader :web_content_item, :content_item_id, :payload_version,
-    :update_dependencies, :alert_on_invalid_state_error,
-    :dependency_resolution_source_content_id
-
   include DownstreamQueue
   include Sidekiq::Worker
   include PerformAsyncInQueue
@@ -15,7 +11,8 @@ class DownstreamDraftWorker
 
   def self.uniq_args(args)
     [
-      args.first.fetch("content_item_id"),
+      args.first["content_id"] || args.first["content_item_id"],
+      args.first["locale"],
       args.first.fetch("update_dependencies", true),
       name,
     ]
@@ -25,7 +22,7 @@ class DownstreamDraftWorker
     assign_attributes(args.symbolize_keys)
 
     unless web_content_item
-      raise AbortWorkerError.new("The content item for id: #{content_item_id} was not found")
+      raise AbortWorkerError.new("A downstreamable content item was not found for content_id: #{content_id} and locale: #{locale}")
     end
 
     unless dependency_resolution_source_content_id.nil?
@@ -41,31 +38,45 @@ class DownstreamDraftWorker
     end
 
     enqueue_dependencies if update_dependencies
-  rescue DownstreamInvalidStateError => e
-    alert_on_invalid_state_error ? notify_airbrake(e, args) : logger.warn(e.message)
   rescue AbortWorkerError => e
     notify_airbrake(e, args)
   end
 
 private
 
+  attr_reader :content_id, :locale, :web_content_item, :payload_version,
+    :update_dependencies, :dependency_resolution_source_content_id
+
   def assign_attributes(attributes)
-    @content_item_id = attributes.fetch(:content_item_id)
-    @web_content_item = Queries::GetWebContentItems.find(content_item_id)
+    assign_backwards_compatible_content_item(attributes)
+    @web_content_item = Queries::GetWebContentItems.for_content_store(content_id, locale, true)
     @payload_version = attributes.fetch(:payload_version)
     @update_dependencies = attributes.fetch(:update_dependencies, true)
-    @alert_on_invalid_state_error = attributes.fetch(:alert_on_invalid_state_error, true)
     @dependency_resolution_source_content_id = attributes.fetch(
       :dependency_resolution_source_content_id,
       nil
     )
   end
 
+  def assign_backwards_compatible_content_item(attributes)
+    if attributes[:content_item_id]
+      web_content_item = Queries::GetWebContentItems.find(attributes[:content_item_id])
+      unless web_content_item
+        raise AbortWorkerError.new("A content item was not found for content_item_id: #{attributes[:content_item_id]}")
+      end
+      @content_id = web_content_item.content_id
+      @locale = web_content_item.locale
+    else
+      @content_id = attributes.fetch(:content_id)
+      @locale = attributes.fetch(:locale)
+    end
+  end
+
   def enqueue_dependencies
     DependencyResolutionWorker.perform_async(
       content_store: Adapters::DraftContentStore,
       fields: [:content_id],
-      content_id: web_content_item.content_id,
+      content_id: content_id,
       payload_version: payload_version
     )
   end

--- a/app/workers/downstream_draft_worker.rb
+++ b/app/workers/downstream_draft_worker.rb
@@ -18,6 +18,11 @@ class DownstreamDraftWorker
     ]
   end
 
+  # FIXME: This worker can be initialised using a legacy interface with
+  # "content_item_id" and the updated interface which uses "content_id" and
+  # "locale". Both interfaces are supported until we are confident there are
+  # no longer items in the sidekiq queue. They should all be long gone by
+  # December 2016 and probably sooner.
   def perform(args = {})
     assign_attributes(args.symbolize_keys)
 

--- a/app/workers/downstream_live_worker.rb
+++ b/app/workers/downstream_live_worker.rb
@@ -19,6 +19,11 @@ class DownstreamLiveWorker
     ]
   end
 
+  # FIXME: This worker can be initialised using a legacy interface with
+  # "content_item_id" and the updated interface which uses "content_id" and
+  # "locale". Both interfaces are supported until we are confident there are
+  # no longer items in the sidekiq queue. They should all be long gone by
+  # December 2016 and probably sooner.
   def perform(args = {})
     assign_attributes(args.symbolize_keys)
 

--- a/app/workers/downstream_live_worker.rb
+++ b/app/workers/downstream_live_worker.rb
@@ -1,10 +1,6 @@
 require 'sidekiq-unique-jobs'
 
 class DownstreamLiveWorker
-  attr_reader :content_item_id, :web_content_item, :payload_version,
-    :message_queue_update_type, :update_dependencies,
-    :alert_on_invalid_state_error, :dependency_resolution_source_content_id
-
   include DownstreamQueue
   include Sidekiq::Worker
   include PerformAsyncInQueue
@@ -15,8 +11,9 @@ class DownstreamLiveWorker
 
   def self.uniq_args(args)
     [
-      args.first.fetch("content_item_id"),
-      args.first.fetch("message_queue_update_type", nil),
+      args.first["content_id"] || args.first["content_item_id"],
+      args.first["locale"],
+      args.first["message_queue_update_type"],
       args.first.fetch("update_dependencies", true),
       name,
     ]
@@ -26,7 +23,7 @@ class DownstreamLiveWorker
     assign_attributes(args.symbolize_keys)
 
     unless web_content_item
-      raise AbortWorkerError.new("The content item for id: #{content_item_id} was not found")
+      raise AbortWorkerError.new("A downstreamable content item was not found for content_id: #{content_id} and locale: #{locale}")
     end
 
     unless dependency_resolution_source_content_id.nil?
@@ -45,25 +42,40 @@ class DownstreamLiveWorker
     end
 
     enqueue_dependencies if update_dependencies
-  rescue DownstreamInvalidStateError => e
-    alert_on_invalid_state_error ? notify_airbrake(e, args) : logger.warn(e.message)
   rescue AbortWorkerError => e
     notify_airbrake(e, args)
   end
 
 private
 
+  attr_reader :content_id, :locale, :web_content_item, :payload_version,
+    :message_queue_update_type, :update_dependencies,
+    :dependency_resolution_source_content_id
+
   def assign_attributes(attributes)
-    @content_item_id = attributes.fetch(:content_item_id)
-    @web_content_item = Queries::GetWebContentItems.find(content_item_id)
+    assign_backwards_compatible_content_item(attributes)
+    @web_content_item = Queries::GetWebContentItems.for_content_store(content_id, locale, false)
     @payload_version = attributes.fetch(:payload_version)
     @message_queue_update_type = attributes.fetch(:message_queue_update_type, nil)
     @update_dependencies = attributes.fetch(:update_dependencies, true)
-    @alert_on_invalid_state_error = attributes.fetch(:alert_on_invalid_state_error, true)
     @dependency_resolution_source_content_id = attributes.fetch(
       :dependency_resolution_source_content_id,
       nil
     )
+  end
+
+  def assign_backwards_compatible_content_item(attributes)
+    if attributes[:content_item_id]
+      web_content_item = Queries::GetWebContentItems.find(attributes[:content_item_id])
+      unless web_content_item
+        raise AbortWorkerError.new("A content item was not found for content_item_id: #{attributes[:content_item_id]}")
+      end
+      @content_id = web_content_item.content_id
+      @locale = web_content_item.locale
+    else
+      @content_id = attributes.fetch(:content_id)
+      @locale = attributes.fetch(:locale)
+    end
   end
 
   def enqueue_dependencies

--- a/spec/commands/v2/discard_draft_spec.rb
+++ b/spec/commands/v2/discard_draft_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Commands::V2::DiscardDraft do
 
     context "when a draft content item exists for the given content_id" do
       let(:user_facing_version) { 2 }
-      let!(:existing_draft_item) {
+      let!(:existing_draft_item) do
         FactoryGirl.create(:access_limited_draft_content_item,
           content_id: content_id,
           base_path: base_path,
@@ -28,7 +28,7 @@ RSpec.describe Commands::V2::DiscardDraft do
           lock_version: 5,
           user_facing_version: user_facing_version,
         )
-      }
+      end
 
       it "deletes the draft item" do
         expect {
@@ -91,7 +91,7 @@ RSpec.describe Commands::V2::DiscardDraft do
       end
 
       context "a published content item exists with the same base_path" do
-        let!(:published_item) {
+        let!(:published_item) do
           FactoryGirl.create(:live_content_item,
             content_id: content_id,
             lock_version: 3,
@@ -99,7 +99,7 @@ RSpec.describe Commands::V2::DiscardDraft do
             locale: locale,
             user_facing_version: user_facing_version - 1,
           )
-        }
+        end
 
         it "increments the lock version of the published item" do
           published_lock_version = LockVersion.find_by!(target: published_item)
@@ -148,7 +148,7 @@ RSpec.describe Commands::V2::DiscardDraft do
       end
 
       context "a published content item exists with a different base_path" do
-        let!(:published_item) {
+        let!(:published_item) do
           FactoryGirl.create(:live_content_item,
             content_id: content_id,
             lock_version: 3,
@@ -156,7 +156,7 @@ RSpec.describe Commands::V2::DiscardDraft do
             locale: locale,
             user_facing_version: user_facing_version - 1,
           )
-        }
+        end
 
         it "it uses downstream discard draft worker" do
           expect(DownstreamDiscardDraftWorker).to receive(:perform_async_in_queue)
@@ -173,14 +173,14 @@ RSpec.describe Commands::V2::DiscardDraft do
       end
 
       context "an unpublished content item exits" do
-        let(:unpublished_item) {
+        let(:unpublished_item) do
           FactoryGirl.create(:unpublished_content_item,
             base_path: base_path,
             content_id: content_id,
             locale: locale,
             user_facing_version: user_facing_version - 1,
           )
-        }
+        end
 
         it "it uses downstream discard draft worker" do
           expect(DownstreamDiscardDraftWorker).to receive(:perform_async_in_queue)
@@ -197,13 +197,13 @@ RSpec.describe Commands::V2::DiscardDraft do
       end
 
       context "when a locale is provided in the payload" do
-        let!(:french_draft_item) {
+        let!(:french_draft_item) do
           FactoryGirl.create(:draft_content_item,
             content_id: content_id,
             base_path: "#{base_path}.fr",
             locale: "fr",
           )
-        }
+        end
 
         before do
           payload.merge!(locale: "fr")

--- a/spec/commands/v2/discard_draft_spec.rb
+++ b/spec/commands/v2/discard_draft_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe Commands::V2::DiscardDraft do
 
     let(:expected_content_store_payload) { { base_path: "/vat-rates" } }
     let(:content_id) { SecureRandom.uuid }
+    let(:locale) { "en" }
     let(:base_path) { "/vat-rates" }
     let(:payload) { { content_id: content_id } }
 
@@ -23,6 +24,7 @@ RSpec.describe Commands::V2::DiscardDraft do
         FactoryGirl.create(:access_limited_draft_content_item,
           content_id: content_id,
           base_path: base_path,
+          locale: locale,
           lock_version: 5,
           user_facing_version: user_facing_version,
         )
@@ -58,7 +60,7 @@ RSpec.describe Commands::V2::DiscardDraft do
         expect(DownstreamDiscardDraftWorker).to receive(:perform_async_in_queue)
           .with(
             "downstream_high",
-            a_hash_including(base_path: base_path, content_id: content_id),
+            a_hash_including(base_path: base_path, content_id: content_id, locale: locale),
           )
 
         described_class.call(payload)
@@ -94,6 +96,7 @@ RSpec.describe Commands::V2::DiscardDraft do
             content_id: content_id,
             lock_version: 3,
             base_path: base_path,
+            locale: locale,
             user_facing_version: user_facing_version - 1,
           )
         }
@@ -113,7 +116,7 @@ RSpec.describe Commands::V2::DiscardDraft do
               a_hash_including(
                 base_path: base_path,
                 content_id: content_id,
-                live_content_item_id: published_item.id,
+                locale: locale,
               ),
             )
           described_class.call(payload)
@@ -150,6 +153,7 @@ RSpec.describe Commands::V2::DiscardDraft do
             content_id: content_id,
             lock_version: 3,
             base_path: "/hat-rates",
+            locale: locale,
             user_facing_version: user_facing_version - 1,
           )
         }
@@ -161,7 +165,7 @@ RSpec.describe Commands::V2::DiscardDraft do
               a_hash_including(
                 base_path: base_path,
                 content_id: content_id,
-                live_content_item_id: published_item.id,
+                locale: locale,
               ),
             )
           described_class.call(payload)
@@ -173,6 +177,7 @@ RSpec.describe Commands::V2::DiscardDraft do
           FactoryGirl.create(:unpublished_content_item,
             base_path: base_path,
             content_id: content_id,
+            locale: locale,
             user_facing_version: user_facing_version - 1,
           )
         }
@@ -184,7 +189,7 @@ RSpec.describe Commands::V2::DiscardDraft do
               a_hash_including(
                 base_path: base_path,
                 content_id: content_id,
-                live_content_item_id: unpublished_item.id,
+                locale: locale,
               ),
             )
           described_class.call(payload)

--- a/spec/commands/v2/publish_spec.rb
+++ b/spec/commands/v2/publish_spec.rb
@@ -108,12 +108,12 @@ RSpec.describe Commands::V2::Publish do
     context "with another content item blocking the publish action" do
       let(:draft_locale) { Translation.find_by!(content_item: draft_item).locale }
 
-      let!(:other_content_item) {
+      let!(:other_content_item) do
         FactoryGirl.create(:redirect_live_content_item,
           locale: draft_locale,
           base_path: base_path,
         )
-      }
+      end
 
       it "unpublishes the content item which is in the way" do
         described_class.call(payload)

--- a/spec/commands/v2/publish_spec.rb
+++ b/spec/commands/v2/publish_spec.rb
@@ -3,6 +3,7 @@ require "rails_helper"
 RSpec.describe Commands::V2::Publish do
   describe "call" do
     let(:base_path) { "/vat-rates" }
+    let(:locale) { "en" }
     let(:user_facing_version) { 5 }
 
     let!(:draft_item) do
@@ -11,6 +12,7 @@ RSpec.describe Commands::V2::Publish do
         content_id: content_id,
         lock_version: 2,
         base_path: base_path,
+        locale: locale,
         user_facing_version: user_facing_version,
       )
     end
@@ -152,7 +154,7 @@ RSpec.describe Commands::V2::Publish do
           .to receive(:perform_async_in_queue)
           .with(
             "downstream_high",
-            a_hash_including(:content_item_id, :payload_version),
+            a_hash_including(:content_id, :locale, :payload_version),
           )
 
         described_class.call(payload)
@@ -239,7 +241,7 @@ RSpec.describe Commands::V2::Publish do
               .to receive(:perform_async_in_queue)
               .with(
                 "downstream_low",
-                a_hash_including(:content_item_id, :payload_version, message_queue_update_type: "republish"),
+                a_hash_including(:content_id, :locale, :payload_version, message_queue_update_type: "republish"),
               )
 
             described_class.call(payload)

--- a/spec/commands/v2/put_content_spec.rb
+++ b/spec/commands/v2/put_content_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Commands::V2::PutContent do
       expect(DownstreamDraftWorker).to receive(:perform_async_in_queue)
         .with(
           "downstream_high",
-          a_hash_including(:content_item_id, :payload_version, update_dependencies: true),
+          a_hash_including(:content_id, :locale, :payload_version, update_dependencies: true),
         )
 
       described_class.call(payload)

--- a/spec/commands/v2/put_content_spec.rb
+++ b/spec/commands/v2/put_content_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Commands::V2::PutContent do
     let(:base_path) { "/vat-rates" }
     let(:locale) { "en" }
 
-    let(:payload) {
+    let(:payload) do
       {
         content_id: content_id,
         base_path: base_path,
@@ -26,7 +26,7 @@ RSpec.describe Commands::V2::PutContent do
         redirects: [],
         phase: "beta",
       }
-    }
+    end
 
     it "sends to the downstream draft worker" do
       expect(DownstreamDraftWorker).to receive(:perform_async_in_queue)
@@ -322,7 +322,7 @@ RSpec.describe Commands::V2::PutContent do
     end
 
     context "when the payload is for an already drafted content item" do
-      let!(:previously_drafted_item) {
+      let!(:previously_drafted_item) do
         FactoryGirl.create(:draft_content_item,
           content_id: content_id,
           base_path: base_path,
@@ -330,7 +330,7 @@ RSpec.describe Commands::V2::PutContent do
           lock_version: 1,
           publishing_app: "publisher",
         )
-      }
+      end
 
       it "updates the content item" do
         described_class.call(payload)
@@ -433,7 +433,7 @@ RSpec.describe Commands::V2::PutContent do
         end
 
         context "when there is a draft at the new base path" do
-          let!(:substitute_item) {
+          let!(:substitute_item) do
             FactoryGirl.create(:draft_content_item,
               content_id: SecureRandom.uuid,
               base_path: base_path,
@@ -442,7 +442,7 @@ RSpec.describe Commands::V2::PutContent do
               publishing_app: "publisher",
               document_type: "coming_soon",
             )
-          }
+          end
 
           it "deletes the substitute item" do
             described_class.call(payload)
@@ -501,9 +501,9 @@ RSpec.describe Commands::V2::PutContent do
       end
 
       context "when the previous draft has an access limit" do
-        let!(:access_limit) {
+        let!(:access_limit) do
           FactoryGirl.create(:access_limit, content_item: previously_drafted_item, users: ["old-user"])
-        }
+        end
 
         context "when the params includes an access limit" do
           before do
@@ -732,11 +732,11 @@ RSpec.describe Commands::V2::PutContent do
     end
 
     context "when the draft does exist" do
-      let!(:content_item) {
+      let!(:content_item) do
         FactoryGirl.create(:draft_content_item,
           content_id: content_id,
         )
-      }
+      end
 
       context "with a provided last_edited_at" do
         %w(minor major republish).each do |update_type|

--- a/spec/commands/v2/unpublish_spec.rb
+++ b/spec/commands/v2/unpublish_spec.rb
@@ -3,6 +3,7 @@ require "rails_helper"
 RSpec.describe Commands::V2::Unpublish do
   let(:content_id) { SecureRandom.uuid }
   let(:base_path) { "/vat-rates" }
+  let(:locale) { "en" }
 
   describe "call" do
     let(:payload) do
@@ -23,6 +24,7 @@ RSpec.describe Commands::V2::Unpublish do
         FactoryGirl.create(:live_content_item,
           content_id: content_id,
           base_path: base_path,
+          locale: locale,
         )
       end
 
@@ -57,6 +59,7 @@ RSpec.describe Commands::V2::Unpublish do
         FactoryGirl.create(:live_content_item,
           content_id: content_id,
           base_path: base_path,
+          locale: locale,
         )
       end
 
@@ -80,12 +83,12 @@ RSpec.describe Commands::V2::Unpublish do
         expect(DownstreamDraftWorker).to receive(:perform_async_in_queue)
           .with(
             "downstream_high",
-            a_hash_including(content_item_id: live_content_item.id)
+            a_hash_including(content_id: content_id, locale: locale)
           )
         expect(DownstreamLiveWorker).to receive(:perform_async_in_queue)
           .with(
             "downstream_high",
-            a_hash_including(content_item_id: live_content_item.id)
+            a_hash_including(content_id: content_id, locale: locale)
           )
 
         described_class.call(payload)
@@ -114,6 +117,7 @@ RSpec.describe Commands::V2::Unpublish do
           :draft_content_item,
           content_id: content_id,
           user_facing_version: 3,
+          locale: locale,
         )
       end
 
@@ -152,7 +156,7 @@ RSpec.describe Commands::V2::Unpublish do
           expect(DownstreamLiveWorker).to receive(:perform_async_in_queue)
             .with(
               "downstream_high",
-              a_hash_including(content_item_id: draft_content_item.id)
+              a_hash_including(content_id: content_id, locale: locale)
             )
 
           described_class.call(payload_with_allow_draft)
@@ -228,6 +232,7 @@ RSpec.describe Commands::V2::Unpublish do
             FactoryGirl.create(:live_content_item,
               content_id: content_id,
               base_path: base_path,
+              locale: locale,
               user_facing_version: 1,
             )
           end
@@ -258,6 +263,7 @@ RSpec.describe Commands::V2::Unpublish do
           :live_content_item,
           :with_draft,
           content_id: content_id,
+          locale: locale,
         )
       end
 
@@ -307,6 +313,7 @@ RSpec.describe Commands::V2::Unpublish do
         FactoryGirl.create(:unpublished_content_item,
           content_id: content_id,
           base_path: base_path,
+          locale: locale,
           explanation: "This explnatin has a typo",
           alternative_path: "/new-path",
         )
@@ -336,7 +343,7 @@ RSpec.describe Commands::V2::Unpublish do
         expect(DownstreamDraftWorker).to receive(:perform_async_in_queue)
           .with(
             "downstream_high",
-            a_hash_including(content_item_id: unpublished_content_item.id)
+            a_hash_including(content_id: content_id)
           )
 
         described_class.call(payload)
@@ -346,7 +353,7 @@ RSpec.describe Commands::V2::Unpublish do
         expect(DownstreamDraftWorker).to receive(:perform_async_in_queue)
           .with(
             "downstream_high",
-            a_hash_including(content_item_id: unpublished_content_item.id)
+            a_hash_including(content_id: content_id)
           )
 
         described_class.call(payload)
@@ -356,7 +363,7 @@ RSpec.describe Commands::V2::Unpublish do
         expect(DownstreamLiveWorker).to receive(:perform_async_in_queue)
           .with(
             "downstream_high",
-            a_hash_including(content_item_id: unpublished_content_item.id)
+            a_hash_including(content_id: content_id)
           )
 
         described_class.call(payload)
@@ -366,6 +373,7 @@ RSpec.describe Commands::V2::Unpublish do
         let!(:unpublished_content_item) do
           FactoryGirl.create(:substitute_unpublished_content_item,
             content_id: content_id,
+            locale: locale,
           )
         end
 
@@ -384,6 +392,7 @@ RSpec.describe Commands::V2::Unpublish do
       before do
         FactoryGirl.create(:live_content_item, :with_draft,
           content_id: content_id,
+          locale: locale,
         )
       end
 
@@ -436,6 +445,7 @@ RSpec.describe Commands::V2::Unpublish do
       let!(:live_content_item) do
         FactoryGirl.create(:live_content_item,
           content_id: content_id,
+          locale: locale,
           base_path: nil,
         )
       end

--- a/spec/queries/locales_for_content_item_spec.rb
+++ b/spec/queries/locales_for_content_item_spec.rb
@@ -1,0 +1,111 @@
+require "rails_helper"
+
+RSpec.describe Queries::LocalesForContentItem do
+  describe '.call' do
+    let(:base_content_id) { "05626609-f046-41cc-ba84-a07d1064ac96" }
+    let(:content_id) { base_content_id }
+    let(:states) { %w[draft published unpublished] }
+    let(:include_substitutes) { false }
+
+    subject { described_class.call(content_id, states, include_substitutes) }
+
+    before do
+      FactoryGirl.create(
+        :live_content_item,
+        content_id: base_content_id,
+        locale: "en",
+        base_path: "/vat-en",
+        user_facing_version: 1,
+      )
+
+      FactoryGirl.create(
+        :draft_content_item,
+        content_id: base_content_id,
+        locale: "en",
+        base_path: "/vat-en",
+        user_facing_version: 2,
+      )
+
+      FactoryGirl.create(
+        :draft_content_item,
+        content_id: base_content_id,
+        locale: "fr",
+        base_path: "/vat-fr",
+        user_facing_version: 1,
+      )
+
+      FactoryGirl.create(
+        :unpublished_content_item,
+        content_id: base_content_id,
+        locale: "es",
+        base_path: "/vat-es",
+        user_facing_version: 1,
+      )
+
+      FactoryGirl.create(
+        :superseded_content_item,
+        content_id: base_content_id,
+        locale: "de",
+        base_path: "/vat-de",
+        user_facing_version: 1,
+      )
+
+      FactoryGirl.create(
+        :substitute_unpublished_content_item,
+        content_id: base_content_id,
+        locale: "cy",
+        base_path: "/vat-cy",
+        user_facing_version: 1,
+      )
+    end
+
+    it { is_expected.to be_a(Array) }
+
+    context "where there are no content items for the content id" do
+      let(:content_id) { "43466ca6-46d4-4a92-9783-c29a40cc77e3" }
+      it { is_expected.to be_empty }
+    end
+
+    context "when we access draft, published and unpublished content items, excluding substitute unpublishings" do
+      let(:states) { %w[draft published unpublished] }
+      let(:include_substitutes) { false }
+      it { is_expected.to match_array(%w[en fr es]) }
+
+      context "when states are symbols" do
+        let(:states) { %i[draft published unpublished] }
+        it { is_expected.to match_array(%w[en fr es]) }
+      end
+    end
+
+    context "when we access draft items" do
+      let(:states) { %w[draft] }
+
+      it { is_expected.to match_array(%w[en fr]) }
+    end
+
+    context "when we access published items" do
+      let(:states) { %w[published] }
+
+      it { is_expected.to match_array(%w[en]) }
+    end
+
+    context "when we access unpublished items, without substitutes" do
+      let(:states) { %w[unpublished] }
+
+      it { is_expected.to match_array(%w[es]) }
+    end
+
+    context "when we access unpublished items, with substitutes" do
+      let(:states) { %w[unpublished] }
+      let(:include_substitutes) { true }
+
+      it { is_expected.to match_array(%w[es cy]) }
+    end
+
+    context "when we access superseded items" do
+      let(:states) { %w[superseded] }
+
+      it { is_expected.to match_array(%w[de]) }
+    end
+  end
+end

--- a/spec/workers/dependency_resolution_worker_spec.rb
+++ b/spec/workers/dependency_resolution_worker_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe DependencyResolutionWorker, :perform do
-  let(:live_content_item) { FactoryGirl.create(:live_content_item) }
+  let(:live_content_item) { FactoryGirl.create(:live_content_item, locale: "en") }
 
   subject(:worker_perform) do
     described_class.new.perform(content_id: "123",
@@ -31,7 +31,8 @@ RSpec.describe DependencyResolutionWorker, :perform do
     expect(DownstreamLiveWorker).to receive(:perform_async_in_queue).with(
       "downstream_low",
       a_hash_including(
-        :content_item_id,
+        :content_id,
+        :locale,
         :payload_version,
         message_queue_update_type: "links",
         update_dependencies: false,
@@ -45,6 +46,7 @@ RSpec.describe DependencyResolutionWorker, :perform do
     let!(:draft_content_item) {
       FactoryGirl.create(:draft_content_item,
         content_id: live_content_item.content_id,
+        locale: "en",
         user_facing_version: 2,
       )
     }
@@ -53,7 +55,8 @@ RSpec.describe DependencyResolutionWorker, :perform do
       expect(DownstreamLiveWorker).to receive(:perform_async_in_queue).with(
         anything,
         a_hash_including(
-          content_item_id: live_content_item.id,
+          content_id: live_content_item.content_id,
+          locale: "en",
         )
       )
 
@@ -69,7 +72,8 @@ RSpec.describe DependencyResolutionWorker, :perform do
       expect(DownstreamDraftWorker).to receive(:perform_async_in_queue).with(
         anything,
         a_hash_including(
-          content_item_id: draft_content_item.id,
+          content_id: draft_content_item.content_id,
+          locale: "en",
         )
       )
 

--- a/spec/workers/downstream_live_worker_spec.rb
+++ b/spec/workers/downstream_live_worker_spec.rb
@@ -1,16 +1,20 @@
 require "rails_helper"
 
 RSpec.describe DownstreamLiveWorker do
-  let(:content_item) { FactoryGirl.create(:live_content_item, base_path: "/foo") }
-  let(:base_arguments) {
+  let(:content_item) do
+    FactoryGirl.create(:live_content_item, base_path: "/foo", locale: "en")
+  end
+
+  let(:base_arguments) do
     {
-      "content_item_id" => content_item.id,
+      "content_id" => content_item.content_id,
+      "locale" => "en",
       "payload_version" => 1,
       "message_queue_update_type" => "major",
       "update_dependencies" => true,
-      "alert_on_invariant_error" => true,
     }
-  }
+  end
+
   let(:arguments) { base_arguments }
 
   before do
@@ -18,10 +22,13 @@ RSpec.describe DownstreamLiveWorker do
   end
 
   describe "arguments" do
-    it "requires content_item_id" do
+    it "requires content_item_id or content_id" do
       expect {
-        subject.perform(arguments.except("content_item_id"))
+        subject.perform(arguments.except("content_id"))
       }.to raise_error(KeyError)
+      expect {
+        subject.perform(arguments.merge("content_item_id" => content_item.id))
+      }.not_to raise_error
     end
 
     it "requires payload_version" do
@@ -39,12 +46,6 @@ RSpec.describe DownstreamLiveWorker do
     it "doesn't require update_dependencies" do
       expect {
         subject.perform(arguments.except("update_dependencies"))
-      }.not_to raise_error
-    end
-
-    it "doesn't require alert_on_invalid_state_error" do
-      expect {
-        subject.perform(arguments.except("alert_on_invalid_state_error"))
       }.not_to raise_error
     end
   end
@@ -78,7 +79,7 @@ RSpec.describe DownstreamLiveWorker do
 
       it "absorbs an error" do
         expect(Airbrake).to receive(:notify)
-          .with(an_instance_of(DownstreamInvalidStateError), a_hash_including(:parameters))
+          .with(an_instance_of(AbortWorkerError), a_hash_including(:parameters))
         subject.perform(superseded_arguments)
       end
     end
@@ -131,7 +132,7 @@ RSpec.describe DownstreamLiveWorker do
       draft = FactoryGirl.create(:draft_content_item)
 
       expect(Airbrake).to receive(:notify)
-        .with(an_instance_of(DownstreamInvalidStateError), a_hash_including(:parameters))
+        .with(an_instance_of(AbortWorkerError), a_hash_including(:parameters))
       subject.perform(arguments.merge("content_item_id" => draft.id))
     end
 
@@ -148,43 +149,6 @@ RSpec.describe DownstreamLiveWorker do
       expect(Airbrake).to receive(:notify)
         .with(an_instance_of(AbortWorkerError), a_hash_including(:parameters))
       subject.perform(arguments.merge("content_item_id" => "made-up-id"))
-    end
-  end
-
-  describe "error alerting" do
-    let(:message) { "Can only send published and unpublished items to the live content store" }
-    let(:logger) { Sidekiq::Logging.logger }
-
-    before do
-      allow(DownstreamService).to receive(:update_live_content_store)
-        .and_raise(DownstreamInvalidStateError, message)
-    end
-
-    context "when alert_on_invalid_state_error is true" do
-      let(:arguments) { base_arguments.merge("alert_on_invalid_state_error" => true) }
-      it "notifies airbrake" do
-        expect(Airbrake).to receive(:notify)
-        subject.perform(arguments)
-      end
-
-      it "doesn't log the message" do
-        expect(logger).to_not receive(:warn).with(message)
-        subject.perform(arguments)
-      end
-    end
-
-    context "when alert_on_invalid_state_error is false" do
-      let(:arguments) { base_arguments.merge("alert_on_invalid_state_error" => false) }
-
-      it "doesn't notify airbrake" do
-        expect(Airbrake).to_not receive(:notify)
-        subject.perform(arguments)
-      end
-
-      it "logs the message" do
-        expect(logger).to receive(:warn).with(message)
-        subject.perform(arguments)
-      end
     end
   end
 end


### PR DESCRIPTION
This changes how we approach downstreaming content items. Previously we would downstream a content item with a particular id and reject it if the state of the item was unsuitable for downstreaming. Instead we now enqueue the content_id and locale which will look up the latest version of the content item and downstream that.

This provides us with a couple of advantages:

1. We should get less items in the Sidekiq queue as it will not be populated by multiple versions of the same content item.
2. We should have less DownstreamInvalidState errors as these will only be possible if the state of a content item changes during downstreaming.
3. We will broadcast each type of update enqueued to the message queue. Previously these could be rejected if the state was superseded.

We no longer catch exceptions from DownstreamInvalidState, instead these continue up to Sidekiq as a means a trigger a job to retry. Since we run unique jobs based on content_id and locale it is important that as many jobs as possible run even if they require a retry.

These changes are intended to be backwards compatible with the existing items queued into the workers. Once we have cleared the Sidekiq queues of items with the old definitions we can refactor the workers to remove the backwards compatible aspects.

Also, it looks like this fixes an undiscovered issue where dependency resolution could miss updating multiple locales of a content item. 