### PR TITLE
Create and dual-populate documents

### DIFF
--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -39,6 +39,10 @@ class ContentItem < ApplicationRecord
 
   scope :renderable_content, -> { where.not(document_type: NON_RENDERABLE_FORMATS) }
 
+  belongs_to :document
+
+  validates :document, presence: true
+
   validates :schema_name, presence: true
   validates :document_type, presence: true
 
@@ -93,6 +97,11 @@ class ContentItem < ApplicationRecord
       UserFacingVersion.find_or_initialize_by(content_item_id: id)
         .update!(number: changes[:user_facing_version].last)
     end
+  end
+
+  before_validation do
+    self.document = Document.find_or_create_by(content_id: content_id,
+                                               locale: locale)
   end
 
   def requires_base_path?

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -1,0 +1,3 @@
+class Document < ApplicationRecord
+
+end

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -1,3 +1,10 @@
 class Document < ApplicationRecord
+  has_many :content_item
 
+  validates :content_id, presence: true, uuid: true
+
+  validates :locale, inclusion: {
+    in: I18n.available_locales.map(&:to_s),
+    message: 'must be a supported locale'
+  }
 end

--- a/db/migrate/20161220134413_create_documents.rb
+++ b/db/migrate/20161220134413_create_documents.rb
@@ -1,0 +1,10 @@
+class CreateDocuments < ActiveRecord::Migration[5.0]
+  def change
+    create_table :documents do |t|
+      t.uuid :content_id, null: false
+      t.string :locale, null: false
+    end
+
+    add_index :documents, [:content_id, :locale], :unique => true
+  end
+end

--- a/db/migrate/20161222102024_link_documents_to_content_items.rb
+++ b/db/migrate/20161222102024_link_documents_to_content_items.rb
@@ -1,0 +1,6 @@
+class LinkDocumentsToContentItems < ActiveRecord::Migration[5.0]
+  def change
+    add_column :content_items, :document_id, :integer
+    add_foreign_key :content_items, :documents
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -85,6 +85,12 @@ ActiveRecord::Schema.define(version: 20161220161528) do
     t.index ["updated_at"], name: "index_content_items_on_updated_at", using: :btree
   end
 
+  create_table "documents", force: :cascade do |t|
+    t.uuid   "content_id", null: false
+    t.string "locale", null: false
+    t.index ["content_id", "locale"], name: "index_documents_on_content_id_and_locale", unique: true, using: :btree
+  end
+
   create_table "events", force: :cascade do |t|
     t.string   "action",                  null: false
     t.json     "payload",    default: {}

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161220161528) do
+ActiveRecord::Schema.define(version: 20161222102024) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -74,6 +74,7 @@ ActiveRecord::Schema.define(version: 20161220161528) do
     t.integer  "user_facing_version",  default: 1,              null: false
     t.string   "base_path"
     t.string   "content_store"
+    t.integer  "document_id"
     t.index ["content_id", "state", "locale"], name: "index_content_items_on_content_id_and_state_and_locale", using: :btree
     t.index ["content_id"], name: "index_content_items_on_content_id", using: :btree
     t.index ["document_type"], name: "index_content_items_on_document_type", using: :btree
@@ -202,5 +203,6 @@ ActiveRecord::Schema.define(version: 20161220161528) do
   end
 
   add_foreign_key "change_notes", "content_items"
+  add_foreign_key "content_items", "documents"
   add_foreign_key "links", "link_sets"
 end


### PR DESCRIPTION
Create a table to store documents and dual-populate it with content item data when performing saves, but continue to use the data in the content items table as the canonical source in queries.