### PR TITLE
Support "search_in" parameter in get_content.

### DIFF
--- a/app/controllers/v2/content_items_controller.rb
+++ b/app/controllers/v2/content_items_controller.rb
@@ -9,7 +9,8 @@ module V2
         fields: query_params[:fields],
         filters: filters,
         pagination: pagination,
-        search_query: query_params.fetch("q", "")
+        search_query: query_params.fetch("q", ""),
+        search_in: query_params["search_in"]
       )
 
       render json: Presenters::ResultsPresenter.new(results, pagination, request.original_url).present

--- a/app/queries/get_content_collection.rb
+++ b/app/queries/get_content_collection.rb
@@ -90,11 +90,15 @@ module Queries
           raise_error("Invalid search field: #{field}")
         end
         if elements.length == 2
-          "#{elements[0]}->>'#{elements[1]}'"
+          "#{elements[0]}->>'#{escape_nested_field(elements[1])}'"
         else
           elements[0]
         end
       end
+    end
+
+    def escape_nested_field(field)
+      ActiveRecord::Base.connection.quote_string(field)
     end
 
     def query

--- a/app/queries/get_content_collection.rb
+++ b/app/queries/get_content_collection.rb
@@ -8,10 +8,11 @@ module Queries
       :locale,
       :pagination,
       :search_query,
+      :search_in,
       :states,
     )
 
-    def initialize(document_types:, fields:, filters: {}, pagination: Pagination.new, search_query: "")
+    def initialize(document_types:, fields:, filters: {}, pagination: Pagination.new, search_query: "", search_in: nil)
       self.document_types = Array(document_types)
       self.fields = (fields || default_fields) + ["total"]
       self.publishing_app = filters[:publishing_app]
@@ -20,6 +21,7 @@ module Queries
       self.locale = filters[:locale] || "en"
       self.pagination = pagination
       self.search_query = search_query.strip
+      self.search_in = search_in
 
       validate_fields!
     end
@@ -42,6 +44,7 @@ module Queries
       :link_filters,
       :pagination,
       :search_query,
+      :search_in,
       :states,
     )
 
@@ -64,12 +67,7 @@ module Queries
       invalid_fields = fields - permitted_fields
       return unless invalid_fields.any?
 
-      raise CommandError.new(code: 400, error_details: {
-        error: {
-          code: 400,
-          message: "Invalid column name(s): #{invalid_fields.to_sentence}"
-        }
-      })
+      raise_error("Invalid column name(s): #{invalid_fields.to_sentence}")
     end
 
     def permitted_fields
@@ -80,6 +78,25 @@ module Queries
       presenter::DEFAULT_FIELDS.map(&:to_s)
     end
 
+    def default_search_fields
+      presenter::DEFAULT_SEARCH_FIELDS
+    end
+
+    def search_fields
+      return default_search_fields if search_in.blank?
+      search_in.split(',').map do |field|
+        elements = field.strip.split('.')
+        unless permitted_fields.include?(elements.first) && elements.length <= 2
+          raise_error("Invalid search field: #{field}")
+        end
+        if elements.length == 2
+          "#{elements[0]}->>'#{elements[1]}'"
+        else
+          elements[0]
+        end
+      end
+    end
+
     def query
       @query ||= presenter.new(
         editions,
@@ -88,12 +105,22 @@ module Queries
         offset: pagination.offset,
         locale: locale,
         limit: pagination.per_page,
-        search_query: search_query
+        search_query: search_query,
+        search_in: search_fields,
       )
     end
 
     def presenter
       Presenters::Queries::ContentItemPresenter
+    end
+
+    def raise_error(message)
+      raise CommandError.new(code: 400, error_details: {
+        error: {
+          code: 400,
+          message: message
+        }
+      })
     end
   end
 end

--- a/bench/get_content_items.rb
+++ b/bench/get_content_items.rb
@@ -8,16 +8,21 @@ require 'stackprof'
 
 abort "Refusing to run outside of development" unless Rails.env.development?
 
+search = (ARGV.first == '--search')
+
+params = {
+  document_types: ['taxon', 'organisation', 'topic', 'mainstream_browse_page', 'policy'],
+  fields: ['content_id', 'document_type', 'title', 'base_path']
+}
+params.merge(q: "school", search_in: "details.internal_name") if search
+
 queries = 0
 ActiveSupport::Notifications.subscribe("sql.active_record") { |_| queries += 1 }
 StackProf.run(mode: :wall, out: "tmp/get_editions_wall.dump") do
   puts Benchmark.measure {
     10.times do
       Presenters::ResultsPresenter.new(
-        Queries::GetContentCollection.new(
-          document_types: ['taxon', 'organisation', 'topic', 'mainstream_browse_page', 'policy'],
-          fields: ['content_id', 'document_type', 'title', 'base_path']
-        ),
+        Queries::GetContentCollection.new(params),
         Pagination.new,
         'http://dev.gov.uk'
       ).present

--- a/doc/api.md
+++ b/doc/api.md
@@ -347,7 +347,11 @@ and a state has been specified, the draft is returned.
 - `per_page` *(optional, default: 50)*
   - The number of results to be shown on a given page.
 - `q` *(optional)*
-  - Search term to match against `title` and `base_path` fields.
+  - Search term to match against the fields in `search_in`.
+- `search_in` *(optional)*
+  - Comma-seperated list of fields to search against. Each field can indicate a
+    single level of nesting via the dot operator. If not provided, will default
+    to `title` and `base_path`.
 - `publishing_app` *(optional)*
   - Used to restrict editions to those for a given publishing app.
 - `states` *(optional)*

--- a/spec/queries/get_content_collection_spec.rb
+++ b/spec/queries/get_content_collection_spec.rb
@@ -385,20 +385,31 @@ RSpec.describe Queries::GetContentCollection do
         document_type: "topic",
         schema_name: "topic",
         title: "Baz",
+        details: {
+          body: "A page about windows.",
+          internal_name: "newtopic"
+        }
       )
       FactoryGirl.create(:live_edition,
         base_path: "/baz",
         document_type: "topic",
         schema_name: "topic",
-        title: "zip"
+        title: "zip",
+        details: {
+          body: "A page all about doors.",
+          internal_name: "baz"
+        }
       )
     end
+
+    let(:search_in) { nil }
 
     subject do
       Queries::GetContentCollection.new(
         document_types: "topic",
         fields: ["base_path"],
-        search_query: search_query
+        search_query: search_query,
+        search_in: search_in
       )
     end
 
@@ -413,6 +424,48 @@ RSpec.describe Queries::GetContentCollection do
       let(:search_query) { "zip" }
       it "finds the edition" do
         expect(subject.call.map(&:to_hash)).to eq([{ "base_path" => "/baz" }])
+      end
+    end
+
+    context "search in" do
+      context "with a single nested field" do
+        let(:search_in) { "details.body" }
+        let(:search_query) { 'doors' }
+        it "finds the edition" do
+          expect(subject.call.map(&:to_hash)).to eq([{ "base_path" => "/baz" }])
+        end
+      end
+
+      context "with multiple nested fields" do
+        let(:search_in) { "details.body,details.internal_name" }
+        let(:search_query) { 'newtopic' }
+        it "finds the edition" do
+          expect(subject.call.map(&:to_hash)).to eq([{ "base_path" => "/bar/foo" }])
+        end
+      end
+
+      context "with a mixture of nested and non-nested fields" do
+        let(:search_in) { "title,details.internal_name" }
+        let(:search_query) { 'baz' }
+        it "finds the edition" do
+          expect(subject.call.map(&:to_hash)).to eq([{ "base_path" => "/bar/foo" }, { "base_path" => "/baz" }])
+        end
+      end
+
+      context "with invalid top-level fields" do
+        let(:search_in) { "nonexistent_field" }
+        let(:search_query) { 'baz' }
+        it "raises a CommandError" do
+          expect { subject.call }.to raise_error(CommandError)
+        end
+      end
+
+      context "with fields nested more than one level deep" do
+        let(:search_in) { "details.foo.bar" }
+        let(:search_query) { 'baz' }
+        it "raises a CommandError" do
+          expect { subject.call }.to raise_error(CommandError)
+        end
       end
     end
   end

--- a/spec/queries/get_content_collection_spec.rb
+++ b/spec/queries/get_content_collection_spec.rb
@@ -466,6 +466,14 @@ RSpec.describe Queries::GetContentCollection do
         it "raises a CommandError" do
           expect { subject.call }.to raise_error(CommandError)
         end
+
+        context "with SQL injection in nested fields" do
+          let(:search_in) { "details.foo' = '') OR 1=1--" }
+          let(:search_query) { 'baz' }
+          it "returns an empty result" do
+            expect(subject.call.to_a).to eq([])
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
This allows specifying which fields to search against, as a comma
separated list. We support a single level of nesting with a dot
seperator. So, to search against title and the value inside the
description hash, do:

    ?search_in=title,description.value

If not provided, it will default to the existing title and base_path.


Benchmarks, from bench/get_content_items.rb

without search:
..........  0.790000   0.260000   1.050000 (  3.063176)
queries: 30

with search
..........  0.800000   0.270000   1.070000 (  3.084760)
queries: 30