### PR TITLE
Fix slow query in lookup_previous_item.

### DIFF
--- a/app/commands/v2/publish.rb
+++ b/app/commands/v2/publish.rb
@@ -157,7 +157,7 @@ module Commands
           raise "There should only be one previous published or unpublished item"
         end
 
-        previous_items.first
+        previous_items.order("content_id").first
       end
 
       def send_downstream(content_id, locale, update_type)


### PR DESCRIPTION
Rails adds an `ORDER BY id` when you call `first` if there's no other
ordering on the query; this was causing Postgres to choose an expensive
scan on the id index, rather than using the content_id/locale/state
index. Explicitly ordering by content_id allows it to choose the
right idnex.