### PR TITLE
Set up one off rake task to export events to s3

### DIFF
--- a/lib/tasks/events.rake
+++ b/lib/tasks/events.rake
@@ -1,7 +1,7 @@
 namespace :events do
   desc "Export events to S3. Defaults to the beginning of week 2 months ago, otherwise dates can be specified in a form that Date.parse understands."
   task :export_to_s3, [:created_before, :created_on_or_after] => :environment do |_, args|
-    created_before = args[:created_before] ? Time.zone.parse(args[:created_before]) : 2.months.ago.beginning_of_week(:sunday)
+    created_before = args[:created_before] ? Time.zone.parse(args[:created_before]) : 1.months.ago.beginning_of_week(:sunday)
     created_on_or_after = args[:created_on_or_after] ? Time.zone.parse(args[:created_on_or_after]) : nil
     exported, s3_key = Events::S3Exporter.new(created_before, created_on_or_after).export
     puts "Exported #{exported} event#{exported == 1 ? '' : 's'} successfully to #{s3_key} 🎉"

--- a/lib/tasks/events.rake
+++ b/lib/tasks/events.rake
@@ -14,4 +14,18 @@ namespace :events do
     imported = Events::S3Importer.new(args[:s3_key]).import
     puts "Imported #{imported} event#{imported == 1 ? '' : 's'} successfully 🍾"
   end
+
+  desc "One of task to export events before 1 month ago to S3"
+  task export_all_to_s3: :environment do |_, _args|
+    created_on_or_after = (Date.new(2014, 07, 01)..(Date.today - 1.month)).select(&:sunday?)
+
+    created_on_or_after.each do |created_on_date|
+      created_before = date + 7.days
+      exported, s3_key = Events::S3Exporter.new(
+        Time.zone.parse(created_before.to_s),
+        Time.zone.parse(created_on_date.to_s)
+      ).export
+      puts "Exported: #{exported}, S3 key: #{s3_key}"
+    end
+  end
 end


### PR DESCRIPTION
Creates a date range of Sundays between the first event created at and 1
month ago and uploads that weeks data to s3.

There is an average of 46000 events a week.