### PR TITLE
Change autoload_paths to eager_load_paths

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -21,9 +21,9 @@ module PublishingAPI
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.
 
-    config.autoload_paths << "#{config.root}/app"
-    config.autoload_paths << "#{config.root}/lib"
-    config.autoload_paths += Dir["#{config.root}/lib/**/"]
+    config.eager_load_paths << "#{config.root}/app"
+    config.eager_load_paths << "#{config.root}/lib"
+    config.eager_load_paths += Dir["#{config.root}/lib/**/"]
 
     config.i18n.available_locales = [
       :en, :ar, :az, :be, :bg, :bn, :cs, :cy, :de, :dr, :el, :es, :'es-419',


### PR DESCRIPTION
When Rails 5 runs in production it does not autoload files anymore.
Any files that are not included within config.eager_load_paths and are
accessed will result in a `NameError: uninitialized constant`.

This problem only affects production environments as both development
and test have the following configurations:

  config.cache_classes = true
  config.eager_load = false

Setting these to false/true respectively allows these issues to be
experienced in development.

Eager load paths are used in autoloading so these do not need to be
defined twice[1].

[1]: https://github.com/rails/rails/blob/v4.1.7/railties/lib/rails/engine.rb#L684