### PR TITLE
Add diffy to gems for all environments

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,7 @@ gem "json-schema", require: false
 gem "hashdiff"
 gem "sidekiq-unique-jobs", require: false
 gem "govspeak", "~> 5.0.2"
+gem "diffy", "~> 3.1", require: false
 
 group :development do
   # Access an IRB console on exception pages or by using <%= console %> in views
@@ -55,5 +56,4 @@ group :development, :test do
   gem "spring"
   gem "spring-commands-rspec"
   gem "govuk_schemas", "~> 1.0"
-  gem "diffy", "~> 3.1", require: false
 end


### PR DESCRIPTION
This allows the file to be required in an environment where classes are
eager loaded - which is the case for production environments in rails 5.