### PR TITLE
Specify a nil ordering so first doesn't order by id

### DIFF
--- a/app/commands/v2/unpublish.rb
+++ b/app/commands/v2/unpublish.rb
@@ -129,7 +129,7 @@ module Commands
           content_id: content_id,
           locale: locale,
           state: allowed_states
-        ).lock.first
+        ).order(nil).lock.first
 
         content_item if content_item && (payload[:allow_draft] || !Unpublishing.is_substitute?(content_item))
       end
@@ -144,7 +144,7 @@ module Commands
           content_id: content_id,
           locale: locale,
           state: %w(published unpublished),
-        )
+        ).order(nil)
       end
 
       def draft_exists?

--- a/app/validators/state_for_locale_validator.rb
+++ b/app/validators/state_for_locale_validator.rb
@@ -8,7 +8,7 @@ class StateForLocaleValidator < ActiveModel::Validator
       locale: record.locale,
     }
 
-    conflict = ContentItem.where(criteria).where.not(id: record.id).first
+    conflict = ContentItem.where(criteria).where.not(id: record.id).order(nil).first
 
     if conflict
       error = "state=#{record.state} and locale=#{record.locale} "

--- a/app/validators/version_for_locale_validator.rb
+++ b/app/validators/version_for_locale_validator.rb
@@ -8,7 +8,7 @@ class VersionForLocaleValidator < ActiveModel::Validator
       locale: record.locale,
     }
 
-    conflict = ContentItem.where(criteria).where.not(id: record.id).first
+    conflict = ContentItem.where(criteria).where.not(id: record.id).order(nil).first
 
     if conflict
       error = "user_facing_version=#{record.user_facing_version} and "


### PR DESCRIPTION
We've had some problems where Postgres is picking different indexes to
use in different environments. Using the rails `.first` method on an
ActiveRecord scope creates an `ORDER BY` if one is not set on the query
which can cause the query to run slow in some environments.

This change removes the `order_by` which helps prevent the slow query.
Other options we have are: seeing if `VACUUM ANALYZE`, or even creating
an index that includes id for pillar based queries.