### PR TITLE
Fix web and json links on debug page

### DIFF
--- a/app/presenters/debug_presenter.rb
+++ b/app/presenters/debug_presenter.rb
@@ -26,7 +26,7 @@ module Presenters
     end
 
     def latest_content_items
-      ::Queries::GetLatest.call(content_items)
+      @latest_content_items ||= ::Queries::GetLatest.call(content_items)
     end
 
     def latest_state_with_locale
@@ -77,7 +77,7 @@ module Presenters
     end
 
     def web_content_item
-      ::Queries::GetWebContentItems.find(
+      @web_content_item ||= ::Queries::GetWebContentItems.find(
         latest_content_items.last.id
       )
     end

--- a/app/presenters/debug_presenter.rb
+++ b/app/presenters/debug_presenter.rb
@@ -77,7 +77,9 @@ module Presenters
     end
 
     def web_content_item
-      WebContentItem.new(latest_content_items.last)
+      ::Queries::GetWebContentItems.find(
+        latest_content_items.last.id
+      )
     end
 
     def web_url


### PR DESCRIPTION
These were broken due to the `web_content_item` method being broken.