### PR TITLE
Include the details for needs when expanding links

### DIFF
--- a/app/queries/dependee_expansion_rules.rb
+++ b/app/queries/dependee_expansion_rules.rb
@@ -14,6 +14,7 @@ module Queries
         organisation: default_fields + [:details],
         placeholder_organisation: default_fields + [:details],
         taxon: default_fields + [:details],
+        need: default_fields + [:details],
       }[link_type]
     end
   end


### PR DESCRIPTION
This allows the info frontend to use the information in the expanded
links.