### PR TITLE
Run tests locally using Docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
 .git
 .gitignore
 README.md
+log

--- a/docker_tests.sh
+++ b/docker_tests.sh
@@ -1,0 +1,23 @@
+#! /bin/bash
+set -x
+
+docker build -t publishing-api:dev .
+
+DB_CONTAINER=$(docker run -d --name db postgres:9.3)
+trap 'docker rm -f ${DB_CONTAINER}' EXIT
+
+docker_run() {
+  docker run \
+    --link db \
+    -v ${PWD}:/app \
+    -v ${PWD/%publishing-api/govuk-content-schemas}:/tmp/govuk-content-schemas \
+    -e GOVUK_CONTENT_SCHEMAS_PATH=/tmp/govuk-content-schemas \
+    -e RAILS_ENV=test \
+    -e DATABASE_URL=postgresql://postgres@db/publishing_api_development \
+    -e VIRTUAL_HOST=publishing-api.dev.gov.uk \
+    publishing-api:dev \
+    $@
+}
+
+docker_run bin/rails db:create db:environment:set db:schema:load
+docker_run bin/rspec


### PR DESCRIPTION
This is mostly just for documentation for now, and a proof-of-concept about how we'd run the tests under Docker in CI.

Builds and tags a “dev” image of the publishing api that tests can be
run against. We boot a postgres container and link to it, so the schema
loading needs to happen on each run. The id for the postgres container
is kept so it can be removed when the script exits.

The app directory is volume mounted into the container so that logs get
saved to the host. The content schemas directory is also mounted into
the container.

This doesn’t run the pact tests yet as I couldn’t work out the external
dependency.