### PR TITLE
Remove unpublished collection with base_path clash

### DIFF
--- a/db/migrate/20161114151042_remove_unpublished_collection_with_base_path_clash.rb
+++ b/db/migrate/20161114151042_remove_unpublished_collection_with_base_path_clash.rb
@@ -1,0 +1,7 @@
+require_relative "helpers/delete_content_item"
+
+class RemoveUnpublishedCollectionWithBasePathClash < ActiveRecord::Migration[5.0]
+  def change
+    Helpers::DeleteContentItem.destroy_content_items_with_links("5eb78f34-7631-11e4-a3cb-005056011aef")
+  end
+end


### PR DESCRIPTION
https://trello.com/c/DoIbAkZB/428-11-document-collection-migration-implement-publishing-of-format-to-publishing-api-sync-checks-16-4-363-partial-check

This document collection was renamed in Whitehall but that slug change
created a conflict in the Publishing API, we need to remove content items
and supporting objects for this item to allow republishing