### PR TITLE
Remove AccessLimit on Unpublishing

### DIFF
--- a/app/commands/v2/unpublish.rb
+++ b/app/commands/v2/unpublish.rb
@@ -5,6 +5,7 @@ module Commands
         validate
         previous_item.supersede if previous_item
         transition_state
+        AccessLimit.find_by(content_item: content_item).try(:destroy)
 
         after_transaction_commit do
           send_downstream

--- a/spec/commands/v2/unpublish_spec.rb
+++ b/spec/commands/v2/unpublish_spec.rb
@@ -208,6 +208,21 @@ RSpec.describe Commands::V2::Unpublish do
           expect(unpublishing.alternative_path).to eq("/new-path")
         end
 
+        context "where there is an access limit" do
+          before do
+            AccessLimit.create!(
+              content_item: draft_content_item,
+              users: [SecureRandom.uuid]
+            )
+          end
+
+          it "removes the access limit model" do
+            expect {
+              described_class.call(payload_with_allow_draft)
+            }.to change(AccessLimit, :count).by(-1)
+          end
+        end
+
         it "sends an unpublishing to the live content store" do
           expect(DownstreamLiveWorker).to receive(:perform_async_in_queue)
             .with(


### PR DESCRIPTION
We don't remove AccessLimit entries when a draft is unpublished, which provides opportunities for live items to have AccessLimit rules.

I've seen we have some unpublishings with access limits existing so this could be a part of the problem we have seen with live items being sent to the content store. It's not a solution to the whole problem though - although I haven't been able to work out how it has occurred on published items.