### PR TITLE
A slightly more resilient delete_content_item helper

### DIFF
--- a/db/migrate/helpers/delete_content_item.rb
+++ b/db/migrate/helpers/delete_content_item.rb
@@ -15,7 +15,6 @@ module Helpers
 
       supporting_classes = [
         AccessLimit,
-        Linkable,
         Location,
         State,
         Translation,
@@ -25,6 +24,7 @@ module Helpers
       ]
 
       supporting_classes.each do |klass|
+        next unless ActiveRecord::Base.connection.data_source_exists?(klass.table_name)
         klass.where(content_item: content_items).destroy_all
       end
 


### PR DESCRIPTION
This no longer uses Linkable which has vanished as a model, and performs
a check whether a table exists on the supporting models for situations
when you are migrating before a table has been created (as was the case
today with change_notes).

This still kinda sucks because of the models in the migration, it'd be
nicer if we had cascading deletes at database level.