### PR TITLE
Order links when presenting them downstream

### DIFF
--- a/app/presenters/queries/expanded_link_set.rb
+++ b/app/presenters/queries/expanded_link_set.rb
@@ -51,7 +51,9 @@ module Presenters
 
       def all_links(content_id, link_type = nil)
         sql = <<-SQL
-          select links.link_type, json_agg(links.target_content_id) as target_content_ids from links
+          select links.link_type,
+            json_agg(links.target_content_id order by links.link_type asc, links.position asc) as target_content_ids
+          from links
           join link_sets on link_sets.id = links.link_set_id
           where link_sets.content_id = '#{content_id}'
           #{"and link_type = '#{link_type}'" if link_type}
@@ -99,6 +101,7 @@ module Presenters
           .where(target_content_id: content_id)
           .joins(:link_set)
           .where(link_type: rules.reverse_recursive_types)
+          .order(link_type: :asc, position: :asc)
           .pluck(:link_type, :content_id)
       end
 

--- a/app/queries/get_grouped_content_and_links.rb
+++ b/app/queries/get_grouped_content_and_links.rb
@@ -118,7 +118,8 @@ module Queries
         WHERE
           link_sets.content_id IN (#{sql_value_placeholders(content_ids.size)})
         ORDER BY
-          links.target_content_id ASC
+          links.link_type ASC,
+          links.position ASC
       SQL
 
       ActiveRecord::Base.connection.raw_connection.exec(query, content_ids)

--- a/spec/presenters/queries/expanded_link_set_spec.rb
+++ b/spec/presenters/queries/expanded_link_set_spec.rb
@@ -129,10 +129,10 @@ RSpec.describe Presenters::Queries::ExpandedLinkSet do
 
     context "graph with multiple links of the same type" do
       it "expands the links for node a correctly" do
-        create_link(a, b, "related")
-        create_link(a, c, "related")
+        create_link(a, b, "related", 0)
+        create_link(a, c, "related", 1)
 
-        expect(expanded_links[:related].sort_by { |r| r[:base_path] }).to match([
+        expect(expanded_links[:related]).to match([
           a_hash_including(base_path: "/b", links: {}),
           a_hash_including(base_path: "/c", links: {}),
         ])

--- a/spec/queries/get_grouped_content_and_links_spec.rb
+++ b/spec/queries/get_grouped_content_and_links_spec.rb
@@ -166,13 +166,16 @@ RSpec.describe Queries::GetGroupedContentAndLinks do
         context "with links" do
           let(:first_target_content_id) { SecureRandom.uuid }
           let(:second_target_content_id) { SecureRandom.uuid }
+          let(:third_target_content_id) { SecureRandom.uuid }
+          let(:fourth_target_content_id) { SecureRandom.uuid }
 
           before do
             FactoryGirl.create(
               :link_set,
               links_hash: {
                 "topics" => [
-                  first_target_content_id
+                  first_target_content_id,
+                  second_target_content_id
                 ]
               },
               content_id: ordered_content_ids.first
@@ -182,7 +185,8 @@ RSpec.describe Queries::GetGroupedContentAndLinks do
               :link_set,
               links_hash: {
                 "topics" => [
-                  second_target_content_id
+                  third_target_content_id,
+                  fourth_target_content_id
                 ]
               },
               content_id: ordered_content_ids.last
@@ -199,6 +203,11 @@ RSpec.describe Queries::GetGroupedContentAndLinks do
                 "content_id" => ordered_content_ids.first,
                 "link_type" => "topics",
                 "target_content_id" => first_target_content_id,
+              },
+              {
+                "content_id" => ordered_content_ids.first,
+                "link_type" => "topics",
+                "target_content_id" => second_target_content_id,
               }
             ])
 
@@ -207,7 +216,12 @@ RSpec.describe Queries::GetGroupedContentAndLinks do
               {
                 "content_id" => ordered_content_ids.last,
                 "link_type" => "topics",
-                "target_content_id" => second_target_content_id,
+                "target_content_id" => third_target_content_id,
+              },
+              {
+                "content_id" => ordered_content_ids.last,
+                "link_type" => "topics",
+                "target_content_id" => fourth_target_content_id,
               }
             ])
           end

--- a/spec/support/dependency_resolution_helper.rb
+++ b/spec/support/dependency_resolution_helper.rb
@@ -23,7 +23,7 @@ module DependencyResolutionHelper
     )
   end
 
-  def create_link(from, to, link_type)
+  def create_link(from, to, link_type, link_position = 0)
     link_set = LinkSet.find_by(content_id: from)
 
     FactoryGirl.create(
@@ -31,6 +31,7 @@ module DependencyResolutionHelper
       link_set: link_set,
       target_content_id: to,
       link_type: link_type,
+      position: link_position
     )
   end
 end


### PR DESCRIPTION
https://github.com/alphagov/publishing-api/pull/538 changed the publishing-api to store the order of links. This commit changes the downstream presenters to preserve this ordering when sending links downstream to other apps.

Trello: https://trello.com/c/5GjAHutI/193-make-sure-the-links-are-returned-in-correct-order-from-content-store-and-friends