### PR TITLE
Unambigiously refer to columns

### DIFF
--- a/app/controllers/lookups_controller.rb
+++ b/app/controllers/lookups_controller.rb
@@ -7,7 +7,7 @@ class LookupsController < ApplicationController
 
     base_paths_and_content_ids = ContentItemFilter
       .filter(state: states, base_path: base_paths)
-      .pluck(:base_path, :content_id)
+      .pluck('locations.base_path', :content_id)
       .uniq
 
     response = Hash[base_paths_and_content_ids]

--- a/app/presenters/queries/available_translations.rb
+++ b/app/presenters/queries/available_translations.rb
@@ -22,7 +22,7 @@ module Presenters
         scope = ContentItem.where(content_id: content_id)
         scope = State.join_content_items(scope)
         scope = Translation.join_content_items(scope)
-        scope.select(*%w(id locale name))
+        scope.select(*%w(id translations.locale name))
       end
 
       def filter_states

--- a/app/presenters/queries/content_item_presenter.rb
+++ b/app/presenters/queries/content_item_presenter.rb
@@ -89,6 +89,10 @@ module Presenters
             "states.name AS publication_state"
           when :user_facing_version
             "user_facing_versions.number AS user_facing_version"
+          when :base_path
+            "locations.base_path AS base_path"
+          when :locale
+            "translations.locale AS locale"
           when :lock_version
             "lock_versions.number AS lock_version"
           when :description
@@ -113,7 +117,7 @@ module Presenters
 
       def search(scope)
         return scope unless search_query.present?
-        scope.where("title ilike ? OR base_path ilike ?", "%#{search_query}%", "%#{search_query}%")
+        scope.where("title ilike ? OR locations.base_path ilike ?", "%#{search_query}%", "%#{search_query}%")
       end
 
       STATE_HISTORY_SQL = <<-SQL.freeze

--- a/app/queries/get_latest.rb
+++ b/app/queries/get_latest.rb
@@ -6,7 +6,7 @@ module Queries
       def call(content_item_scope)
         scope = Translation.join_content_items(content_item_scope)
         scope = UserFacingVersion.join_content_items(scope)
-        scope = scope.select(:id, :content_id, :locale, :number)
+        scope = scope.select(:id, :content_id, 'translations.locale', :number)
 
         ContentItem.joins <<-SQL
           INNER JOIN (

--- a/app/validators/unpublishing_redirect_validator.rb
+++ b/app/validators/unpublishing_redirect_validator.rb
@@ -4,7 +4,7 @@ class UnpublishingRedirectValidator < ActiveModel::Validator
 
     base_path = Location.join_content_items(
       ContentItem.where(id: unpublishing.content_item_id)
-    ).pluck(:base_path).first
+    ).pluck('locations.base_path').first
 
     if base_path == unpublishing.alternative_path
       unpublishing.errors.add(

--- a/db/migrate/helpers/supersede_previous_published_or_unpublished.rb
+++ b/db/migrate/helpers/supersede_previous_published_or_unpublished.rb
@@ -6,7 +6,7 @@ module Helpers
         .joins(:content_item)
         .joins("INNER JOIN translations t on t.content_item_id = content_items.id")
         .joins("INNER JOIN user_facing_versions u on u.content_item_id = content_items.id")
-        .group(:content_id, :locale)
+        .group(:content_id, 't.locale')
         .having("count(content_id) > 1")
         .pluck("json_agg((states.id, u.number))")
         .map do |results|

--- a/lib/data_hygiene/duplicate_content_item/version_for_locale.rb
+++ b/lib/data_hygiene/duplicate_content_item/version_for_locale.rb
@@ -48,7 +48,7 @@ module DataHygiene
       def sql
         <<-SQL
           SELECT content_items.content_id,
-            translations.locale,
+            translations.locale as locale,
             user_facing_versions.number as user_facing_version,
             ARRAY_AGG(
               ROW(content_items.id, content_items.updated_at)
@@ -59,7 +59,7 @@ module DataHygiene
             ON translations.content_item_id = content_items.id
           INNER JOIN user_facing_versions
             ON user_facing_versions.content_item_id = content_items.id
-          GROUP BY content_id, locale, user_facing_version
+          GROUP BY content_id, translations.locale, user_facing_versions.number
           HAVING COUNT(*) > 1
         SQL
       end


### PR DESCRIPTION
This is required as the first step to making the Publishing API schema simpler, so that queries can be written easier and run faster.