### PR TITLE
Allow publishing apps to override time content was withdrawn

### DIFF
--- a/app/commands/v2/unpublish.rb
+++ b/app/commands/v2/unpublish.rb
@@ -82,7 +82,10 @@ module Commands
       end
 
       def unpublish
-        State.unpublish(content_item, payload.slice(:type, :explanation, :alternative_path))
+        State.unpublish(
+          content_item,
+          payload.slice(:type, :explanation, :alternative_path, :unpublished_at)
+        )
       rescue ActiveRecord::RecordInvalid => e
         raise_command_error(422, e.message, fields: {})
       end

--- a/app/models/state.rb
+++ b/app/models/state.rb
@@ -23,16 +23,19 @@ class State < ApplicationRecord
     change_state(content_item, name: "published")
   end
 
-  def self.unpublish(content_item, type:, explanation: nil, alternative_path: nil)
+  def self.unpublish(content_item, type:, explanation: nil, alternative_path: nil, unpublished_at: nil)
     change_state(content_item, name: "unpublished")
 
     unpublishing = Unpublishing.find_by(content_item: content_item)
+
+    unpublished_at = nil unless type == "withdrawal"
 
     if unpublishing.present?
       unpublishing.update_attributes(
         type: type,
         explanation: explanation,
         alternative_path: alternative_path,
+        unpublished_at: unpublished_at,
       )
       unpublishing
     else
@@ -41,6 +44,7 @@ class State < ApplicationRecord
         type: type,
         explanation: explanation,
         alternative_path: alternative_path,
+        unpublished_at: unpublished_at,
       )
     end
   end

--- a/app/presenters/downstream_presenter.rb
+++ b/app/presenters/downstream_presenter.rb
@@ -95,10 +95,11 @@ module Presenters
       unpublishing = Unpublishing.find_by(content_item_id: web_content_item.id)
 
       if unpublishing && unpublishing.withdrawal?
+        withdrawn_at = (unpublishing.unpublished_at || unpublishing.created_at).iso8601
         {
           withdrawn_notice: {
             explanation: unpublishing.explanation,
-            withdrawn_at: unpublishing.created_at.iso8601,
+            withdrawn_at: withdrawn_at
           },
         }
       else

--- a/db/migrate/20161027165922_add_unpublished_at.rb
+++ b/db/migrate/20161027165922_add_unpublished_at.rb
@@ -1,0 +1,5 @@
+class AddUnpublishedAt < ActiveRecord::Migration[5.0]
+  def change
+    add_column :unpublishings, :unpublished_at, :datetime, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,11 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161013104311) do
+ActiveRecord::Schema.define(version: 20161027165922) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
   create_table "access_limits", force: :cascade do |t|
     t.json     "users",           default: [], null: false
     t.datetime "created_at",                   null: false
@@ -143,6 +144,7 @@ ActiveRecord::Schema.define(version: 20161013104311) do
     t.string   "alternative_path"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.datetime "unpublished_at"
     t.index ["content_item_id", "type"], name: "index_unpublishings_on_content_item_id_and_type", using: :btree
     t.index ["content_item_id"], name: "index_unpublishings_on_content_item_id", using: :btree
   end

--- a/doc/api.md
+++ b/doc/api.md
@@ -262,6 +262,15 @@ type. Uses [optimistic-locking](#optimistic-locking-previous_version).
 - `type` *(required)*
   - Accepts: "gone", "redirect", "withdrawal", "vanish"
   - The type of unpublishing that is being performed.
+- `unpublished_at` *(optional)*
+  - An [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) formatted timestamp
+    should be provided, although [other formats](http://apidock.com/rails/String/to_time)
+    may be accepted.
+  - Specifies when this content item was withdrawn. Ignored for unpublishing
+    types other than `withdrawn`.
+  - If omitted, the `withdrawn_at` time will be taken to be the time this call
+    was made.
+
 
 ### State changes
 - If the unpublishing `type` is "gone", "redirect" or "withdrawal":

--- a/spec/commands/v2/unpublish_spec.rb
+++ b/spec/commands/v2/unpublish_spec.rb
@@ -109,6 +109,44 @@ RSpec.describe Commands::V2::Unpublish do
           }
         end
       end
+
+      context "and the unpublished_at parameter is set" do
+        let(:payload) do
+          {
+            content_id: content_id,
+            type: "gone",
+            explanation: "Removed for testing porpoises",
+            alternative_path: "/new-path",
+            unpublished_at: DateTime.new(2016, 8, 1, 1, 1, 1).rfc3339
+          }
+        end
+
+        it "ignores the provided unpublished_at" do
+          described_class.call(payload)
+
+          unpublishing = Unpublishing.find_by(content_item: live_content_item)
+          expect(unpublishing.unpublished_at).to be_nil
+        end
+
+        context "for a withdrawal" do
+          let(:payload) do
+            {
+              content_id: content_id,
+              type: "withdrawal",
+              explanation: "Removed for testing porpoises",
+              alternative_path: "/new-path",
+              unpublished_at: DateTime.new(2016, 8, 1, 10, 10, 10).rfc3339
+            }
+          end
+
+          it "persists the provided unpublished_at" do
+            described_class.call(payload)
+
+            unpublishing = Unpublishing.find_by(content_item: live_content_item)
+            expect(unpublishing.unpublished_at).to eq DateTime.new(2016, 8, 1, 10, 10, 10)
+          end
+        end
+      end
     end
 
     context "when only a draft is present" do

--- a/spec/factories/unpublished_content_item.rb
+++ b/spec/factories/unpublished_content_item.rb
@@ -5,6 +5,7 @@ FactoryGirl.define do
       unpublishing_type "gone"
       explanation "Removed for testing reasons"
       alternative_path "/new-path"
+      unpublished_at nil
     end
 
     after(:create) do |content_item, evaluator|
@@ -13,6 +14,7 @@ FactoryGirl.define do
         type: evaluator.unpublishing_type,
         explanation: evaluator.explanation,
         alternative_path: evaluator.alternative_path,
+        unpublished_at: evaluator.unpublished_at,
       )
     end
   end
@@ -20,24 +22,28 @@ FactoryGirl.define do
   factory :withdrawn_unpublished_content_item, parent: :unpublished_content_item do
     transient do
       unpublishing_type "withdrawal"
+      unpublished_at nil
     end
   end
 
   factory :redirect_unpublished_content_item, parent: :unpublished_content_item do
     transient do
       unpublishing_type "redirect"
+      unpublished_at nil
     end
   end
 
   factory :vanish_unpublished_content_item, parent: :unpublished_content_item do
     transient do
       unpublishing_type "vanish"
+      unpublished_at nil
     end
   end
 
   factory :substitute_unpublished_content_item, parent: :unpublished_content_item do
     transient do
       unpublishing_type "substitute"
+      unpublished_at nil
     end
   end
 end

--- a/spec/presenters/downstream_presenter_spec.rb
+++ b/spec/presenters/downstream_presenter_spec.rb
@@ -89,6 +89,30 @@ RSpec.describe Presenters::DownstreamPresenter do
           )
         )
       end
+
+      context "with an overridden unpublished_at" do
+        let!(:content_item) do
+          FactoryGirl.create(
+            :withdrawn_unpublished_content_item,
+            base_path: base_path,
+            details: details,
+            unpublished_at: DateTime.new(2016, 9, 10, 4, 5, 6)
+          )
+        end
+
+        it "merges in a withdrawal notice with the withdrawn_at set correctly" do
+          unpublishing = Unpublishing.find_by(content_item: content_item)
+
+          expect(result).to eq(
+            expected.merge(
+              withdrawn_notice: {
+                explanation: unpublishing.explanation,
+                withdrawn_at: unpublishing.unpublished_at.iso8601,
+              }
+            )
+          )
+        end
+      end
     end
 
     context "for a content item with dependencies" do


### PR DESCRIPTION
Part of https://trello.com/c/Bnj1Z6K4/504-fix-withdrawn-date-for-rendered-formats

Adds a new column to the `unpublishings` table to store the date and time a piece of content was Unpublished. This is currently only valid for Unpublishings of type "withdrawal" as this is the only type where the date might be exposed to the end user. 

Publishing apps (like Whitehall) already have knowledge of the date a piece of content was originally withdrawn, and that date should be maintained during migration, otherwise users will get confused about the state and freshness of content.

I've chosen to not interfere with the `created_at` and `updated_at` timestamp fields as these are useful for debugging. And the `unpublished_at` field is only set if explicitly provided by the publishing app for similar reasons.

Adding a nullable column in Postgres is a quick operation that won't block writes to the table for more than a few milliseconds.

/cc @gpeng 