### PR TITLE
Update DB Schema

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161104185652) do
+ActiveRecord::Schema.define(version: 20161114151042) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
This was missed off in the following PR's: https://github.com/alphagov/publishing-api/pull/601 and https://github.com/alphagov/publishing-api/pull/603

A consequence of this is that if you run `rake db:setup` you can't stop the app as there are pending migrations.