### PR TITLE
Add a script to check edition consistency with the content-store

### DIFF
--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -183,6 +183,15 @@ class Edition < ApplicationRecord
     )
   end
 
+  def gone?
+    if state == "unpublished"
+      unpublishing = Unpublishing.find_by!(edition: self)
+      unpublishing.type == "gone"
+    else
+      document_type == "gone"
+    end
+  end
+
 private
 
   def check_document_fields_from_options(options)

--- a/lib/content_consistency_checker.rb
+++ b/lib/content_consistency_checker.rb
@@ -1,0 +1,76 @@
+require 'gds_api/content_store'
+
+class ContentConsistencyChecker
+  attr_reader :errors
+
+  def initialize(content_id, locale = "en")
+    @content_id = content_id
+    @locale = locale
+    @errors = []
+  end
+
+  def call
+    unless document
+      errors << "Document (#{content_id}, #{locale}) could not be found."
+      return errors
+    end
+
+    check_edition(draft, draft_content_store) if draft
+    check_edition(live, live_content_store) if live
+
+    errors
+  end
+
+private
+
+  attr_reader :content_id, :locale
+
+  def item_from_content_store(path, content_store)
+    begin
+      content_store.content_item(path).parsed_content
+    rescue GdsApi::ContentStore::ItemNotFound, GdsApi::HTTPGone, GdsApi::HTTPForbidden
+      nil
+    end
+  end
+
+  def check_edition(edition, content_store)
+    content_item = item_from_content_store(edition.base_path, content_store)
+
+    if edition.gone? && content_item
+      errors << "Content exists in the content store."
+    elsif content_item.nil?
+      errors << "Content is missing from the content store."
+      return
+    end
+
+    fields = [:rendering_app, :publishing_app, :schema_name, :document_type]
+    fields.each do |field|
+      edition_value = edition.send(field)
+      content_item_value = content_item[field.to_s]
+
+      if edition_value != content_item_value
+        errors << "Edition #{field} (#{edition_value}) does not match content store (#{content_item_value})."
+      end
+    end
+  end
+
+  def live
+    document.live
+  end
+
+  def draft
+    document.draft
+  end
+
+  def document
+    @document ||= Document.find_by(content_id: content_id, locale: locale)
+  end
+
+  def live_content_store
+    GdsApi::ContentStore.new(Plek.find("content-store"))
+  end
+
+  def draft_content_store
+    GdsApi::ContentStore.new(Plek.find("draft-content-store"))
+  end
+end

--- a/lib/tasks/check_content_consistency.rake
+++ b/lib/tasks/check_content_consistency.rake
@@ -1,0 +1,29 @@
+namespace :check_content_consistency do
+  def check_content(content_id, locale)
+    checker = ContentConsistencyChecker.new(content_id, locale)
+    errors = checker.call
+
+    if errors.any?
+      puts "#{content_id} 😱"
+      puts errors
+    end
+
+    errors.none?
+  end
+
+  desc "Check documents for consistency with the router-api and content-store"
+  task :one, [:content_id, :locale] => [:environment] do |_, args|
+    content_id = args[:content_id]
+    locale = args[:locale] || "en"
+    check_content(content_id, locale)
+  end
+
+  desc "Check all the documents for consistency with the router-api and content-store"
+  task all: :environment do
+    documents = Document.pluck(:content_id, :locale)
+    failures = documents.reject do |content_id, locale|
+      check_content(content_id, locale)
+    end
+    puts "Results: #{failures.count} failures out of #{documents.count}."
+  end
+end

--- a/spec/factories/edition.rb
+++ b/spec/factories/edition.rb
@@ -56,6 +56,8 @@ FactoryGirl.define do
     sequence(:base_path) { |n| "/dodo-sanctuary-#{n}" }
     schema_name "gone"
     document_type "gone"
+    state "superseded"
+    rendering_app nil
   end
 
   factory :access_limited_edition, aliases: [:access_limited_draft_edition], parent: :edition do

--- a/spec/lib/content_consistency_checker_spec.rb
+++ b/spec/lib/content_consistency_checker_spec.rb
@@ -1,0 +1,83 @@
+require "rails_helper"
+
+RSpec.describe ContentConsistencyChecker do
+  describe "#call" do
+    describe "unknown content" do
+      subject { described_class.new(SecureRandom.uuid).call }
+
+      it "should have errors" do
+        expect(subject).not_to be_empty
+      end
+    end
+
+    describe "valid content" do
+      let(:item) { FactoryGirl.create(:edition) }
+      let(:body) do
+        {
+          schema_name: "guide",
+          document_type: "guide",
+          rendering_app: "frontend",
+          publishing_app: "publisher"
+        }
+      end
+
+      subject { described_class.new(item.document.content_id).call }
+
+      it "should not have errors" do
+        stub_content_store("draft", body, item.base_path)
+        expect(subject).to be_empty
+      end
+    end
+
+    context "has redirects" do
+      subject { described_class.new(item.document.content_id).call }
+
+      context "item is published but not in the content store" do
+        let(:item) { FactoryGirl.create(:redirect_live_edition) }
+        before do
+          stub_content_store("live", {}, item.base_path, 404)
+        end
+
+        it "should produce an error" do
+          expect(subject.first).to match(/missing from the content store/)
+        end
+      end
+    end
+
+    context "has routes" do
+      subject { described_class.new(item.document.content_id).call }
+
+      context "item is gone but exists in the content store" do
+        let(:item) { FactoryGirl.create(:gone_edition) }
+        before do
+          stub_content_store("draft", {}, item.base_path)
+        end
+
+        it "should produce an error" do
+          expect(subject.first).to match(/Content exists in the content store/)
+        end
+      end
+
+      context "item is published but not in the content store" do
+        let(:item) { FactoryGirl.create(:live_edition) }
+        before do
+          stub_content_store("live", {}, item.base_path, 404)
+        end
+
+        it "should produce an error" do
+          expect(subject.first).to match(/missing from the content store/)
+        end
+      end
+    end
+  end
+end
+
+def content_store_url(instance)
+  prefix = instance == "draft" ? "draft-" : ""
+  Plek.find("#{prefix}content-store")
+end
+
+def stub_content_store(instance, body, path, status = 200)
+  stub_request(:get, "#{content_store_url(instance)}/content#{path}").
+  and_return(status: status, body: body.to_json, headers: {})
+end


### PR DESCRIPTION
This PR adds a script to check for content consistency across the `publishing-api` and `content-store`s.

See alphagov/content-store#262 for the equivalent script in the `content-store`.