### PR TITLE
Add locks for concurrent requests on publish and unpublish endpoints

### DIFF
--- a/app/commands/v2/publish.rb
+++ b/app/commands/v2/publish.rb
@@ -76,13 +76,17 @@ module Commands
       end
 
       def find_draft_content_item
-        filter = ContentItemFilter.new(scope: ContentItem.where(content_id: content_id))
+        filter = ContentItemFilter.new(scope: pessimistic_content_item_scope)
         filter.filter(locale: locale, state: "draft").first
       end
 
       def already_published?
-        filter = ContentItemFilter.new(scope: ContentItem.where(content_id: content_id))
+        filter = ContentItemFilter.new(scope: pessimistic_content_item_scope)
         filter.filter(locale: locale, state: "published").first
+      end
+
+      def pessimistic_content_item_scope
+        ContentItem.where(content_id: content_id).lock
       end
 
       def clear_published_items_of_same_locale_and_base_path(content_item, translation, location)

--- a/app/commands/v2/unpublish.rb
+++ b/app/commands/v2/unpublish.rb
@@ -120,7 +120,7 @@ module Commands
           allowed_states = %w(draft)
         end
 
-        filter = ContentItemFilter.new(scope: ContentItem.where(content_id: content_id))
+        filter = ContentItemFilter.new(scope: ContentItem.where(content_id: content_id).lock)
         content_item = filter.filter(locale: locale, state: allowed_states).last
         content_item if content_item && (payload[:allow_draft] || !Unpublishing.is_substitute?(content_item))
       end


### PR DESCRIPTION
We hit some [deadlock](https://errbit.integration.publishing.service.gov.uk/apps/552637940da1157bfa000399/problems/57ff93816578635612b00000) [errors](https://errbit.integration.publishing.service.gov.uk/apps/552637940da1157bfa000399/problems/57ff98f76578633c5c000000) today. When we had a bunch of [concurrent](https://kibana.integration.publishing.service.gov.uk/kibana#dashboard/temp/AVe-yjJz0cCZMaemNd-C) [requests](https://kibana.integration.publishing.service.gov.uk/kibana#dashboard/temp/AVe-ylkr0cCZMaemNefI) 

I noticed that we actually only do locking on put-content and not on the publish and unpublish endpoints, so here is an implementation.