### PR TITLE
Revert to sending deprecated 'format' downstream

### DIFF
--- a/app/presenters/downstream_presenter.rb
+++ b/app/presenters/downstream_presenter.rb
@@ -88,6 +88,7 @@ module Presenters
 
     def format
       {
+        format: web_content_item.schema_name,
         schema_name: web_content_item.schema_name,
         document_type: web_content_item.document_type
       }

--- a/spec/presenters/downstream_presenter_spec.rb
+++ b/spec/presenters/downstream_presenter_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe Presenters::DownstreamPresenter do
         description: "VAT rates for goods and services",
         details: details,
         document_type: "guide",
+        format: "guide",
         expanded_links: {},
         locale: "en",
         need_ids: %w(100123 100124),

--- a/spec/requests/content_item_requests/downstream_requests_spec.rb
+++ b/spec/requests/content_item_requests/downstream_requests_spec.rb
@@ -250,6 +250,7 @@ RSpec.describe "Downstream requests", type: :request do
           locale: "en",
           document_type: "guide",
           schema_name: "guide",
+          format: "guide",
         )
         .except(
           :id,

--- a/spec/support/request_helpers/mocks.rb
+++ b/spec/support/request_helpers/mocks.rb
@@ -22,6 +22,7 @@ module RequestHelpers
         description: "VAT rates for goods and services",
         document_type: "guide",
         schema_name: "guide",
+        format: "guide",
         need_ids: %w(100123 100124),
         first_published_at: "2014-01-02T03:04:05Z",
         public_updated_at: "2014-05-14T13:00:06Z",
@@ -88,6 +89,7 @@ module RequestHelpers
         base_path: "/crb-checks",
         document_type: "redirect",
         schema_name: "redirect",
+        format: "redirect",
         public_updated_at: "2014-05-14T13:00:06Z",
         publishing_app: "publisher",
         redirects: [


### PR DESCRIPTION
This was removed in 9cdd0e499ac55f1d7a3c18afb002770868e91fb3 but it should be left for the time being as it is still being used.