### PR TITLE
Include Rcov report in Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,6 +20,15 @@ node {
             }
           }
         }
+
+        publishHTML(target: [
+          allowMissing: false,
+          alwaysLinkToLastBuild: false,
+          keepAll: true,
+          reportDir: 'coverage/rcov',
+          reportFiles: 'index.html',
+          reportName: 'RCov Report'
+        ])
       }
 
       stage("Push release tag") {


### PR DESCRIPTION
Based on blog post here: https://jenkins.io/blog/2016/07/01/html-publisher-plugin/

Example one: https://ci.integration.publishing.service.gov.uk/job/publishing-api/job/jenkins-rcov-report/RCov_Report/