### PR TITLE
Ensure access limits are not sent for live items.

### DIFF
--- a/app/presenters/downstream_presenter.rb
+++ b/app/presenters/downstream_presenter.rb
@@ -47,11 +47,19 @@ module Presenters
 
     def access_limited
       return {} unless access_limit
-      {
-        access_limited: {
-          users: access_limit.users
+      if web_content_item.state != 'draft'
+        Airbrake.notify(
+          'Tried to send non-draft item with access_limited data',
+          content_id: web_content_item.content_id
+        )
+        {}
+      else
+        {
+          access_limited: {
+            users: access_limit.users
+          }
         }
-      }
+      end
     end
 
     def expanded_link_set_presenter

--- a/spec/presenters/downstream_presenter_spec.rb
+++ b/spec/presenters/downstream_presenter_spec.rb
@@ -197,6 +197,33 @@ RSpec.describe Presenters::DownstreamPresenter do
       end
     end
 
+    context "for an access-limited item" do
+      let!(:access_limit) {
+        FactoryGirl.create(:access_limit, content_item: content_item)
+      }
+
+      context "in draft" do
+        let(:content_item) { FactoryGirl.create(:draft_content_item) }
+
+        it "populates the access_limited hash" do
+          expect(result[:access_limited][:users].length).to eq(1)
+        end
+      end
+
+      context "in live" do
+        let(:content_item) { FactoryGirl.create(:live_content_item) }
+
+        it "does not send an access_limited hash" do
+          expect(result).not_to include(:access_limited)
+        end
+
+        it "notifies Airbrake" do
+          expect(Airbrake).to receive(:notify)
+          result
+        end
+      end
+    end
+
     describe "rendering govspeak" do
       let(:details) do
         {


### PR DESCRIPTION
Although the publish command destroys any access limit items, we have
seen occasions when the access_limited hash has been populated in the
live content store. This ensures that it will never be sent for
published items, and notifies airbrake if it encounters this situation.