### PR TITLE
Switch to using native UUID types in the database

### DIFF
--- a/db/migrate/20161220090000_remove_invalid_content_ids.rb
+++ b/db/migrate/20161220090000_remove_invalid_content_ids.rb
@@ -1,0 +1,14 @@
+class RemoveInvalidContentIds < ActiveRecord::Migration[5.0]
+  def up
+    events_to_remove = [20, 41, 83, 51, 42, 61, 40, 44, 41, 39, 42, 40, 26, 83,
+                        89, 88, 90, 86, 88, 87, 89, 90, 87, 92, 26, 39, 61, 20,
+                        44, 51, 29, 18, 94, 86, 87, 94, 18, 29, 89, 90]
+
+    Event.where(content_id: events_to_remove).delete_all
+
+    link_sets_to_remove = [40, 42, 26, 39, 61, 20, 41, 83, 51, 44, 90, 88, 29,
+                           18, 86, 89, 87, 94, 92]
+
+    LinkSet.where(content_id: link_sets_to_remove).delete_all
+  end
+end

--- a/db/migrate/20161220090001_make_content_id_uuid_type.rb
+++ b/db/migrate/20161220090001_make_content_id_uuid_type.rb
@@ -1,0 +1,15 @@
+class MakeContentIdUuidType < ActiveRecord::Migration[5.0]
+  def up
+    change_column :content_items, :content_id, 'UUID USING content_id::uuid'
+    change_column :events, :content_id, 'UUID USING content_id::uuid'
+    change_column :link_sets, :content_id, 'UUID USING content_id::uuid'
+    change_column :links, :target_content_id, 'UUID USING target_content_id::uuid'
+  end
+
+  def down
+    change_column :content_items, :content_id, :text
+    change_column :events, :content_id, :text
+    change_column :link_sets, :content_id, :text
+    change_column :links, :target_content_id, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -50,7 +50,6 @@ ActiveRecord::Schema.define(version: 20161220161528) do
   end
 
   create_table "content_items", force: :cascade do |t|
-    t.string   "content_id"
     t.string   "title"
     t.datetime "public_updated_at"
     t.json     "details",              default: {}
@@ -76,6 +75,7 @@ ActiveRecord::Schema.define(version: 20161220161528) do
     t.string   "content_store"
     t.index ["content_id", "state", "locale"], name: "index_content_items_on_content_id_and_state_and_locale", using: :btree
     t.index ["content_id"], name: "index_content_items_on_content_id", using: :btree
+    t.uuid     "content_id",                                    null: false
     t.index ["document_type"], name: "index_content_items_on_document_type", using: :btree
     t.index ["last_edited_at"], name: "index_content_items_on_last_edited_at", using: :btree
     t.index ["public_updated_at"], name: "index_content_items_on_public_updated_at", using: :btree
@@ -92,12 +92,12 @@ ActiveRecord::Schema.define(version: 20161220161528) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.string   "request_id"
-    t.string   "content_id"
+    t.uuid     "content_id"
     t.index ["content_id"], name: "index_events_on_content_id", using: :btree
   end
 
   create_table "link_sets", force: :cascade do |t|
-    t.string   "content_id"
+    t.uuid     "content_id"
     t.datetime "created_at"
     t.datetime "updated_at"
     t.index ["content_id"], name: "index_link_sets_on_content_id", unique: true, using: :btree
@@ -105,7 +105,7 @@ ActiveRecord::Schema.define(version: 20161220161528) do
 
   create_table "links", force: :cascade do |t|
     t.integer  "link_set_id"
-    t.string   "target_content_id"
+    t.uuid     "target_content_id"
     t.string   "link_type",                     null: false
     t.datetime "created_at",                    null: false
     t.datetime "updated_at",                    null: false

--- a/spec/controllers/v2/content_items_controller_spec.rb
+++ b/spec/controllers/v2/content_items_controller_spec.rb
@@ -364,7 +364,15 @@ RSpec.describe V2::ContentItemsController do
 
     context "for a non-existent content item" do
       it "responds with 404" do
-        get :show, params: { content_id: "missing" }
+        get :show, params: { content_id: SecureRandom.uuid }
+
+        expect(response.status).to eq(404)
+      end
+    end
+
+    context "for an invalid content ID" do
+      it "responds with 404" do
+        get :show, params: { content_id: "invalid" }
 
         expect(response.status).to eq(404)
       end

--- a/spec/lib/events/s3_importer_spec.rb
+++ b/spec/lib/events/s3_importer_spec.rb
@@ -17,32 +17,32 @@ RSpec.describe Events::S3Importer do
   let(:file_contents) do
     <<-CSV.strip_heredoc
       id,action,payload,user_uid,created_at,updated_at,request_id,content_id
-      10,Publish,"{""content_id"":""6070ce2c4-cf7d-427c-bb78-96cbb1a88910""}",,2015-11-11 09:55:00 UTC,2015-11-11 09:55:00 UTC,,6070ce2c4-cf7d-427c-bb78-96cbb1a88910
-      11,Publish,"{""content_id"":""62e1c58e4-9ea5-4be4-8d98-28ead976a590""}",e676cb22-0c0c-4534-9514-a65ebcc7a9e2,2015-11-11 14:00:00 UTC,2015-11-11 14:00:00 UTC,2027-1477408502.282-80.194.77.100-1361,62e1c58e4-9ea5-4be4-8d98-28ead976a590
+      10,Publish,"{""content_id"":""2cc503f1-5fef-4fac-8381-63f6689cd6a2""}",,2015-11-11 09:55:00 UTC,2015-11-11 09:55:00 UTC,,2cc503f1-5fef-4fac-8381-63f6689cd6a2
+      11,Publish,"{""content_id"":""8bc0c1dd-4842-4283-a123-5671a34b67eb""}",e676cb22-0c0c-4534-9514-a65ebcc7a9e2,2015-11-11 14:00:00 UTC,2015-11-11 14:00:00 UTC,2027-1477408502.282-80.194.77.100-1361,8bc0c1dd-4842-4283-a123-5671a34b67eb
     CSV
   end
   let(:event_10_attributes) do
     {
       id: 10,
       action: "Publish",
-      payload: { "content_id" => "6070ce2c4-cf7d-427c-bb78-96cbb1a88910" },
+      payload: { "content_id" => "2cc503f1-5fef-4fac-8381-63f6689cd6a2" },
       user_uid: nil,
       created_at: DateTime.new(2015, 11, 11, 9, 55),
       updated_at: DateTime.new(2015, 11, 11, 9, 55),
       request_id: nil,
-      content_id: "6070ce2c4-cf7d-427c-bb78-96cbb1a88910",
+      content_id: "2cc503f1-5fef-4fac-8381-63f6689cd6a2",
     }
   end
   let(:event_11_attributes) do
     {
       id: 11,
       action: "Publish",
-      payload: { "content_id" => "62e1c58e4-9ea5-4be4-8d98-28ead976a590" },
+      payload: { "content_id" => "8bc0c1dd-4842-4283-a123-5671a34b67eb" },
       user_uid: "e676cb22-0c0c-4534-9514-a65ebcc7a9e2",
       created_at: Time.utc(2015, 11, 11, 14),
       updated_at: Time.utc(2015, 11, 11, 14),
       request_id: "2027-1477408502.282-80.194.77.100-1361",
-      content_id: "62e1c58e4-9ea5-4be4-8d98-28ead976a590",
+      content_id: "8bc0c1dd-4842-4283-a123-5671a34b67eb",
     }
   end
 

--- a/spec/presenters/queries/link_set_presenter_spec.rb
+++ b/spec/presenters/queries/link_set_presenter_spec.rb
@@ -2,15 +2,16 @@ require 'rails_helper'
 
 RSpec.describe Presenters::Queries::LinkSetPresenter do
   describe ".present" do
+    let(:content_id) { SecureRandom.uuid }
+    let(:link_set) { FactoryGirl.create(:link_set, content_id: content_id) }
+
     before do
       FactoryGirl.create(:lock_version, target: link_set, number: 101)
       @result = Presenters::Queries::LinkSetPresenter.present(link_set)
     end
 
-    let(:link_set) { FactoryGirl.create(:link_set, content_id: "foo") }
-
     it "returns link set attributes as a hash" do
-      expect(@result.fetch(:content_id)).to eq("foo")
+      expect(@result.fetch(:content_id)).to eq(content_id)
     end
 
     it "exposes the lock_version of the link set" do


### PR DESCRIPTION
This was implemented during the _Documents and Editions_ work, but has been spun out into its own PR here to deploy in stages.

Migrations take about 5 minutes in total to run.