### PR TITLE
Update Docs for schema error

### DIFF
--- a/app/validators/schema_validator.rb
+++ b/app/validators/schema_validator.rb
@@ -57,6 +57,6 @@ private
   end
 
   def dev_help
-    "Ensure GOVUK_CONTENT_SCHEMAS_PATH env variable is set and points to the dist directory of govuk-content-schemas"
+    "Ensure GOVUK_CONTENT_SCHEMAS_PATH env variable is set and points to the root directory of govuk-content-schemas"
   end
 end

--- a/doc/api.md
+++ b/doc/api.md
@@ -2,7 +2,7 @@
 
 This is the primary interface from publishing apps to the publishing pipeline.
 Applications PUT items as JSON conforming to a schema specified in
-[govuk-content-schemas](https://github.com/alphagov/govuk-content-schemas).
+[govuk-content-schemas][govuk-content-schemas-repo]
 
 Content locations are arbitrated internally by the Publishing API, the content is then
 forwarded to the live and draft content stores, and placed on the message queue
@@ -57,7 +57,7 @@ of the draft, the blocking item will be unpublished.
 
 ## `PUT /v2/content/:content_id`
 
-[Request/Response detail](https://pact-broker.dev.publishing.service.gov.uk/pacts/provider/Publishing%20API/consumer/GDS%20API%20Adapters/latest#a_request_from_the_Whitehall_application_to_create_a_content_item_at_/test-item_given_/test-item_has_been_reserved_by_the_Publisher_application)
+[Request/Response detail][put-content-pact]
 
 Used to create or update a draft content item. It will restrict creation if
 there is already a draft content item with the same `base_path` and `locale`.
@@ -68,9 +68,9 @@ doesn't a 422 response will be returned with an error message stating that the
 payload did not conform to the schema with further error details. In
 development, an error can occur if you do not have the govuk-content-schemas
 locally, in which case ensure that you have pulled the latest
-version of [GOV.UK content schema](https://github.com/alphagov/govuk-content-schemas) and set the
-GOVUK_CONTENT_SCHEMAS_PATH environment variable to the location on your machine
-- eg `export GOVUK_CONTENT_SCHEMAS_PATH=/var/govuk/govuk-content-schemas`.
+version of [GOV.UK content schema][govuk-content-schemas-repo] and set the
+GOVUK_CONTENT_SCHEMAS_PATH environment variable to the location on your
+machine - eg `export GOVUK_CONTENT_SCHEMAS_PATH=/var/govuk/govuk-content-schemas`.
 
 If the request is successful, this endpoint will respond with the
 presented content item and [warnings](#warnings).
@@ -120,18 +120,17 @@ presented content item and [warnings](#warnings).
   - This is required if either `document_type` or `schema_name` is not
     specified.
 - `last_edited_at` *(optional)*
-  - An [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) formatted timestamp
-    should be provided, although [other formats](http://apidock.com/rails/String/to_time)
-    may be accepted.
+  - An [ISO 8601][iso-8601] formatted timestamp should be provided, although
+    [other formats][to-time-docs] may be accepted.
   - Specifies when this content item was last edited.
   - If omitted and `update_type` is "major" or "minor" `last_edited_at` will be
     set to the current time.
   - TODO: What should happen if the update_type is changed in a later request?
 - [`locale`](model.md#locale) *(optional, default: "en")*
-  - Accepts: An available locale from the [Rails I18n gem](https://github.com/svenfuchs/rails-i18n).
+  - Accepts: An available locale from the [Rails I18n gem][i18n-gem]
   - Specifies the locale of the content item.
 - [`need_ids`](model.md#need_ids) *(optional)*
-  - An array of user need ids from the [Maslow application](https://github.com/alphagov/maslow).
+  - An array of user need ids from the [Maslow application][maslow-repo]
 - [`phase`](model.md#phase) *(optional, default: "live")*
   - Accepts: "alpha", "beta", "live"
   - TODO: What is this for?
@@ -139,34 +138,38 @@ presented content item and [warnings](#warnings).
   - Used to ensure that the most recent version of the draft is being updated.
 - [`public_updated_at`](model.md#public_updated_at) *(conditionally required)*
   - Required if `document_type` (or `format`) is not "contact" or "government".
-  - An [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) formatted timestamp
-    should be provided, although [other formats](http://apidock.com/rails/String/to_time)
-    may be accepted.
+  - An [ISO 8601][iso-8601] formatted timestamp should be provided, although
+    [other formats][to-time-docs] may be accepted.
   - The publicly shown date that this content item was last edited at.
   - TODO: Check whether this validation is enforced in the API.
 - [`publishing_app`](model.md#publishing_app) *(required)*
-  - The name of the application making this request, words separated with hyphens.
+  - The name of the application making this request, words separated with
+    hyphens.
 - [`redirects`](model.md#redirects) *(conditionally required)*
   - Required for a `document_type` (or `format`) of "redirect".
   - An array of redirect values. (TODO: link directly to example)
 - [`rendering_app`](model.md#rendering_app) *(conditionally required)*
-  - Required for a `document_type` (or `format`) that is not "redirect" or "gone".
-  - The hostname for the frontend application that will render this content item.
+  - Required for a `document_type` (or `format`) that is not "redirect" or
+    "gone".
+  - The hostname for the frontend application that will render this content
+    item.
 - [`routes`](model.md#routes) *(conditionally required)*
   - Required for a `document_type` (or `format`) that is not "redirect".
   - An array of route values. (TODO: link directly to example)
 - [`schema_name`](model.md#schema_name) *(conditionally required)*
   - Required if `format` is not provided.
-  - The name of the [GOV.UK content schema](https://github.com/alphagov/govuk-content-schemas)
+  - The name of the [GOV.UK content schema][govuk-content-schemas-repo]
     that the request body will be validated against.
 - [`title`](model.md#title) *(conditionally required)*
-  - Required for a `document_type` (or `format`) that is not "redirect" or "gone".
+  - Required for a `document_type` (or `format`) that is not "redirect" or
+    "gone".
 - [`update_type`](model.md#update_type) *(optional)*
   - Accepts: "major", "minor", "republish"
   - TODO: Check this is validated against.
 
 ### State changes
-- If a `base_path` is provided it is reserved for use of the given `publishing_app`.
+- If a `base_path` is provided it is reserved for use of the given
+  `publishing_app`.
 - Any draft content items that have a matching `base_path` and `locale` and
   have a document_type of "coming soon", "gone", "redirect" or "unpublishing"
   will be deleted.
@@ -186,10 +189,11 @@ presented content item and [warnings](#warnings).
 
 ## `POST /v2/content/:content_id/publish`
 
-[Request/Response detail](https://pact-broker.dev.publishing.service.gov.uk/pacts/provider/Publishing%20API/consumer/GDS%20API%20Adapters/latest#a_publish_request_for_version_3_given_the_content_item_bed722e6-db68-43e5-9079-063f623335a7_is_at_version_3)
+[Request/Response detail][publish-pact]
 
 Transitions a content item from a draft state to a published state. The content
-item will be sent to the live content store. Uses [optimistic-locking](#optimistic-locking-previous_version).
+item will be sent to the live content store. Uses
+[optimistic-locking](#optimistic-locking-previous_version).
 
 ### Path parameters
 - [`content_id`](model.md#content_id)
@@ -201,7 +205,7 @@ item will be sent to the live content store. Uses [optimistic-locking](#optimist
   - Will fallback to the `update_type` set when the draft was created if not
     specified in the request.
 - [`locale`](model.md#locale) *(optional, default: "en")*
-  - Accepts: An available locale from the [Rails I18n gem](https://github.com/svenfuchs/rails-i18n).
+  - Accepts: An available locale from the [Rails I18n gem][i18n-gem]
   - Specifies the locale of the content item to be published.
 - `previous_version` *(optional, recommended)*
   - Used to ensure that the version being published is the most recent draft
@@ -232,7 +236,7 @@ item will be sent to the live content store. Uses [optimistic-locking](#optimist
 
 ## `POST /v2/content/:content_id/unpublish`
 
- [Request/Response detail](https://pact-broker.dev.publishing.service.gov.uk/pacts/provider/Publishing%20API/consumer/GDS%20API%20Adapters/latest#an_unpublish_request_given_a_published_content_item_exists_with_content_id:_bed722e6-db68-43e5-9079-063f623335a7)
+[Request/Response detail][unpublish-pact]
 
 Transitions a content item into an unpublished state. The content item will be
 updated or removed from the live content store depending on the unpublishing
@@ -256,7 +260,7 @@ type. Uses [optimistic-locking](#optimistic-locking-previous_version).
   - Required for a `type` of "withdrawal", Optional for a type of "gone".
   - Message that will be displayed publicly on the page that has been unpublished.
 - [`locale`](model.md#locale) *(optional, default: "en")*
-  - Accepts: An available locale from the [Rails I18n gem](https://github.com/svenfuchs/rails-i18n).
+  - Accepts: An available locale from the [Rails I18n gem][i18n-gem]
   - Specifies the locale of the content item to unpublish.
 - `previous_version` *(optional, recommended)*
   - Used to ensure that the version being unpublished is the most recent
@@ -265,9 +269,8 @@ type. Uses [optimistic-locking](#optimistic-locking-previous_version).
   - Accepts: "gone", "redirect", "withdrawal", "vanish"
   - The type of unpublishing that is being performed.
 - `unpublished_at` *(optional)*
-  - An [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) formatted timestamp
-    should be provided, although [other formats](http://apidock.com/rails/String/to_time)
-    may be accepted.
+  - An [ISO 8601][iso-8601] formatted timestamp should be provided, although
+    [other formats][to-time-docs] may be accepted.
   - Specifies when this content item was withdrawn. Ignored for unpublishing
     types other than `withdrawn`.
   - If omitted, the `withdrawn_at` time will be taken to be the time this call
@@ -297,7 +300,7 @@ type. Uses [optimistic-locking](#optimistic-locking-previous_version).
 
 ## `POST /v2/content/:content_id/discard-draft`
 
-[Request/Response detail](https://pact-broker.dev.publishing.service.gov.uk/pacts/provider/Publishing%20API/consumer/GDS%20API%20Adapters/latest#a_request_to_discard_draft_content_given_a_content_item_exists_with_content_id:_bed722e6-db68-43e5-9079-063f623335a7)
+[Request/Response detail][discard-draft-pact]
 
 Deletes a draft version of a content item. Replaces the draft content item on
 the draft content store with the published item, if one exists. Uses
@@ -309,7 +312,7 @@ the draft content store with the published item, if one exists. Uses
 
 ### JSON attributes
 - [`locale`](model.md#locale) *(optional, default: "en")*
-  - Accepts: An available locale from the [Rails I18n gem](https://github.com/svenfuchs/rails-i18n).
+  - Accepts: An available locale from the [Rails I18n gem][i18n-gem]
   - Specifies which locale of the draft content item to delete.
 - `previous_version` *(optional, recommended)*
   - Used to ensure the version being discarded is the current draft.
@@ -321,7 +324,7 @@ the draft content store with the published item, if one exists. Uses
 
 ## `GET /v2/content`
 
- [Request/Response detail](https://pact-broker.dev.publishing.service.gov.uk/pacts/provider/Publishing%20API/consumer/GDS%20API%20Adapters/latest#a_get_entries_request_given_a_content_item_exists_in_multiple_locales_with_content_id:_bed722e6-db68-43e5-9079-063f623335a7)
+ [Request/Response detail][index-content-pact]
 
 Retrieves a paginated list of content items for the provided query string
 parameters. If content items exists in both a published and a draft state, the
@@ -337,7 +340,7 @@ draft is returned.
   - Determines which fields will be returned in the response, if omitted all
     fields will be returned.
 - [`locale`](model.md#locale) *(optional, default "en")*
-  - Accepts: An available locale from the [Rails I18n gem](https://github.com/svenfuchs/rails-i18n).
+  - Accepts: An available locale from the [Rails I18n gem][i18n-gem]
   - Used to restrict content items to a given locale.
 - `order` *(optional, default: "-public_updated_at")*
   - The field to sort the results by.
@@ -357,7 +360,7 @@ draft is returned.
 
 ## `GET /v2/content/:content_id`
 
-[Request/Response detail](https://pact-broker.dev.publishing.service.gov.uk/pacts/provider/Publishing%20API/consumer/GDS%20API%20Adapters/latest#a_request_to_return_the_content_item_given_a_content_item_exists_with_content_id:_bed722e6-db68-43e5-9079-063f623335a7)
+[Request/Response detail][show-content-pact]
 
 Retrieves a single content item for a `content_id` and `locale`. By default the
 most recent version is returned, which may be a draft.
@@ -371,7 +374,7 @@ included within the response.
 
 ### Query string parameters
 - [`locale`](model.md#locale) *(optional, default "en")*
-  - Accepts: An available locale from the [Rails I18n gem](https://github.com/svenfuchs/rails-i18n).
+  - Accepts: An available locale from the [Rails I18n gem][i18n-gem]
   - Used to return a specific locale.
 - `version` *(optional)*
   - Specify a particular user facing version of this content item.
@@ -379,13 +382,13 @@ included within the response.
 
 ## `PATCH /v2/links/:content_id`
 
-[Request/Response detail](https://pact-broker.dev.publishing.service.gov.uk/pacts/provider/Publishing%20API/consumer/GDS%20API%20Adapters/latest#a_request_to_update_the_linkset_at_version_3_given_the_linkset_for_bed722e6-db68-43e5-9079-063f623335a7_is_at_version_3)
+[Request/Response detail][patch-link-set-pact]
 
 Creates or updates a set of links for the given `content_id`. Link sets can be
 created before or after the [PUT request](#put_v2contentcontent-id) for the
 content item. These are tied to a content item solely by matching `content_id`
-and they are not associated with a content item's locale or version. The ordering
-of links in the request is preserved.
+and they are not associated with a content item's locale or version. The
+ordering of links in the request is preserved.
 
 ### Path parameters
 - [`content_id`](model.md#content_id)
@@ -417,7 +420,7 @@ of links in the request is preserved.
 
 ## `GET /v2/links/:content_id`
 
-[Request/Response detail](https://pact-broker.dev.publishing.service.gov.uk/pacts/provider/Publishing%20API/consumer/GDS%20API%20Adapters/latest#a_get-links_request_given_empty_links_exist_for_content_id_bed722e6-db68-43e5-9079-063f623335a7)
+[Request/Response detail][show-links-pact]
 
 Retrieves the link set for the given `content_id`. Returns arrays of
 `content_id`s representing content items. These are grouped by `link_type`.
@@ -429,7 +432,7 @@ The ordering of the returned links matches the ordering when they were created.
 
 ## `GET /v2/expanded-links/:content_id`
 
-[Request/Response detail](https://pact-broker.dev.publishing.service.gov.uk/pacts/provider/Publishing%20API/consumer/GDS%20API%20Adapters/latest#a_get-expanded-links_request_given_empty_links_exist_for_content_id_bed722e6-db68-43e5-9079-063f623335a7)
+[Request/Response detail][show-expanded-links-pact]
 
 Retrieves the expanded link set for the given `content_id`. Returns arrays of
 details for each linked content item in groupings of `link_type`.
@@ -440,7 +443,7 @@ details for each linked content item in groupings of `link_type`.
 
 ## `GET /v2/linked/:content_id`
 
- [Request/Response detail](https://pact-broker.dev.publishing.service.gov.uk/pacts/provider/Publishing%20API/consumer/GDS%20API%20Adapters/latest#a_request_to_return_the_items_linked_to_it_given_no_content_exists)
+ [Request/Response detail][show-linked-pact]
 
 Retrieves all content items that link to the given `content_id` for some
 `link_type`.
@@ -460,7 +463,7 @@ Retrieves all content items that link to the given `content_id` for some
 
 ## `GET /v2/linkables`
 
- [Request/Response detail](https://pact-broker.dev.publishing.service.gov.uk/pacts/provider/Publishing%20API/consumer/GDS%20API%20Adapters/latest#a_get_linkables_request_given_there_is_content_with_format_'topic')
+ [Request/Response detail][index-linkables-pact]
 
 Returns abridged versions of all content items matching the given
 `document_type`. Returns `title`, `content_id`, `publication_state`, `base_path`
@@ -473,7 +476,7 @@ from the content item. It also adds a special field `internal_name`, which is
 
 ## `POST /lookup-by-base-path`
 
- [Request/Response detail](https://pact-broker.dev.publishing.service.gov.uk/pacts/provider/Publishing%20API/consumer/GDS%20API%20Adapters/latest#a_/lookup-by-base-path-request_given_there_are_live_content_items_with_base_paths_/foo_and_/bar)
+ [Request/Response detail][lookup-by-base-path-pact]
 
 Retrieves published content items for a given collection of base paths. Returns
 a mapping of `base_path` to `content_id`.
@@ -507,7 +510,7 @@ http://publishing-api.integration.publishing.service.gov.uk:8888/debug/f141fa95-
 
 ## `PUT /paths/:base_path`
 
- [Request/response detail](https://pact-broker.dev.publishing.service.gov.uk/pacts/provider/Publishing%20API/consumer/GDS%20API%20Adapters/latest#a_request_to_put_a_path_given_no_content_exists)
+ [Request/response detail][reserve-path-pact]
 
 Reserves a path for a publishing application. Returns success or failure only.
 
@@ -530,3 +533,22 @@ Reserves a path for a publishing application. Returns success or failure only.
 - If a path reservation exists for the supplied base_path and a different a
   publishing_app, and `override_existing` is true, the existing reservation will
   be updated to the supplied publishing_app.
+
+[govuk-content-schemas-repo]: https://github.com/alphagov/govuk-content-schemas
+[put-content-pact]: https://pact-broker.dev.publishing.service.gov.uk/pacts/provider/Publishing%20API/consumer/GDS%20API%20Adapters/latest#a_request_from_the_Whitehall_application_to_create_a_content_item_at_/test-item_given_/test-item_has_been_reserved_by_the_Publisher_application
+[iso-8601]: https://en.wikipedia.org/wiki/ISO_8601
+[to-time-docs]: http://apidock.com/rails/String/to_time
+[i18n-gem]: https://github.com/svenfuchs/rails-i18n
+[maslow-repo]: https://github.com/alphagov/maslow
+[publish-pact]: https://pact-broker.dev.publishing.service.gov.uk/pacts/provider/Publishing%20API/consumer/GDS%20API%20Adapters/latest#a_publish_request_for_version_3_given_the_content_item_bed722e6-db68-43e5-9079-063f623335a7_is_at_version_3
+[unpublish-pact]: https://pact-broker.dev.publishing.service.gov.uk/pacts/provider/Publishing%20API/consumer/GDS%20API%20Adapters/latest#an_unpublish_request_given_a_published_content_item_exists_with_content_id:_bed722e6-db68-43e5-9079-063f623335a7
+[discard-draft-pact]: https://pact-broker.dev.publishing.service.gov.uk/pacts/provider/Publishing%20API/consumer/GDS%20API%20Adapters/latest#a_request_to_discard_draft_content_given_a_content_item_exists_with_content_id:_bed722e6-db68-43e5-9079-063f623335a7
+[index-content-pact]: https://pact-broker.dev.publishing.service.gov.uk/pacts/provider/Publishing%20API/consumer/GDS%20API%20Adapters/latest#a_get_entries_request_given_a_content_item_exists_in_multiple_locales_with_content_id:_bed722e6-db68-43e5-9079-063f623335a7
+[show-content-pact]: https://pact-broker.dev.publishing.service.gov.uk/pacts/provider/Publishing%20API/consumer/GDS%20API%20Adapters/latest#a_request_to_return_the_content_item_given_a_content_item_exists_with_content_id:_bed722e6-db68-43e5-9079-063f623335a7
+[patch-link-set-pact]: https://pact-broker.dev.publishing.service.gov.uk/pacts/provider/Publishing%20API/consumer/GDS%20API%20Adapters/latest#a_request_to_update_the_linkset_at_version_3_given_the_linkset_for_bed722e6-db68-43e5-9079-063f623335a7_is_at_version_3
+[show-links-pact]: https://pact-broker.dev.publishing.service.gov.uk/pacts/provider/Publishing%20API/consumer/GDS%20API%20Adapters/latest#a_get-links_request_given_empty_links_exist_for_content_id_bed722e6-db68-43e5-9079-063f623335a7
+[show-expaned-links-pact]: https://pact-broker.dev.publishing.service.gov.uk/pacts/provider/Publishing%20API/consumer/GDS%20API%20Adapters/latest#a_get-expanded-links_request_given_empty_links_exist_for_content_id_bed722e6-db68-43e5-9079-063f623335a7
+[show-linked-pact]: https://pact-broker.dev.publishing.service.gov.uk/pacts/provider/Publishing%20API/consumer/GDS%20API%20Adapters/latest#a_request_to_return_the_items_linked_to_it_given_no_content_exists
+[index-linkables-pact]: https://pact-broker.dev.publishing.service.gov.uk/pacts/provider/Publishing%20API/consumer/GDS%20API%20Adapters/latest#a_get_linkables_request_given_there_is_content_with_format_'topic'
+[lookup-by-base-path-pact]: https://pact-broker.dev.publishing.service.gov.uk/pacts/provider/Publishing%20API/consumer/GDS%20API%20Adapters/latest#a_/lookup-by-base-path-request_given_there_are_live_content_items_with_base_paths_/foo_and_/bar
+[reserve-path-pact]: https://pact-broker.dev.publishing.service.gov.uk/pacts/provider/Publishing%20API/consumer/GDS%20API%20Adapters/latest#a_request_to_put_a_path_given_no_content_exists

--- a/doc/api.md
+++ b/doc/api.md
@@ -64,9 +64,10 @@ there is already a draft content item with the same `base_path` and `locale`.
 Uses [optimistic-locking](#optimistic-locking-previous_version).
 
 The request must conform to the schema defined in govuk-content-schemas if it
-doesn't a 422 with error message stating that the payload did not conform to the schema,
-and more details in the error details. In development, an error can occur if you do not
-have the govuk-content-schemas locally, in which case ensure that you have pulled the latest
+doesn't a 422 response will be returned with an error message stating that the
+payload did not conform to the schema with further error details. In
+development, an error can occur if you do not have the govuk-content-schemas
+locally, in which case ensure that you have pulled the latest
 version of [GOV.UK content schema](https://github.com/alphagov/govuk-content-schemas) and set the
 GOVUK_CONTENT_SCHEMAS_PATH environment variable to the location on your machine
 - eg `export GOVUK_CONTENT_SCHEMAS_PATH=/var/govuk/govuk-content-schemas`.

--- a/doc/api.md
+++ b/doc/api.md
@@ -68,7 +68,8 @@ doesn't a 422 with error message stating that the payload did not conform to the
 and more details in the error details. In development, an error can occur if you do not
 have the govuk-content-schemas locally, in which case ensure that you have pulled the latest
 version of [GOV.UK content schema](https://github.com/alphagov/govuk-content-schemas) and set the
-GOVUK_CONTENT_SCHEMAS_PATH to point to the dist folder.
+GOVUK_CONTENT_SCHEMAS_PATH environment variable to the location on your machine
+- eg `export GOVUK_CONTENT_SCHEMAS_PATH=/var/govuk/govuk-content-schemas`.
 
 If the request is successful, this endpoint will respond with the
 presented content item and [warnings](#warnings).


### PR DESCRIPTION
This updates the docs about setting the env var to root of directory not the dist folder.

I then went and got a bit carried away formatting the long links in the api.md file. 