### PR TITLE
Add public_timestamp when creating ChangeNote

### DIFF
--- a/app/models/change_note.rb
+++ b/app/models/change_note.rb
@@ -25,7 +25,11 @@ private
 
   def create_from_top_level_change_note
     return unless change_note
-    ChangeNote.create!(change_note.merge(content_item: content_item))
+    ChangeNote.create!(
+      content_item: content_item,
+      note: change_note,
+      public_timestamp: Time.zone.now
+    )
   end
 
   def create_from_details_hash_change_note

--- a/spec/models/change_note_spec.rb
+++ b/spec/models/change_note_spec.rb
@@ -20,12 +20,14 @@ RSpec.describe ChangeNote do
     end
 
     context "payload contains top-level change note entry" do
-      let(:payload_change_note) do
-        { note: "Excellent", public_timestamp: 1.day.ago.to_s }
-      end
+      let(:payload_change_note) { "Excellent" }
       it "populates change note from top-level change note entry" do
-        expect { subject }.to change { ChangeNote.count }.by(1)
-        expect(ChangeNote.last.note).to eq "Excellent"
+        Timecop.freeze do
+          expect { subject }.to change { ChangeNote.count }.by(1)
+          result = ChangeNote.last
+          expect(result.note).to eq "Excellent"
+          expect(result.public_timestamp.iso8601).to eq Time.zone.now.iso8601
+        end
       end
     end
 


### PR DESCRIPTION
There was an implicit assumption that the payload included a change_note
element in the form of a hash with keys `:note` and `:public_timestamp`.
In fact the schemas just define a string for change_note, so we need to
set the public_timestamp in the Publishing API (which is probably a
better place for it anyway).