### PR TITLE
Run rcov by default

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,7 +50,7 @@ group :development, :test do
   gem "timecop"
   gem "rspec"
   gem "rspec-rails", "~> 3.5"
-  gem "simplecov", "0.10.0", require: false
+  gem "simplecov", "0.13.0", require: false
   gem "simplecov-rcov", "0.2.3", require: false
   gem "factory_girl_rails", "4.7.0"
   gem "pact_broker-client"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -146,7 +146,7 @@ GEM
       multi_xml (>= 0.5.2)
     i18n (0.7.0)
     jmespath (1.3.1)
-    json (1.8.3)
+    json (2.0.3)
     json-schema (2.5.2)
       addressable (~> 2.3.8)
     jwt (1.5.6)
@@ -334,9 +334,9 @@ GEM
       activesupport
       sidekiq (>= 2.6)
       statsd-ruby (>= 1.1.0)
-    simplecov (0.10.0)
+    simplecov (0.13.0)
       docile (~> 1.1.0)
-      json (~> 1.8)
+      json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.0)
     simplecov-rcov (0.2.3)
@@ -429,7 +429,7 @@ DEPENDENCIES
   rspec
   rspec-rails (~> 3.5)
   sidekiq-unique-jobs!
-  simplecov (= 0.10.0)
+  simplecov (= 0.13.0)
   simplecov-rcov (= 0.2.3)
   spring
   spring-commands-rspec
@@ -441,4 +441,4 @@ DEPENDENCIES
   whenever (= 0.9.4)
 
 BUNDLED WITH
-   1.13.1
+   1.13.6

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,8 +1,8 @@
-if ENV["RCOV"]
-  require 'simplecov'
-  require 'simplecov-rcov'
-  SimpleCov.formatter = SimpleCov::Formatter::RcovFormatter
-  SimpleCov.start 'rails'
+require 'simplecov'
+require 'simplecov-rcov'
+SimpleCov.formatter = SimpleCov::Formatter::RcovFormatter
+SimpleCov.start 'rails' do
+  add_filter '.bundle'
 end
 
 require 'pry'


### PR DESCRIPTION
I originally made rcov optional on local machines
(https://github.com/alphagov/publishing-api/commit/4874c5aaab9b12c2882414fa58456857b716f328) as it was causing a big delay at the end of
running any tests, and was rarely used locally.

Following some advice on the simplecov issue I raised back in May
(https://github.com/colszowka/simplecov/issues/499#issuecomment-275237948), 
adding a filter to exclude vendored (bundled) gems brings the speed
back up to acceptable levels.

This change restores the original behaviour, adds the filter, and
upgrades simplecov for good measure.