### PR TITLE
delete_all with conditions is deprecated

### DIFF
--- a/app/commands/v2/publish.rb
+++ b/app/commands/v2/publish.rb
@@ -63,7 +63,7 @@ module Commands
 
       def delete_change_notes_if_not_major_update(content_item, update_type)
         unless update_type == "major"
-          ChangeNote.delete_all(content_item: content_item)
+          ChangeNote.where(content_item: content_item).delete_all
         end
       end
 


### PR DESCRIPTION
Silences these warnings: DEPRECATION WARNING: Passing conditions to
delete_all is deprecated and will be removed in Rails 5.1. To achieve
the same use where(conditions).delete_all. (called from
delete_change_notes_if_not_major_update at
/var/govuk/publishing-api/app/commands/v2/publish.rb:66)