### PR TITLE
[DO NOT MERGE] Return a 409 rather than 500 for concurrent content items

### DIFF
--- a/app/commands/v2/put_content.rb
+++ b/app/commands/v2/put_content.rb
@@ -161,6 +161,9 @@ module Commands
 
         link_set = LinkSet.create!(content_id: content_item.content_id)
         LockVersion.create!(target: link_set, number: 1)
+      rescue ActiveRecord::RecordNotUnique => e
+        Airbrake.notify(e)
+        raise_command_error(409, "Concurrent PUT Content requests for same content_id", {})
       end
 
       def lock_version_number_for_new_draft


### PR DESCRIPTION
Bad things happen when we receive >1 requests concurrently to put an item with the same content_id. One of the problems that can occur is that we 500 due to trying to create the same link set twice.

This changes the behaviour in this scenario to return a 409 rather than a 500. 

I'm not 100% sure this is the best way to play it as:

- -ve it's not a consistent response to the same request
- +ve it's a better error response than a 500 for the scenario

Additional opinions on this would be great. Options:

A. 409 on this scenario as per this PR
B. 500 on this scenario as per current behaviour
C. Refactor so we can accept the content item - which will most likely result in us having conflicting data
