### PR TITLE
Allow env vars for database configuration

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -3,6 +3,9 @@ default: &default
   encoding: unicode
   pool: 5
   template: template0
+  host: <%= ENV["DATABASE_HOST"] %>
+  username: <%= ENV["DATABASE_USERNAME"] %>
+  password: <%= ENV["DATABASE_PASSWORD"] %>
 
 development:
   <<: *default


### PR DESCRIPTION
This makes it easier to define different credentials to run the application. The naming format is based off DATABASE_URL.

I've set 3 environment variables as I don't think there's a way to do it for dev and test by using a single one as per DATABASE_URL, if anyone knows an approach let me know.