### PR TITLE
Fix method call in `destroy_document_with_links`

### DIFF
--- a/db/migrate/helpers/delete_content.rb
+++ b/db/migrate/helpers/delete_content.rb
@@ -4,7 +4,7 @@ module Helpers
       content_ids = Array(content_ids)
 
       Document.where(content_id: content_ids).each do |document|
-        destroy_supporting_objects(documents.editions)
+        destroy_edition_supporting_objects(document.editions)
         document.editions.destroy_all
         document.destroy
       end


### PR DESCRIPTION
The call to `destroy_supporting_objects` looks like it should now be
`destroy_edition_supporting_objects`. Similarly, `documents.editions` in
the block should be singular `document` to match the block parameter.