### PR TITLE
Allow Bunny configuration with environment variables

### DIFF
--- a/config/initializers/services.rb
+++ b/config/initializers/services.rb
@@ -27,6 +27,8 @@ PublishingAPI.register_service(
 
 if ENV['DISABLE_QUEUE_PUBLISHER'] || (Rails.env.test? && ENV['ENABLE_QUEUE_IN_TEST_MODE'].blank?)
   rabbitmq_config = { noop: true }
+elsif ENV["RABBITMQ_URL"] && ENV["RABBITMQ_EXCHANGE"]
+  rabbitmq_config = { url: ENV["RABBITMQ_URL"], exchange: ENV["RABBITMQ_EXCHANGE"] }
 else
   rabbitmq_config = Rails.application.config_for(:rabbitmq).symbolize_keys
 end


### PR DESCRIPTION
If the `RABBITMQ_URL` and `RABBITMQ_EXCHANGE` variables are set in the
environment, use them to configure Bunny instead of the YAML file.