### PR TITLE
Update deprecated usage of Downstream*Workers

### DIFF
--- a/app/commands/v2/patch_link_set.rb
+++ b/app/commands/v2/patch_link_set.rb
@@ -110,7 +110,8 @@ module Commands
         queue = bulk_publishing? ? DownstreamDraftWorker::LOW_QUEUE : DownstreamDraftWorker::HIGH_QUEUE
         DownstreamDraftWorker.perform_async_in_queue(
           queue,
-          content_item_id: content_item.id,
+          content_id: content_item.content_id,
+          locale: content_item.locale,
           payload_version: event.id,
         )
       end
@@ -119,7 +120,8 @@ module Commands
         queue = bulk_publishing? ? DownstreamLiveWorker::LOW_QUEUE : DownstreamLiveWorker::HIGH_QUEUE
         DownstreamLiveWorker.perform_async_in_queue(
           queue,
-          content_item_id: content_item.id,
+          content_id: content_item.content_id,
+          locale: content_item.locale,
           message_queue_update_type: "links",
           payload_version: event.id,
         )

--- a/app/commands/v2/represent_downstream.rb
+++ b/app/commands/v2/represent_downstream.rb
@@ -9,55 +9,73 @@ module Commands
         filter = ContentItemFilter.new(scope: scope)
 
         if draft
-          items_for_draft_store(filter).pluck(:id, :content_id).each do |(content_item_id, content_id)|
-            downstream_draft(content_item_id, content_id)
+          content_ids = content_ids_for_draft_store(filter)
+          content_ids_with_locales(content_ids, draft_states).each do |(content_id, locale)|
+            downstream_draft(content_id, locale)
           end
         end
 
-        items_for_live_store(filter).pluck(:id, :content_id).each_with_index do |(content_item_id, content_id), index|
+        content_ids = content_ids_for_live_store(filter)
+        content_ids_with_locales(content_ids, live_states).each_with_index do |(content_id, locale), index|
           sleep 60 if (index + 1) % 10_000 == 0
-          downstream_live(content_item_id, content_id)
+          downstream_live(content_id, locale)
         end
       end
 
     private
 
-      def items_for_draft_store(filter)
-        Queries::GetLatest.call(
-          filter.filter(state: %w{draft published unpublished})
-        )
+      def content_ids_with_locales(content_ids, states)
+        content_ids.inject([]) do |memo, content_id|
+          memo + Queries::LocalesForContentItem.call(content_id, states).map { |locale| [content_id, locale] }
+        end
       end
 
-      def items_for_live_store(filter)
-        filter.filter(state: %w{published unpublished})
+      def content_ids_for_draft_store(filter)
+        Queries::GetLatest.call(filter.filter(state: draft_states)).distinct.pluck(:content_id)
       end
 
-      def downstream_draft(content_item_id, content_id)
+      def content_ids_for_live_store(filter)
+        filter.filter(state: live_states).distinct.pluck(:content_id)
+      end
+
+      def draft_states
+        %w{draft published unpublished}
+      end
+
+      def live_states
+        %w{published unpublished}
+      end
+
+      def downstream_draft(content_id, locale)
         event_payload = {
           content_id: content_id,
+          locale: locale,
           message: "Representing downstream draft",
         }
 
         EventLogger.log_command(self.class, event_payload) do |event|
           DownstreamDraftWorker.perform_async_in_queue(
             DownstreamDraftWorker::LOW_QUEUE,
-            content_item_id: content_item_id,
+            content_id: content_id,
+            locale: locale,
             payload_version: event.id,
             update_dependencies: false,
           )
         end
       end
 
-      def downstream_live(content_item_id, content_id)
+      def downstream_live(content_id, locale)
         event_payload = {
           content_id: content_id,
-          message: "Representing downstream publish",
+          locale: locale,
+          message: "Representing downstream live",
         }
 
         EventLogger.log_command(self.class, event_payload) do |event|
           DownstreamLiveWorker.perform_async_in_queue(
             DownstreamLiveWorker::LOW_QUEUE,
-            content_item_id: content_item_id,
+            content_id: content_id,
+            locale: locale,
             payload_version: event.id,
             message_queue_update_type: "links",
             update_dependencies: false,

--- a/app/commands/v2/represent_downstream.rb
+++ b/app/commands/v2/represent_downstream.rb
@@ -24,12 +24,12 @@ module Commands
 
       def items_for_draft_store(filter)
         Queries::GetLatest.call(
-          filter.filter(state: %w{draft published})
+          filter.filter(state: %w{draft published unpublished})
         )
       end
 
       def items_for_live_store(filter)
-        filter.filter(state: "published")
+        filter.filter(state: %w{published unpublished})
       end
 
       def downstream_draft(content_item_id, content_id)

--- a/app/workers/downstream_draft_worker.rb
+++ b/app/workers/downstream_draft_worker.rb
@@ -22,7 +22,7 @@ class DownstreamDraftWorker
   # "content_item_id" and the updated interface which uses "content_id" and
   # "locale". Both interfaces are supported until we are confident there are
   # no longer items in the sidekiq queue. They should all be long gone by
-  # December 2016 and probably sooner.
+  # January 2017 and probably sooner.
   def perform(args = {})
     assign_attributes(args.symbolize_keys)
 

--- a/app/workers/downstream_live_worker.rb
+++ b/app/workers/downstream_live_worker.rb
@@ -23,7 +23,7 @@ class DownstreamLiveWorker
   # "content_item_id" and the updated interface which uses "content_id" and
   # "locale". Both interfaces are supported until we are confident there are
   # no longer items in the sidekiq queue. They should all be long gone by
-  # December 2016 and probably sooner.
+  # January 2017 and probably sooner.
   def perform(args = {})
     assign_attributes(args.symbolize_keys)
 

--- a/spec/commands/v2/patch_link_set_spec.rb
+++ b/spec/commands/v2/patch_link_set_spec.rb
@@ -238,7 +238,7 @@ RSpec.describe Commands::V2::PatchLinkSet do
       expect(DownstreamDraftWorker).to receive(:perform_async_in_queue)
         .with(
           "downstream_high",
-          a_hash_including(:content_item_id, :payload_version),
+          a_hash_including(:content_id, :locale, :payload_version),
         )
 
       described_class.call(payload)
@@ -262,12 +262,13 @@ RSpec.describe Commands::V2::PatchLinkSet do
       end
 
       it "sends the draft content items for all locales downstream" do
-        [draft_content_item, french_draft_content_item].each do |ci|
+        %w(en fr).each do |locale|
           expect(DownstreamDraftWorker).to receive(:perform_async_in_queue)
             .with(
               "downstream_high",
               a_hash_including(
-                content_item_id: ci.id,
+                content_id: content_id,
+                locale: locale,
                 payload_version: an_instance_of(Fixnum),
               ),
             )
@@ -299,7 +300,8 @@ RSpec.describe Commands::V2::PatchLinkSet do
         .with(
           "downstream_high",
           a_hash_including(
-            :content_item_id,
+            :content_id,
+            :locale,
             :payload_version,
             message_queue_update_type: "links",
           ),
@@ -313,7 +315,8 @@ RSpec.describe Commands::V2::PatchLinkSet do
         .with(
           "downstream_low",
           a_hash_including(
-            :content_item_id,
+            :content_id,
+            :locale,
             :payload_version,
             message_queue_update_type: "links",
           ),
@@ -333,11 +336,12 @@ RSpec.describe Commands::V2::PatchLinkSet do
       end
 
       it "sends the live content item for all locales downstream" do
-        [live_content_item, french_live_content_item].each do |ci|
+        %w(en fr).each do |locale|
           expect(DownstreamLiveWorker).to receive(:perform_async_in_queue)
             .with(
               "downstream_high",
-              content_item_id: ci.id,
+              content_id: content_id,
+              locale: locale,
               payload_version: an_instance_of(Fixnum),
               message_queue_update_type: "links",
             )
@@ -374,7 +378,8 @@ RSpec.describe Commands::V2::PatchLinkSet do
         .with(
           "downstream_high",
           a_hash_including(
-            :content_item_id,
+            :content_id,
+            :locale,
             :payload_version
           ),
         )
@@ -387,7 +392,8 @@ RSpec.describe Commands::V2::PatchLinkSet do
         .with(
           "downstream_high",
           a_hash_including(
-            :content_item_id,
+            :content_id,
+            :locale,
             :payload_version,
             message_queue_update_type: "links",
           ),

--- a/spec/workers/downstream_draft_worker_spec.rb
+++ b/spec/workers/downstream_draft_worker_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe DownstreamDraftWorker do
         )
 
         expect(Adapters::DraftContentStore).to_not receive(:put_content_item)
-        subject.perform(arguments.merge("content_item_id" => pathless.id))
+        subject.perform(arguments.merge("content_id" => pathless.content_id))
       end
     end
   end

--- a/spec/workers/downstream_live_worker_spec.rb
+++ b/spec/workers/downstream_live_worker_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe DownstreamLiveWorker do
 
     context "unpublished content item" do
       let(:unpublished_content_item) { FactoryGirl.create(:unpublished_content_item) }
-      let(:unpublished_arguments) { arguments.merge(content_item_id: unpublished_content_item.id) }
+      let(:unpublished_arguments) { arguments.merge(content_id: unpublished_content_item.content_id) }
 
       it "sends content to live content store" do
         expect(Adapters::ContentStore).to receive(:put_content_item)
@@ -70,7 +70,7 @@ RSpec.describe DownstreamLiveWorker do
 
     context "superseded content item" do
       let(:superseded_content_item) { FactoryGirl.create(:live_content_item, state: "superseded") }
-      let(:superseded_arguments) { arguments.merge(content_item_id: superseded_content_item.id) }
+      let(:superseded_arguments) { arguments.merge(content_id: superseded_content_item.content_id) }
 
       it "doesn't send to live content store" do
         expect(Adapters::ContentStore).to_not receive(:put_content_item)
@@ -92,7 +92,7 @@ RSpec.describe DownstreamLiveWorker do
         schema_name: "contact"
       )
       expect(Adapters::ContentStore).to_not receive(:put_content_item)
-      subject.perform(arguments.merge("content_item_id" => pathless.id))
+      subject.perform(arguments.merge("content_id" => pathless.content_id))
     end
   end
 
@@ -133,14 +133,14 @@ RSpec.describe DownstreamLiveWorker do
 
       expect(Airbrake).to receive(:notify)
         .with(an_instance_of(AbortWorkerError), a_hash_including(:parameters))
-      subject.perform(arguments.merge("content_item_id" => draft.id))
+      subject.perform(arguments.merge("content_id" => draft.content_id))
     end
 
     it "allows live content items" do
       live = FactoryGirl.create(:live_content_item)
 
       expect(Airbrake).to_not receive(:notify)
-      subject.perform(arguments.merge("content_item_id" => live.id))
+      subject.perform(arguments.merge("content_id" => live.content_id))
     end
   end
 
@@ -148,7 +148,7 @@ RSpec.describe DownstreamLiveWorker do
     it "swallows the error" do
       expect(Airbrake).to receive(:notify)
         .with(an_instance_of(AbortWorkerError), a_hash_including(:parameters))
-      subject.perform(arguments.merge("content_item_id" => "made-up-id"))
+      subject.perform(arguments.merge("content_id" => "made-up-id"))
     end
   end
 end


### PR DESCRIPTION
I noticed that in some places we're still calling the downstream workers with the deprecated interface (`content_item_id` rather than `content_id` and `locale`)

I've now updated the places where these are used so now once the fallback code is removed the application will still work and the tests will pass. 

I've also updated the dates in the fixme note for removing the code.