### PR TITLE
Add Appsignal configuration

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ gem "logstasher", "0.6.2"
 gem "plek", "~> 1.10"
 gem 'airbrake', '~> 5.5'
 gem 'airbrake-ruby', '1.5'
+gem 'appsignal', '~> 2.0'
 gem "pg"
 gem 'dalli'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -52,6 +52,9 @@ GEM
       airbrake-ruby (~> 1.5)
     airbrake-ruby (1.5.0)
     amq-protocol (2.0.1)
+    appsignal (2.0.5)
+      rack
+      thread_safe
     arel (7.1.4)
     ast (2.3.0)
     awesome_print (1.7.0)
@@ -395,6 +398,7 @@ PLATFORMS
 DEPENDENCIES
   airbrake (~> 5.5)
   airbrake-ruby (= 1.5)
+  appsignal (~> 2.0)
   arel (= 7.1.4)
   aws-sdk (~> 2)
   bunny (= 2.5.1)

--- a/config/appsignal.yml
+++ b/config/appsignal.yml
@@ -1,0 +1,10 @@
+default: &defaults
+  push_api_key: "<%= ENV['APPSIGNAL_API_KEY'] %>"
+  name: "Publishing API"
+  active: <%= ENV['APPSIGNAL_API_KEY'] ? true : false %>
+
+development:
+  <<: *defaults
+
+production:
+  <<: *defaults


### PR DESCRIPTION
This adds Appsignal to the app. We're evaluating to see if it is a good
replacement for Errbit, while also adding performance tracking.

It's only activated if APPSIGNAL_API_KEY is set, which is currently only in
integration (alphagov/govuk-puppet#5376
https://github.gds/gds/deployment/pull/1215).

https://trello.com/c/J3kDeZD7

cc/ @tijmenb 