### PR TITLE
Reduce Sidekiq log verbosity

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,5 +1,5 @@
 ---
-:verbose: true
+:verbose: false
 :concurrency:  2
 :logfile: ./log/sidekiq.json.log
 :queues:

--- a/lib/sidekiq_logger_middleware.rb
+++ b/lib/sidekiq_logger_middleware.rb
@@ -1,6 +1,6 @@
 class SidekiqLoggerMiddleware
   def call(worker_class, job, queue, _redis_pool)
-    logger.info "Enqueuing #{worker_class} to queue: #{queue} with arguments: #{job['args'].try(:first)}"
+    logger.info "Enqueuing #{worker_class} to queue: #{queue} with job id: #{job['jid']} and arguments: #{job['args'].try(:first)}"
     yield
   end
 end


### PR DESCRIPTION
We're generating a lot of data by having sidekiq logging set to verbose. On the 26th of October we produced over 20G of log data on integration, the vast majority were a log of severity: DEBUG.

I don't believe we're making any use of the data it produces as we already log in the Rails application the parameters of a Content Item being sent downstream and if an error occurs we will still get all the information.

I've added a job id to our rails logging which should allow us to link our rails queuing to sidekiq logs.