### PR TITLE
Delete all the taxons links

### DIFF
--- a/db/migrate/20170207155436_clear_alpha_taxons_again.rb
+++ b/db/migrate/20170207155436_clear_alpha_taxons_again.rb
@@ -1,0 +1,5 @@
+class ClearAlphaTaxonsAgain < ActiveRecord::Migration[5.0]
+  def up
+    Link.where(link_type: "taxons").where("created_at < '2017-02-7'").delete_all
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170131092110) do
+ActiveRecord::Schema.define(version: 20170207155436) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
We're going to do a fresh import of the tagging from the finding things tagathon.

This migration will delete any education taxonomy tags created before today.
https://trello.com/c/O1LI5ctS/472-clear-tag-associations-in-content-tagger

See also eec6e7b06da223348e31b26179462fc165000d79