### PR TITLE
Add content_store column to content_items

### DIFF
--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -3,6 +3,11 @@ class ContentItem < ApplicationRecord
   include SymbolizeJSON
   include DescriptionOverrides
 
+  enum content_store: {
+    draft: 'draft',
+    live: 'live'
+  }
+
   DEFAULT_LOCALE = "en".freeze
 
   TOP_LEVEL_FIELDS = [

--- a/app/models/state.rb
+++ b/app/models/state.rb
@@ -28,7 +28,7 @@ class State < ApplicationRecord
   end
 
   def self.unpublish(content_item, type:, explanation: nil, alternative_path: nil, unpublished_at: nil)
-    change_state(content_item, name: "unpublished")
+    change_state(content_item, name: "unpublished", type: type)
 
     unpublishing = Unpublishing.find_by(content_item: content_item)
 
@@ -60,9 +60,17 @@ class State < ApplicationRecord
     )
   end
 
-  def self.change_state(content_item, name:)
+  def self.content_store_from_name(name, type)
+    return if name == "superseded"
+    return if type == 'substitute'
+    name == "draft" ? "draft" : "live"
+  end
+  private_class_method :content_store_from_name
+
+  def self.change_state(content_item, name:, type: nil)
     state = self.find_by!(content_item: content_item)
     state.update_attributes!(name: name)
+    content_item.update_attributes!(content_store: content_store_from_name(name, type))
   end
   private_class_method :change_state
 end

--- a/db/migrate/20161219143746_add_content_store_to_content_items.rb
+++ b/db/migrate/20161219143746_add_content_store_to_content_items.rb
@@ -1,0 +1,5 @@
+class AddContentStoreToContentItems < ActiveRecord::Migration[5.0]
+  def change
+    add_column :content_items, :content_store, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161219102828) do
+ActiveRecord::Schema.define(version: 20161219143746) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -73,6 +73,7 @@ ActiveRecord::Schema.define(version: 20161219102828) do
     t.string   "locale"
     t.integer  "user_facing_version"
     t.string   "base_path"
+    t.string   "content_store"
     t.index ["content_id", "state", "locale"], name: "index_content_items_on_content_id_and_state_and_locale", using: :btree
     t.index ["content_id"], name: "index_content_items_on_content_id", using: :btree
     t.index ["document_type"], name: "index_content_items_on_document_type", using: :btree

--- a/lib/data_hygiene/duplicate_content_item/base_path_for_state.rb
+++ b/lib/data_hygiene/duplicate_content_item/base_path_for_state.rb
@@ -53,7 +53,7 @@ module DataHygiene
               WHEN 'draft'
               THEN 'draft'
               ELSE 'live'
-            END AS content_store,
+            END AS state_content_store,
             ARRAY_AGG(DISTINCT content_items.content_id) as content_ids,
             ARRAY_AGG(
               ROW(content_items.id, content_items.updated_at)
@@ -70,7 +70,7 @@ module DataHygiene
           WHERE locations.base_path IS NOT NULL
             AND states.name IN ('draft', 'published', 'unpublished')
             AND (unpublishings.type IS NULL OR unpublishings.type != 'substitute')
-          GROUP BY locations.base_path, content_store
+          GROUP BY locations.base_path, state_content_store
           HAVING COUNT(*) > 1
         SQL
       end

--- a/lib/data_hygiene/duplicate_content_item/state_for_locale.rb
+++ b/lib/data_hygiene/duplicate_content_item/state_for_locale.rb
@@ -51,7 +51,7 @@ module DataHygiene
             translations.locale,
             CASE states.name
               WHEN 'draft' THEN 'draft' ELSE 'live'
-            END AS content_store,
+            END AS state_content_store,
             ARRAY_AGG(
               ROW(content_items.id, content_items.updated_at)
               ORDER BY content_items.updated_at DESC
@@ -62,7 +62,7 @@ module DataHygiene
           INNER JOIN states
             ON states.content_item_id = content_items.id
           WHERE states.name IN ('draft', 'published', 'unpublished')
-          GROUP BY content_items.content_id, translations.locale, content_store
+          GROUP BY content_items.content_id, translations.locale, state_content_store
           HAVING COUNT(*) > 1
         SQL
       end

--- a/spec/factories/content_item.rb
+++ b/spec/factories/content_item.rb
@@ -17,6 +17,7 @@ FactoryGirl.define do
     phase "beta"
     update_type "minor"
     analytics_identifier "GDS01"
+    content_store "draft"
     routes {
       [
         {

--- a/spec/factories/draft_content_item.rb
+++ b/spec/factories/draft_content_item.rb
@@ -1,5 +1,6 @@
 FactoryGirl.define do
   factory :draft_content_item, parent: :content_item do
+    content_store 'draft'
     transient do
       state "draft"
     end

--- a/spec/factories/live_content_item.rb
+++ b/spec/factories/live_content_item.rb
@@ -1,5 +1,6 @@
 FactoryGirl.define do
   factory :live_content_item, parent: :content_item do
+    content_store 'live'
     transient do
       user_facing_version 1
       draft_version_number 2

--- a/spec/factories/superseded_content_item.rb
+++ b/spec/factories/superseded_content_item.rb
@@ -1,5 +1,6 @@
 FactoryGirl.define do
   factory :superseded_content_item, parent: :live_content_item do
+    content_store nil
     state "superseded"
   end
 end

--- a/spec/factories/unpublished_content_item.rb
+++ b/spec/factories/unpublished_content_item.rb
@@ -20,6 +20,7 @@ FactoryGirl.define do
   end
 
   factory :withdrawn_unpublished_content_item, parent: :unpublished_content_item do
+    content_store 'live'
     transient do
       unpublishing_type "withdrawal"
       unpublished_at nil
@@ -27,6 +28,7 @@ FactoryGirl.define do
   end
 
   factory :redirect_unpublished_content_item, parent: :unpublished_content_item do
+    content_store 'live'
     transient do
       unpublishing_type "redirect"
       unpublished_at nil
@@ -34,6 +36,7 @@ FactoryGirl.define do
   end
 
   factory :vanish_unpublished_content_item, parent: :unpublished_content_item do
+    content_store 'live'
     transient do
       unpublishing_type "vanish"
       unpublished_at nil
@@ -41,6 +44,7 @@ FactoryGirl.define do
   end
 
   factory :substitute_unpublished_content_item, parent: :unpublished_content_item do
+    content_store nil
     transient do
       unpublishing_type "substitute"
       unpublished_at nil

--- a/spec/lib/data_hygiene/duplicate_content_item/base_path_for_state_spec.rb
+++ b/spec/lib/data_hygiene/duplicate_content_item/base_path_for_state_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe DataHygiene::DuplicateContentItem::BasePathForState do
 
     {
       base_path: base_path,
-      content_store: content_store,
+      state_content_store: content_store,
       content_ids: array_including(content_ids),
       content_items: array_including(content_items_entry),
     }

--- a/spec/lib/data_hygiene/duplicate_content_item/state_for_locale_spec.rb
+++ b/spec/lib/data_hygiene/duplicate_content_item/state_for_locale_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe DataHygiene::DuplicateContentItem::StateForLocale do
     {
       content_id: content_id,
       locale: locale,
-      content_store: content_store,
+      state_content_store: content_store,
       content_items: array_including(content_items_entry),
     }
   end

--- a/spec/models/state_spec.rb
+++ b/spec/models/state_spec.rb
@@ -100,6 +100,12 @@ RSpec.describe State do
     let(:draft_item) { FactoryGirl.create(:draft_content_item) }
     let(:draft_state) { State.find_by!(content_item: draft_item) }
 
+    it "changes the content_item content_store to nil" do
+      expect {
+        described_class.supersede(draft_item)
+      }.to change { draft_item.reload.content_store }.to(nil)
+    end
+
     it "changes the state name to 'superseded'" do
       expect {
         described_class.supersede(draft_item)
@@ -111,6 +117,12 @@ RSpec.describe State do
     let(:draft_item) { FactoryGirl.create(:draft_content_item) }
     let(:draft_state) { State.find_by!(content_item: draft_item) }
 
+    it "changes the content_item content_store to live" do
+      expect {
+        described_class.publish(draft_item)
+      }.to change { draft_item.reload.content_store }.from('draft').to('live')
+    end
+
     it "changes the state name to 'published'" do
       expect {
         described_class.publish(draft_item)
@@ -121,6 +133,30 @@ RSpec.describe State do
   describe ".unpublish" do
     let(:live_item) { FactoryGirl.create(:live_content_item) }
     let(:live_state) { State.find_by!(content_item: live_item) }
+
+    it "doesn't change the content_item content_store if it is not a substitute" do
+      expect {
+        described_class.unpublish(live_item, type: "gone", explanation: 'gone')
+      }.to_not change { live_item.reload.content_store }
+    end
+
+    it "doesn't change the content_item content_store if it is not a substitute" do
+      expect {
+        described_class.unpublish(live_item, type: "vanish", explanation: 'gone')
+      }.to_not change { live_item.reload.content_store }
+    end
+
+    it "doesn't change the content_item content_store if it is not a substitute" do
+      expect {
+        described_class.unpublish(live_item, type: "withdrawal", explanation: 'gone')
+      }.to_not change { live_item.reload.content_store }
+    end
+
+    it "changes the content_item content_store to nil when substitute" do
+      expect {
+        described_class.unpublish(live_item, type: "substitute")
+      }.to change { live_item.reload.content_store }.to(nil)
+    end
 
     it "changes the state name to 'unpublished'" do
       expect {
@@ -178,6 +214,12 @@ RSpec.describe State do
   describe ".substitute" do
     let(:live_item) { FactoryGirl.create(:live_content_item) }
     let(:live_state) { State.find_by!(content_item: live_item) }
+
+    it "changes the content_store to nil" do
+      expect {
+        described_class.substitute(live_item)
+      }.to change { live_item.reload.content_store }.to(nil)
+    end
 
     it "changes the state name to 'unpublished'" do
       expect {

--- a/spec/requests/content_item_requests/downstream_requests_spec.rb
+++ b/spec/requests/content_item_requests/downstream_requests_spec.rb
@@ -267,7 +267,8 @@ RSpec.describe "Downstream requests", type: :request do
 
           # hide attributes that won't exist when calling as_json
           :state,
-          :user_facing_version
+          :user_facing_version,
+          :content_store,
         )
     }
 


### PR DESCRIPTION
This will be used to add a uniqueness constraint to content_items and to
simplify code around knowing which content_store a content_item is in.

We will have a uniqueness constraint on content_store and base_path,
since only one base_path can live in the content_store at any one time.

Secondly it will have a uniqueness constraint on content_store, locale
and content_id to ensure we can't create any duplicate content items.
For example when two requests come in we reject the duplicate at
database level.

Defines a loose ordering of a content_item content store journey from none -> draft -> live -> none
Note that a live content_store also implies that it is in the draft
store too, and when an item is redrafted its latest version is in draft
even though a previous edition is live.

When an item is unpublished it is still 'live' unless it was unpublished
as type 'substitute'