### PR TITLE
Second unpublishing doesn't set state to superseded

### DIFF
--- a/app/commands/v2/unpublish.rb
+++ b/app/commands/v2/unpublish.rb
@@ -3,7 +3,7 @@ module Commands
     class Unpublish < BaseCommand
       def call
         validate
-        previous_item.supersede if previous_item
+        previous_item.supersede if previous_item_should_be_superseded?
         transition_state
         AccessLimit.find_by(content_item: content_item).try(:destroy)
 
@@ -132,6 +132,10 @@ module Commands
         ).order(nil).lock.first
 
         content_item if content_item && (payload[:allow_draft] || !Unpublishing.is_substitute?(content_item))
+      end
+
+      def previous_item_should_be_superseded?
+        previous_item && find_unpublishable_content_item != previous_item
       end
 
       def previous_item

--- a/spec/commands/v2/unpublish_spec.rb
+++ b/spec/commands/v2/unpublish_spec.rb
@@ -374,6 +374,11 @@ RSpec.describe Commands::V2::Unpublish do
 
       include_examples "creates an action"
 
+      it "maintains the state of unpublished" do
+        described_class.call(payload)
+        expect(unpublished_content_item.reload.state).to eq("unpublished")
+      end
+
       it "updates the Unpublishing" do
         unpublishing = Unpublishing.find_by(content_item: unpublished_content_item)
         expect(unpublishing.explanation).to eq("This explnatin has a typo")


### PR DESCRIPTION
This fixes a bug that we found in the Publishing API where a 2nd
unpublishing of a content_item causes the state to be set to superseded.