### PR TITLE
Fix bug in bench/get_expanded_links

### DIFF
--- a/bench/get_expanded_links.rb
+++ b/bench/get_expanded_links.rb
@@ -50,7 +50,7 @@ SQL
 def get_content_id_and_locale(content_id)
   [
       content_id,
-      Edition.where(content_id: content_id).pluck(:locale).first,
+      Document.where(content_id: content_id).pluck(:locale).first,
   ]
 end
 


### PR DESCRIPTION
Many reverse dependencies: 4bda0be5-3e65-4cc1-850c-0541e95a40ca
..........  4.250000   0.220000   4.470000 (  6.074460)
queries: {"LinkSet Load"=>10, nil=>70, "SCHEMA"=>3, "SQL"=>40}
total: 123
query time: {"LinkSet Load"=>0.003931747000000001, nil=>0.6888031799999998, "SCHEMA"=>0.002396737, "SQL"=>1.057506646}

log file written to log/many-reverse-dependencies.output
Many forward dependencies: 5f4f1e91-7631-11e4-a3cb-005056011aef
..........  2.890000   0.160000   3.050000 (  4.009408)
queries: {"LinkSet Load"=>10, nil=>70, "SQL"=>30}
total: 110
query time: {"LinkSet Load"=>0.005146658, nil=>0.5514709270000001, "SQL"=>0.603900341}

log file written to log/many-forward-dependencies.output
No dependencies: cacd92c1-42ef-4e2d-9ed4-817c8f03ff23
..........  0.040000   0.000000   0.040000 (  0.063418)
queries: {"LinkSet Load"=>10, nil=>30, "SQL"=>10}
total: 50
query time: {"LinkSet Load"=>0.005095277, nil=>0.020447687000000003, "SQL"=>0.008251711}

log file written to log/no-dependencies.output
Single link each way: 00012147-49f6-4e90-be1f-e50bb719f53d
..........  0.130000   0.010000   0.140000 (  0.195083)
queries: {"LinkSet Load"=>10, nil=>60, "SQL"=>40}
total: 110
query time: {"LinkSet Load"=>0.005107074, nil=>0.055591671000000016, "SQL"=>0.028369339}

log file written to log/single-link-each-way.output