### PR TITLE
Revert auto-populating ContentItem from pillars

### DIFF
--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -3,10 +3,6 @@ class Location < ApplicationRecord
 
   validates :base_path, absolute_path: true, if: :base_path_present?
 
-  after_save do
-    content_item.update_attributes!(base_path: base_path)
-  end
-
   def self.filter(content_item_scope, base_path:)
     join_content_items(content_item_scope)
       .where("locations.base_path" => base_path)

--- a/app/models/state.rb
+++ b/app/models/state.rb
@@ -1,10 +1,6 @@
 class State < ApplicationRecord
   belongs_to :content_item
 
-  after_save do
-    content_item.update_attributes!(state: name)
-  end
-
   def self.filter(content_item_scope, name:)
     join_content_items(content_item_scope)
       .where("states.name" => name)

--- a/app/models/translation.rb
+++ b/app/models/translation.rb
@@ -6,10 +6,6 @@ class Translation < ApplicationRecord
     message: 'must be a supported locale'
   }
 
-  after_save do
-    content_item.update_attributes!(locale: locale)
-  end
-
   def self.filter(content_item_scope, locale:)
     join_content_items(content_item_scope)
       .where("translations.locale" => locale)

--- a/app/models/user_facing_version.rb
+++ b/app/models/user_facing_version.rb
@@ -3,10 +3,6 @@ class UserFacingVersion < ApplicationRecord
 
   belongs_to :content_item
 
-  after_save do
-    content_item.update_attributes!(user_facing_version: number)
-  end
-
   def self.filter(content_item_scope, number:)
     join_content_items(content_item_scope)
       .where("user_facing_versions.number" => number)


### PR DESCRIPTION
This reverts the temporary changes introduced in #7e6c05e and stops
pillar tables auto-populating ContentItem.