### PR TITLE
Remove conflicting content items in Publishing API

### DIFF
--- a/db/migrate/20161216111426_december_16_remove_conflicting_content_items.rb
+++ b/db/migrate/20161216111426_december_16_remove_conflicting_content_items.rb
@@ -1,0 +1,31 @@
+require_relative "helpers/delete_content_item"
+
+class December16RemoveConflictingContentItems < ActiveRecord::Migration[5.0]
+  def up
+    to_remove = [
+      1066093, # conflicts with 1066092 - same base_path, state and user_facing_version
+      # The remaining are all version conflicts, they don't have base_paths
+      # all are contacts from whitehall
+      1035642, # conflicts with 1035643
+      1078051, # conflicts with 1078053
+      1035336, # conflicts with 1035337
+      1235630, # conflicts with 1235630
+      1035342, # conflcits with 1035343
+      1066050, # conflicts with 1066051
+      1038420, # conflicts with 1038420
+      1055010, # conflicts with 1055011
+      1054963, # conflicts with 1054962
+      1302370, # conflicts with 1302371
+      1481684, # conflicts with 1481685
+      1059527, # conflicts with 1059528
+      1299098, # conflicts with 1299099
+      1067658, # conflicts with 1067659
+    ]
+    content_items = ContentItem.where(id: to_remove)
+    Helpers::DeleteContentItem.destroy_supporting_objects(content_items)
+    content_items.destroy_all
+  end
+
+  def down
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161116114622) do
+ActiveRecord::Schema.define(version: 20161216111426) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
Set up to make way for uniqueness constraints, hopefully no fresh
conflicts slip in the mean time.