### PR TITLE
Exclude pathless items from conflict check

### DIFF
--- a/app/queries/check_for_content_item_preventing_draft_from_being_published.rb
+++ b/app/queries/check_for_content_item_preventing_draft_from_being_published.rb
@@ -6,6 +6,8 @@ module Queries
     # specified content_id and base_path from being published (from the draft
     # state).
     def self.call(content_id, base_path, document_type)
+      return unless base_path
+
       if SubstitutionHelper::SUBSTITUTABLE_DOCUMENT_TYPES.include?(document_type)
         return # The SubstitionHelper will unpublish any item that is in the way
       end

--- a/spec/queries/check_for_content_item_preventing_draft_from_being_published_spec.rb
+++ b/spec/queries/check_for_content_item_preventing_draft_from_being_published_spec.rb
@@ -166,5 +166,43 @@ RSpec.describe Queries::CheckForContentItemPreventingDraftFromBeingPublished do
         expect(subject).to eq(@blocking_content_item.id)
       end
     end
+
+    context "with no base_path" do
+      let(:base_path) { nil }
+
+      let!(:blocking_content_item) do
+        FactoryGirl.create(:live_content_item,
+          content_id: SecureRandom.uuid,
+          base_path: base_path,
+          document_type: document_type,
+          user_facing_version: 1,
+          locale: "en",
+        )
+      end
+
+      let!(:blocking_content_item_2) do
+        FactoryGirl.create(:live_content_item,
+          content_id: SecureRandom.uuid,
+          base_path: base_path,
+          document_type: document_type,
+          user_facing_version: 1,
+          locale: "en",
+        )
+      end
+
+      let!(:content) do
+        FactoryGirl.create(:draft_content_item,
+          content_id: content_id,
+          base_path: base_path,
+          document_type: document_type,
+          user_facing_version: 1,
+          locale: "en",
+        )
+      end
+
+      it "doesn't raise any errors" do
+        expect { subject }.to_not raise_error
+      end
+    end
   end
 end


### PR DESCRIPTION
This is raising errors on production since it it checking pathless items
which returns multiple rows and errors out.
see https://errbit.publishing.service.gov.uk/apps/552f95820da11577b4000032/problems/585baca66578634737901000

This returns when there is no base_path