### PR TITLE
Allow withdrawn related_statistical_data_sets to appear in links...

### DIFF
--- a/lib/link_expansion.rb
+++ b/lib/link_expansion.rb
@@ -53,8 +53,12 @@ private
   end
 
   def should_link?(link_type, content_item)
-    # Only children and parents can be withdrawn
-    %i(children parent).include?(link_type) || content_item.state != "unpublished"
+    # Only specific link types can be withdrawn
+    # FIXME: We're leaking publishing app domain knowledge into the API here.
+    # The agreed approach will be to allow any withdrawn links to appear but
+    # this requires we assess impact on the rendering applications first.
+    %i(children parent related_statistical_data_sets).include?(link_type) ||
+      content_item.state != "unpublished"
   end
 
   def rules

--- a/spec/lib/link_expansion_spec.rb
+++ b/spec/lib/link_expansion_spec.rb
@@ -55,6 +55,12 @@ RSpec.describe LinkExpansion do
 
         it { is_expected.to be_empty }
       end
+
+      context "and a related_statistical_data_sets link_type" do
+        let(:link_type) { :related_statistical_data_sets }
+
+        it { is_expected.to match(related_statistical_data_sets: [a_hash_including(withdrawn: true)]) }
+      end
     end
 
     context "with recursive links" do


### PR DESCRIPTION
https://trello.com/c/oyOq9WtM/369-9-publications-migration-implement-publishing-of-format-to-publishing-api-large-sync-checks-100ish-107-321

Whitehall renders withdrawn statistical datasets linked to publications so
another exception to presenting withdrawn links is needed.
This is a short-term solution as part of format migration, the long-term
plan is to expose all withdrawn links but some assessment of the impact of
this change is needed first.

cc @gpeng @kevindew 