### PR TITLE
Remove clashing content item

### DIFF
--- a/db/migrate/20161110110113_remove_deleted_item_with_base_path_clash.rb
+++ b/db/migrate/20161110110113_remove_deleted_item_with_base_path_clash.rb
@@ -1,0 +1,7 @@
+require_relative "helpers/delete_content_item"
+
+class RemoveDeletedItemWithBasePathClash < ActiveRecord::Migration[5.0]
+  def change
+    Helpers::DeleteContentItem.destroy_content_items_with_links("7f25968a-4705-428b-9f34-93001bb0c475")
+  end
+end


### PR DESCRIPTION
This content item has had its slug updated in Whitehall as a result of 'deletion' which it appears does not currently get communicated to Publishing API. A newer `Document` has since been created with the same path and Whitehall is now unable to publish the new document as the base path
conflicts.

The old document has no editions and is no longer visible on the site so this can be safely deleted.

Content Id: "7f25968a-4705-428b-9f34-93001bb0c475"
Path in Whitehall: /government/publications/deleted-a-guide-to-the-veterans-welfare-service
Path in Publishing API: /government/publications/a-guide-to-the-veterans-welfare-service