### PR TITLE
Add ChangeNote to manage ContentItem change history

### DIFF
--- a/app/commands/v2/publish.rb
+++ b/app/commands/v2/publish.rb
@@ -32,6 +32,8 @@ module Commands
 
         State.supersede(previous_item) if previous_item
 
+        delete_change_notes_if_not_major_update(content_item, update_type)
+
         unless content_item.pathless?
           if previous_item
             previous_location = Location.find_by(content_item: previous_item)
@@ -58,6 +60,12 @@ module Commands
       end
 
     private
+
+      def delete_change_notes_if_not_major_update(content_item, update_type)
+        unless update_type == "major"
+          ChangeNote.delete_all(content_item: content_item)
+        end
+      end
 
       def content_id
         payload[:content_id]

--- a/app/commands/v2/put_content.rb
+++ b/app/commands/v2/put_content.rb
@@ -22,6 +22,8 @@ module Commands
           fill_out_new_content_item(content_item)
         end
 
+        ChangeNote.create_from_content_item(payload, content_item)
+
         after_transaction_commit do
           send_downstream(content_item.content_id, locale)
         end

--- a/app/models/change_note.rb
+++ b/app/models/change_note.rb
@@ -1,0 +1,57 @@
+class ChangeNote < ActiveRecord::Base
+  belongs_to :content_item
+
+  def self.create_from_content_item(payload, content_item)
+    ChangeNoteFactory.new(payload, content_item).build
+  end
+end
+
+class ChangeNoteFactory
+  def initialize(payload, content_item)
+    @payload = payload
+    @content_item = content_item
+  end
+
+  def build
+    return unless content_item.update_type == "major"
+    create_from_top_level_change_note ||
+      create_from_details_hash_change_note ||
+      create_from_details_hash_change_history
+  end
+
+private
+
+  attr_reader :payload, :content_item
+
+  def create_from_top_level_change_note
+    return unless change_note
+    ChangeNote.create!(change_note.merge(content_item: content_item))
+  end
+
+  def create_from_details_hash_change_note
+    return unless note
+    ChangeNote.create!(
+      content_item: content_item,
+      public_timestamp: content_item.updated_at,
+      note: note,
+    )
+  end
+
+  def create_from_details_hash_change_history
+    return unless history
+    history_element = history.sort_by { |h| h[:public_timestamp] }.last
+    ChangeNote.create!(history_element.merge(content_item: content_item))
+  end
+
+  def change_note
+    payload[:change_note]
+  end
+
+  def note
+    content_item.details[:change_note]
+  end
+
+  def history
+    content_item.details[:change_history]
+  end
+end

--- a/app/presenters/change_history_presenter.rb
+++ b/app/presenters/change_history_presenter.rb
@@ -1,0 +1,23 @@
+module Presenters
+  class ChangeHistoryPresenter
+    attr_reader :content_item
+
+    def initialize(content_item)
+      @content_item = content_item
+    end
+
+    def change_history
+      content_item.details[:change_history] || change_notes_for_content_item
+    end
+
+  private
+
+    def change_notes_for_content_item
+      ChangeNote
+        .joins(:content_item)
+        .where("content_items.content_id" => content_item.content_id)
+        .order(public_timestamp: :desc)
+        .map { |cn| cn.slice(:note, :public_timestamp) }
+    end
+  end
+end

--- a/app/presenters/change_history_presenter.rb
+++ b/app/presenters/change_history_presenter.rb
@@ -16,8 +16,17 @@ module Presenters
       ChangeNote
         .joins(:content_item)
         .where("content_items.content_id" => content_item.content_id)
+        .joins("INNER JOIN user_facing_versions ON user_facing_versions.content_item_id = content_items.id")
+        .where("user_facing_versions.number <= ?", version_number)
         .order(public_timestamp: :desc)
-        .map { |cn| cn.slice(:note, :public_timestamp) }
+        .pluck(:note, :public_timestamp)
+        .map do |note, timestamp|
+          { note: note, public_timestamp: timestamp }.stringify_keys
+        end
+    end
+
+    def version_number
+      UserFacingVersion.where(content_item_id: content_item.id).last.number
     end
   end
 end

--- a/app/presenters/details_presenter.rb
+++ b/app/presenters/details_presenter.rb
@@ -2,22 +2,29 @@ require "govspeak"
 
 module Presenters
   class DetailsPresenter
-    attr_reader :content_item_details
+    attr_reader :content_item_details, :change_history_presenter
 
-    def initialize(content_item_details)
+    def initialize(content_item_details, change_history_presenter)
       @content_item_details = SymbolizeJSON.symbolize(content_item_details)
+      @change_history_presenter = change_history_presenter
     end
 
     def details
       @_details ||=
         begin
-          content_item_details.each_with_object({}) do |(key, val), seed|
+          updated = content_item_details.each_with_object({}) do |(key, val), seed|
             seed[key] = append_transformed_govspeak(val)
           end
+          updated[:change_history] = change_history unless change_history.blank?
+          updated
         end
     end
 
   private
+
+    def change_history
+      @_change_history ||= change_history_presenter.change_history
+    end
 
     def append_transformed_govspeak(value)
       wrapped_value = Array.wrap(value)

--- a/app/presenters/downstream_presenter.rb
+++ b/app/presenters/downstream_presenter.rb
@@ -64,7 +64,15 @@ module Presenters
     end
 
     def details_presenter
-      @details_presenter ||= Presenters::DetailsPresenter.new(symbolized_attributes[:details])
+      @details_presenter ||= Presenters::DetailsPresenter.new(
+        symbolized_attributes[:details],
+        change_history_presenter,
+      )
+    end
+
+    def change_history_presenter
+      @change_history_presenter ||=
+        Presenters::ChangeHistoryPresenter.new(web_content_item)
     end
 
     def access_limit

--- a/db/migrate/20161007080213_create_change_notes.rb
+++ b/db/migrate/20161007080213_create_change_notes.rb
@@ -1,0 +1,10 @@
+class CreateChangeNotes < ActiveRecord::Migration
+  def change
+    create_table :change_notes do |t|
+      t.string :note, default: ""
+      t.datetime :public_timestamp
+      t.references :content_item, index: true, foreign_key: true
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -14,13 +14,21 @@ ActiveRecord::Schema.define(version: 20161013104311) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
-
   create_table "access_limits", force: :cascade do |t|
     t.json     "users",           default: [], null: false
     t.datetime "created_at",                   null: false
     t.datetime "updated_at",                   null: false
     t.integer  "content_item_id"
     t.index ["content_item_id"], name: "index_access_limits_on_content_item_id", using: :btree
+  end
+
+  create_table "change_notes", force: :cascade do |t|
+    t.string   "note",             default: ""
+    t.datetime "public_timestamp"
+    t.integer  "content_item_id"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.index ["content_item_id"], name: "index_change_notes_on_content_item_id", using: :btree
   end
 
   create_table "content_items", force: :cascade do |t|
@@ -161,5 +169,6 @@ ActiveRecord::Schema.define(version: 20161013104311) do
     t.datetime "updated_at"
   end
 
+  add_foreign_key "change_notes", "content_items"
   add_foreign_key "links", "link_sets"
 end

--- a/lib/data_hygiene/govspeak_compare.rb
+++ b/lib/data_hygiene/govspeak_compare.rb
@@ -14,7 +14,10 @@ module DataHygiene
 
     def generated_html
       @generated_html ||= html_from_details(
-        Presenters::DetailsPresenter.new(content_item.details_for_govspeak_conversion).details
+        Presenters::DetailsPresenter.new(
+          content_item.details_for_govspeak_conversion,
+          Presenters::ChangeHistoryPresenter.new(content_item)
+        ).details
       )
     end
 

--- a/spec/commands/v2/publish_spec.rb
+++ b/spec/commands/v2/publish_spec.rb
@@ -248,6 +248,18 @@ RSpec.describe Commands::V2::Publish do
           end
         end
       end
+
+      context "update_type changes from major to minor" do
+        before do
+          draft_item.update(update_type: "major")
+          payload[:update_type] = "minor"
+          ChangeNote.create(content_item: draft_item)
+        end
+        it "deletes associated ChangeNote records" do
+          expect { described_class.call(payload) }
+            .to change { ChangeNote.count }.by(-1)
+        end
+      end
     end
 
     context "with a first_published_at set on the draft content item" do

--- a/spec/commands/v2/put_content_spec.rb
+++ b/spec/commands/v2/put_content_spec.rb
@@ -25,6 +25,7 @@ RSpec.describe Commands::V2::PutContent do
         routes: [{ path: base_path, type: "exact" }],
         redirects: [],
         phase: "beta",
+        change_note: { note: "Info", public_timestamp: Time.now.utc.to_s }
       }
     end
 
@@ -318,6 +319,11 @@ RSpec.describe Commands::V2::PutContent do
 
         location = Location.find_by!(content_item: content_item)
         expect(location.base_path).to eq(base_path)
+      end
+
+      it "creates a change note" do
+        expect { described_class.call(payload) }.
+          to change { ChangeNote.count }.by(1)
       end
     end
 

--- a/spec/models/change_note_spec.rb
+++ b/spec/models/change_note_spec.rb
@@ -1,0 +1,54 @@
+require "rails_helper"
+
+RSpec.describe ChangeNote do
+  let(:payload) { { change_note: payload_change_note } }
+  let(:details) { {} }
+  let(:payload_change_note) { nil }
+  let(:update_type) { "major" }
+  let(:content_item) do
+    FactoryGirl.create(:content_item, update_type: update_type, details: details)
+  end
+
+  describe ".create_from_content_item" do
+    subject { described_class.create_from_content_item(payload, content_item) }
+
+    context "update_type is not major" do
+      let(:update_type) { "minor" }
+      it "doesn't create a change note" do
+        expect { subject }.to_not change { ChangeNote.count }
+      end
+    end
+
+    context "payload contains top-level change note entry" do
+      let(:payload_change_note) do
+        { note: "Excellent", public_timestamp: 1.day.ago.to_s }
+      end
+      it "populates change note from top-level change note entry" do
+        expect { subject }.to change { ChangeNote.count }.by(1)
+        expect(ChangeNote.last.note).to eq "Excellent"
+      end
+    end
+
+    context "content item has change_note entry in details hash" do
+      let(:details) { { change_note: "Marvellous" }.stringify_keys }
+      it "populates change note from details hash" do
+        expect { subject }.to change { ChangeNote.count }.by(1)
+        expect(ChangeNote.last.note).to eq "Marvellous"
+      end
+    end
+
+    context "content item has change_history entry in details hash" do
+      let(:details) do
+        { change_history: [
+          { public_timestamp: 3.day.ago.to_s, note: "note 3" },
+          { public_timestamp: 1.day.ago.to_s, note: "note 1" },
+          { public_timestamp: 2.days.ago.to_s, note: "note 2" },
+        ] }
+      end
+      it "populates change note from most recent history item" do
+        expect { subject }.to change { ChangeNote.count }.by(1)
+        expect(ChangeNote.last.note).to eq "note 1"
+      end
+    end
+  end
+end

--- a/spec/presenters/change_history_presenter_spec.rb
+++ b/spec/presenters/change_history_presenter_spec.rb
@@ -52,23 +52,38 @@ RSpec.describe Presenters::ChangeHistoryPresenter do
     end
 
     context "multiple content items for a single content id" do
-      let!(:other_item) do
+      let!(:item1) do
         FactoryGirl.create(
           :content_item,
           details: details,
           content_id: content_id,
-          state: "published",
-          user_facing_version: 2
+          user_facing_version: 1
         )
       end
-      let!(:change_notes) do
-        [
-          ChangeNote.create(content_item: content_item),
-          ChangeNote.create(content_item: other_item)
-        ]
+      let!(:item2) do
+        FactoryGirl.create(
+          :content_item,
+          details: details,
+          content_id: content_id,
+          user_facing_version: 2,
+          state: "published"
+        )
       end
-      it "constructs content history from all change notes for content id" do
-        expect(subject.count).to eq 2
+      before do
+        ChangeNote.create(content_item: item1)
+        ChangeNote.create(content_item: item2)
+      end
+
+      context "reviewing latest version of a content item" do
+        it "constructs content history from all change notes for content id" do
+          expect(described_class.new(item2).change_history.count).to eq 2
+        end
+      end
+
+      context "reviewing older version of a content item" do
+        it "doesn't include change notes corresponding to newer versions" do
+          expect(described_class.new(item1).change_history.count).to eq 1
+        end
       end
     end
   end

--- a/spec/presenters/change_history_presenter_spec.rb
+++ b/spec/presenters/change_history_presenter_spec.rb
@@ -1,0 +1,75 @@
+require "rails_helper"
+
+RSpec.describe Presenters::ChangeHistoryPresenter do
+  let(:content_id) { SecureRandom.uuid }
+  let(:content_item) do
+    FactoryGirl.create(
+      :content_item,
+      details: details,
+      content_id: content_id,
+    )
+  end
+  let(:details) { {} }
+  subject { described_class.new(content_item).change_history }
+
+  describe "#change_history" do
+    context "details hash includes content_history" do
+      let(:details) do
+        { change_history: [
+          { public_timestamp: 1.day.ago.to_s, note: "note 1" },
+          { public_timestamp: 2.days.ago.to_s, note: "note 2" },
+        ] }
+      end
+      it "returns content_history from details hash" do
+        expect(subject).to eq details[:change_history]
+      end
+    end
+
+    context "details hash doesn't include content_history" do
+      before do
+        2.times do |i|
+          ChangeNote.create(
+            content_item: content_item,
+            note: i.to_s,
+            public_timestamp: Time.now.utc
+          )
+        end
+      end
+      it "constructs content history from change notes" do
+        expect(subject.map { |item| item["note"] }).to eq %w(1 0)
+      end
+    end
+
+    it "orders change notes by public_timestamp" do
+      [1, 3, 2].to_a.each do |i|
+        ChangeNote.create(
+          content_item: content_item,
+          note: i.to_s,
+          public_timestamp: i.days.ago
+        )
+      end
+      expect(subject.map { |item| item["note"] }).to eq %w(1 2 3)
+    end
+
+    context "multiple content items for a single content id" do
+      let!(:other_item) do
+        FactoryGirl.create(
+          :content_item,
+          details: details,
+          content_id: content_id,
+          state: "published",
+          user_facing_version: 2
+        )
+      end
+      let!(:change_notes) do
+        [
+          ChangeNote.create(content_item: content_item),
+          ChangeNote.create(content_item: other_item)
+        ]
+      end
+      it "constructs content history from all change notes for content id" do
+        expect(subject.count).to eq 2
+      end
+    end
+  end
+end

--- a/spec/presenters/details_presenter_spec.rb
+++ b/spec/presenters/details_presenter_spec.rb
@@ -2,7 +2,14 @@ require "rails_helper"
 
 RSpec.describe Presenters::DetailsPresenter do
   describe ".details" do
-    subject { described_class.new(content_item_details).details }
+    let(:change_history_presenter) do
+      instance_double(Presenters::ChangeHistoryPresenter, change_history: [])
+    end
+    subject do
+      described_class.new(
+        content_item_details, change_history_presenter
+      ).details
+    end
 
     context "when we're passed details without a body" do
       let(:content_item_details) { {} }


### PR DESCRIPTION
[Trello](https://trello.com/c/PUldwy8A/823-public-content-history-medium)

We don't want the publishing apps to have to include change history as
part of the content item PUT request any more. Therefore we are moving
to a model whereby we save a ChangeNote for every such request.
Ultimately this will be a top level property in the schemas, but for the
moment we will continue to support `change_note` as part of the details
hash.