### PR TITLE
Expose the unpublishing information through GetContentCollection

### DIFF
--- a/app/models/unpublishing.rb
+++ b/app/models/unpublishing.rb
@@ -28,4 +28,10 @@ class Unpublishing < ApplicationRecord
   def self.is_substitute?(edition)
     where(edition: edition).pluck(:type).first == "substitute"
   end
+
+  def self.join_editions(edition_scope)
+    edition_scope.joins(
+      "LEFT OUTER JOIN unpublishings ON content_items.id = unpublishings.content_item_id"
+    )
+  end
 end

--- a/spec/queries/get_content_collection_spec.rb
+++ b/spec/queries/get_content_collection_spec.rb
@@ -89,6 +89,34 @@ RSpec.describe Queries::GetContentCollection do
     ])
   end
 
+  context "for unpublished content" do
+    it "can include information about the unpublishing" do
+      edition = FactoryGirl.create(
+        :unpublished_edition,
+        document_type: "topic",
+      )
+      unpublishing = Unpublishing.find_by(edition: edition)
+
+      expect(
+        Queries::GetContentCollection.new(
+          document_types: 'topic',
+          fields: %w(base_path publication_state unpublishing),
+        ).call
+      ).to match_array(
+        [
+          hash_including(
+            "unpublishing" => hash_including(
+              "explanation" => unpublishing.explanation,
+              "type" => unpublishing.type,
+              "alternative_path" => unpublishing.alternative_path,
+              "unpublished_at" => unpublishing.unpublished_at
+            )
+          )
+        ]
+      )
+    end
+  end
+
   context "when there's no items for the format" do
     it "returns an empty array" do
       expect(Queries::GetContentCollection.new(


### PR DESCRIPTION
Adds a new supported field "unpublishing" to
GetContentCollection. If the content item is unpublished, this will
contain the type, explanation, alternative_path and unpublished_at
information.

This will enable publishing applications using the Publishing API to
get back the information they put in when they unpublish content, and
was motivated by this requirement for the Maslow application.

https://trello.com/c/MhXnrU1C/29-contentitempresenter-should-include-unpublishing-details