### PR TITLE
Ignore only the files inside logs, not entire directory

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,4 @@
 .git
 .gitignore
 README.md
-log
+log/*


### PR DESCRIPTION
If the whole directory is ignored Sidekiq will abort with: "No such file
or directory @ rb_sysopen - ./log/sidekiq.json.log"