### PR TITLE
Include translations of current content item in dependency resolution

### DIFF
--- a/app/workers/dependency_resolution_worker.rb
+++ b/app/workers/dependency_resolution_worker.rb
@@ -7,6 +7,9 @@ class DependencyResolutionWorker
   def perform(args = {})
     assign_attributes(args.deep_symbolize_keys)
 
+    # downstream translations of this content item
+    downstream_content_item(content_id, exclude_locale: locale)
+
     content_item_dependees.each do |dependent_content_id|
       downstream_content_item(dependent_content_id)
     end
@@ -14,10 +17,13 @@ class DependencyResolutionWorker
 
 private
 
-  attr_reader :content_id, :fields, :content_store, :payload_version
+  attr_reader :content_id, :locale, :fields, :content_store, :payload_version
 
   def assign_attributes(args)
     @content_id = args.fetch(:content_id)
+    # FIXME: As of December 2016 locale is a optional field to be backwards
+    # compatible. By January 2017 it will be safe to make locale required.
+    @locale = args[:locale]
     @fields = args.fetch(:fields, []).map(&:to_sym)
     @content_store = args.fetch(:content_store).constantize
     @payload_version = args.fetch(:payload_version)
@@ -29,11 +35,12 @@ private
                                      dependent_lookup: Queries::GetDependees.new).call
   end
 
-  def downstream_content_item(dependent_content_id)
+  def downstream_content_item(dependent_content_id, exclude_locale: nil)
     states = draft? ? %w[draft published unpublished] : %w[published unpublished]
     locales = Queries::LocalesForContentItem.call(dependent_content_id, states)
 
     locales.each do |locale|
+      next if locale == exclude_locale
       if draft?
         downstream_draft(dependent_content_id, locale)
       else

--- a/app/workers/downstream_discard_draft_worker.rb
+++ b/app/workers/downstream_discard_draft_worker.rb
@@ -59,6 +59,7 @@ private
       content_store: Adapters::DraftContentStore,
       fields: [:content_id],
       content_id: content_id,
+      locale: locale,
       payload_version: payload_version,
     )
   end

--- a/app/workers/downstream_draft_worker.rb
+++ b/app/workers/downstream_draft_worker.rb
@@ -82,6 +82,7 @@ private
       content_store: Adapters::DraftContentStore,
       fields: [:content_id],
       content_id: content_id,
+      locale: locale,
       payload_version: payload_version
     )
   end

--- a/app/workers/downstream_live_worker.rb
+++ b/app/workers/downstream_live_worker.rb
@@ -87,7 +87,8 @@ private
     DependencyResolutionWorker.perform_async(
       content_store: Adapters::ContentStore,
       fields: [:content_id],
-      content_id: web_content_item.content_id,
+      content_id: content_id,
+      locale: locale,
       payload_version: payload_version,
     )
   end

--- a/spec/requests/discard_draft_request_spec.rb
+++ b/spec/requests/discard_draft_request_spec.rb
@@ -48,15 +48,6 @@ RSpec.describe "Discard draft requests", type: :request do
           stub_request(:delete, Plek.find('draft-content-store') + "/content#{french_base_path}")
         end
 
-        it "does not send to the live content store" do
-          expect(PublishingAPI.service(:live_content_store)).to receive(:put_content_item).never
-          expect(WebMock).not_to have_requested(:any, /[^-]content-store.*/)
-
-          post "/v2/content/#{content_id}/discard-draft", params: {}.to_json
-
-          expect(response.status).to eq(200)
-        end
-
         it "only deletes the French content item from the draft content store" do
           expect(PublishingAPI.service(:draft_content_store)).to receive(:delete_content_item)
             .with(french_base_path)

--- a/spec/workers/dependency_resolution_worker_spec.rb
+++ b/spec/workers/dependency_resolution_worker_spec.rb
@@ -4,11 +4,12 @@ RSpec.describe DependencyResolutionWorker, :perform do
   let(:live_content_item) { FactoryGirl.create(:live_content_item, locale: "en") }
 
   subject(:worker_perform) do
-    described_class.new.perform(content_id: "123",
-                    fields: ["base_path"],
-                    content_store: "Adapters::ContentStore",
-                    payload_version: "123",
-                   )
+    described_class.new.perform(
+      content_id: "123",
+      fields: ["base_path"],
+      content_store: "Adapters::ContentStore",
+      payload_version: "123",
+    )
   end
 
   let(:content_item_dependee) { double(:content_item_dependent, call: []) }
@@ -42,13 +43,13 @@ RSpec.describe DependencyResolutionWorker, :perform do
   end
 
   context "with a draft version available" do
-    let!(:draft_content_item) {
+    let!(:draft_content_item) do
       FactoryGirl.create(:draft_content_item,
         content_id: live_content_item.content_id,
         locale: "en",
         user_facing_version: 2,
       )
-    }
+    end
 
     it "doesn't send draft content to the live content store" do
       expect(DownstreamLiveWorker).to receive(:perform_async_in_queue).with(


### PR DESCRIPTION
Trello: https://trello.com/c/21wSjcbG/851-fix-dependency-resolution-2

Previously the translations of a content item were not downstreamed as part of dependency resolution, this adds this in.

The DependencyResolutionWorker now takes an optional argument of locale to inform it of the locale that triggered this and allowing that locale to be ignored in the linking process.