### PR TITLE
Reproaching LinkedTo query without recursive SQL

### DIFF
--- a/app/queries/content_dependencies.rb
+++ b/app/queries/content_dependencies.rb
@@ -32,10 +32,7 @@ module Queries
     attr_reader :content_id, :locale, :state_fallback_order
 
     def linked_to(content_id)
-      Queries::LinkedTo.new.(
-        content_id: content_id,
-        expansion_rules: DependeeExpansionRules,
-      )
+      Queries::LinkedTo.new(content_id, DependeeExpansionRules).call
     end
 
     def automatic_reverse_links(content_id)

--- a/app/queries/dependent_expansion_rules.rb
+++ b/app/queries/dependent_expansion_rules.rb
@@ -42,6 +42,23 @@ module Queries
       end
     end
 
+    def next_reverse_recursive_types(reverse_link_type_path)
+      link_types = reverse_link_type_path.map(&:to_sym)
+      next_types = recursive_link_types.each_with_object([]) do |valid_path, memo|
+        sticky = valid_path.last
+        # strip path to not include sticky
+        without_sticky = link_types.inject([]) do |types, item|
+          types << item
+          types.uniq == [sticky] ? types.uniq : types
+        end
+        # determine if this array is within the link types and which index
+        index = index_inside_array(valid_path, without_sticky.reverse)
+        memo << sticky if index == valid_path.index(sticky)
+        memo << valid_path[index - 1] if index.present? && index > 0
+      end
+      next_types.uniq
+    end
+
     def next_level(type, current_level)
       group = recursive_link_types.find { |e| e.include?(type.to_sym) }
       group[current_level] || group.last
@@ -82,6 +99,14 @@ module Queries
         working_groups: 'policies',
         parent_taxons: "child_taxons",
       }
+    end
+
+    def index_inside_array(super_set, sub_set)
+      index_sequence = sub_set.map { |value| super_set.index(value) }
+      return if index_sequence.include?(nil)
+      first_index = index_sequence[0]
+      last_index = first_index + (sub_set.length - 1)
+      index_sequence == (first_index..last_index).to_a ? first_index : nil
     end
   end
 end

--- a/spec/queries/dependent_expansion_rules_spec.rb
+++ b/spec/queries/dependent_expansion_rules_spec.rb
@@ -53,6 +53,20 @@ RSpec.describe Queries::DependentExpansionRules do
     specify { expect(subject.valid_link_recursion?([:mainstream_browse_pages, :ordered_related_items, :parent])).to eq(false) }
   end
 
+  describe "#next_reverse_recursive_types" do
+    specify { expect(subject.next_reverse_recursive_types([:parent])).to match_array([:parent, :mainstream_browse_pages]) }
+    specify { expect(subject.next_reverse_recursive_types([:parent_taxons])).to match_array([:parent_taxons]) }
+    specify { expect(subject.next_reverse_recursive_types(["parent"])).to match_array([:parent, :mainstream_browse_pages]) }
+    specify { expect(subject.next_reverse_recursive_types([:parent, :parent])).to match_array([:parent, :mainstream_browse_pages]) }
+    specify { expect(subject.next_reverse_recursive_types([:parent, :parent, :parent])).to match_array([:parent, :mainstream_browse_pages]) }
+    specify { expect(subject.next_reverse_recursive_types([:parent, :child])).to be_empty }
+    specify { expect(subject.next_reverse_recursive_types([:mainstream_browse_pages])).to match_array([:ordered_related_items]) }
+    specify { expect(subject.next_reverse_recursive_types([:parent, :mainstream_browse_pages])).to match_array([:ordered_related_items]) }
+    specify { expect(subject.next_reverse_recursive_types([:parent, :parent, :mainstream_browse_pages])).to match_array([:ordered_related_items]) }
+    specify { expect(subject.next_reverse_recursive_types([:parent, :test, :parent, :mainstream_browse_pages])).to be_empty }
+    specify { expect(subject.next_reverse_recursive_types([:ordered_related_items])).to be_empty }
+  end
+
   describe "#next_level" do
     specify { expect(subject.next_level(:parent, 2)).to eq(:parent) }
     specify { expect(subject.next_level(:parent, 0)).to eq(:parent) }

--- a/spec/queries/linked_to_spec.rb
+++ b/spec/queries/linked_to_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Queries::LinkedTo do
   end
 
   describe "#call" do
-    subject { described_class.new.call(content_id: content_id, expansion_rules: expansion_rules) }
+    subject { described_class.new(content_id, expansion_rules).call }
     let(:content_id) { SecureRandom.uuid }
     let(:expansion_rules) { Queries::DependeeExpansionRules }
     let(:recursive_link_types) { [] }


### PR DESCRIPTION
Sadly the recursive SQL had all got a bit complicated and will be
backburned until a time that we need to squeeze that extra performance
now. I'll shed a tear for it later 😥.

This does the recursion via Ruby and only calls a single level items
from the DB.

It still has some complexity working out to correctly obey the "sticky"
rules. Potentially these could be refactored to something simpler
somehow.

An alternative to: https://github.com/alphagov/publishing-api/pull/628