### PR TITLE
Add a migration to link documents and editions

### DIFF
--- a/db/migrate/20170106122400_link_documents_and_editions.rb
+++ b/db/migrate/20170106122400_link_documents_and_editions.rb
@@ -1,0 +1,6 @@
+class LinkDocumentsAndEditions < ActiveRecord::Migration[5.0]
+  def change
+    add_column :content_items, :document_id, :integer
+    add_foreign_key :content_items, :documents
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -74,6 +74,7 @@ ActiveRecord::Schema.define(version: 20170111161439) do
     t.string   "base_path"
     t.string   "content_store"
     t.uuid     "content_id",                                    null: false
+    t.integer  "document_id"
     t.index ["base_path", "content_store"], name: "index_content_items_on_base_path_and_content_store", unique: true, using: :btree
     t.index ["content_id", "locale", "content_store"], name: "index_content_items_on_content_id_and_locale_and_content_store", unique: true, using: :btree
     t.index ["content_id", "locale", "user_facing_version"], name: "index_unique_ufv_content_id_locale", unique: true, using: :btree
@@ -207,5 +208,6 @@ ActiveRecord::Schema.define(version: 20170111161439) do
   end
 
   add_foreign_key "change_notes", "content_items"
+  add_foreign_key "content_items", "documents"
   add_foreign_key "links", "link_sets"
 end


### PR DESCRIPTION
This should be deployed early to make sure the `document_id` field is available for when the _Documents and Editions_ PRs are ready to deploy.