### PR TITLE
Skip lookup of unpublished pages unless withdrawn

### DIFF
--- a/app/controllers/lookups_controller.rb
+++ b/app/controllers/lookups_controller.rb
@@ -6,7 +6,10 @@ class LookupsController < ApplicationController
     base_paths = params.fetch(:base_paths)
 
     base_paths_and_content_ids = Edition.with_document
+      .left_outer_joins(:unpublishing)
       .where(state: states, base_path: base_paths)
+      .where("state = 'published' OR unpublishings.type = 'withdrawal'")
+      .where("document_type NOT IN ('gone', 'redirect')")
       .pluck(:base_path, 'documents.content_id')
       .uniq
 

--- a/spec/commands/v2/unpublish_spec.rb
+++ b/spec/commands/v2/unpublish_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe Commands::V2::Unpublish do
         }
       end
 
-      it "raises an error when expanation is blank" do
+      it "raises an error when explanation is blank" do
         msg = "Validation failed: Explanation can't be blank"
         expect { described_class.call(payload) }
           .to raise_error(CommandError, msg) do |error|

--- a/spec/requests/lookups_spec.rb
+++ b/spec/requests/lookups_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "POST /lookup-by-base-path", type: :request do
   end
 
   context "returning content_ids" do
-    it "returns content_ids for user-visible states (published, unpublished)" do
+    it "returns content_ids for user-visible states (published, withdrawn)" do
       create_test_content
 
       post "/lookup-by-base-path", params: { base_paths: test_base_paths }
@@ -20,7 +20,24 @@ RSpec.describe "POST /lookup-by-base-path", type: :request do
       expect(parsed_response).to eql(
         "/published-and-draft-page" => "aa491126-77ed-4e81-91fa-8dc7f74e9657",
         "/only-published-page" => "bbabcd3c-7c45-4403-8490-db51e4bfc4f6",
+        "/withdrawn-page" => "00abcd3c-7c45-4403-8490-db51e4bfc4f6"
       )
+    end
+
+    it "excludes redirect content items" do
+      FactoryGirl.create(:redirect_edition, state: "published", base_path: "/redirect-page", user_facing_version: 1)
+
+      post "/lookup-by-base-path", params: { base_paths: %w(/redirect-page) }
+
+      expect(parsed_response).to eql({})
+    end
+
+    it "excludes gone content items" do
+      FactoryGirl.create(:gone_edition, state: "published", base_path: "/gone-page", user_facing_version: 1)
+
+      post "/lookup-by-base-path", params: { base_paths: %w(/gone-page) }
+
+      expect(parsed_response).to eql({})
     end
   end
 
@@ -28,15 +45,35 @@ RSpec.describe "POST /lookup-by-base-path", type: :request do
     doc1 = FactoryGirl.create(:document, content_id: "aa491126-77ed-4e81-91fa-8dc7f74e9657")
     doc2 = FactoryGirl.create(:document, content_id: "bbabcd3c-7c45-4403-8490-db51e4bfc4f6")
     doc3 = FactoryGirl.create(:document, content_id: "dd1bf833-f91c-4e45-9f97-87b165808176")
+    doc4 = FactoryGirl.create(:document, content_id: "ee491126-77ed-4e81-91fa-8dc7f74e9657")
+    doc5 = FactoryGirl.create(:document, content_id: "ffabcd3c-7c45-4403-8490-db51e4bfc4f6")
+    doc6 = FactoryGirl.create(:document, content_id: "00abcd3c-7c45-4403-8490-db51e4bfc4f6")
 
     FactoryGirl.create(:live_edition, state: "published", base_path: "/published-and-draft-page", document: doc1, user_facing_version: 1)
     FactoryGirl.create(:edition, state: "draft", base_path: "/published-and-draft-page", document: doc1, user_facing_version: 2)
     FactoryGirl.create(:live_edition, state: "published", base_path: "/only-published-page", document: doc2)
     FactoryGirl.create(:edition, state: "draft", base_path: "/draft-and-superseded-page", document: doc3, user_facing_version: 2)
     FactoryGirl.create(:superseded_edition, state: "superseded", base_path: "/draft-and-superseded-page", document: doc3, user_facing_version: 1)
+
+    unpublished1 = FactoryGirl.create(:live_edition, state: "published", base_path: "/redirected-from-page", document: doc4, user_facing_version: 1)
+    unpublished1.unpublish(type: "redirect", alternative_path: "/redirected-to-page")
+
+    unpublished2 = FactoryGirl.create(:live_edition, state: "published", base_path: "/gone-page", document: doc5, user_facing_version: 1)
+    unpublished2.unpublish(type: "gone")
+
+    unpublished3 = FactoryGirl.create(:live_edition, state: "published", base_path: "/withdrawn-page", document: doc6, user_facing_version: 1)
+    unpublished3.unpublish(type: "withdrawal", explanation: "Consolidated into another page")
   end
 
   def test_base_paths
-    ["/published-and-draft-page", "/only-published-page", "/draft-and-superseded-page", "/does-not-exist"]
+    [
+      "/published-and-draft-page",
+      "/only-published-page",
+      "/draft-and-superseded-page",
+      "/does-not-exist",
+      "/redirected-from-page",
+      "/gone-page",
+      "/withdrawn-page"
+    ]
   end
 end


### PR DESCRIPTION
This request currently returns the content ids for any base paths that belong to _published_ or _unpublished_ editions.

The intention of including unpublished pages was to support withdrawn content:
these pages are still live, but show a message saying the content is not current.

However, there are 5 types of unpublishing, and the others mean content is not
visible on live.

It's not useful to complete the lookup in these cases. This request is used for
tagging, and tagging to content that isn't visible has no meaning.

There are also separate content items with document types of "redirect" and
"gone" which do not represent content. This means that the current
implementation is not very strict about only including content ids that are
"visible", and this makes it more difficult to predict what will and won't work
with this request.

We noticed this when looking into redirected content. Ideally we should be able
to distinguish content that has been redirected to another page (consolidated)
from content that never existed, so that publishers or users of content tagger
don't get confused (just saying the content doesn't exist suggests they made a
mistake) and they can choose whether to tag to the new thing instead.

For now I think it's best to deliberately include this from the lookup, and
make an API change later to expose extra information about redirected content.
We are also considering whether we need to be able to query content ids
of base paths belonging to drafts.

This PR replaces https://github.com/alphagov/publishing-api/pull/748

Trello:
https://trello.com/c/rC2btscW/448-content-tagger-show-appropriate-error-messages-when-uploading-untaggable-content
https://trello.com/c/ivoxhbhT/459-decide-what-we-need-from-lookup-by-base-path-so-that-we-can-handle-draft-and-redirected-content-when-tagging