### PR TITLE
Remove all existing taxon tags

### DIFF
--- a/db/migrate/20170123111649_clear_alpha_taxons.rb
+++ b/db/migrate/20170123111649_clear_alpha_taxons.rb
@@ -1,0 +1,5 @@
+class ClearAlphaTaxons < ActiveRecord::Migration[5.0]
+  def up
+    Link.where(link_type: "taxons").where("created_at < '2017-01-23'").delete_all
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170118104115) do
+ActiveRecord::Schema.define(version: 20170123111649) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
The education taxonomy is currently very alpha - it's not visible to the public
yet.

The finding things team has just completed a bulk tagging exercise with
publishers so we want to clear all existing tags and import the new ones.

This change removes those tags (links with type `taxons`).

There will be a follow up change to clear out remaining taxon content items,
that do not belong to the current taxonomy (i.e. there is no chain of
`parent_taxon` links linking them).