### PR TITLE
Allow dev and test dbs to be configured with URL

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -7,10 +7,12 @@ default: &default
 development:
   <<: *default
   database: publishing_api_development
+  url: <%= ENV["DATABASE_URL"]%>
 
 test:
   <<: *default
   database: publishing_api_test
+  url: <%= ENV["DATABASE_URL"].try(:sub, /([-_]development)?$/, '_test')%>
 
 production:
   <<: *default


### PR DESCRIPTION
For use in Docker environments. When running in development or test we
still want to be able to be able to set the database using Docker
environment variables. If a `DATABASE_URL` variable is provided it will
use it for the development environment. For test, it will strip the
`_development` suffix and replace it with `_test`.

If a `DATABASE_URL` is not supplied, Rails will fall back to using the
YAML configuration.