### PR TITLE
Remove Linkable reference from DeleteContentItem

### DIFF
--- a/db/migrate/helpers/delete_content_item.rb
+++ b/db/migrate/helpers/delete_content_item.rb
@@ -15,7 +15,6 @@ module Helpers
 
       supporting_classes = [
         AccessLimit,
-        Linkable,
         Location,
         State,
         Translation,


### PR DESCRIPTION
`Linkable` was removed in #559