### PR TITLE
Set up TEST_DATABASE_URL env var

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -10,6 +10,7 @@ development:
 
 test:
   <<: *default
+  url: <%= ENV["TEST_DATABASE_URL"] %>
   database: publishing_api_test
 
 production:


### PR DESCRIPTION
This allows us to specify an env var for the test database which can be configured in parallel with DATABASE_URL.

