### PR TITLE
Explicit ordering of Content Items to ensure deterministic HTTP responses

### DIFF
--- a/app/presenters/queries/content_item_presenter.rb
+++ b/app/presenters/queries/content_item_presenter.rb
@@ -31,7 +31,7 @@ module Presenters
       def initialize(scope, params = {})
         self.scope = scope
         self.fields = (params[:fields] || DEFAULT_FIELDS).map(&:to_sym)
-        self.order = params[:order]
+        self.order = params[:order] || { "content_items.id" => "asc" }
         self.limit = params[:limit]
         self.offset = params[:offset]
         self.search_query = params[:search_query]

--- a/app/queries/get_web_content_items.rb
+++ b/app/queries/get_web_content_items.rb
@@ -51,6 +51,7 @@ module Queries
         .join(states).on(content_items[:id].eq(states[:content_item_id]))
         .join(translations).on(content_items[:id].eq(translations[:content_item_id]))
         .join(user_facing_versions).on(content_items[:id].eq(user_facing_versions[:content_item_id]))
+        .order(content_items[:id].asc)
     end
   end
 end


### PR DESCRIPTION
Endpoints such as `GET /v2/linkables/:content_id` and `GET /v2/linked/:content_id` provide collections of results in no specific ordering. This leads to Postgres to order the items by whatever it sees fit. 

This leads to inconsistent responses, which causes us problems in our Pact tests and is likely non-ideal for people consuming the endpoint if they are checking if items have changed.

## Benchmarks

### Content Item Presenter

#### Before (master)
```
vm  publishing-api git:(master) ruby bench/content_item_presenter.rb

Presenting 64 content items
  0.040000   0.010000   0.050000 (  0.072739)
  Queries: 1
Presenting 128 content items
  0.020000   0.010000   0.030000 (  0.063594)
  Queries: 1
Presenting 256 content items
  0.030000   0.010000   0.040000 (  0.077472)
  Queries: 1
Presenting 512 content items
  0.040000   0.010000   0.050000 (  0.153011)
  Queries: 1
Presenting 1024 content items
  0.080000   0.020000   0.100000 (  0.240683)
  Queries: 1
```

#### After (fix-pact-issues)
```
vm  publishing-api git:(fix-pact-issues) ruby bench/content_item_presenter.rb
Presenting 64 content items
  0.040000   0.010000   0.050000 (  0.067384)
  Queries: 1
Presenting 128 content items
  0.020000   0.000000   0.020000 (  0.059404)
  Queries: 1
Presenting 256 content items
  0.030000   0.010000   0.040000 (  0.073086)
  Queries: 1
Presenting 512 content items
  0.050000   0.010000   0.060000 (  0.141775)
  Queries: 1
Presenting 1024 content items
  0.080000   0.020000   0.100000 (  0.261461)
  Queries: 1
```

### Linkables

#### Before (master)

```
vm  publishing-api git:(master) ruby bench/linkables.rb
topic
..........  0.120000   0.030000   0.150000 (  0.243002)
queries: 15

organisation
..........  0.200000   0.030000   0.230000 (  0.446660)
queries: 13

mainstream_browse_page
..........  0.040000   0.000000   0.040000 (  0.109355)
queries: 13

policy
..........  0.080000   0.010000   0.090000 (  0.158889)
queries: 13

taxon
..........  0.040000   0.000000   0.040000 (  0.071469)
queries: 13
```

#### After (fix-pact-issues)

```
vm  publishing-api git:(fix-pact-issues) ruby bench/linkables.rb
topic
..........  0.120000   0.020000   0.140000 (  0.227404)
queries: 15

organisation
..........  0.180000   0.010000   0.190000 (  0.395639)
queries: 13

mainstream_browse_page
..........  0.040000   0.010000   0.050000 (  0.100756)
queries: 13

policy
..........  0.090000   0.000000   0.090000 (  0.162498)
queries: 13

taxon
..........  0.040000   0.000000   0.040000 (  0.070616)
queries: 13
```

