### PR TITLE
[DO NOT MERGE] Change dependency resolution

### DIFF
--- a/app/workers/dependency_resolution_worker.rb
+++ b/app/workers/dependency_resolution_worker.rb
@@ -7,7 +7,7 @@ class DependencyResolutionWorker
   def perform(args = {})
     assign_attributes(args.deep_symbolize_keys)
 
-    content_item_dependees.each do |dependent_content_id|
+    content_item_dependents.each do |dependent_content_id|
       downstream_content_item(dependent_content_id)
     end
   end
@@ -23,10 +23,10 @@ private
     @payload_version = args.fetch(:payload_version)
   end
 
-  def content_item_dependees
+  def content_item_dependents
     Queries::ContentDependencies.new(content_id: content_id,
                                      fields: fields,
-                                     dependent_lookup: Queries::GetDependees.new).call
+                                     dependent_lookup: Queries::GetDependents.new).call
   end
 
   def downstream_content_item(dependent_content_id)

--- a/spec/integration/dependency_resolution_spec.rb
+++ b/spec/integration/dependency_resolution_spec.rb
@@ -1,0 +1,166 @@
+require 'rails_helper'
+
+RSpec.describe 'Dependency Resolution' do
+  let(:draft_content_store_base) { Plek.find('draft-content-store') }
+
+  context 'with two drafts' do
+    def draft_payload(
+          base_path,
+          content_id: SecureRandom.uuid,
+          locale: 'en',
+          title: 'Some title'
+        )
+      {
+        content_id: content_id,
+        base_path: base_path,
+        update_type: 'major',
+        title: title,
+        publishing_app: 'publisher',
+        rendering_app: 'frontend',
+        document_type: 'guide',
+        schema_name: 'guide',
+        locale: locale,
+        routes: [{ path: base_path, type: 'exact' }],
+        redirects: [],
+        phase: 'beta',
+        change_note: { note: 'Info', public_timestamp: Time.now.utc.to_s }
+      }
+    end
+
+    let(:draft_1_content_id) { SecureRandom.uuid }
+    let(:draft_2_content_id) { SecureRandom.uuid }
+
+    let(:draft_1_base_path) { '/draft1' }
+    let(:draft_2_base_path) { '/draft2' }
+
+    before do
+      [draft_1_base_path, draft_2_base_path].each do |base_path|
+        stub_request(
+          :put,
+          Plek.find('draft-content-store') + "/content#{base_path}"
+        )
+      end
+    end
+
+    context 'when a test link is already present' do
+      before do
+        Commands::V2::PatchLinkSet.call(
+          content_id: draft_2_content_id,
+          links: {
+            test_link_type: [
+              draft_1_content_id
+            ]
+          }
+        )
+      end
+
+      it 'the link is presented to the content store when the target becomes available' do
+        Commands::V2::PutContent.call(
+          draft_payload(
+            draft_2_base_path,
+            content_id: draft_2_content_id
+          )
+        )
+        expect(WebMock).to have_requested(
+          :put,
+          "#{draft_content_store_base}/content#{draft_2_base_path}"
+        ).with(
+          body: hash_including(
+            'expanded_links' => hash_excluding('test_link_type')
+          )
+        ).once
+
+        Commands::V2::PutContent.call(
+          draft_payload(
+            draft_1_base_path,
+            content_id: draft_1_content_id
+          )
+        )
+        expect(WebMock).to have_requested(
+          :put,
+          "#{draft_content_store_base}/content#{draft_2_base_path}"
+        ).with(
+          body: hash_including(
+            'expanded_links' => hash_including('test_link_type')
+          )
+        ).once
+      end
+    end
+
+    context 'when updating an existing draft' do
+      let(:draft_1_first_title) { 'First Title' }
+      let(:draft_1_second_title) { 'Second Title' }
+
+      before do
+        stub_request(
+          :put,
+          "#{draft_content_store_base}/content#{draft_1_base_path}"
+        )
+
+        Commands::V2::PatchLinkSet.call(
+          content_id: draft_2_content_id,
+          links: {
+            test_link_type: [
+              draft_1_content_id
+            ]
+          }
+        )
+
+        Commands::V2::PutContent.call(
+          draft_payload(
+            draft_1_base_path,
+            content_id: draft_1_content_id,
+            title: draft_1_first_title
+          )
+        )
+      end
+
+      it 'dependency resolution correctly updates the title in the expanded_links' do
+        Commands::V2::PutContent.call(
+          draft_payload(
+            draft_2_base_path,
+            content_id: draft_2_content_id
+          )
+        )
+
+        expect(WebMock).to have_requested(
+          :put,
+          "#{draft_content_store_base}/content#{draft_2_base_path}"
+        ).with(
+          body: hash_including(
+            'expanded_links' => hash_including(
+              'test_link_type' => contain_exactly(
+                hash_including(
+                  'title' => draft_1_first_title
+                )
+              )
+            )
+          )
+        ).once
+
+        Commands::V2::PutContent.call(
+          draft_payload(
+            draft_1_base_path,
+            content_id: draft_1_content_id,
+            title: draft_1_second_title
+          )
+        )
+
+        expect(WebMock).to have_requested(
+          :put,
+          "#{draft_content_store_base}/content#{draft_2_base_path}"
+        ).with(
+          body: hash_including(
+            'expanded_links' => hash_including(
+              'test_link_type' => contain_exactly(
+                hash_including(
+                  'title' => draft_1_second_title
+                )
+              )
+            )
+          )
+        ).once
+      end
+    end
+  end
+end

--- a/spec/requests/content_item_requests/downstream_requests_spec.rb
+++ b/spec/requests/content_item_requests/downstream_requests_spec.rb
@@ -277,7 +277,7 @@ RSpec.describe "Downstream requests", type: :request do
     let!(:draft_b) { create_content_item(b, "/b", "draft") }
 
     before do
-      create_link(a, b, "parent")
+      create_link(b, a, "parent")
     end
 
     it "sends the dependencies to the draft content store" do

--- a/spec/requests/logging_requests_spec.rb
+++ b/spec/requests/logging_requests_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe "Logging requests", type: :request do
     let!(:draft_b) { create_content_item(b, "/b", "draft") }
 
     before do
-      create_link(a, b, "parent")
+      create_link(b, a, "parent")
     end
 
     it "is added to the request to the content store" do

--- a/spec/workers/dependency_resolution_worker_spec.rb
+++ b/spec/workers/dependency_resolution_worker_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe DependencyResolutionWorker, :perform do
     expect(Queries::ContentDependencies).to receive(:new).with(
       content_id: "123",
       fields: [:base_path],
-      dependent_lookup: an_instance_of(Queries::GetDependees),
+      dependent_lookup: an_instance_of(Queries::GetDependents),
     ).and_return(content_item_dependee)
     worker_perform
   end


### PR DESCRIPTION
As part of https://trello.com/c/iok78RXu/832-update-user-documentation-for-dependency-resolution-2 , I've been looking at how the dependency resolution code in the Publishing API works, and I think that it is going about things the wrong way around.

[DO NOT MERGE] as I want to do some more thinking on dependency resolution before trying to change things.

Message from the 1st commit:
Previously, GetDependees was used in dependency resolution. This means
that some of the basic assumed functionality of dependnecy resolution
does not work.

Consider for example two draft content items, A and B, where A has a
link to B. This link means that when A is presented to the content
store, the link to B will be "expanded", including information from B,
e.g. the title. Dependency resolution should trigger A to be presented
to the content store when changes are made to B, to keep the information
in the expanded link consistent with B.

In the terminology of dependency resolution, A is the "dependent" and B
is the "dependee". So, to view the above example in terms of dependency
resolution, upon changes to B (the dependee), any dependents of B must
be presented to the content store, as the information in there expanded
links could have become inconsistent with B.

Previously, GetDependees was used, which means that in the example
above, the dependency resolution worker would look for links from B to
other content items (the dependees). Now, GetDependents is used, which
means that the dependency resolution worker will look for content items
linking to B, fixing the above example.