### PR TITLE
Rename lock_version column

### DIFF
--- a/db/migrate/20170106122800_rename_lock_version_column.rb
+++ b/db/migrate/20170106122800_rename_lock_version_column.rb
@@ -1,0 +1,11 @@
+class RenameLockVersionColumn < ActiveRecord::Migration[5.0]
+  def up
+    rename_column :documents, :lock_version, :stale_lock_version
+    rename_column :link_sets, :lock_version, :stale_lock_version
+  end
+
+  def down
+    rename_column :documents, :stale_lock_version, :lock_version
+    rename_column :link_sets, :stale_lock_version, :lock_version
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -50,6 +50,7 @@ ActiveRecord::Schema.define(version: 20170111161439) do
   end
 
   create_table "content_items", force: :cascade do |t|
+    t.uuid     "content_id",                                    null: false
     t.string   "title"
     t.datetime "public_updated_at"
     t.json     "details",              default: {}
@@ -73,7 +74,6 @@ ActiveRecord::Schema.define(version: 20170111161439) do
     t.integer  "user_facing_version",  default: 1,              null: false
     t.string   "base_path"
     t.string   "content_store"
-    t.uuid     "content_id",                                    null: false
     t.integer  "document_id"
     t.index ["base_path", "content_store"], name: "index_content_items_on_base_path_and_content_store", unique: true, using: :btree
     t.index ["content_id", "locale", "content_store"], name: "index_content_items_on_content_id_and_locale_and_content_store", unique: true, using: :btree
@@ -90,9 +90,9 @@ ActiveRecord::Schema.define(version: 20170111161439) do
   end
 
   create_table "documents", force: :cascade do |t|
-    t.uuid    "content_id",               null: false
-    t.string  "locale",                   null: false
-    t.integer "lock_version", default: 1, null: false
+    t.uuid    "content_id",                     null: false
+    t.string  "locale",                         null: false
+    t.integer "stale_lock_version", default: 1, null: false
     t.index ["content_id", "locale"], name: "index_documents_on_content_id_and_locale", unique: true, using: :btree
   end
 
@@ -111,7 +111,7 @@ ActiveRecord::Schema.define(version: 20170111161439) do
     t.uuid     "content_id"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.integer  "lock_version", default: 1
+    t.integer  "stale_lock_version", default: 1
     t.index ["content_id"], name: "index_link_sets_on_content_id", unique: true, using: :btree
   end
 


### PR DESCRIPTION
This is required to avoid it conflicting with the built-in Rails `lock_version` feature.