### PR TITLE
Make 'Edition' available as an alias for 'ContentItem'

### DIFF
--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -1,0 +1,4 @@
+# Needed to work around the fact that we use a polymorphic type and to avoid
+# including a migration which changed the class name in the database, we simply
+# make sure it is available under both names
+Edition = ContentItem

--- a/app/models/lock_version.rb
+++ b/app/models/lock_version.rb
@@ -42,7 +42,7 @@ class LockVersion < ApplicationRecord
 private
 
   def content_item_target?
-    target_type == 'ContentItem'
+    %w(ContentItem Edition).include? target_type
   end
 
   def numbers_must_increase


### PR DESCRIPTION
This makes it easier to rollback from the `documents-and-editions`
branch by making sure that any newly created LockVersions with the
polymorphic target field set to a type of 'Edition' work.