### PR TITLE
Clearer schema errors

### DIFF
--- a/app/validators/schema_validator.rb
+++ b/app/validators/schema_validator.rb
@@ -31,7 +31,7 @@ private
   rescue Errno::ENOENT => error
     if Rails.env.development?
       errors << missing_schema_message
-      errors << dev_help
+      errors << dev_help if GovukSchemas::Schema.all.empty?
     end
     Airbrake.notify(error, parameters: {
       explanation: missing_schema_message,

--- a/spec/validators/schema_validator_spec.rb
+++ b/spec/validators/schema_validator_spec.rb
@@ -26,6 +26,15 @@ RSpec.describe SchemaValidator do
       end
     end
 
+    context "empty schema name" do
+      let(:schema) { nil }
+      let(:payload) { { schema_name: "" } }
+
+      it "returns false" do
+        expect(validator.valid?).to be false
+      end
+    end
+
     context "valid payload" do
       let(:payload) { { a: 1 } }
 
@@ -64,6 +73,16 @@ RSpec.describe SchemaValidator do
         expect(subject.count).to eq 1
         expected = /property '#\/' did not contain a required property of 'a'/
         expect(subject.first[:message]).to match expected
+      end
+    end
+
+    context "empty schema name" do
+      let(:schema) { nil }
+      let(:payload) { { schema_name: "" } }
+      let(:message) { "Schema could not be validated as the schema_name was not provided" }
+
+      it "has an error" do
+        expect(subject).to match_array([message])
       end
     end
   end


### PR DESCRIPTION
Since our switch to remove format a couple of people have been caught out with the errors they have got from the Publishing API in regards to validating schemas.

In dev for a missing schema field you get an error of: "Unable to find schema for schema_name  Ensure GOVUK_CONTENT_SCHEMAS_PATH env variable is set and points to the root directory of govuk-content-schemas" which can be confusing as their schemas may be set up correctly and it is the missing field that causes the problem.

This change makes the reasons a user has hit an error clearer.