### PR TITLE
Delete `document_collections` links

### DIFF
--- a/db/migrate/20170111161439_delete_document_collection_links.rb
+++ b/db/migrate/20170111161439_delete_document_collection_links.rb
@@ -1,0 +1,5 @@
+class DeleteDocumentCollectionLinks < ActiveRecord::Migration[5.0]
+  def change
+    Link.delete_all(link_type: "document_collections")
+  end
+end


### PR DESCRIPTION
Whitehall used to send these but they are no longer required as the `document_collection` is inferred from the inverse `document` link type.