### PR TITLE
Expand the parent taxons of the taxon a content item is tagged to

### DIFF
--- a/app/queries/dependent_expansion_rules.rb
+++ b/app/queries/dependent_expansion_rules.rb
@@ -30,6 +30,7 @@ module Queries
       [
         [:parent],
         [:parent_taxons],
+        [:taxons, :parent_taxons],
         [:ordered_related_items, :mainstream_browse_pages, :parent],
       ]
     end

--- a/spec/queries/dependent_expansion_rules_spec.rb
+++ b/spec/queries/dependent_expansion_rules_spec.rb
@@ -46,6 +46,12 @@ RSpec.describe Queries::DependentExpansionRules do
     specify { expect(subject.valid_link_recursion?([:parent, :parent])).to eq(true) }
     specify { expect(subject.valid_link_recursion?([:parent, :parent, :parent])).to eq(true) }
     specify { expect(subject.valid_link_recursion?([:parent, :child])).to eq(false) }
+    specify { expect(subject.valid_link_recursion?([:taxons])).to eq(true) }
+    specify { expect(subject.valid_link_recursion?([:taxons, :parent_taxons])).to eq(true) }
+    specify { expect(subject.valid_link_recursion?([:taxons, :parent_taxons, :parent_taxons])).to eq(true) }
+    specify { expect(subject.valid_link_recursion?([:parent_taxons])).to eq(true) }
+    specify { expect(subject.valid_link_recursion?([:parent_taxons, :parent_taxons])).to eq(true) }
+    specify { expect(subject.valid_link_recursion?([:parent_taxons, :taxons])).to eq(false) }
     specify { expect(subject.valid_link_recursion?([:ordered_related_items])).to eq(true) }
     specify { expect(subject.valid_link_recursion?([:ordered_related_items, :mainstream_browse_pages])).to eq(true) }
     specify { expect(subject.valid_link_recursion?([:ordered_related_items, :mainstream_browse_pages, :parent])).to eq(true) }
@@ -56,7 +62,7 @@ RSpec.describe Queries::DependentExpansionRules do
 
   describe "#next_reverse_recursive_types" do
     specify { expect(subject.next_reverse_recursive_types([:parent])).to match_array([:parent, :mainstream_browse_pages]) }
-    specify { expect(subject.next_reverse_recursive_types([:parent_taxons])).to match_array([:parent_taxons]) }
+    specify { expect(subject.next_reverse_recursive_types([:parent_taxons])).to match_array([:parent_taxons, :taxons]) }
     specify { expect(subject.next_reverse_recursive_types(["parent"])).to match_array([:parent, :mainstream_browse_pages]) }
     specify { expect(subject.next_reverse_recursive_types([:parent, :parent])).to match_array([:parent, :mainstream_browse_pages]) }
     specify { expect(subject.next_reverse_recursive_types([:parent, :parent, :parent])).to match_array([:parent, :mainstream_browse_pages]) }


### PR DESCRIPTION
The links to the taxon hierarchy were being expanded correctly when the root node was a taxon, but not when the root node was a regular piece of content.

Trello: https://trello.com/c/QCxXilwI/360-get-expanded-taxons-in-the-link-section-of-content-pages

Are there any integration tests for link expansion? i.e. a test that when you send a link PATCH request, that it ultimately sends the right thing to the content store? If so, I'll update them with a test for this dependency tree.