### PR TITLE
Fix issues with change notes

### DIFF
--- a/app/models/change_note.rb
+++ b/app/models/change_note.rb
@@ -31,11 +31,9 @@ private
 
   def create_from_top_level_change_note
     return unless change_note
-    ChangeNote.create!(
-      content_item: content_item,
-      note: change_note,
-      public_timestamp: Time.zone.now
-    )
+    ChangeNote.
+      find_or_create_by!(content_item: content_item).
+      update!(note: change_note, public_timestamp: Time.zone.now)
   end
 
   def create_from_details_hash_change_note

--- a/app/models/change_note.rb
+++ b/app/models/change_note.rb
@@ -4,6 +4,12 @@ class ChangeNote < ActiveRecord::Base
   def self.create_from_content_item(payload, content_item)
     ChangeNoteFactory.new(payload, content_item).build
   end
+
+  def self.join_content_items(content_item_scope)
+    content_item_scope.joins(
+      "LEFT JOIN change_notes ON change_notes.content_item_id = content_items.id"
+    )
+  end
 end
 
 class ChangeNoteFactory

--- a/app/models/change_note.rb
+++ b/app/models/change_note.rb
@@ -33,13 +33,18 @@ private
     return unless change_note
     ChangeNote.
       find_or_create_by!(content_item: content_item).
-      update!(note: change_note, public_timestamp: Time.zone.now)
+      update!(
+        note: change_note,
+        content_id: content_item.content_id,
+        public_timestamp: Time.zone.now
+      )
   end
 
   def create_from_details_hash_change_note
     return unless note
     ChangeNote.create!(
       content_item: content_item,
+      content_id: content_item.content_id,
       public_timestamp: content_item.updated_at,
       note: note,
     )
@@ -48,7 +53,12 @@ private
   def create_from_details_hash_change_history
     return unless change_history.present?
     history_element = change_history.max_by { |h| h[:public_timestamp] }
-    ChangeNote.create!(history_element.merge(content_item: content_item))
+    ChangeNote.create!(
+      history_element.merge(
+        content_item: content_item,
+        content_id: content_item.content_id
+      )
+    )
   end
 
   def change_note

--- a/app/presenters/change_history_presenter.rb
+++ b/app/presenters/change_history_presenter.rb
@@ -22,7 +22,7 @@ module Presenters
         .where("content_items.content_id" => content_item.content_id)
         .joins("INNER JOIN user_facing_versions ON user_facing_versions.content_item_id = content_items.id")
         .where("user_facing_versions.number <= ?", version_number)
-        .order(public_timestamp: :desc)
+        .order(:public_timestamp)
         .pluck(:note, :public_timestamp)
         .map do |note, timestamp|
           { note: note, public_timestamp: timestamp }.stringify_keys

--- a/app/presenters/change_history_presenter.rb
+++ b/app/presenters/change_history_presenter.rb
@@ -18,15 +18,21 @@ module Presenters
 
     def change_notes_for_content_item
       ChangeNote
-        .joins(:content_item)
-        .where("content_items.content_id" => content_item.content_id)
-        .joins("INNER JOIN user_facing_versions ON user_facing_versions.content_item_id = content_items.id")
-        .where("user_facing_versions.number <= ?", version_number)
+        .where(content_id: content_item.content_id)
+        .where("content_item_id IS NULL OR content_item_id IN (?)", content_item_ids)
         .order(:public_timestamp)
         .pluck(:note, :public_timestamp)
         .map do |note, timestamp|
           { note: note, public_timestamp: timestamp }.stringify_keys
         end
+    end
+
+    def content_item_ids
+      UserFacingVersion.join_content_items(
+        ContentItem.where(content_id: content_item.content_id
+      ))
+      .where("user_facing_versions.number <= ?", version_number)
+      .pluck(:id)
     end
 
     def version_number

--- a/app/presenters/queries/content_item_presenter.rb
+++ b/app/presenters/queries/content_item_presenter.rb
@@ -15,6 +15,7 @@ module Presenters
         :lock_version,
         :updated_at,
         :state_history,
+        :change_note,
       ].freeze
 
       def self.present_many(scope, params = {})
@@ -68,6 +69,7 @@ module Presenters
         scope = UserFacingVersion.join_content_items(scope)
         scope = Translation.join_content_items(scope)
         scope = Location.join_content_items(scope)
+        scope = ChangeNote.join_content_items(scope)
 
         LockVersion.join_content_items(scope)
       end
@@ -99,6 +101,8 @@ module Presenters
             "to_char(first_published_at, '#{ISO8601_SQL}') as first_published_at"
           when :state_history
             "#{STATE_HISTORY_SQL} AS state_history"
+          when :change_note
+            "change_notes.note AS change_note"
           else
             field
           end
@@ -137,7 +141,7 @@ module Presenters
 
             result["warnings"] = get_warnings(result) if include_warnings
 
-            yielder.yield result
+            yielder.yield result.compact
           end
         end
       end

--- a/db/migrate/20161104181821_update_change_notes.rb
+++ b/db/migrate/20161104181821_update_change_notes.rb
@@ -1,0 +1,9 @@
+class UpdateChangeNotes < ActiveRecord::Migration[5.0]
+  def change
+    change_table :change_notes do |t|
+      t.string :content_id
+      t.index :content_id
+      t.change :content_item_id, :integer, null: true
+    end
+  end
+end

--- a/db/migrate/20161104185652_unique_change_note_for_content_item.rb
+++ b/db/migrate/20161104185652_unique_change_note_for_content_item.rb
@@ -1,0 +1,52 @@
+class UniqueChangeNoteForContentItem < ActiveRecord::Migration[5.0]
+  def change
+    puts "Setting content_ids"
+    ChangeNote.connection.execute(<<-SQL
+      UPDATE change_notes cn SET content_id = ci.content_id
+      FROM content_items ci WHERE cn.content_item_id = ci.id
+      SQL
+    )
+
+    # For each major change published since change history was originally
+    # migrated, delete all change notes other than the last one created since
+    # the change was published.
+    puts "Deleting duplicates"
+    dupes = []
+    UserFacingVersion.join_content_items(ContentItem.where(
+      "public_updated_at > '2016-10-18' AND publishing_app = 'specialist-publisher' AND update_type = 'major'"
+    )).each do |content_item|
+      change_notes = ChangeNote.where("public_timestamp > '2016-10-18' AND content_item_id = ?", content_item.id).order(public_timestamp: :desc).pluck(:id)
+      dupes.concat(change_notes.from(1))
+    end
+    puts "#{dupes.count} notes to delete"
+    ChangeNote.where(id: dupes).delete_all
+
+    # For each content_id, set most recent change note to most recent major
+    # update (draft or published) and other change notes content_items to nil.
+    # 97% of change notes are the only one for their content id, so limit the
+    # query to where that is not true.
+    puts "Calculating content item relationships"
+    multiple_change_notes.map(&:content_id).each do |content_id|
+      ChangeNote.where(content_id: content_id).update_all(content_item_id: nil)
+      sql = <<-SQL
+        UPDATE change_notes SET content_item_id = (
+          SELECT ci.id FROM content_items ci
+          INNER JOIN user_facing_versions ufv ON ufv.content_item_id = ci.id
+          WHERE content_id = '#{content_id}'
+          AND update_type = 'major'
+          ORDER BY number DESC LIMIT 1
+        )
+        WHERE id = (
+          SELECT id FROM change_notes WHERE content_id='#{content_id}'
+          ORDER BY public_timestamp DESC LIMIT 1
+        )
+      SQL
+      ChangeNote.connection.execute(sql)
+      print '.'
+    end
+  end
+
+  def multiple_change_notes
+    ChangeNote.select(:content_id).having('COUNT(*) > 1').group(:content_id)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161102115422) do
+ActiveRecord::Schema.define(version: 20161104181821) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -44,6 +44,8 @@ ActiveRecord::Schema.define(version: 20161102115422) do
     t.integer  "content_item_id"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.string   "content_id"
+    t.index ["content_id"], name: "index_change_notes_on_content_id", using: :btree
     t.index ["content_item_id"], name: "index_change_notes_on_content_item_id", using: :btree
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161104181821) do
+ActiveRecord::Schema.define(version: 20161104185652) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/spec/factories/change_note.rb
+++ b/spec/factories/change_note.rb
@@ -1,0 +1,3 @@
+FactoryGirl.define do
+  factory :change_note
+end

--- a/spec/factories/content_item.rb
+++ b/spec/factories/content_item.rb
@@ -44,7 +44,7 @@ FactoryGirl.define do
       unless evaluator.base_path.nil?
         FactoryGirl.create(:location, base_path: evaluator.base_path, content_item: item)
       end
-      unless item.update_type == 'minor'
+      unless item.update_type == "minor" || evaluator.change_note.nil?
         FactoryGirl.create(:change_note, note: evaluator.change_note, content_item: item)
       end
     end

--- a/spec/factories/content_item.rb
+++ b/spec/factories/content_item.rb
@@ -32,6 +32,7 @@ FactoryGirl.define do
       locale "en"
       sequence(:base_path) { |n| "/vat-rates-#{n}" }
       user_facing_version 1
+      change_note "note"
     end
 
     after(:create) do |item, evaluator|
@@ -42,6 +43,9 @@ FactoryGirl.define do
 
       unless evaluator.base_path.nil?
         FactoryGirl.create(:location, base_path: evaluator.base_path, content_item: item)
+      end
+      unless item.update_type == 'minor'
+        FactoryGirl.create(:change_note, note: evaluator.change_note, content_item: item)
       end
     end
   end

--- a/spec/models/change_note_spec.rb
+++ b/spec/models/change_note_spec.rb
@@ -6,7 +6,12 @@ RSpec.describe ChangeNote do
   let(:payload_change_note) { nil }
   let(:update_type) { "major" }
   let(:content_item) do
-    FactoryGirl.create(:content_item, update_type: update_type, details: details)
+    FactoryGirl.create(
+      :content_item,
+      update_type: update_type,
+      details: details,
+      change_note: nil,
+    )
   end
 
   describe ".create_from_content_item" do

--- a/spec/models/change_note_spec.rb
+++ b/spec/models/change_note_spec.rb
@@ -34,6 +34,15 @@ RSpec.describe ChangeNote do
           expect(result.public_timestamp.iso8601).to eq Time.zone.now.iso8601
         end
       end
+
+      context "change note is entered for an existing content item" do
+        it "updates the change note rather than creating a new one" do
+          subject
+          expect {
+            described_class.create_from_content_item(payload, content_item)
+          }.to_not change { ChangeNote.count }
+        end
+      end
     end
 
     context "content item has change_note entry in details hash" do

--- a/spec/presenters/change_history_presenter_spec.rb
+++ b/spec/presenters/change_history_presenter_spec.rb
@@ -36,11 +36,11 @@ RSpec.describe Presenters::ChangeHistoryPresenter do
         end
       end
       it "constructs content history from change notes" do
-        expect(subject.map { |item| item["note"] }).to eq %w(1 0)
+        expect(subject.map { |item| item["note"] }).to eq %w(0 1)
       end
     end
 
-    it "orders change notes by public_timestamp" do
+    it "orders change notes by public_timestamp (ascending)" do
       [1, 3, 2].to_a.each do |i|
         ChangeNote.create(
           content_item: content_item,
@@ -48,7 +48,7 @@ RSpec.describe Presenters::ChangeHistoryPresenter do
           public_timestamp: i.days.ago
         )
       end
-      expect(subject.map { |item| item["note"] }).to eq %w(1 2 3)
+      expect(subject.map { |item| item["note"] }).to eq %w(3 2 1)
     end
 
     context "multiple content items for a single content id" do

--- a/spec/presenters/change_history_presenter_spec.rb
+++ b/spec/presenters/change_history_presenter_spec.rb
@@ -30,6 +30,7 @@ RSpec.describe Presenters::ChangeHistoryPresenter do
         2.times do |i|
           ChangeNote.create(
             content_item: content_item,
+            content_id: content_item.content_id,
             note: i.to_s,
             public_timestamp: Time.now.utc
           )
@@ -44,6 +45,7 @@ RSpec.describe Presenters::ChangeHistoryPresenter do
       [1, 3, 2].to_a.each do |i|
         ChangeNote.create(
           content_item: content_item,
+          content_id: content_item.content_id,
           note: i.to_s,
           public_timestamp: i.days.ago
         )
@@ -52,7 +54,7 @@ RSpec.describe Presenters::ChangeHistoryPresenter do
     end
 
     context "multiple content items for a single content id" do
-      let!(:item1) do
+      let(:item1) do
         FactoryGirl.create(
           :content_item,
           details: details,
@@ -60,7 +62,7 @@ RSpec.describe Presenters::ChangeHistoryPresenter do
           user_facing_version: 1
         )
       end
-      let!(:item2) do
+      let(:item2) do
         FactoryGirl.create(
           :content_item,
           details: details,
@@ -70,19 +72,20 @@ RSpec.describe Presenters::ChangeHistoryPresenter do
         )
       end
       before do
-        ChangeNote.create(content_item: item1)
-        ChangeNote.create(content_item: item2)
+        ChangeNote.create(content_item: item1, content_id: content_id)
+        ChangeNote.create(content_item: item2, content_id: content_id)
+        ChangeNote.create(content_id: content_id)
       end
 
       context "reviewing latest version of a content item" do
         it "constructs content history from all change notes for content id" do
-          expect(described_class.new(item2).change_history.count).to eq 2
+          expect(described_class.new(item2).change_history.count).to eq 3
         end
       end
 
       context "reviewing older version of a content item" do
         it "doesn't include change notes corresponding to newer versions" do
-          expect(described_class.new(item1).change_history.count).to eq 1
+          expect(described_class.new(item1).change_history.count).to eq 2
         end
       end
     end

--- a/spec/presenters/downstream_presenter_spec.rb
+++ b/spec/presenters/downstream_presenter_spec.rb
@@ -166,7 +166,7 @@ RSpec.describe Presenters::DownstreamPresenter do
           details: details.slice(:body))
       end
       before do
-        ChangeNote.create(change_history.merge(content_item: content_item))
+        ChangeNote.create(change_history.merge(content_item: content_item, content_id: content_item.content_id))
       end
 
       it "constructs the change history" do

--- a/spec/presenters/queries/content_item_presenter_spec.rb
+++ b/spec/presenters/queries/content_item_presenter_spec.rb
@@ -93,10 +93,11 @@ RSpec.describe Presenters::Queries::ContentItemPresenter do
       end
 
       it "presents the item including the change note" do
-        expect(result).to eq(payload.merge(
+        expected = payload.merge(
           "change_note" => "note",
           "update_type" => "major"
-        ))
+        )
+        expect(result).to eq expected
       end
     end
   end


### PR DESCRIPTION
This fixes a number of issues with change notes:
* Return change notes in the get_content action.
* Make change notes unique for a content item, and update an existing note on put_content rather than always creating a new one.
* Remove duplicates created since the original change went live.

Because publishing-api does not contain all the historical content items, we needed to break the relationship between change note and content item for those previous changes; we now compare on content_id rather than content_item_id when working out what change notes to include.