### PR TITLE
Change s3 environment variable

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -34,7 +34,7 @@ module PublishingAPI
 
     config.s3_export = OpenStruct.new(
       region: ENV["S3_EXPORT_REGION"] || "eu-west-1",
-      bucket: ENV["S3_EXPORT_BUCKET"],
+      bucket: ENV["EVENT_LOG_AWS_BUCKETNAME"],
       events_key_prefix: "events/",
     )
   end


### PR DESCRIPTION
It is now set up in puppet as event_log_aws_bucketname see
https://github.com/alphagov/govuk-puppet/pull/5141