### PR TITLE
Expand parent links for ordered_related_items

### DIFF
--- a/app/presenters/queries/expand_dependees.rb
+++ b/app/presenters/queries/expand_dependees.rb
@@ -1,0 +1,71 @@
+module Presenters
+  module Queries
+    class ExpandDependees
+      def initialize(content_id, controller)
+        @content_id = content_id
+        @controller = controller
+      end
+
+      def expand
+        parents(content_id)
+      end
+
+    private
+
+      attr_reader :content_id, :controller
+
+      def parents(content_id, type = nil, visited = [], level_index = 0)
+        visited << content_id
+        links = all_links(content_id, type)
+        cached_web_content_items = all_web_content_items(links)
+        level = links.each_with_object({}) do |link, memo|
+          link_type = link["link_type"].to_sym
+          memo[link_type] = expand_level(link, cached_web_content_items, visited, level_index).compact
+        end
+        level.select { |_k, v| v.present? }
+      end
+
+      def all_web_content_items(links)
+        uniq_links = links.flat_map { |l| JSON.parse(l["target_content_ids"]) }.uniq
+        controller.web_content_items(uniq_links).each_with_object({}) { |w, memo| memo[w.content_id] = w }
+      end
+
+      def expand_level(link, all_web_content_items, visited, level_index)
+        JSON.parse(link["target_content_ids"]).map do |target_id|
+          rules.expand_field(all_web_content_items[target_id]).tap do |expanded|
+            next_level = next_level(link, target_id, visited, level_index)
+            expanded.merge!(links: next_level) if expanded
+          end
+        end
+      end
+
+      def next_level(current_level, target_id, visited, level_index)
+        return {} if visited.include?(target_id)
+        link_type = current_level["link_type"]
+        return {} unless rules.recurse?(current_level["link_type"], level_index)
+        level_index += 1
+        visited << target_id
+        next_level_type = rules.next_level(current_level["link_type"], level_index)
+        parents(target_id, next_level_type, visited.uniq, level_index)
+      end
+
+      def all_links(content_id, link_type = nil)
+        sql = <<-SQL
+          select links.link_type,
+            json_agg(links.target_content_id order by links.link_type asc, links.position asc) as target_content_ids
+          from links
+          join link_sets on link_sets.id = links.link_set_id
+          where link_sets.content_id = '#{content_id}'
+          #{"and link_type = '#{link_type}'" if link_type}
+          group by links.link_type;
+        SQL
+        ActiveRecord::Base.connection.execute(sql)
+      end
+
+      def rules
+        ::Queries::DependeeExpansionRules
+      end
+
+    end
+  end
+end

--- a/app/presenters/queries/expand_dependees.rb
+++ b/app/presenters/queries/expand_dependees.rb
@@ -41,7 +41,6 @@ module Presenters
 
       def next_level(current_level, target_id, visited, level_index)
         return {} if visited.include?(target_id)
-        link_type = current_level["link_type"]
         return {} unless rules.recurse?(current_level["link_type"], level_index)
         level_index += 1
         visited << target_id
@@ -65,7 +64,6 @@ module Presenters
       def rules
         ::Queries::DependeeExpansionRules
       end
-
     end
   end
 end

--- a/app/presenters/queries/expand_dependents.rb
+++ b/app/presenters/queries/expand_dependents.rb
@@ -1,0 +1,64 @@
+module Presenters
+  module Queries
+    class ExpandDependents
+      def initialize(content_id, controller)
+        @content_id = content_id
+        @controller = controller
+      end
+
+      def expand
+        dependents
+      end
+
+    private
+
+      attr_reader :content_id, :controller
+
+      def dependents
+        links = dependent_links
+        all_web_content_items = controller.web_content_items(links.map(&:last))
+
+        links.group_by(&:first).each_with_object({}) do |(type, link_array), hash|
+          reverse = ::Queries::DependeeExpansionRules.reverse_name_for(type).to_sym
+          link_ids = link_array.map(&:last)
+          items = all_web_content_items.select { |item| link_ids.include?(item.content_id) }
+          expanded = dependent_expanded_items(items)
+          if parent
+            expanded.map { |e| e[:links] = { type.to_s.to_sym => [expanded_parent] } }
+          else
+            expanded.map { |e| e[:links] = {} }
+          end
+          hash[reverse] = expanded
+        end
+      end
+
+      def expanded_parent
+        @expanded_parent ||= parent.to_h.select { |k, _v| rules.expansion_fields(parent.document_type.to_sym).include?(k) }.merge(links: {})
+      end
+
+      def parent
+        @parent ||= controller.web_content_items([content_id]).first
+      end
+
+      def dependent_links
+        Link
+          .where(target_content_id: content_id)
+          .joins(:link_set)
+          .where(link_type: rules.reverse_recursive_types)
+          .order(link_type: :asc, position: :asc)
+          .pluck(:link_type, :content_id)
+      end
+
+      def dependent_expanded_items(items)
+        items.map do |item|
+          expansion_fields = rules.expansion_fields(item.document_type.to_sym)
+          item.to_h.select { |k, _v| expansion_fields.include?(k) }
+        end
+      end
+
+      def rules
+        ::Queries::DependeeExpansionRules
+      end
+    end
+  end
+end

--- a/app/presenters/queries/expanded_link_set.rb
+++ b/app/presenters/queries/expanded_link_set.rb
@@ -11,108 +11,6 @@ module Presenters
         @links ||= dependees.merge(dependents).merge(translations)
       end
 
-    private
-
-      attr_reader :state_fallback_order, :locale_fallback_order, :content_id
-
-      def children(content_id, type = nil, visited = [], level_index = 0)
-        visited << content_id
-        links = all_links(content_id, type)
-        cached_web_content_items = all_web_content_items(links)
-        level = links.each_with_object({}) do |link, memo|
-          link_type = link["link_type"].to_sym
-          memo[link_type] = expand_level(link, cached_web_content_items, visited, level_index).compact
-        end
-        level.select { |_k, v| v.present? }
-      end
-
-      def all_web_content_items(links)
-        uniq_links = links.flat_map { |l| JSON.parse(l["target_content_ids"]) }.uniq
-        web_content_items(uniq_links).each_with_object({}) { |w, memo| memo[w.content_id] = w }
-      end
-
-      def expand_level(link, all_web_content_items, visited, level_index)
-        JSON.parse(link["target_content_ids"]).map do |target_id|
-          rules.expand_field(all_web_content_items[target_id]).tap do |expanded|
-            next_level = next_level(link, target_id, visited, level_index)
-            expanded.merge!(links: next_level) if expanded
-          end
-        end
-      end
-
-      def next_level(current_level, target_id, visited, level_index)
-        return {} if visited.include?(target_id)
-        link_type = current_level["link_type"]
-        return {} unless rules.recurse?(current_level["link_type"], level_index)
-        level_index += 1
-        visited << target_id
-        next_level_type = rules.next_level(current_level["link_type"], level_index)
-        children(target_id, next_level_type, visited.uniq, level_index)
-      end
-
-      def all_links(content_id, link_type = nil)
-        sql = <<-SQL
-          select links.link_type,
-            json_agg(links.target_content_id order by links.link_type asc, links.position asc) as target_content_ids
-          from links
-          join link_sets on link_sets.id = links.link_set_id
-          where link_sets.content_id = '#{content_id}'
-          #{"and link_type = '#{link_type}'" if link_type}
-          group by links.link_type;
-        SQL
-        ActiveRecord::Base.connection.execute(sql)
-      end
-
-      def rules
-        ::Queries::DependeeExpansionRules
-      end
-
-      def dependees
-        children(content_id)
-      end
-
-      def parent
-        @parent ||= web_content_items([content_id]).first
-      end
-
-      def expanded_parent
-        @expanded_parent ||= parent.to_h.select { |k, _v| rules.expansion_fields(parent.document_type.to_sym).include?(k) }.merge(links: {})
-      end
-
-      def dependents
-        links = dependent_links
-        all_web_content_items = web_content_items(links.map(&:last))
-
-        links.group_by(&:first).each_with_object({}) do |(type, link_array), hash|
-          reverse = ::Queries::DependeeExpansionRules.reverse_name_for(type).to_sym
-          link_ids = link_array.map(&:last)
-          items = all_web_content_items.select { |item| link_ids.include?(item.content_id) }
-          expanded = dependent_expanded_items(items)
-          if parent
-            expanded.map { |e| e[:links] = { type.to_s.to_sym => [expanded_parent] } }
-          else
-            expanded.map { |e| e[:links] = {} }
-          end
-          hash[reverse] = expanded
-        end
-      end
-
-      def dependent_links
-        Link
-          .where(target_content_id: content_id)
-          .joins(:link_set)
-          .where(link_type: rules.reverse_recursive_types)
-          .order(link_type: :asc, position: :asc)
-          .pluck(:link_type, :content_id)
-      end
-
-      def dependent_expanded_items(items)
-        items.map do |item|
-          expansion_fields = rules.expansion_fields(item.document_type.to_sym)
-          item.to_h.select { |k, _v| expansion_fields.include?(k) }
-        end
-      end
-
       def web_content_items(target_content_ids)
         return [] unless target_content_ids.present?
         ::Queries::GetWebContentItems.(
@@ -122,6 +20,18 @@ module Presenters
             state_fallback_order: state_fallback_order
           )
         )
+      end
+
+    private
+
+      attr_reader :state_fallback_order, :locale_fallback_order, :content_id
+
+      def dependees
+        ExpandDependees.new(content_id, self).expand
+      end
+
+      def dependents
+        ExpandDependents.new(content_id, self).expand
       end
 
       def translations

--- a/app/queries/dependent_expansion_rules.rb
+++ b/app/queries/dependent_expansion_rules.rb
@@ -13,7 +13,7 @@ module Queries
 
     def recurse?(link_type, level_index = 0)
       recursive_link_types.any? do |t|
-        t[level_index] == link_type.to_sym || t.last == link_type.to_sym
+        t.values_at(level_index, -1).include?(link_type.to_sym)
       end
     end
 

--- a/app/queries/dependent_expansion_rules.rb
+++ b/app/queries/dependent_expansion_rules.rb
@@ -21,6 +21,11 @@ module Queries
       reverse_names[link_type.to_sym]
     end
 
+    # eg: ['parent', 'parent_taxons', 'parent'] would expand the parent at
+    # level one, parent_taxons at level two, and parents for all levels
+    # greater then n, (the size of the array), the last element being the
+    # "sticky" recursive element. so for array of size 1, it would recurse on just
+    # that element.
     def recursive_link_types
       [
         [:parent],

--- a/app/queries/dependent_expansion_rules.rb
+++ b/app/queries/dependent_expansion_rules.rb
@@ -11,8 +11,10 @@ module Queries
       web_content_item.to_h.slice(*expansion_fields(web_content_item.document_type.to_sym))
     end
 
-    def recurse?(link_type)
-      recursive_link_types.include?(link_type.to_sym)
+    def recurse?(link_type, level_index = 0)
+      recursive_link_types.any? do |t|
+        t[level_index] == link_type.to_sym || t.last == link_type.to_sym
+      end
     end
 
     def reverse_name_for(link_type)
@@ -20,7 +22,16 @@ module Queries
     end
 
     def recursive_link_types
-      reverse_names.keys - [:documents, :working_groups]
+      [
+        [:parent],
+        [:parent_taxons],
+        [:ordered_related_items, :parent],
+      ]
+    end
+
+    def next_level(type, current_level)
+      group = recursive_link_types.find { |e| e.include?(type.to_sym) }
+      group[current_level] || group.last
     end
 
     def reverse_recursive_types

--- a/spec/queries/dependent_expansion_rules_spec.rb
+++ b/spec/queries/dependent_expansion_rules_spec.rb
@@ -24,10 +24,27 @@ RSpec.describe Queries::DependentExpansionRules do
 
   describe "#recurse?" do
     specify { expect(subject.recurse?(:parent)).to eq(true) }
+    specify { expect(subject.recurse?("parent")).to eq(true) }
     specify { expect(subject.recurse?(:parent_taxons)).to eq(true) }
     specify { expect(subject.recurse?(:working_groups)).to eq(false) }
     specify { expect(subject.recurse?(:documents)).to eq(false) }
     specify { expect(subject.recurse?(:foo)).to eq(false) }
+
+    context "multi-level" do
+      specify { expect(subject.recurse?(:ordered_related_items, 0)).to eq(true) }
+      specify { expect(subject.recurse?(:ordered_related_items, 1)).to eq(false) }
+      specify { expect(subject.recurse?(:parent, 1)).to eq(true) }
+      specify { expect(subject.recurse?(:parent, 2)).to eq(true) }
+      specify { expect(subject.recurse?(:parent, 3)).to eq(true) }
+    end
+  end
+
+  describe "#next_level" do
+    specify { expect(subject.next_level(:parent, 2)).to eq(:parent) }
+    specify { expect(subject.next_level(:parent, 0)).to eq(:parent) }
+    specify { expect(subject.next_level(:ordered_related_items, 0)).to eq(:ordered_related_items) }
+    specify { expect(subject.next_level(:ordered_related_items, 1)).to eq(:parent) }
+    specify { expect(subject.next_level(:ordered_related_items, 3)).to eq(:parent) }
   end
 
   describe "#reverse_name_for(link_type)" do


### PR DESCRIPTION
Introduce rules to allow for named link types to have other types to be
recursed on.

Before you could only expand on the same type as the first level, this
lets you expand different types by supplying an array of levels.

eg: ['parent', 'parent_taxons', 'parent'] would expand the parent at
level one, parent_taxons at level two, and parents for all levels
greater then n, (the size of the array), the last element being the
"sticky" recursive element. so for array of size 1, it would recurse on just
that element.

This also introduces the ability to expanded recursively for multiple
parent_taxons.

ruby bench/downstream_payload.rb
Many reverse dependencies: 4bda0be5-3e65-4cc1-850c-0541e95a40ca
..........  4.160000   0.190000   4.350000 (  9.104915)
queries: 198

Many forward dependencies: 5f4f1e91-7631-11e4-a3cb-005056011aef
..........  2.240000   0.070000   2.310000 (  3.923168)
queries: 180

No dependencies: 23e13323-874f-4210-aad3-ca6ade9206f8
..........  0.120000   0.010000   0.130000 (  0.189995)
queries: 120

Single link each way: 00012147-49f6-4e90-be1f-e50bb719f53d
..........  0.180000   0.010000   0.190000 (  0.337268)
queries: 180