### PR TITLE
Change ordered_related_items to expand mainstream_browse_pages

### DIFF
--- a/app/queries/dependent_expansion_rules.rb
+++ b/app/queries/dependent_expansion_rules.rb
@@ -30,7 +30,7 @@ module Queries
       [
         [:parent],
         [:parent_taxons],
-        [:ordered_related_items, :parent],
+        [:ordered_related_items, :mainstream_browse_pages, :parent],
       ]
     end
 

--- a/spec/presenters/queries/expanded_link_set_spec.rb
+++ b/spec/presenters/queries/expanded_link_set_spec.rb
@@ -85,19 +85,15 @@ RSpec.describe Presenters::Queries::ExpandedLinkSet do
       it "expands the links for node a correctly" do
         create_link(b, d, "ordered_related_items")
         create_link(a, b, "ordered_related_items")
-        create_link(b, c, "parent")
+        create_link(b, c, "mainstream_browse_pages")
         create_link(c, e, "parent")
-        create_link(a, f, "parent")
+        create_link(a, f, "mainstream_browse_pages")
         create_link(f, g, "parent")
 
-        expect(expanded_links[:parent]).to match([
+        expect(expanded_links[:mainstream_browse_pages]).to match([
           a_hash_including(
             base_path: "/f",
-            links: {
-            parent: [a_hash_including(
-              base_path: "/g",
-              links: {})]
-            }
+            links: {}
           )
         ])
 
@@ -105,7 +101,7 @@ RSpec.describe Presenters::Queries::ExpandedLinkSet do
           a_hash_including(
             base_path: "/b",
             links: {
-            parent: [a_hash_including(
+            mainstream_browse_pages: [a_hash_including(
               base_path: "/c",
               links: {
                 parent: [

--- a/spec/queries/dependent_expansion_rules_spec.rb
+++ b/spec/queries/dependent_expansion_rules_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe Queries::DependentExpansionRules do
     specify { expect(subject.next_level(:parent, 2)).to eq(:parent) }
     specify { expect(subject.next_level(:parent, 0)).to eq(:parent) }
     specify { expect(subject.next_level(:ordered_related_items, 0)).to eq(:ordered_related_items) }
-    specify { expect(subject.next_level(:ordered_related_items, 1)).to eq(:parent) }
+    specify { expect(subject.next_level(:ordered_related_items, 1)).to eq(:mainstream_browse_pages) }
     specify { expect(subject.next_level(:ordered_related_items, 3)).to eq(:parent) }
   end
 


### PR DESCRIPTION
Currently, `ordered_related_items` have their `parent` links expanded. This commit changes the expansion rules to expand their `mainstream_browse_pages` instead at the first level, then the `parent` links of those `mainstream_browse_pages` at all further levels. This enables the grouping of related items based on common `mainstream_browse_pages`.

Trello: https://trello.com/c/mOeDK914/107-epic-related-links-migration

Code by @tijmenb 

CC: @dougdroper 