### PR TITLE
Switch dependency resolution header to be a symbol rather than a string

### DIFF
--- a/app/services/downstream_service.rb
+++ b/app/services/downstream_service.rb
@@ -75,7 +75,7 @@ module DownstreamService
   # (header value) and the respective content for the request.
   def self.set_govuk_dependency_resolution_source_content_id_header(value)
     GdsApi::GovukHeaders.set_header(
-      "govuk_dependency_resolution_source_content_id",
+      :govuk_dependency_resolution_source_content_id,
       value,
     )
   end


### PR DESCRIPTION
It took me a while to work out what was going on with this. If this is set as a string that is how the header is sent, whereas if it is sent as a symbol it is converted to standard header format (dash separated, Capital letters following each dash). Then where it gets a bit weird is how other items treat a header sent in lowercase with underscores. The [test suite converts it to standard format](https://github.com/bblimke/webmock/blob/master/lib/webmock/util/headers.rb#L12) - which is why the tests pass for this. Whereas it seems either Nginx or Rack rejects them, hence why we weren't seeing any results.

We can see this header coming through on integration:
<img width="753" alt="screen shot 2016-10-19 at 17 38 02" src="https://cloud.githubusercontent.com/assets/282717/19528256/29c12c6a-9623-11e6-8b8e-81a44c2c62c6.png">

Note: build failing due to Pact certificate.