### PR TITLE
Update tests and fix for intermittent test failures

### DIFF
--- a/app/presenters/change_history_presenter.rb
+++ b/app/presenters/change_history_presenter.rb
@@ -17,14 +17,13 @@ module Presenters
     end
 
     def change_notes_for_content_item
-      ChangeNote
+      change_notes = ChangeNote
         .where(content_id: content_item.content_id)
         .where("content_item_id IS NULL OR content_item_id IN (?)", content_item_ids)
         .order(:public_timestamp)
         .pluck(:note, :public_timestamp)
-        .map do |note, timestamp|
-          { note: note, public_timestamp: timestamp }.stringify_keys
-        end
+        .map { |note, timestamp| { note: note, public_timestamp: timestamp } }
+      SymbolizeJSON.symbolize(change_notes.as_json)
     end
 
     def content_item_ids

--- a/spec/presenters/change_history_presenter_spec.rb
+++ b/spec/presenters/change_history_presenter_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Presenters::ChangeHistoryPresenter do
         end
       end
       it "constructs content history from change notes" do
-        expect(subject.map { |item| item["note"] }).to eq %w(0 1)
+        expect(subject.map { |item| item[:note] }).to eq %w(0 1)
       end
     end
 
@@ -50,7 +50,7 @@ RSpec.describe Presenters::ChangeHistoryPresenter do
           public_timestamp: i.days.ago
         )
       end
-      expect(subject.map { |item| item["note"] }).to eq %w(3 2 1)
+      expect(subject.map { |item| item[:note] }).to eq %w(3 2 1)
     end
 
     context "multiple content items for a single content id" do

--- a/spec/presenters/downstream_presenter_spec.rb
+++ b/spec/presenters/downstream_presenter_spec.rb
@@ -172,7 +172,7 @@ RSpec.describe Presenters::DownstreamPresenter do
       end
 
       it "constructs the change history" do
-        expect(result[:details][:change_history].first["note"]).to eq "Note"
+        expect(result[:details][:change_history].first[:note]).to eq "Note"
       end
     end
 


### PR DESCRIPTION
This won't pass until https://github.com/alphagov/govuk-content-schemas/pull/466 is merged into `deployed-to-production` 

This is an update of our tests to cover the intermittent failure we've been getting regarding schema validity and change_history. The failing test was caused by a randomly generated schema, that was only valid in some cases. The test is updated to cover both cases individually to reduce risk of regression.

Also needed the `change_history` presentation to be more consistent (as_json, symbolized) with the  rest of a content_item presentation