### PR TITLE
Render withdrawn parent

### DIFF
--- a/app/presenters/queries/expanded_link_set.rb
+++ b/app/presenters/queries/expanded_link_set.rb
@@ -1,30 +1,32 @@
 module Presenters
   module Queries
     class ExpandedLinkSet
+      attr_reader :state_fallback_order
+
       def initialize(content_id:, state_fallback_order:, locale_fallback_order: ContentItem::DEFAULT_LOCALE)
         @content_id = content_id
-        @state_fallback_order = Array(state_fallback_order)
-        @locale_fallback_order = Array(locale_fallback_order)
+        @state_fallback_order = Array(state_fallback_order.freeze)
+        @locale_fallback_order = Array(locale_fallback_order.freeze)
       end
 
       def links
         @links ||= dependees.merge(dependents).merge(translations)
       end
 
-      def web_content_items(target_content_ids)
+      def web_content_items(target_content_ids, fallback_order = state_fallback_order)
         return [] unless target_content_ids.present?
         ::Queries::GetWebContentItems.(
           ::Queries::GetContentItemIdsWithFallbacks.(
             target_content_ids,
             locale_fallback_order: locale_fallback_order,
-            state_fallback_order: state_fallback_order
+            state_fallback_order: fallback_order
           )
         )
       end
 
     private
 
-      attr_reader :state_fallback_order, :locale_fallback_order, :content_id
+      attr_reader :locale_fallback_order, :content_id
 
       def dependees
         ExpandDependees.new(content_id, self).expand

--- a/app/queries/dependent_expansion_rules.rb
+++ b/app/queries/dependent_expansion_rules.rb
@@ -7,7 +7,6 @@ module Queries
     end
 
     def expand_field(web_content_item)
-      return unless web_content_item
       web_content_item.to_h.slice(*expansion_fields(web_content_item.document_type.to_sym))
     end
 

--- a/app/queries/get_content_item_ids_with_fallbacks.rb
+++ b/app/queries/get_content_item_ids_with_fallbacks.rb
@@ -12,7 +12,7 @@ module Queries
       unpublishings = Unpublishing.arel_table
 
       fallback_scope = content_items.project(
-          content_items[:id],
+        content_items[:id],
             content_items[:content_id],
           )
           .join(states).on(states[:content_item_id].eq(content_items[:id]))

--- a/app/queries/get_content_item_ids_with_fallbacks.rb
+++ b/app/queries/get_content_item_ids_with_fallbacks.rb
@@ -9,9 +9,9 @@ module Queries
       content_items = ContentItem.arel_table
       states = State.arel_table
       translations = Translation.arel_table
+      unpublishings = Unpublishing.arel_table
 
-      fallbacks = cte(
-        content_items.project(
+      fallback_scope = content_items.project(
           content_items[:id],
             content_items[:content_id],
           )
@@ -19,14 +19,24 @@ module Queries
           .join(translations).on(translations[:content_item_id].eq(content_items[:id]))
           .where(content_items[:content_id].in(content_ids))
           .where(content_items[:document_type].not_in(::ContentItem::NON_RENDERABLE_FORMATS))
-          .where(states[:name].in(state_fallback_order))
           .where(translations[:locale].in(locale_fallback_order))
-          .order(
-            order_by_clause(:states, :name, state_fallback_order),
-            order_by_clause(:translations, :locale, locale_fallback_order)
-          ),
-        as: "fallbacks"
+
+      if state_fallback_order.include?("withdrawn")
+        fallback_scope = fallback_scope.where(states[:name].in(state_fallback_order).or(states[:name]
+                                                           .eq("unpublished")
+                                                           .and(unpublishings[:type]
+                                                                .eq("withdrawal"))))
+        .join(unpublishings, Arel::Nodes::OuterJoin).on(unpublishings[:content_item_id].eq(content_items[:id]))
+      else
+        fallback_scope = fallback_scope.where(states[:name].in(state_fallback_order))
+      end
+
+      fallback_scope = fallback_scope.order(
+        order_by_clause(:states, :name, state_fallback_order),
+        order_by_clause(:translations, :locale, locale_fallback_order)
       )
+
+      fallbacks = cte(fallback_scope, as: "fallbacks")
 
       aggregates = cte(
         fallbacks.table

--- a/spec/presenters/queries/expanded_link_set_spec.rb
+++ b/spec/presenters/queries/expanded_link_set_spec.rb
@@ -69,13 +69,13 @@ RSpec.describe Presenters::Queries::ExpandedLinkSet do
           a_hash_including(
             base_path: "/b",
             links: {
-            parent: [a_hash_including(
-              base_path: "/c",
-              links: {
-                parent: [
-                  a_hash_including(base_path: "/d", details: {}, links: {})
-                ]
-              })]
+              parent: [a_hash_including(
+                base_path: "/c",
+                links: {
+                  parent: [
+                    a_hash_including(base_path: "/d", details: {}, links: {})
+                  ]
+                })]
             })
         ])
       end
@@ -101,13 +101,13 @@ RSpec.describe Presenters::Queries::ExpandedLinkSet do
           a_hash_including(
             base_path: "/b",
             links: {
-            mainstream_browse_pages: [a_hash_including(
-              base_path: "/c",
-              links: {
-                parent: [
-                  a_hash_including(base_path: "/e", links: {})
-                ]
-              })]
+              mainstream_browse_pages: [a_hash_including(
+                base_path: "/c",
+                links: {
+                  parent: [
+                    a_hash_including(base_path: "/e", links: {})
+                  ]
+                })]
             }
           )
         ])


### PR DESCRIPTION
This adds support for whitehall formats that require a link to a withdrawn parent 
eg `HtmlAttachment`

before: 
Many reverse dependencies: 4bda0be5-3e65-4cc1-850c-0541e95a40ca
..........  3.940000   0.150000   4.090000 (  7.054913)
queries: 198

Many forward dependencies: 5f4f1e91-7631-11e4-a3cb-005056011aef
..........  2.130000   0.060000   2.190000 (  3.008070)
queries: 180

No dependencies: 23e13323-874f-4210-aad3-ca6ade9206f8
..........  0.100000   0.010000   0.110000 (  0.158590)
queries: 120

Single link each way: 00012147-49f6-4e90-be1f-e50bb719f53d
..........  0.150000   0.010000   0.160000 (  0.267114)
queries: 160

after: 
Many reverse dependencies: 4bda0be5-3e65-4cc1-850c-0541e95a40ca
..........  4.190000   0.160000   4.350000 (  7.296519)
queries: 198

Many forward dependencies: 5f4f1e91-7631-11e4-a3cb-005056011aef
..........  2.120000   0.050000   2.170000 (  3.024749)
queries: 180

No dependencies: 23e13323-874f-4210-aad3-ca6ade9206f8
..........  0.090000   0.010000   0.100000 (  0.151902)
queries: 120

Single link each way: 00012147-49f6-4e90-be1f-e50bb719f53d
..........  0.150000   0.010000   0.160000 (  0.269801)
queries: 160