### PR TITLE
Add content_store to ContentItem top level fields

### DIFF
--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -14,6 +14,7 @@ class ContentItem < ApplicationRecord
     :analytics_identifier,
     :base_path,
     :content_id,
+    :content_store,
     :description,
     :details,
     :document_type,

--- a/app/presenters/queries/content_item_presenter.rb
+++ b/app/presenters/queries/content_item_presenter.rb
@@ -16,7 +16,7 @@ module Presenters
         :updated_at,
         :state_history,
         :change_note,
-      ] - [:state]).freeze # state appears as 'publication_state'
+      ] - [:state, :content_store]).freeze # state appears as 'publication_state'
 
       def self.present_many(scope, params = {})
         new(scope, params).present_many


### PR DESCRIPTION
I'm not sure what TOP_LEVEL_FIELDS means, but content_store is now a
field, so it should probably be in this list.

The presenter has been changed to keep the current behaviour of not
presenting this.