### PR TITLE
Populate content_store field in content_items

### DIFF
--- a/db/migrate/20161220161528_populate_content_store_field.rb
+++ b/db/migrate/20161220161528_populate_content_store_field.rb
@@ -1,0 +1,22 @@
+class PopulateContentStoreField < ActiveRecord::Migration[5.0]
+  def up
+    execute "UPDATE content_items SET content_store = (
+              SELECT
+              CASE
+                WHEN state = 'draft' THEN 'draft'
+                WHEN state IN ('published', 'unpublished')
+                AND (unpublishings.type IS NULL OR unpublishings.type != 'substitute') THEN 'live'
+                ELSE NULL
+              END
+              FROM content_items c
+              LEFT JOIN
+                unpublishings ON state = 'unpublished'
+                AND
+                unpublishings.content_item_id = c.id
+              WHERE c.id = content_items.id
+             )"
+  end
+
+  def down
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161219143746) do
+ActiveRecord::Schema.define(version: 20161220161528) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
This moves the migration from https://github.com/alphagov/publishing-api/pull/659/commits/2711caa4adc93cab623182b51b825dd721d11ff2 into this commit of it's own. It seemed to be less confusing to generate this as a fresh migration since it a) makes the timestamps easier to follow and b) can be run twice without problems.

This should be merged in and deployed prior to deploying uniqueness_constraint. I'm not merging in at the moment as it will probably be slow to run and I wonder if there's a way we can run it that is less resource hungry.