### PR TITLE
Validate links schema in patch link set

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,7 @@ else
 end
 
 gem "gds-sso", "13.0.0"
-gem "govuk_schemas", "~> 1.0"
+gem "govuk_schemas", require: false
 
 gem 'bunny', '2.5.1'
 gem 'whenever', '0.9.4', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -116,7 +116,7 @@ GEM
     govuk-lint (1.2.1)
       rubocop (~> 0.39.0)
       scss_lint
-    govuk_schemas (1.0.0)
+    govuk_schemas (2.0.0)
       json-schema (~> 2.5.0)
     govuk_sidekiq (1.0.1)
       airbrake (>= 3.1.0)
@@ -402,7 +402,7 @@ DEPENDENCIES
   gds-sso (= 13.0.0)
   govspeak (~> 5.0.2)
   govuk-lint
-  govuk_schemas (~> 1.0)
+  govuk_schemas
   govuk_sidekiq (~> 1.0.1)
   hashdiff
   json-schema

--- a/app/commands/v2/patch_link_set.rb
+++ b/app/commands/v2/patch_link_set.rb
@@ -3,6 +3,7 @@ module Commands
     class PatchLinkSet < BaseCommand
       def call
         raise_unless_links_hash_is_provided
+        validate_schema
         link_set = find_or_create_link_set(content_id)
 
         check_version_and_raise_if_conflicting(link_set, previous_version_number)
@@ -120,6 +121,26 @@ module Commands
           message_queue_update_type: "links",
           payload_version: event.id,
         )
+      end
+
+      def validate_schema
+        # Do not raise anything yet
+        # Only send errbit notification
+        schema_validator.valid?
+      end
+
+      def schema_validator
+        @schema_validator ||= SchemaValidator.new(
+          payload: payload[:links],
+          links: true,
+          schema_name: schema_name
+        )
+      end
+
+      def schema_name
+        Queries::GetLatest.(
+          ContentItem.where(content_id: payload[:content_id])
+        ).pluck(:schema_name).first || ""
       end
     end
   end

--- a/app/commands/v2/patch_link_set.rb
+++ b/app/commands/v2/patch_link_set.rb
@@ -124,6 +124,9 @@ module Commands
       end
 
       def validate_schema
+        # There may not be a ContentItem yet.
+        return true unless schema_name
+
         # Do not raise anything yet
         # Only send errbit notification
         schema_validator.valid?
@@ -138,9 +141,9 @@ module Commands
       end
 
       def schema_name
-        Queries::GetLatest.(
+        @schema_name ||= Queries::GetLatest.(
           ContentItem.where(content_id: payload[:content_id])
-        ).pluck(:schema_name).first || ""
+        ).pluck(:schema_name).first
       end
     end
   end

--- a/app/queries/dependent_expansion_rules.rb
+++ b/app/queries/dependent_expansion_rules.rb
@@ -63,6 +63,9 @@ module Queries
       ]
     end
 
+    # Ensure when modifying the values to also include them in
+    # govuk-content-schemas LINK_NAMES_ADDED_BY_PUBLISHING_API array
+    # in FrontendSchemaGenerator
     def reverse_names
       {
         parent: "children",

--- a/spec/controllers/v2/content_items_controller_spec.rb
+++ b/spec/controllers/v2/content_items_controller_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe V2::ContentItemsController do
   let(:content_id) { SecureRandom.uuid }
   let(:validator) do
-    instance_double(SchemaValidator, validate: false, errors: [])
+    instance_double(SchemaValidator, valid?: true, errors: [])
   end
 
   before do

--- a/spec/integration/draft_substitution_spec.rb
+++ b/spec/integration/draft_substitution_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe "Substituting content that is not published" do
   end
 
   let(:validator) do
-    instance_double(SchemaValidator, validate: false, errors: [])
+    instance_double(SchemaValidator, valid?: true, errors: [])
   end
 
   before do

--- a/spec/integration/message_queue_publishing_spec.rb
+++ b/spec/integration/message_queue_publishing_spec.rb
@@ -1,4 +1,5 @@
 require "rails_helper"
+require "govuk_schemas"
 
 RSpec.describe "Message queue publishing" do
   it "puts the correct message on the queue" do
@@ -28,7 +29,7 @@ RSpec.describe "Message queue publishing" do
   end
 
   def generate_random_content_item(base_path)
-    GovukSchemas::RandomExample.for_schema("placeholder", schema_type: "publisher").merge_and_validate(
+    GovukSchemas::RandomExample.for_schema(publisher_schema: "placeholder").merge_and_validate(
       base_path: base_path,
       rendering_app: "something", # schema do not enforce a "dns-hostname" pattern yet
       publishing_app: "something", # schema do not enforce a "dns-hostname" pattern yet
@@ -42,7 +43,7 @@ RSpec.describe "Message queue publishing" do
   def ensure_message_queue_payload_validates_against_notification_schema
     expect(PublishingAPI.service(:queue_publisher)).to have_received(:send_message) do |payload|
       errors = JSON::Validator.fully_validate(
-        GovukSchemas::Schema.find("placeholder", schema_type: "notification"),
+        GovukSchemas::Schema.find(notification_schema: "placeholder"),
         payload,
         errors_as_objects: true,
       )

--- a/spec/integration/reinstating_spec.rb
+++ b/spec/integration/reinstating_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe "Reinstating Content Items that were previously unpublished" do
   end
 
   let(:validator) do
-    instance_double(SchemaValidator, validate: false, errors: [])
+    instance_double(SchemaValidator, valid?: true, errors: [])
   end
 
   before do

--- a/spec/validators/schema_validator_spec.rb
+++ b/spec/validators/schema_validator_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe SchemaValidator do
     }.deep_stringify_keys
   end
 
-  subject(:validator) { SchemaValidator.new(schema: schema) }
+  subject(:validator) { SchemaValidator.new(schema: schema, payload: payload) }
 
   describe "#validate" do
     context "unknown schema name" do
@@ -22,7 +22,7 @@ RSpec.describe SchemaValidator do
         expect(Airbrake)
           .to receive(:notify)
           .with(an_instance_of(Errno::ENOENT), a_hash_including(:parameters))
-        validator.validate(payload)
+        validator.valid?
       end
     end
 
@@ -30,7 +30,7 @@ RSpec.describe SchemaValidator do
       let(:payload) { { a: 1 } }
 
       it "returns true" do
-        expect(validator.validate(payload)).to be true
+        expect(validator.valid?).to be true
       end
     end
 
@@ -38,14 +38,14 @@ RSpec.describe SchemaValidator do
       let(:payload) { { b: 1 } }
 
       it "returns false" do
-        expect(validator.validate(payload)).to be false
+        expect(validator.valid?).to be false
       end
     end
   end
 
   describe "#errors" do
     subject do
-      validator.validate(payload)
+      validator.valid?
       validator.errors
     end
 


### PR DESCRIPTION
SchemaValidate now takes an extra argument of links to validate it
against the links schema in govuk-content-schemas

Only logs to errbit for the moment.

https://trello.com/c/3KgDbBck/833-problem-with-expansion-rules-in-automatic-link-expansion-3