### PR TITLE
Add filtering by state to content item search

### DIFF
--- a/app/controllers/v2/content_items_controller.rb
+++ b/app/controllers/v2/content_items_controller.rb
@@ -60,11 +60,16 @@ module V2
       query_params[:publishing_app]
     end
 
+    def states
+      query_params[:states]
+    end
+
     def filters
       {
         publishing_app: publishing_app,
         locale: query_params[:locale],
         links: link_filters,
+        states: Array(states),
       }
     end
 

--- a/app/queries/get_content_collection.rb
+++ b/app/queries/get_content_collection.rb
@@ -1,11 +1,21 @@
 module Queries
   class GetContentCollection
-    attr_reader :document_types, :fields, :publishing_app, :link_filters, :locale, :pagination, :search_query
+    attr_reader(
+      :document_types,
+      :fields,
+      :publishing_app,
+      :link_filters,
+      :locale,
+      :pagination,
+      :search_query,
+      :states,
+    )
 
     def initialize(document_types:, fields:, filters: {}, pagination: Pagination.new, search_query: "")
       self.document_types = Array(document_types)
       self.fields = fields
       self.publishing_app = filters[:publishing_app]
+      self.states = filters[:states]
       self.link_filters = filters[:links]
       self.locale = filters[:locale] || "en"
       self.pagination = pagination
@@ -34,16 +44,25 @@ module Queries
 
   private
 
-    attr_writer :document_types, :fields, :publishing_app, :locale, :link_filters, :pagination, :search_query
+    attr_writer(
+      :document_types,
+      :fields,
+      :publishing_app,
+      :locale,
+      :link_filters,
+      :pagination,
+      :search_query,
+      :states,
+    )
 
     def content_items
       scope = ContentItem.where(document_type: lookup_document_types)
       scope = scope.where(publishing_app: publishing_app) if publishing_app
+      scope = State.filter(scope, name: states) if states.present?
       scope = Link.filter_content_items(scope, link_filters) unless link_filters.blank?
       scope = Translation.filter(scope, locale: locale) unless locale == "all"
       scope
     end
-
 
     def lookup_document_types
       document_types.flat_map { |d| [d, "placeholder_#{d}"] }

--- a/doc/api.md
+++ b/doc/api.md
@@ -319,6 +319,8 @@ draft is returned.
     [`base_path`](model.md#base_path) fields.
 - `publishing_app` *(optional)*
   - Used to restrict content items to those for a given publishing app.
+- `states` *(optional)*
+  - Used to restrict content items to those in the specified states.
 
 ## `GET /v2/content/:content_id`
 

--- a/spec/controllers/v2/content_items_controller_spec.rb
+++ b/spec/controllers/v2/content_items_controller_spec.rb
@@ -458,8 +458,8 @@ RSpec.describe V2::ContentItemsController do
     before do
       FactoryGirl.create(:draft_content_item, publishing_app: 'publisher', base_path: '/content')
       FactoryGirl.create(:draft_content_item, publishing_app: 'whitehall', base_path: '/item1')
-      FactoryGirl.create(:draft_content_item, publishing_app: 'whitehall', base_path: '/item2')
-      FactoryGirl.create(:draft_content_item, publishing_app: 'specialist_publisher', base_path: '/item3')
+      FactoryGirl.create(:live_content_item, publishing_app: 'whitehall', base_path: '/item2')
+      FactoryGirl.create(:unpublished_content_item, publishing_app: 'specialist_publisher', base_path: '/item3')
     end
 
     it "displays items filtered by publishing_app parameter" do
@@ -472,6 +472,17 @@ RSpec.describe V2::ContentItemsController do
       items = parsed_response["results"]
       expect(items.length).to eq(2)
       expect(items.all? { |i| i["publishing_app"] == "whitehall" }).to be true
+    end
+
+    it "filters by state" do
+      get :index, params: { document_type: "guide", states: %w(published draft) }
+
+      items = parsed_response["results"]
+      draft, published = items.partition { |item| item["publication_state"] == "draft" }
+
+      expect(items.length).to eq(3)
+      expect(draft.length).to eq(2)
+      expect(published.length).to eq(1)
     end
 
     it "displays all items by default" do


### PR DESCRIPTION
Update GET /content to support filtering by any number of passed in states.

A quick and dirty benchmark suggests inconsequential difference in performance:

```
Benchmarked with:
ab -n 100 -c 1 http://publishing-api.dev.gov.uk/v2/content\?document_type\=taxons\&fields\[\]\=base_path\&states\=published

master
======
Time taken for tests:   7.129 seconds
Requests per second:    14.03 [#/sec] (mean)
Time per request:       71.292 [ms] (mean)

Percentage of the requests served within a certain time (ms)
  50%     67
  66%     71
  75%     76
  80%     77
  90%     86
  95%     95
  98%    115
  99%    193
 100%    193 (longest request)


this branch
===========
Time taken for tests:   7.423 seconds
Requests per second:    13.47 [#/sec] (mean)
Time per request:       74.234 [ms] (mean)

Percentage of the requests served within a certain time (ms)
  50%     69
  66%     74
  75%     80
  80%     81
  90%     97
  95%    104
  98%    137
  99%    220
```