### PR TITLE
Simplify get latest query

### DIFF
--- a/app/commands/v2/patch_link_set.rb
+++ b/app/commands/v2/patch_link_set.rb
@@ -119,7 +119,7 @@ module Commands
 
       def schema_name
         @schema_name ||= Queries::GetLatest.(
-          ContentItem.where(documents: { content_id: content_id })
+          ContentItem.where(documents: { content_id: content_id }).joins(:document)
         ).pluck(:schema_name).first
       end
     end

--- a/app/presenters/queries/content_item_presenter.rb
+++ b/app/presenters/queries/content_item_presenter.rb
@@ -61,7 +61,7 @@ module Presenters
       end
 
       def latest
-        ::Queries::GetLatest.call(self.scope)
+        ::Queries::GetLatest.call(self.scope.joins(:document))
       end
 
       def join_supporting_objects(scope)
@@ -102,9 +102,9 @@ module Presenters
           when :base_path
             "content_items.base_path as base_path"
           when :locale
-            "documents_content_items.locale as locale"
+            "documents.locale as locale"
           when :content_id
-            "documents_content_items.content_id as content_id"
+            "documents.content_id as content_id"
           when :total
             "COUNT(*) OVER () as total"
           else
@@ -124,8 +124,8 @@ module Presenters
         (
           SELECT json_agg((user_facing_version, state))
           FROM content_items c
-          WHERE c.document_id = documents_content_items.id
-          GROUP BY documents_content_items.content_id
+          WHERE c.document_id = documents.id
+          GROUP BY documents.content_id
         )
       SQL
 

--- a/app/queries/get_latest.rb
+++ b/app/queries/get_latest.rb
@@ -1,26 +1,15 @@
 module Queries
   module GetLatest
     class << self
-      # Returns a new scope for the content items with the highest user-facing
-      # version number per content_id and locale of the given scope.
       def call(content_item_scope)
-        scope = content_item_scope.select(:id, 'documents.content_id',
-                                          'documents.locale',
-                                          :user_facing_version)
-          .joins(:document)
+        content_item_scope.where(id: inner_scope(content_item_scope))
+      end
 
-        ContentItem.joins(:document).joins <<-SQL
-          INNER JOIN (
-            WITH scope AS (#{scope.to_sql})
-            SELECT s1.id FROM scope s1
-            LEFT OUTER JOIN scope s2 ON
-              s1.content_id = s2.content_id AND
-              s1.locale = s2.locale AND
-              s1.user_facing_version < s2.user_facing_version
-            WHERE s2.content_id IS NULL
-          ) AS latest_versions
-          ON latest_versions.id = content_items.id
-        SQL
+      def inner_scope(content_item_scope)
+        content_item_scope
+          .order(:document_id, user_facing_version: :desc)
+          .select("distinct on(content_items.document_id) content_items.document_id, content_items.id")
+          .map(&:id)
       end
     end
   end

--- a/spec/queries/get_latest_spec.rb
+++ b/spec/queries/get_latest_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Queries::GetLatest do
     result = subject.call(scope)
     expect(base_paths(result)).to match_array(["/a3", "/b1", "/b2", "/c2"])
 
-    scope = scope.where('documents.content_id': [a, b])
+    scope = scope.joins(:document).where('documents.content_id': [a, b])
     result = subject.call(scope)
     expect(base_paths(result)).to match_array(["/a3", "/b1", "/b2"])
 


### PR DESCRIPTION
Removes the join on documents from the latest scope since this
should not be the responsibility of the GetLatest query.
This also removes the documents_content_items weirdness as a positive
side effect.

before:
..........  0.380000   0.220000   0.600000 ( 13.029060)
queries: 20

after:
..........  0.660000   0.090000   0.750000 (  2.742333)
queries: 30