### PR TITLE
Calculate total items using a window function

### DIFF
--- a/app/presenters/queries/content_item_presenter.rb
+++ b/app/presenters/queries/content_item_presenter.rb
@@ -43,13 +43,13 @@ module Presenters
       end
 
       def total
-        full_scope.count
+        results.first.nil? ? 0 : results.first["total"]
       end
 
     private
 
       def results
-        execute_query(ordered_fields)
+        @results ||= execute_query(ordered_fields)
       end
 
       def ordered_fields
@@ -103,6 +103,8 @@ module Presenters
             "content_items.base_path as base_path"
           when :locale
             "content_items.locale as locale"
+          when :total
+            "COUNT(*) OVER () as total"
           else
             field
           end
@@ -139,7 +141,7 @@ module Presenters
 
             result["warnings"] = get_warnings(result) if include_warnings
 
-            yielder.yield result.compact
+            yielder.yield(result.except("total").compact)
           end
         end
       end

--- a/app/presenters/results_presenter.rb
+++ b/app/presenters/results_presenter.rb
@@ -1,31 +1,32 @@
 module Presenters
   class ResultsPresenter
     def initialize(results, pagination, request_url)
-      @results = results
+      @results = results.call
+      @total = results.total
       @pagination = pagination
       @request_url = request_url.to_s
     end
 
     def present
       {
-        total: results.total,
+        total: total,
         pages: pagination_pages,
         current_page: current_page,
         links: links,
-        results: results.call
+        results: results
       }
     end
 
   private
 
-    attr_reader :results, :pagination, :request_url
+    attr_reader :results, :pagination, :request_url, :total
 
     def current_page
       pagination.page.to_i
     end
 
     def pagination_pages
-      pagination.pages(results.total)
+      pagination.pages(total)
     end
 
     def links

--- a/bench/get_content_items.rb
+++ b/bench/get_content_items.rb
@@ -13,10 +13,14 @@ ActiveSupport::Notifications.subscribe("sql.active_record") { |_| queries += 1 }
 StackProf.run(mode: :wall, out: "tmp/get_content_items_wall.dump") do
   puts Benchmark.measure {
     10.times do
-      Queries::GetContentCollection.new(
-        document_types: ['taxon', 'organisation', 'topic', 'mainstream_browse_page', 'policy'],
-        fields: ['content_id', 'document_type', 'title', 'base_path']
-      ).call
+      Presenters::ResultsPresenter.new(
+        Queries::GetContentCollection.new(
+          document_types: ['taxon', 'organisation', 'topic', 'mainstream_browse_page', 'policy'],
+          fields: ['content_id', 'document_type', 'title', 'base_path']
+        ),
+        Pagination.new,
+        'http://dev.gov.uk'
+      ).present
       print "."
     end
   }


### PR DESCRIPTION
Rather than run the expensive content_item_presenter query a second
time to get the total of all items, we can do it in the same query
using a window function over the whole result set.

This has involved a bit of refactoring in the GetContentCollection
class to make it possible to extract the total from the result rows.
The window function returns the (same) total in every row; we remove
the field from the presented results to avoid polluting them.


Benchmarks (from revised bench/get_content_items.rb script included in this PR)

Before: 
..........  1.200000   1.910000   3.110000 ( 24.792798)
queries: 27

After:
..........  0.730000   0.870000   1.600000 ( 11.934926)
queries: 17