### PR TITLE
[DISCUSS] allow lookup of redirected base paths

### DIFF
--- a/spec/requests/lookups_spec.rb
+++ b/spec/requests/lookups_spec.rb
@@ -24,6 +24,33 @@ RSpec.describe "POST /lookup-by-base-path", type: :request do
     end
   end
 
+  context "passing included parameter" do
+    it "returns content_ids for user-visible states (published, unpublished)" do
+      create_test_content
+
+      post "/lookup-by-base-path", params: { base_paths: test_base_paths, include: ["published"] }
+
+      expect(parsed_response).to eql(
+        "published" => {
+          "/published-and-draft-page" => "aa491126-77ed-4e81-91fa-8dc7f74e9657",
+          "/only-published-page" => "bbabcd3c-7c45-4403-8490-db51e4bfc4f6",
+        }
+      )
+    end
+
+    it "returns content_ids for unpublished and redirected base paths" do
+      create_test_content
+
+      post "/lookup-by-base-path", params: { base_paths: test_base_paths, include: ["redirected"] }
+
+      expect(parsed_response).to eql(
+        "redirected" => {
+          "/original-base-path" => "/new-base-path",
+        }
+      )
+    end
+  end
+
   def create_test_content
     doc1 = FactoryGirl.create(:document, content_id: "aa491126-77ed-4e81-91fa-8dc7f74e9657")
     doc2 = FactoryGirl.create(:document, content_id: "bbabcd3c-7c45-4403-8490-db51e4bfc4f6")
@@ -34,9 +61,23 @@ RSpec.describe "POST /lookup-by-base-path", type: :request do
     FactoryGirl.create(:live_edition, state: "published", base_path: "/only-published-page", document: doc2)
     FactoryGirl.create(:edition, state: "draft", base_path: "/draft-and-superseded-page", document: doc3, user_facing_version: 2)
     FactoryGirl.create(:superseded_edition, state: "superseded", base_path: "/draft-and-superseded-page", document: doc3, user_facing_version: 1)
+
+    create_unpublished_content
+  end
+
+  def create_unpublished_content
+    doc1 = FactoryGirl.create(:document, content_id: "ee491126-77ed-4e81-91fa-8dc7f74e9657")
+    doc2 = FactoryGirl.create(:document, content_id: "ffabcd3c-7c45-4403-8490-db51e4bfc4f6")
+
+    published1 = FactoryGirl.create(:live_edition, state: "published", base_path: "/original-base-path", document: doc1, user_facing_version: 1)
+    published1.unpublish(type: "redirect", alternative_path: "/new-base-path")
+
+    published2 = FactoryGirl.create(:live_edition, state: "published", base_path: "/gone-page", document: doc2, user_facing_version: 1)
+    published2.unpublish(type: "gone")
+
   end
 
   def test_base_paths
-    ["/published-and-draft-page", "/only-published-page", "/draft-and-superseded-page", "/does-not-exist"]
+    ["/published-and-draft-page", "/only-published-page", "/draft-and-superseded-page", "/does-not-exist", "/original-base-path", "/gone-page"]
   end
 end


### PR DESCRIPTION
This request is used in content tagger and publishing apps to lookup content ids, so that users can refer to pages by base paths when tagging to them.

For example:
- related links
- topics
- taxons

The request currently silently ignores some editions that have been redirected. The implementation looks for any editions with state `published` or `unpublished`.

There are different ways of unpublishing an edition:
- withdrawal (content is still shown, with a message)
- substitute (I'm ignoring this)
- gone (content is not there, HTTP gone)
- vanished (content is not there, HTTP not found)
- redirect (page redirects to another one)

This is an example of a redirected page that doesn't work with the request:
`/government/publications/impact-evaluation-of-the-send-pathfinder-programme` was
unpublished (consolidated) and redirected to
`/government/publications/send-pathfinder-programme-final-report`

As far as the frontend is concerned, everything works as expected, but I have
had trouble making sense of publishing api's record of this page and others
that have been redirected.

In this case, no non-superseded editions in publishing api are associated with
the **old URL**. The unpublished edition has the **new URL**. I haven't figured out
why this is, it could be intentional behaviour, or a historical bug (this
document was apparently unpublished multiple times).

I've had trouble understanding what the system is doing when unpublishing documents, because whitehall also behaves in an unusual way: every unpublish is followed by the creation of a new draft, using put content. This is so that an unpublished document can be "un-unpublished" by going through 2i or force publish again.

Put content can sometimes have the side effect of creating separate content
items with document type "redirect". I originally thought that I should expect
to see one of these "redirect" editions for the **old URL**, which would mean
that lookup_by_base_path would be able to successfully look up the content id
for this page. **This does not appear to be the case**.

In fact, in this example, there is a "redirect" edition, but it's a draft. I
don't understand how this was created or why.

Regardless of how the data got into this state, I think the implementation of this
request is imprecise. I've made two changes to it:

1. Add a parameter to request additional information about base paths that have
been redirected. This allows to display a more useful error to the user and
suggest they tag to the redirect target instead. (This is the problem I actually want to solve!)

I don't think this works at the moment, because it assumes that the unpublished
edition still has the old base path - which wasn't the case for the example I
looked at.

2. Don't return unpublished editions unless it was actually withdrawn (I
believe this was the original intent)

Tagging to a "gone" or "not found" page has no meaning, so I don't expect this to break anything.

**This shouldn't be merged as is** - I'd just like a review from someone with more understanding of how unpublishing actually works.