### PR TITLE
Set default and null constraints for pillar columns

### DIFF
--- a/db/migrate/20161214113229_pillar_column_defaults.rb
+++ b/db/migrate/20161214113229_pillar_column_defaults.rb
@@ -1,0 +1,13 @@
+class PillarColumnDefaults < ActiveRecord::Migration[5.0]
+  def up
+    change_column :content_items, :state, :string, null: false
+    change_column :content_items, :locale, :string, null: false
+    change_column :content_items, :user_facing_version, :integer, null: false, default: 1
+  end
+
+  def down
+    change_column :content_items, :state, :string
+    change_column :content_items, :locale, :string
+    change_column :content_items, :user_facing_version, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -69,9 +69,9 @@ ActiveRecord::Schema.define(version: 20161219143746) do
     t.string   "schema_name"
     t.datetime "first_published_at"
     t.datetime "last_edited_at"
-    t.string   "state"
-    t.string   "locale"
-    t.integer  "user_facing_version"
+    t.string   "state",                                         null: false
+    t.string   "locale",                                        null: false
+    t.integer  "user_facing_version",  default: 1,              null: false
     t.string   "base_path"
     t.string   "content_store"
     t.index ["content_id", "state", "locale"], name: "index_content_items_on_content_id_and_state_and_locale", using: :btree


### PR DESCRIPTION
Took nearly 2 minutes to run on my machine

== 20161214113229 PillarColumnDefaults: migrating =============================
-- change_column(:content_items, :state, :string, {:null=>false})
   -> 25.4151s
-- change_column(:content_items, :locale, :string, {:null=>false})
   -> 24.5337s
-- change_column(:content_items, :user_facing_version, :integer, {:null=>false, :default=>0})
   -> 49.3209s
== 20161214113229 PillarColumnDefaults: migrated (99.2704s) ===================