### PR TITLE
Include 'content_store' in content item presenter output

### DIFF
--- a/app/presenters/queries/content_item_presenter.rb
+++ b/app/presenters/queries/content_item_presenter.rb
@@ -15,7 +15,7 @@ module Presenters
         :updated_at,
         :state_history,
         :change_note,
-      ] - [:state, :content_store]).freeze # state appears as 'publication_state'
+      ] - [:state]).freeze # state appears as 'publication_state'
 
       def self.present_many(scope, params = {})
         new(scope, params).present_many

--- a/spec/presenters/queries/content_item_presenter_spec.rb
+++ b/spec/presenters/queries/content_item_presenter_spec.rb
@@ -45,6 +45,7 @@ RSpec.describe Presenters::Queries::ContentItemPresenter do
         "lock_version" => 1,
         "updated_at" => "2016-01-01 00:00:00",
         "state_history" => { 1 => "draft" },
+        "content_store" => "draft",
       }
     end
 


### PR DESCRIPTION
There is no reason for it to be excluded and having this information available is useful.