### PR TITLE
Migrate specialist-publisher change history

### DIFF
--- a/app/queries/get_change_history.rb
+++ b/app/queries/get_change_history.rb
@@ -1,0 +1,20 @@
+module Queries
+  class GetChangeHistory
+    def self.call(publishing_app)
+      Queries::GetLatest.
+        call(content_items(publishing_app)).
+        pluck(:id, "details->>'change_history'").
+        flat_map do |content_item_id, item_history|
+          JSON.parse(item_history).map do |item_history_element|
+            item_history_element.symbolize_keys.merge(content_item_id: content_item_id)
+          end
+        end
+    end
+
+    def self.content_items(publishing_app)
+      ContentItem.
+        where(publishing_app: publishing_app).
+        where("json_array_length(details->'change_history') > 0")
+    end
+  end
+end

--- a/db/migrate/20161027134135_add_specialist_publisher_change_notes.rb
+++ b/db/migrate/20161027134135_add_specialist_publisher_change_notes.rb
@@ -1,0 +1,7 @@
+class AddSpecialistPublisherChangeNotes < ActiveRecord::Migration[5.0]
+  def change
+    Queries::GetChangeHistory.("specialist-publisher").each do |change_data|
+      ChangeNote.find_or_create_by(change_data)
+    end
+  end
+end

--- a/spec/queries/get_change_history_spec.rb
+++ b/spec/queries/get_change_history_spec.rb
@@ -1,0 +1,39 @@
+require "rails_helper"
+
+RSpec.describe Queries::GetChangeHistory do
+  let(:app1) { "baba-ganoush" }
+  let(:app2) { "fattoush" }
+
+  let(:details) do
+    { change_history: [
+      { public_timestamp: 1.day.ago.to_s, note: "note 1" },
+      { public_timestamp: 2.days.ago.to_s, note: "note 2" },
+    ] }
+  end
+
+  subject { described_class }
+
+  let!(:item1) do
+    FactoryGirl.create(:content_item, details: details, publishing_app: app1)
+  end
+  let!(:item2) do
+    FactoryGirl.create(:content_item, details: details, publishing_app: app1)
+  end
+  let!(:item3) do
+    FactoryGirl.create(:content_item, details: details, publishing_app: app2)
+  end
+  let!(:item4) do
+    FactoryGirl.create(:content_item, details: {}, publishing_app: app2)
+  end
+
+  it "gets application-specific history data" do
+    ids = subject.(app1).map { |res| res[:content_item_id] }
+    expect(ids).to match_array [item1.id, item1.id, item2.id, item2.id]
+  end
+
+  it "returns array of hashes with note, timestamp and item id" do
+    result = subject.(app1)
+    expected = details[:change_history].first.merge(content_item_id: item1.id)
+    expect(result).to include expected
+  end
+end


### PR DESCRIPTION
Iterate specialist publisher change_history elements and create
corresponding ChangeNote entries. This enables us to move Specialist
Publisher over to the new way of managing change history (where
Publishing API rather than the app is responsible for maintaining
change history).
