### PR TITLE
Remove unnecessary arguments

### DIFF
--- a/app/workers/dependency_resolution_worker.rb
+++ b/app/workers/dependency_resolution_worker.rb
@@ -53,7 +53,6 @@ private
       locale: locale,
       payload_version: payload_version,
       update_dependencies: false,
-      alert_on_invalid_state_error: false,
       dependency_resolution_source_content_id: content_id,
     )
   end
@@ -66,7 +65,6 @@ private
       message_queue_update_type: "links",
       payload_version: payload_version,
       update_dependencies: false,
-      alert_on_invalid_state_error: false,
       dependency_resolution_source_content_id: content_id,
     )
   end

--- a/spec/workers/dependency_resolution_worker_spec.rb
+++ b/spec/workers/dependency_resolution_worker_spec.rb
@@ -36,7 +36,6 @@ RSpec.describe DependencyResolutionWorker, :perform do
         :payload_version,
         message_queue_update_type: "links",
         update_dependencies: false,
-        alert_on_invalid_state_error: false,
       ),
     )
     worker_perform


### PR DESCRIPTION
These should have been removed as part of:
https://github.com/alphagov/publishing-api/pull/551 but I missed them.