### PR TITLE
Allow multiple document_type values in get_content

### DIFF
--- a/app/controllers/v2/content_items_controller.rb
+++ b/app/controllers/v2/content_items_controller.rb
@@ -1,11 +1,11 @@
 module V2
   class ContentItemsController < ApplicationController
     def index
-      doc_type = query_params.fetch(:document_type) { query_params.fetch(:content_format) }
+      doc_types = query_params.fetch(:document_type) { query_params.fetch(:content_format) }
       pagination = Pagination.new(query_params)
 
       results = Queries::GetContentCollection.new(
-        document_type: doc_type,
+        document_types: doc_types,
         fields: query_params[:fields],
         filters: filters,
         pagination: pagination,

--- a/app/queries/get_content_collection.rb
+++ b/app/queries/get_content_collection.rb
@@ -1,9 +1,9 @@
 module Queries
   class GetContentCollection
-    attr_reader :document_type, :fields, :publishing_app, :link_filters, :locale, :pagination, :search_query
+    attr_reader :document_types, :fields, :publishing_app, :link_filters, :locale, :pagination, :search_query
 
-    def initialize(document_type:, fields:, filters: {}, pagination: Pagination.new, search_query: "")
-      self.document_type = document_type
+    def initialize(document_types:, fields:, filters: {}, pagination: Pagination.new, search_query: "")
+      self.document_types = Array(document_types)
       self.fields = fields
       self.publishing_app = filters[:publishing_app]
       self.link_filters = filters[:links]
@@ -34,7 +34,7 @@ module Queries
 
   private
 
-    attr_writer :document_type, :fields, :publishing_app, :locale, :link_filters, :pagination, :search_query
+    attr_writer :document_types, :fields, :publishing_app, :locale, :link_filters, :pagination, :search_query
 
     def content_items
       scope = ContentItem.where(document_type: lookup_document_types)
@@ -46,7 +46,7 @@ module Queries
 
 
     def lookup_document_types
-      [document_type, "placeholder_#{document_type}"]
+      document_types.flat_map { |d| [d, "placeholder_#{d}"] }
     end
 
     def validate_fields!

--- a/lib/tasks/sanitize_data.rake
+++ b/lib/tasks/sanitize_data.rake
@@ -15,7 +15,7 @@ task :restore_policy_links, [:action] => [:environment] do |_, args|
   puts "Dry run" if dry_run
 
   policy_query = Queries::GetContentCollection.new(
-    document_type: 'policy',
+    document_types: 'policy',
     fields: %w(content_id),
     pagination: NullPagination.new
   )


### PR DESCRIPTION
This is used by the bulk-tagging functionality in content-tagger.