### PR TITLE
Introducing Action concept

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ the system
 potential to mutate its internal state
 - **Unpublishing**: An object indicating a previously published content item
 which has been removed from the live site.  Can be "gone", "withdrawal", or "redirect".
+- **Action**: A record of activity on a particular Content Item, used to assist
+custom workflows of publishing applications.
 
 For more information, refer to [doc/api.md](doc/api.md) and
 [doc/model.md](doc/model.md).

--- a/app/commands/success.rb
+++ b/app/commands/success.rb
@@ -1,14 +1,11 @@
 module Commands
   class Success
-    attr_reader :data, :message
+    attr_reader :data, :message, :code
 
-    def initialize(data, message: "OK")
+    def initialize(data, message: "OK", code: 200)
       @message = message
       @data = data
-    end
-
-    def code
-      200
+      @code = code
     end
 
     def as_json(_options = nil)

--- a/app/commands/v2/discard_draft.rb
+++ b/app/commands/v2/discard_draft.rb
@@ -16,6 +16,7 @@ module Commands
           downstream_discard_draft(draft_path, draft.content_id, locale)
         end
 
+        Action.create_discard_draft_action(draft, locale, event)
         Success.new(content_id: content_id)
       end
 

--- a/app/commands/v2/patch_link_set.rb
+++ b/app/commands/v2/patch_link_set.rb
@@ -26,6 +26,8 @@ module Commands
           send_downstream
         end
 
+        Action.create_patch_link_set_action(link_set, event)
+
         presented = Presenters::Queries::LinkSetPresenter.present(link_set)
         Success.new(presented)
       end

--- a/app/commands/v2/post_action.rb
+++ b/app/commands/v2/post_action.rb
@@ -1,0 +1,61 @@
+module Commands
+  module V2
+    class PostAction < BaseCommand
+      def call
+        check_version_and_raise_if_conflicting(content_item, previous_version_number)
+
+        Action.create!(
+          content_id: content_id,
+          locale: locale,
+          action: action_type,
+          content_item: content_item,
+          user_uid: event.user_uid,
+          event: event,
+        )
+
+        Success.new(
+          { content_id: content_id, locale: locale, action: action_type },
+          code: 201,
+        )
+      end
+
+    private
+
+      def content_id
+        payload.fetch(:content_id)
+      end
+
+      def locale
+        payload.fetch(:locale, ContentItem::DEFAULT_LOCALE)
+      end
+
+      def draft?
+        payload[:draft].nil? ? true : payload[:draft]
+      end
+
+      def content_item
+        @content_item ||= find_content_item
+      end
+
+      def action_type
+        payload[:action]
+      end
+
+      def find_content_item
+        allowed_states = draft? ? %w(draft) : %w(published unpublished)
+
+        filter = ContentItemFilter.new(scope: ContentItem.where(content_id: content_id))
+        found_content_item = filter.filter(locale: locale, state: allowed_states).last
+        unless found_content_item
+          message = "Could not find a content item to associate this action with"
+          raise_command_error(404, message, fields: {})
+        end
+        found_content_item
+      end
+
+      def previous_version_number
+        payload[:previous_version].to_i if payload[:previous_version]
+      end
+    end
+  end
+end

--- a/app/commands/v2/publish.rb
+++ b/app/commands/v2/publish.rb
@@ -56,6 +56,8 @@ module Commands
           send_downstream(content_item.content_id, translation.locale, update_type)
         end
 
+        Action.create_publish_action(content_item, locale, event)
+
         Success.new(content_id: content_id)
       end
 

--- a/app/commands/v2/put_content.rb
+++ b/app/commands/v2/put_content.rb
@@ -32,6 +32,8 @@ module Commands
           content_item,
           include_warnings: true,
         )
+
+        Action.create_put_content_action(content_item, locale, event)
         Success.new(response_hash)
       end
 

--- a/app/commands/v2/unpublish.rb
+++ b/app/commands/v2/unpublish.rb
@@ -10,6 +10,8 @@ module Commands
           send_downstream
         end
 
+        Action.create_unpublish_action(content_item, unpublishing_type, locale, event)
+
         Success.new(content_id: content_id)
       end
 

--- a/app/controllers/v2/actions_controller.rb
+++ b/app/controllers/v2/actions_controller.rb
@@ -1,0 +1,18 @@
+module V2
+  class ActionsController < ApplicationController
+    def create
+      response = Commands::V2::PostAction.call(action_params)
+      render status: response.code, json: response
+    end
+
+  private
+
+    def action_params
+      payload.merge(content_id: content_id)
+    end
+
+    def content_id
+      params.fetch(:content_id)
+    end
+  end
+end

--- a/app/models/action.rb
+++ b/app/models/action.rb
@@ -18,6 +18,10 @@ class Action < ActiveRecord::Base
     create_publishing_action(action, content_item, locale, event)
   end
 
+  def self.create_discard_draft_action(content_item, locale, event)
+    create_publishing_action("DiscardDraft", content_item, locale, event)
+  end
+
   def self.create_publishing_action(action, content_item, locale, event)
     create!(
       content_id: content_item.content_id,

--- a/app/models/action.rb
+++ b/app/models/action.rb
@@ -1,0 +1,15 @@
+class Action < ActiveRecord::Base
+  belongs_to :content_item
+  belongs_to :link_set
+  belongs_to :event
+
+  validate :one_of_content_item_link_set
+
+private
+
+  def one_of_content_item_link_set
+    if content_item_id && link_set_id || content_item && link_set
+      errors.add(:base, "can not be associated with both a content item and link set")
+    end
+  end
+end

--- a/app/models/action.rb
+++ b/app/models/action.rb
@@ -13,6 +13,11 @@ class Action < ActiveRecord::Base
     create_publishing_action("Publish", content_item, locale, event)
   end
 
+  def self.create_unpublish_action(content_item, unpublishing_type, locale, event)
+    action = "Unpublish#{unpublishing_type.camelize}"
+    create_publishing_action(action, content_item, locale, event)
+  end
+
   def self.create_publishing_action(action, content_item, locale, event)
     create!(
       content_id: content_item.content_id,

--- a/app/models/action.rb
+++ b/app/models/action.rb
@@ -29,6 +29,17 @@ class Action < ActiveRecord::Base
     )
   end
 
+  def self.create_patch_link_set_action(link_set, event)
+    create!(
+      content_id: link_set.content_id,
+      locale: nil,
+      action: "PatchLinkSet",
+      user_uid: event.user_uid,
+      link_set: link_set,
+      event: event,
+    )
+  end
+
 private
 
   def one_of_content_item_link_set

--- a/app/models/action.rb
+++ b/app/models/action.rb
@@ -5,6 +5,17 @@ class Action < ActiveRecord::Base
 
   validate :one_of_content_item_link_set
 
+  def self.create_put_content_action(content_item, locale, event)
+    create!(
+      content_id: content_item.content_id,
+      locale: locale,
+      action: "PutContent",
+      user_uid: event.user_uid,
+      content_item: content_item,
+      event: event,
+    )
+  end
+
 private
 
   def one_of_content_item_link_set

--- a/app/models/action.rb
+++ b/app/models/action.rb
@@ -6,10 +6,18 @@ class Action < ActiveRecord::Base
   validate :one_of_content_item_link_set
 
   def self.create_put_content_action(content_item, locale, event)
+    create_publishing_action("PutContent", content_item, locale, event)
+  end
+
+  def self.create_publish_action(content_item, locale, event)
+    create_publishing_action("Publish", content_item, locale, event)
+  end
+
+  def self.create_publishing_action(action, content_item, locale, event)
     create!(
       content_id: content_item.content_id,
       locale: locale,
-      action: "PutContent",
+      action: action,
       user_uid: event.user_uid,
       content_item: content_item,
       event: event,

--- a/app/models/action.rb
+++ b/app/models/action.rb
@@ -4,6 +4,7 @@ class Action < ActiveRecord::Base
   belongs_to :event
 
   validate :one_of_content_item_link_set
+  validates :action, presence: true
 
   def self.create_put_content_action(content_item, locale, event)
     create_publishing_action("PutContent", content_item, locale, event)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,6 +30,8 @@ Rails.application.routes.draw do
       get "/new-linkables", to: "content_items#new_linkables"
 
       get "/grouped-content-and-links", to: "grouped_content_and_links#index"
+
+      post "/actions/:content_id", to: "actions#create"
     end
   end
 

--- a/db/migrate/20161102115422_create_actions.rb
+++ b/db/migrate/20161102115422_create_actions.rb
@@ -1,0 +1,14 @@
+class CreateActions < ActiveRecord::Migration[5.0]
+  def change
+    create_table :actions do |t|
+      t.uuid     :content_id, null: false
+      t.string   :locale
+      t.string   :action, null: false
+      t.uuid     :user_uid
+      t.references :content_item, index: true, foreign_key: false, null: true
+      t.references :link_set, index: true, foreign_key: false, null: true
+      t.references :event, index: true, foreign_key: false, null: false
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161027165922) do
+ActiveRecord::Schema.define(version: 20161102115422) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -21,6 +21,21 @@ ActiveRecord::Schema.define(version: 20161027165922) do
     t.datetime "updated_at",                   null: false
     t.integer  "content_item_id"
     t.index ["content_item_id"], name: "index_access_limits_on_content_item_id", using: :btree
+  end
+
+  create_table "actions", force: :cascade do |t|
+    t.uuid     "content_id",      null: false
+    t.string   "locale"
+    t.string   "action",          null: false
+    t.uuid     "user_uid"
+    t.integer  "content_item_id"
+    t.integer  "link_set_id"
+    t.integer  "event_id",        null: false
+    t.datetime "created_at",      null: false
+    t.datetime "updated_at",      null: false
+    t.index ["content_item_id"], name: "index_actions_on_content_item_id", using: :btree
+    t.index ["event_id"], name: "index_actions_on_event_id", using: :btree
+    t.index ["link_set_id"], name: "index_actions_on_link_set_id", using: :btree
   end
 
   create_table "change_notes", force: :cascade do |t|

--- a/doc/api.md
+++ b/doc/api.md
@@ -15,6 +15,7 @@ for other apps (eg email-alert-service) to consume.
 - [`POST /v2/content/:content_id/discard-draft`](#post-v2contentcontent_iddiscard-draft)
 - [`GET /v2/content`](#get-v2content)
 - [`GET /v2/content/:content_id`](#get-v2contentcontent_id)
+- [`POST /v2/actions/:content_id`](#post-v2actionscontent_id)
 - [`PATCH /v2/links/:content_id`](#patch-v2linkscontent_id)
 - [`GET /v2/links/:content_id`](#get-v2linkscontent_id)
 - [`GET /v2/expanded-links/:content_id`](#get-v2expanded-linkscontent_id)
@@ -380,6 +381,38 @@ included within the response.
   - Specify a particular user facing version of this content item.
   - If omitted the most recent version is returned.
 
+## `POST /v2/actions/:content_id`
+
+TODO: Request/Response pact for actions
+
+**Note - The usage opportunities for this endpoint is currently in discovery,
+this feature may change significantly in time.**
+
+Creates an action for the content item that is specified, defaults to
+targeting a draft version of the content item but can be specified to target
+live version. Uses [optimistic-locking](#optimistic-locking-previous_version).
+
+### Path parameters
+- [`content_id`](model.md#content_id)
+  - Identifies a content item.
+
+### JSON attributes
+- `action` (required)
+  - Currently an arbitrary name describing the workflow a content item has gone
+    through
+  - Provided in CamelCase
+- `draft` (optional, default: "true")
+  - Whether to target the live or draft version of a content item.
+- [`locale`](model.md#locale) *(optional, default: "en")*
+  - Accepts: An available locale from the [Rails I18n gem][i18n-gem]
+  - Specifies which locale of the draft content item to delete.
+- `previous_version` *(optional, recommended)*
+  - Used to ensure the version being discarded is the current draft.
+
+### State changes
+- The draft content item will be deleted from the Publishing API.
+- The draft content item will be removed from the draft content store.
+- If a published content item exists it will be added to the draft content store.
 ## `PATCH /v2/links/:content_id`
 
 [Request/Response detail][patch-link-set-pact]

--- a/spec/commands/v2/discard_draft_spec.rb
+++ b/spec/commands/v2/discard_draft_spec.rb
@@ -39,6 +39,18 @@ RSpec.describe Commands::V2::DiscardDraft do
         expect(ContentItem.exists?(id: existing_draft_item.id)).to eq(false)
       end
 
+      it "creates an action" do
+        expect(Action.count).to be 0
+        described_class.call(payload)
+        expect(Action.count).to be 1
+        expect(Action.first.attributes).to match a_hash_including(
+          "content_id" => content_id,
+          "locale" => locale,
+          "action" => "DiscardDraft",
+          "content_item_id" => existing_draft_item.id,
+        )
+      end
+
       it "deletes the supporting objects for the draft item" do
         described_class.call(payload)
 

--- a/spec/commands/v2/patch_link_set_spec.rb
+++ b/spec/commands/v2/patch_link_set_spec.rb
@@ -35,7 +35,21 @@ RSpec.describe Commands::V2::PatchLinkSet do
       .and_return(expected_content_store_payload)
   end
 
+  shared_examples "creates an action" do
+    it "creates an action" do
+      expect(Action.count).to be 0
+      described_class.call(payload)
+      expect(Action.count).to be 1
+      expect(Action.first.attributes).to match a_hash_including(
+        "content_id" => content_id,
+        "action" => "PatchLinkSet",
+      )
+    end
+  end
+
   context "when no link set exists" do
+    include_examples "creates an action"
+
     it "creates the link set and associated links" do
       described_class.call(payload)
 
@@ -127,6 +141,8 @@ RSpec.describe Commands::V2::PatchLinkSet do
 
       FactoryGirl.create(:lock_version, target: link_set, number: 1)
     end
+
+    include_examples "creates an action"
 
     it "creates links for groups that appear in the payload and not in the database" do
       described_class.call(payload)

--- a/spec/commands/v2/post_action_spec.rb
+++ b/spec/commands/v2/post_action_spec.rb
@@ -1,0 +1,108 @@
+require "rails_helper"
+
+RSpec.describe Commands::V2::PostAction do
+  describe ".call" do
+    let(:content_id) { SecureRandom.uuid }
+    let(:locale) { "en" }
+    let(:action) { "FactCheck" }
+    let(:draft) { nil }
+
+    let(:payload) do
+      {
+        content_id: content_id,
+        locale: locale,
+        action: action,
+        draft: draft,
+      }
+    end
+
+    shared_examples "action behaviour" do
+      it "creates an action" do
+        expect(Action.count).to be 0
+        described_class.call(payload)
+        expect(Action.count).to be 1
+      end
+
+      it "returns a Success object" do
+        expect(described_class.call(payload)).to be_a(Commands::Success)
+      end
+
+      context "when a non existant content id is requested" do
+        before { payload.merge!(content_id: SecureRandom.uuid) }
+        include_examples "raises a 404 command error"
+      end
+
+      context "when a non existant locale is requested" do
+        before { payload.merge!(locale: "fr") }
+        include_examples "raises a 404 command error"
+      end
+
+      context "when no action is provided" do
+        before { payload.merge!(action: nil) }
+        it "raises a 422 command error" do
+          expect {
+            described_class.call(payload)
+          }.to raise_error(CommandError) { |e| expect(e.code).to eq(422) }
+        end
+      end
+
+      context "when a incorrect lock version is provided" do
+        before { payload.merge!(previous_version: 5) }
+        it "raises a 409 command error" do
+          expect {
+            described_class.call(payload)
+          }.to raise_error(CommandError) { |e| expect(e.code).to eq(409) }
+        end
+      end
+    end
+
+    shared_examples "raises a 404 command error" do
+      it "raises a 404 command error" do
+        expect {
+          described_class.call(payload)
+        }.to raise_error(CommandError) { |e| expect(e.code).to eq(404) }
+      end
+    end
+
+    context "when a draft content item exists" do
+      before do
+        FactoryGirl.create(
+          :draft_content_item,
+          content_id: content_id,
+          locale: locale,
+          lock_version: 6,
+        )
+      end
+
+      include_examples "action behaviour"
+      context "and we specify the action is not for a draft" do
+        let(:draft) { false }
+        include_examples "raises a 404 command error"
+      end
+    end
+
+    context "when a published content item exists" do
+      before do
+        FactoryGirl.create(
+          :live_content_item,
+          content_id: content_id,
+          locale: locale,
+          lock_version: 6,
+        )
+      end
+
+      let(:draft) { false }
+
+      include_examples "action behaviour"
+
+      context "and we specify the action is for a draft" do
+        let(:draft) { true }
+        include_examples "raises a 404 command error"
+      end
+    end
+
+    context "when no content item exists" do
+      include_examples "raises a 404 command error"
+    end
+  end
+end

--- a/spec/commands/v2/publish_spec.rb
+++ b/spec/commands/v2/publish_spec.rb
@@ -160,6 +160,17 @@ RSpec.describe Commands::V2::Publish do
         described_class.call(payload)
       end
 
+      it "creates an action" do
+        expect(Action.count).to be 0
+        described_class.call(payload)
+        expect(Action.count).to be 1
+        expect(Action.first.attributes).to match a_hash_including(
+          "content_id" => content_id,
+          "locale" => locale,
+          "action" => "Publish",
+        )
+      end
+
       context "when the 'downstream' parameter is false" do
         it "does not send downstream" do
           expect(DownstreamLiveWorker).not_to receive(:perform_async_in_queue)

--- a/spec/commands/v2/put_content_spec.rb
+++ b/spec/commands/v2/put_content_spec.rb
@@ -49,6 +49,17 @@ RSpec.describe Commands::V2::PutContent do
       described_class.call(payload)
     end
 
+    it "creates an action" do
+      expect(Action.count).to be 0
+      described_class.call(payload)
+      expect(Action.count).to be 1
+      expect(Action.first.attributes).to match a_hash_including(
+        "content_id" => content_id,
+        "locale" => locale,
+        "action" => "PutContent",
+      )
+    end
+
     context "when the 'downstream' parameter is false" do
       it "does not send to the downstream draft worker" do
         expect(DownstreamDraftWorker).not_to receive(:perform_async_in_queue)

--- a/spec/controllers/v2/actions_controller_spec.rb
+++ b/spec/controllers/v2/actions_controller_spec.rb
@@ -1,0 +1,61 @@
+require "rails_helper"
+
+RSpec.describe V2::ActionsController do
+  describe ".create" do
+    let(:content_id) { SecureRandom.uuid }
+    let(:locale) { "en" }
+    let(:action) { "FactCheck" }
+
+    let(:params) { { content_id: content_id, format: :json } }
+    let(:payload) do
+      {
+        locale: locale,
+        action: action,
+      }
+    end
+    let(:json_payload) { payload.to_json }
+
+    context "when a content item exists" do
+      before do
+        FactoryGirl.create(
+          :draft_content_item,
+          content_id: content_id,
+          locale: locale,
+          lock_version: 5
+        )
+      end
+
+      context "and the request is valid" do
+        it "returns 201" do
+          post(:create, params: params, body: json_payload)
+          expect(response).to have_http_status(201)
+        end
+      end
+
+      context "and the request has an empty action" do
+        let(:action) { nil }
+
+        it "returns 422" do
+          post(:create, params: params, body: json_payload)
+          expect(response).to have_http_status(422)
+        end
+      end
+
+      context "and an old version is requested" do
+        before { payload.merge!(previous_version: 6) }
+
+        it "returns 409" do
+          post(:create, params: params, body: json_payload)
+          expect(response).to have_http_status(409)
+        end
+      end
+    end
+
+    context "when the content item does not exist" do
+      it "returns 404" do
+        post(:create, params: params, body: json_payload)
+        expect(response).to have_http_status(404)
+      end
+    end
+  end
+end

--- a/spec/factories/action.rb
+++ b/spec/factories/action.rb
@@ -1,0 +1,9 @@
+FactoryGirl.define do
+  factory :action do
+    content_id { SecureRandom.uuid }
+    locale { "en" }
+    action { "Action" }
+    user_uid { SecureRandom.uuid }
+    event
+  end
+end

--- a/spec/models/action_spec.rb
+++ b/spec/models/action_spec.rb
@@ -1,0 +1,29 @@
+require "rails_helper"
+
+RSpec.describe Action do
+  describe "Content Item and Link Set presence" do
+    let(:content_item) { nil }
+    let(:link_set) { nil }
+    subject { FactoryGirl.build(:action, content_item: content_item, link_set: link_set) }
+
+    context "No Content Item or Link Set" do
+      it { is_expected.to be_valid }
+    end
+
+    context "Content Item and no Link Set" do
+      let(:content_item) { FactoryGirl.create(:content_item) }
+      it { is_expected.to be_valid }
+    end
+
+    context "Content Item and no Link Set" do
+      let(:link_set) { FactoryGirl.create(:link_set) }
+      it { is_expected.to be_valid }
+    end
+
+    context "Content Item and Link Set" do
+      let(:content_item) { FactoryGirl.create(:content_item) }
+      let(:link_set) { FactoryGirl.create(:link_set) }
+      it { is_expected.not_to be_valid }
+    end
+  end
+end


### PR DESCRIPTION
Trello: https://trello.com/c/qohNRymi/831-editor-content-history-3

This adds the basic concept of Actions into the Publishing API as per the Trello card and RFC. Given there's a lot of discovery going on into the features that are expected to use this functionality I've kept this brief and not included aspects such as remark and email recipient until more is known.

Currently Actions have both a tight and loose association to ContentItems and LinkSets - this is done by storing content_id, locale, and also references to the id of the particular ContentItem. I expect as we learn more about this feature we may choose to drop one of these associations.

Also, we currently store DiscardDraft actions, this may be removed in the future if their surplus to requirements.