### PR TITLE
Add task for re-presenting content tagged to taxons

### DIFF
--- a/lib/tasks/represent_downstream.rake
+++ b/lib/tasks/represent_downstream.rake
@@ -54,6 +54,16 @@ namespace :represent_downstream do
     Commands::V2::RepresentDownstream.new.call(content_ids)
   end
 
+  desc "Represent downstream content tagged to a parent taxon"
+  task tagged_to_taxon: :environment do
+    Commands::V2::RepresentDownstream.new.call(
+      Link.
+        joins(:link_set).
+        where(link_type: "taxons").
+        pluck(:content_id)
+    )
+  end
+
   desc "
   Represent an individual edition downstream
   Usage


### PR DESCRIPTION
PR #745 fixed the link expansion between taxons, but it did not fix those links in existing content. To fix this, we must re-present all content pages which are tagged to taxons.

Running 'represent_downstream:all' is excessive in this case, so this commit adds a new task which just re-presents affected content.

https://trello.com/c/QCxXilwI/360-get-expanded-taxons-in-the-link-section-of-content-pages