### PR TITLE
Fix license link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,4 +177,4 @@ see the rake task for more details.
 
 ## Licence
 
-[MIT License](LICENCE)
+[MIT License](LICENSE)


### PR DESCRIPTION
The current link is broken because of a difference in spelling.