### PR TITLE
Remove invalid draft content item

### DIFF
--- a/db/migrate/20161116114622_remove_invalid_draft_content_item.rb
+++ b/db/migrate/20161116114622_remove_invalid_draft_content_item.rb
@@ -1,0 +1,15 @@
+require_relative "helpers/delete_content_item"
+
+class RemoveInvalidDraftContentItem < ActiveRecord::Migration[5.0]
+  def up
+    id = 1238944
+    content_item = ContentItem.find_by(id: id)
+    if content_item
+      Helpers::DeleteContentItem.destroy_supporting_objects(content_item)
+      content_item.destroy
+    end
+  end
+
+  def down
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161114151042) do
+ActiveRecord::Schema.define(version: 20161116114622) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
Trello: https://trello.com/c/DIEDyH9j/507-change-withdrawal-unpublishing-explanation-broken-medium

The content item with content_id `d7ac9eb5-7d6a-420e-a298-04149cc59e96`
and id `1238944` has a `draft` state, which is not reflected in Whitehall.
Furthermore it prevents the unpublishing explanation update of the previous version from Whitehall, because this is not allowed if a draft is present.
As this draft is not present in Whitehall it is probably inconsistent.
So we decided to remove it, with all its associated supporting objects.