### PR TITLE
Use (hopefully) fixed version of sidekiq-unique-jobs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,7 @@ gem 'whenever', '0.9.4', require: false
 gem "govuk_sidekiq", "~> 1.0.1"
 gem "json-schema", require: false
 gem "hashdiff"
-gem "sidekiq-unique-jobs", require: false
+gem "sidekiq-unique-jobs", git: "https://github.com/carlosmartinez/sidekiq-unique-jobs", require: false
 gem "govspeak", "~> 5.0.2"
 gem "diffy", "~> 3.1", require: false
 gem "aws-sdk", "~> 2"

--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,7 @@ gem 'whenever', '0.9.4', require: false
 gem "govuk_sidekiq", "~> 1.0.1"
 gem "json-schema", require: false
 gem "hashdiff"
-gem "sidekiq-unique-jobs", git: "https://github.com/carlosmartinez/sidekiq-unique-jobs", require: false
+gem "sidekiq-unique-jobs", git: "https://github.com/alphagov/sidekiq-unique-jobs", require: false
 gem "govspeak", "~> 5.0.2"
 gem "diffy", "~> 3.1", require: false
 gem "aws-sdk", "~> 2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
-  remote: https://github.com/carlosmartinez/sidekiq-unique-jobs
-  revision: b24fee3d01bf4cd96eff959c8b703be264c00b2c
+  remote: https://github.com/alphagov/sidekiq-unique-jobs
+  revision: 6c03e39c3ad6ba1468d567c22bb99908f6fdb317
   specs:
     sidekiq-unique-jobs (4.0.18)
       sidekiq (>= 2.6)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,11 @@
+GIT
+  remote: https://github.com/carlosmartinez/sidekiq-unique-jobs
+  revision: b24fee3d01bf4cd96eff959c8b703be264c00b2c
+  specs:
+    sidekiq-unique-jobs (4.0.18)
+      sidekiq (>= 2.6)
+      thor
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -323,9 +331,6 @@ GEM
       activesupport
       sidekiq (>= 2.6)
       statsd-ruby (>= 1.1.0)
-    sidekiq-unique-jobs (4.0.18)
-      sidekiq (>= 2.6)
-      thor
     simplecov (0.10.0)
       docile (~> 1.1.0)
       json (~> 1.8)
@@ -419,7 +424,7 @@ DEPENDENCIES
   rails (= 5.0.0.1)
   rspec
   rspec-rails (~> 3.5)
-  sidekiq-unique-jobs
+  sidekiq-unique-jobs!
   simplecov (= 0.10.0)
   simplecov-rcov (= 0.2.3)
   spring
@@ -432,4 +437,4 @@ DEPENDENCIES
   whenever (= 0.9.4)
 
 BUNDLED WITH
-   1.11.2
+   1.13.1


### PR DESCRIPTION
Currently we're seeing a problem where job IDs are not removed from the
`uniquejobs` hash in Redis, leading to Redis memory running out.

The change in my version of the gem is to add the following method and call it from `Unlockable#after_unlock`:

```
    def ensure_job_id_removed
      Sidekiq.redis { |redis| redis.hdel("uniquejobs", jid) }
    end
```

If this works in integration, we can raise a pull request against the sidekiq-unique-jobs gem.

Alternative solutions:

- Ensure job uniqueness via some other means (Sidekiq Pro has it built in)
- Run a nightly job that clears out the uniquejobs hash.