### PR TITLE
Don't return `internal_name` from content endpoint

### DIFF
--- a/app/presenters/queries/content_item_presenter.rb
+++ b/app/presenters/queries/content_item_presenter.rb
@@ -13,7 +13,6 @@ module Presenters
         :base_path,
         :locale,
         :lock_version,
-        :internal_name,
         :updated_at,
         :state_history,
       ].freeze
@@ -92,8 +91,6 @@ module Presenters
             "lock_versions.number AS lock_version"
           when :description
             "description->>'value' AS description"
-          when :internal_name
-            "#{INTERNAL_NAME_SQL} AS internal_name"
           when :last_edited_at
             "to_char(last_edited_at, '#{ISO8601_SQL}') as last_edited_at"
           when :public_updated_at
@@ -127,10 +124,6 @@ module Presenters
       SQL
 
       ISO8601_SQL = "YYYY-MM-DD\"T\"HH24:MI:SS\"Z\"".freeze
-
-      # This returns the internal_name from the details hash if it is present,
-      # otherwise it falls back to the content item's title.
-      INTERNAL_NAME_SQL = "COALESCE(details->>'internal_name', title) ".freeze
 
       def parse_results(results)
         json_columns = %w(details routes redirects need_ids state_history)

--- a/doc/api.md
+++ b/doc/api.md
@@ -429,7 +429,8 @@ Retrieves all content items that link to the given `content_id` for some
 
 Returns abridged versions of all content items matching the given
 `document_type`. Returns `title`, `content_id`, `publication_state`, `base_path`
-and `internal_name` fields.
+from the content item. It also adds a special field `internal_name`, which is
+`details.internal_name` and falls back to `title`.
 
 ### Query string parameters:
 - `document_type` *(required)*

--- a/spec/presenters/queries/content_item_presenter_spec.rb
+++ b/spec/presenters/queries/content_item_presenter_spec.rb
@@ -26,7 +26,6 @@ RSpec.describe Presenters::Queries::ContentItemPresenter do
         "locale" => "en",
         "base_path" => base_path,
         "title" => "VAT rates",
-        "internal_name" => "VAT rates",
         "document_type" => "guide",
         "schema_name" => "guide",
         "public_updated_at" => "2014-05-14T13:00:06Z",
@@ -96,47 +95,6 @@ RSpec.describe Presenters::Queries::ContentItemPresenter do
 
         results = described_class.present_many(content_items, fields: fields)
         expect(results.first.keys).to match_array(%w(title phase publication_state))
-      end
-    end
-
-    context "when internal_name is requested" do
-      let(:fields) { %w(internal_name) }
-
-      context "and an internal_name is present" do
-        before do
-          details = content_item.details
-          details["internal_name"] = "An internal name"
-
-          content_item.update_attributes(
-            details: details,
-          )
-        end
-
-        it "returns the internal_name" do
-          content_items = ContentItem.where(content_id: content_id)
-
-          results = described_class.present_many(content_items, fields: fields)
-          expect(results.first["internal_name"]).to eq("An internal name")
-        end
-      end
-
-      context "but an internal_name is not present" do
-        before do
-          details = content_item.details
-          details.delete(:internal_name)
-
-          content_item.update_attributes(
-            details: details,
-            title: "A normal title",
-          )
-        end
-
-        it "falls back to the title" do
-          content_items = ContentItem.where(content_id: content_id)
-
-          results = described_class.present_many(content_items, fields: fields)
-          expect(results.first["internal_name"]).to eq("A normal title")
-        end
       end
     end
 


### PR DESCRIPTION
The get content endpoint (/v2/content/:content_id) is currently returning an `internal_name` attribute. This is calculated from the `details` hash, with a fallback to the `title` from the root of the document.

We think it might have been introduced by mistake, because the `get_linkables` endpoint has this "magic" attribute (it was introduced in https://github.com/alphagov/publishing-api/pull/216). We assume that at some point the linkables endpoint used the same presenter as the content endpoint, causing this functionality to "leak" into another endpoint.

It has caused some confusion today so we think it's a good idea to remove it now.

Data in the details hash should be accessed via the details hash, and there is no need for special behaviour for this attribute.

Paired with @carvil on this.