### PR TITLE
Refactored queries making use of Documents & content_store

### DIFF
--- a/app/commands/v2/patch_link_set.rb
+++ b/app/commands/v2/patch_link_set.rb
@@ -68,10 +68,10 @@ module Commands
       def send_downstream
         return unless downstream
 
-        draft_locales = Queries::LocalesForContentItems.call([content_id])
+        draft_locales = Queries::LocalesForContentItems.call([content_id], %w[draft live])
         draft_locales.each { |(content_id, locale)| downstream_draft(content_id, locale) }
 
-        live_locales = Queries::LocalesForContentItems.call([content_id], %w[published unpublished])
+        live_locales = Queries::LocalesForContentItems.call([content_id], %w[live])
         live_locales.each { |(content_id, locale)| downstream_live(content_id, locale) }
       end
 

--- a/app/commands/v2/represent_downstream.rb
+++ b/app/commands/v2/represent_downstream.rb
@@ -7,11 +7,11 @@ module Commands
 
       def call(content_ids, draft = false)
         if draft
-          with_locales = Queries::LocalesForContentItems.call(content_ids, draft_states)
+          with_locales = Queries::LocalesForContentItems.call(content_ids, %w[draft live])
           with_locales.each { |(content_id, locale)| downstream_draft(content_id, locale) }
         end
 
-        with_locales = Queries::LocalesForContentItems.call(content_ids, live_states)
+        with_locales = Queries::LocalesForContentItems.call(content_ids, %w[live])
         with_locales.each_with_index do |(content_id, locale), index|
           sleep 60 if (index + 1) % 10_000 == 0
           downstream_live(content_id, locale)
@@ -19,14 +19,6 @@ module Commands
       end
 
     private
-
-      def draft_states
-        %w{draft published unpublished}
-      end
-
-      def live_states
-        %w{published unpublished}
-      end
 
       def downstream_draft(content_id, locale)
         event_payload = {

--- a/app/models/content_item.rb
+++ b/app/models/content_item.rb
@@ -39,6 +39,7 @@ class ContentItem < ApplicationRecord
   EMPTY_BASE_PATH_FORMATS = %w(contact government).freeze
 
   belongs_to :document
+  has_one :unpublishing
 
   scope :renderable_content, -> { where.not(document_type: NON_RENDERABLE_FORMATS) }
 

--- a/app/queries/content_dependencies.rb
+++ b/app/queries/content_dependencies.rb
@@ -14,22 +14,22 @@ module Queries
   #     added as dependencies, as well as all translations of the content_ids
   #     found.
   class ContentDependencies
-    def initialize(content_id:, locale:, state_fallback_order:)
+    def initialize(content_id:, locale:, content_stores:)
       @content_id = content_id
       @locale = locale
-      @state_fallback_order = state_fallback_order
+      @content_stores = content_stores
     end
 
     def call
       content_ids = linked_to(content_id) + automatic_reverse_links(content_id) + [content_id]
-      with_locales = Queries::LocalesForContentItems.call(content_ids.uniq, state_fallback_order)
+      with_locales = Queries::LocalesForContentItems.call(content_ids.uniq, content_stores)
       calling_item = locale ? [content_id, locale] : nil
       with_locales - [calling_item]
     end
 
   private
 
-    attr_reader :content_id, :locale, :state_fallback_order
+    attr_reader :content_id, :locale, :content_stores
 
     def linked_to(content_id)
       Queries::LinkedTo.new(content_id, DependeeExpansionRules).call

--- a/app/queries/locales_for_content_items.rb
+++ b/app/queries/locales_for_content_items.rb
@@ -1,7 +1,5 @@
 module Queries
   module LocalesForContentItems
-    extend ArelHelpers
-
     # returns an array of form:
     # [
     #   [content_id, locale],
@@ -9,39 +7,16 @@ module Queries
     # ]
     def self.call(
       content_ids,
-      states = %w[draft published unpublished],
-      include_substitutes = false
+      content_stores = %w[draft live]
     )
-      documents_table = Document.arel_table
-      content_items_table = ContentItem.arel_table
-
-      scope = documents_table
-        .project(
-          documents_table[:content_id],
-          documents_table[:locale]
+      Document.joins(:content_items)
+        .where(
+          content_id: content_ids,
+          content_items: { content_store: content_stores }
         )
         .distinct
-        .join(content_items_table)
-          .on(content_items_table[:document_id].eq(documents_table[:id])
-            .and(content_items_table[:state].in(states)))
-        .where(documents_table[:content_id].in(content_ids))
-        .order(documents_table[:content_id].asc, documents_table[:locale].asc)
-
-      unless include_substitutes
-        unpublishings_table = Unpublishing.arel_table
-
-        scope = scope.outer_join(unpublishings_table).on(
-          content_items_table[:id].eq(unpublishings_table[:content_item_id])
-            .and(content_items_table[:state].eq("unpublished"))
-          )
-          .where(
-            unpublishings_table[:type].eq(nil).or(
-              unpublishings_table[:type].not_eq("substitute")
-            )
-          )
-      end
-
-      get_rows(scope).map { |row| [row["content_id"], row["locale"]] }
+        .order(:content_id, :locale)
+        .pluck(:content_id, :locale)
     end
   end
 end

--- a/app/workers/dependency_resolution_worker.rb
+++ b/app/workers/dependency_resolution_worker.rb
@@ -30,11 +30,10 @@ private
   end
 
   def dependencies
-    states = draft? ? %w[draft published unpublished] : %w[published unpublished]
     Queries::ContentDependencies.new(
       content_id: content_id,
       locale: locale,
-      state_fallback_order: states,
+      content_stores: draft? ? %w[draft live] : %w[live],
     ).call
   end
 

--- a/spec/queries/check_for_content_item_preventing_draft_from_being_published_spec.rb
+++ b/spec/queries/check_for_content_item_preventing_draft_from_being_published_spec.rb
@@ -52,11 +52,10 @@ RSpec.describe Queries::CheckForContentItemPreventingDraftFromBeingPublished do
 
     context "with a unpublished item, of type \"substitute\", and a draft at the same base path" do
       before do
-        FactoryGirl.create(:unpublished_content_item,
+        FactoryGirl.create(:substitute_unpublished_content_item,
           content_id: SecureRandom.uuid,
           base_path: base_path,
           document_type: document_type,
-          unpublishing_type: "substitute",
           user_facing_version: 1,
           locale: "en",
         )

--- a/spec/queries/content_dependencies_spec.rb
+++ b/spec/queries/content_dependencies_spec.rb
@@ -5,13 +5,13 @@ RSpec.describe Queries::ContentDependencies do
 
   let(:content_id) { SecureRandom.uuid }
   let(:locale) { "en" }
-  let(:state_fallback_order) { %w[published unpublished] }
+  let(:content_stores) { %w[live] }
 
   let(:instance_options) do
     {
       content_id: content_id,
       locale: locale,
-      state_fallback_order: state_fallback_order,
+      content_stores: content_stores,
     }
   end
 
@@ -74,12 +74,12 @@ RSpec.describe Queries::ContentDependencies do
       end
 
       let(:locale) { "en" }
-      let(:state_fallback_order) { %w[published unpublished] }
+      let(:content_stores) { %w[live] }
 
       it { is_expected.to be_empty }
 
-      context "but we requested drafts in state_fallback_order" do
-        let(:state_fallback_order) { %w[draft published unpublished] }
+      context "but we requested drafts in content_stores" do
+        let(:content_stores) { %w[draft live] }
         let(:translations) do
           [
             [content_id, "cy"],
@@ -146,8 +146,8 @@ RSpec.describe Queries::ContentDependencies do
 
       it { is_expected.to match_array(links) }
 
-      context "but we use a different state_fallback_order" do
-        let(:state_fallback_order) { %w[draft published unpublished] }
+      context "and we include drafts" do
+        let(:content_stores) { %w[draft live] }
 
         let(:links) do
           [
@@ -222,12 +222,12 @@ RSpec.describe Queries::ContentDependencies do
       end
 
       let(:reverse_link_content_id) { SecureRandom.uuid }
-      let(:state_fallback_order) { %w[published unpublished] }
+      let(:content_stores) { %w[live] }
 
       it { is_expected.to be_empty }
 
       context "and we allow drafts" do
-        let(:state_fallback_order) { %w[draft published unpublished] }
+        let(:content_stores) { %w[draft live] }
 
         let(:links) do
           [

--- a/spec/queries/get_content_item_ids_with_fallbacks_spec.rb
+++ b/spec/queries/get_content_item_ids_with_fallbacks_spec.rb
@@ -1,0 +1,224 @@
+require "rails_helper"
+
+RSpec.describe Queries::GetContentItemIdsWithFallbacks do
+  describe ".call" do
+    let(:state_fallback_order) { %w(published) }
+    let(:locale_fallback_order) { %w(en) }
+    let(:content_ids) { [] }
+    let(:options) do
+      {
+        state_fallback_order: state_fallback_order,
+        locale_fallback_order: locale_fallback_order,
+      }
+    end
+    subject { described_class.call(content_ids, options) }
+
+    it { is_expected.to be_a(Array) }
+
+    context "when a content item is in a draft state" do
+      let(:content_ids) { [SecureRandom.uuid] }
+      let!(:draft_content_item) do
+        FactoryGirl.create(
+          :draft_content_item,
+          content_id: content_ids.first,
+        )
+      end
+
+      context "and the state_fallback order is [draft]" do
+        let(:state_fallback_order) { %w(draft) }
+        it { is_expected.to match_array([draft_content_item.id]) }
+      end
+
+      context "and the state_fallback order is [published]" do
+        let(:state_fallback_order) { %w(published) }
+        it { is_expected.to be_empty }
+      end
+
+      context "and the state_fallback order is [published, draft]" do
+        let(:state_fallback_order) { %w(published draft) }
+        it { is_expected.to match_array([draft_content_item.id]) }
+      end
+    end
+
+    context "when a content item is in draft and unpublished (withdrawn) states" do
+      let(:content_ids) { [SecureRandom.uuid] }
+      let!(:draft_content_item) do
+        FactoryGirl.create(
+          :draft_content_item,
+          content_id: content_ids.first,
+          user_facing_version: 2,
+        )
+      end
+      let!(:withdrawn_content_item) do
+        FactoryGirl.create(
+          :withdrawn_unpublished_content_item,
+          content_id: content_ids.first,
+          user_facing_version: 1,
+        )
+      end
+
+      context "and the state_fallback order is [draft, withdrawn]" do
+        let(:state_fallback_order) { %w(draft withdrawn) }
+        it { is_expected.to match_array([draft_content_item.id]) }
+      end
+
+      context "and the state_fallback order is [withdrawn, draft]" do
+        let(:state_fallback_order) { %w(withdrawn draft) }
+        it { is_expected.to match_array([withdrawn_content_item.id]) }
+      end
+    end
+
+    context "when a content item is in multiple locales" do
+      let(:content_ids) { [SecureRandom.uuid] }
+      let!(:fr_draft_content_item) do
+        FactoryGirl.create(
+          :draft_content_item,
+          content_id: content_ids.first,
+          locale: "fr",
+        )
+      end
+      let!(:en_draft_content_item) do
+        FactoryGirl.create(
+          :draft_content_item,
+          content_id: content_ids.first,
+          locale: "en",
+          user_facing_version: 2,
+        )
+      end
+      let!(:en_published_content_item) do
+        FactoryGirl.create(
+          :live_content_item,
+          content_id: content_ids.first,
+          locale: "en",
+          user_facing_version: 1,
+        )
+      end
+
+      context "and the locale_fallback_order is [fr]" do
+        let(:locale_fallback_order) { %w(fr) }
+
+        context "and the state_fallback_order is [draft]" do
+          let(:state_fallback_order) { %w(draft) }
+          it { is_expected.to match_array(fr_draft_content_item.id) }
+        end
+
+        context "and the state_fallback_order is [published]" do
+          let(:state_fallback_order) { %w(published) }
+          it { is_expected.to be_empty }
+        end
+      end
+
+      context "and the locale_fallback_order is [fr, en]" do
+        let(:locale_fallback_order) { %w(fr en) }
+
+        context "and the state_fallback_order is [draft]" do
+          let(:state_fallback_order) { %w(draft) }
+          it { is_expected.to match_array(fr_draft_content_item.id) }
+        end
+
+        context "and the state_fallback_order is [published]" do
+          let(:state_fallback_order) { %w(published) }
+          it { is_expected.to match_array(en_published_content_item.id) }
+        end
+      end
+
+      context "and the locale_fallback_order is [en, fr]" do
+        let(:locale_fallback_order) { %w(en fr) }
+
+        context "and the state_fallback_order is [draft]" do
+          let(:state_fallback_order) { %w(draft) }
+          it { is_expected.to match_array(en_draft_content_item.id) }
+        end
+
+        context "and the state_fallback_order is [published]" do
+          let(:state_fallback_order) { %w(published) }
+          it { is_expected.to match_array(en_published_content_item.id) }
+        end
+      end
+    end
+
+    context "when multiple content items are requested" do
+      let(:content_ids) { [SecureRandom.uuid, SecureRandom.uuid] }
+      let!(:vat_draft_content_item) do
+        FactoryGirl.create(
+          :draft_content_item,
+          content_id: content_ids.first,
+          user_facing_version: 2,
+        )
+      end
+      let!(:vat_published_content_item) do
+        FactoryGirl.create(
+          :live_content_item,
+          content_id: content_ids.first,
+          user_facing_version: 1,
+        )
+      end
+      let!(:tax_rates_draft_content_item) do
+        FactoryGirl.create(
+          :draft_content_item,
+          content_id: content_ids.last,
+          user_facing_version: 2,
+        )
+      end
+      let!(:tax_rates_withdrawn_content_item) do
+        FactoryGirl.create(
+          :withdrawn_unpublished_content_item,
+          content_id: content_ids.last,
+          user_facing_version: 1,
+        )
+      end
+
+      context "and the state_fallback order is [draft, published]" do
+        let(:state_fallback_order) { %w(draft published) }
+        let(:expected) { [vat_draft_content_item.id, tax_rates_draft_content_item.id] }
+        it { is_expected.to match_array(expected) }
+      end
+
+      context "and the state_fallback order is [published, draft]" do
+        let(:state_fallback_order) { %w(published draft) }
+        let(:expected) { [vat_published_content_item.id, tax_rates_draft_content_item.id] }
+        it { is_expected.to match_array(expected) }
+      end
+
+      context "and the state_fallback order is [withdrawn, draft]" do
+        let(:state_fallback_order) { %w(withdrawn draft) }
+        let(:expected) { [vat_draft_content_item.id, tax_rates_withdrawn_content_item.id] }
+        it { is_expected.to match_array(expected) }
+      end
+    end
+
+    context "when there is a non-renderable document type" do
+      let(:content_ids) { [SecureRandom.uuid] }
+      let!(:draft_content_item) do
+        FactoryGirl.create(
+          :draft_content_item,
+          content_id: content_ids.first,
+          document_type: "gone",
+          user_facing_version: 2,
+        )
+      end
+      let!(:published_content_item) do
+        FactoryGirl.create(
+          :live_content_item,
+          content_id: content_ids.first,
+          user_facing_version: 1,
+        )
+      end
+
+      context "and the state_fallback order is [draft]" do
+        let(:state_fallback_order) { %w(draft) }
+        it { is_expected.to be_empty }
+      end
+
+      context "and the state_fallback order is [published]" do
+        let(:state_fallback_order) { %w(published) }
+        it { is_expected.to match_array([published_content_item.id]) }
+      end
+
+      context "and the state_fallback order is [draft, published]" do
+        let(:state_fallback_order) { %w(draft published) }
+        it { is_expected.to match_array([published_content_item.id]) }
+      end
+    end
+  end
+end

--- a/spec/queries/locales_for_content_items_spec.rb
+++ b/spec/queries/locales_for_content_items_spec.rb
@@ -22,10 +22,9 @@ RSpec.describe Queries::LocalesForContentItems do
     let(:content_id_2) { SecureRandom.uuid }
     let(:base_content_ids) { [content_id_1, content_id_2] }
     let(:content_ids) { base_content_ids }
-    let(:states) { %w[draft published unpublished] }
-    let(:include_substitutes) { false }
+    let(:content_stores) { %w[draft live] }
 
-    subject { described_class.call(content_ids, states, include_substitutes) }
+    subject { described_class.call(content_ids, content_stores) }
 
     it { is_expected.to be_a(Array) }
 
@@ -88,8 +87,8 @@ RSpec.describe Queries::LocalesForContentItems do
 
       it { is_expected.to match_array(results) }
 
-      context "but we're only filtering on published / unpublished" do
-        let(:states) { %w[published unpublished] }
+      context "but we're only filtering on live " do
+        let(:content_stores) { %w[live] }
 
         let(:results) do
           [
@@ -114,34 +113,6 @@ RSpec.describe Queries::LocalesForContentItems do
       end
 
       it { is_expected.to match_array(results) }
-    end
-
-    context "when some of the items are unpublished type substite" do
-      before do
-        create_content_item(content_id_1, :live_content_item, 1, "en", "path-1")
-        create_content_item(content_id_2, :substitute_unpublished_content_item, 1, "en", "path-2")
-      end
-
-      let(:results) do
-        [
-          [content_id_1, "en"],
-        ]
-      end
-
-      it { is_expected.to match_array(results) }
-
-      context "and we're including substitutes" do
-        let(:include_substitutes) { true }
-
-        let(:results) do
-          [
-            [content_id_1, "en"],
-            [content_id_2, "en"],
-          ]
-        end
-
-        it { is_expected.to match_array(results) }
-      end
     end
   end
 end

--- a/spec/workers/dependency_resolution_worker_spec.rb
+++ b/spec/workers/dependency_resolution_worker_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe DependencyResolutionWorker, :perform do
     expect(Queries::ContentDependencies).to receive(:new).with(
       content_id: content_id,
       locale: locale,
-      state_fallback_order: %w[published unpublished],
+      content_stores: %w[live],
     ).and_return(content_item_dependee)
     worker_perform
   end


### PR DESCRIPTION
This updates the following queries:

**CheckForContentItemPreventingDraftFromBeingPublished** - much simpler with content_store
**GetContentItemIdsWithFallbacks** - refactored to hopefully be easier to understand and fixes issue with state_fallback_ordering not ordering withdrawn, added tests.
**LocalesForContentItems** - much simpler with content_store