### PR TITLE
Merge routes from content item

### DIFF
--- a/app/commands/v2/put_content.rb
+++ b/app/commands/v2/put_content.rb
@@ -232,6 +232,7 @@ module Commands
             locale: locale,
             state: "draft",
             user_facing_version: content_item.user_facing_version,
+            routes: content_item.routes,
           )
         )
         content_item.save!


### PR DESCRIPTION
Fixes `spec/requests/logging_requests_spec.rb:47` (`RouteValidator` was complaining "path must be below the base path")