### PR TITLE
Fact check access limited

### DIFF
--- a/app/commands/v2/put_content.rb
+++ b/app/commands/v2/put_content.rb
@@ -57,9 +57,12 @@ module Commands
       end
 
       def access_limit(edition)
-        if payload[:access_limited] && (users = payload[:access_limited][:users])
+        if payload[:access_limited]
           AccessLimit.find_or_create_by(edition: edition).tap do |access_limit|
-            access_limit.update_attributes!(users: users)
+            access_limit.update_attributes!(
+              users: (payload[:access_limited][:users] || []),
+              fact_check_ids: (payload[:access_limited][:fact_check_ids] || []),
+            )
           end
         else
           AccessLimit.find_by(edition: edition).try(:destroy)

--- a/app/models/access_limit.rb
+++ b/app/models/access_limit.rb
@@ -2,12 +2,19 @@ class AccessLimit < ApplicationRecord
   belongs_to :edition
 
   validate :user_uids_are_strings
+  validate :fact_check_ids_are_uuids
 
 private
 
   def user_uids_are_strings
     unless users.all? { |id| id.is_a?(String) }
       errors.add(:users, ["contains non-string user UIDs"])
+    end
+  end
+
+  def fact_check_ids_are_uuids
+    unless fact_check_ids.all? { |id| UuidValidator.valid?(id) }
+      errors.add(:fact_check_ids, ["contains invalid UUIDs"])
     end
   end
 end

--- a/app/presenters/downstream_presenter.rb
+++ b/app/presenters/downstream_presenter.rb
@@ -56,7 +56,8 @@ module Presenters
       else
         {
           access_limited: {
-            users: access_limit.users
+            users: access_limit.users,
+            fact_check_ids: access_limit.fact_check_ids,
           }
         }
       end

--- a/db/migrate/20170208172603_add_fact_check_ids.rb
+++ b/db/migrate/20170208172603_add_fact_check_ids.rb
@@ -1,0 +1,5 @@
+class AddFactCheckIds < ActiveRecord::Migration[5.0]
+  def change
+    add_column :access_limits, :fact_check_ids, :json, null: false, default: []
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,16 +10,17 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170207155436) do
+ActiveRecord::Schema.define(version: 20170208172603) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "access_limits", force: :cascade do |t|
-    t.json     "users",      default: [], null: false
-    t.datetime "created_at",              null: false
-    t.datetime "updated_at",              null: false
+    t.json     "users",          default: [], null: false
+    t.datetime "created_at",                  null: false
+    t.datetime "updated_at",                  null: false
     t.integer  "edition_id"
+    t.json     "fact_check_ids", default: [], null: false
     t.index ["edition_id"], name: "index_access_limits_on_edition_id", using: :btree
   end
 

--- a/spec/commands/v2/put_content_spec.rb
+++ b/spec/commands/v2/put_content_spec.rb
@@ -487,8 +487,14 @@ RSpec.describe Commands::V2::PutContent do
         end
 
         context "when the params includes an access limit" do
+          let(:fact_check_id) { SecureRandom.uuid }
           before do
-            payload.merge!(access_limited: { users: ["new-user"] })
+            payload.merge!(
+              access_limited: {
+                users: ["new-user"],
+                fact_check_ids: [fact_check_id],
+              }
+            )
           end
 
           it "updates the existing access limit" do
@@ -496,6 +502,7 @@ RSpec.describe Commands::V2::PutContent do
             access_limit.reload
 
             expect(access_limit.users).to eq(["new-user"])
+            expect(access_limit.fact_check_ids).to eq([fact_check_id])
           end
         end
 
@@ -510,8 +517,14 @@ RSpec.describe Commands::V2::PutContent do
 
       context "when the previously drafted item does not have an access limit" do
         context "when the params includes an access limit" do
+          let(:fact_check_id) { SecureRandom.uuid }
           before do
-            payload.merge!(access_limited: { users: ["new-user"] })
+            payload.merge!(
+              access_limited: {
+                users: ["new-user"],
+                fact_check_ids: [fact_check_id],
+              }
+            )
           end
 
           it "creates a new access limit" do
@@ -521,6 +534,7 @@ RSpec.describe Commands::V2::PutContent do
 
             access_limit = AccessLimit.find_by!(edition: previously_drafted_item)
             expect(access_limit.users).to eq(["new-user"])
+            expect(access_limit.fact_check_ids).to eq([fact_check_id])
           end
         end
       end

--- a/spec/models/access_limit_spec.rb
+++ b/spec/models/access_limit_spec.rb
@@ -1,13 +1,44 @@
 require "rails_helper"
 
 RSpec.describe AccessLimit do
-  subject { FactoryGirl.build(:access_limit) }
+  subject do
+    FactoryGirl.build(:access_limit,
+      users: users,
+      fact_check_ids: fact_check_ids,
+    )
+  end
 
-  it "validates that user UIDs are strings" do
-    subject.users << "a-string-uuid"
-    expect(subject).to be_valid
+  let(:users) { [SecureRandom.uuid] }
+  let(:fact_check_ids) { [] }
 
-    subject.users << 123
-    expect(subject).not_to be_valid
+  it { is_expected.to be_valid }
+
+  describe "validates users" do
+    context "where users has an array with a string" do
+      let(:users) { [SecureRandom.uuid] }
+      it { is_expected.to be_valid }
+    end
+
+    context "where users has an array with an integer" do
+      let(:users) { [123] }
+      it { is_expected.to be_invalid }
+    end
+  end
+
+  describe "validates fact_check_ids" do
+    context "where fact_check_ids has an array with a uuids" do
+      let(:fact_check_ids) { [SecureRandom.uuid, SecureRandom.uuid] }
+      it { is_expected.to be_valid }
+    end
+
+    context "where fact_check_ids has an array with non uuids" do
+      let(:fact_check_ids) { ["not-a-uuid"] }
+      it { is_expected.to be_invalid }
+    end
+
+    context "where users has an array with an integer" do
+      let(:fact_check_ids) { [123] }
+      it { is_expected.to be_invalid }
+    end
   end
 end

--- a/spec/presenters/downstream_presenter_spec.rb
+++ b/spec/presenters/downstream_presenter_spec.rb
@@ -205,6 +205,7 @@ RSpec.describe Presenters::DownstreamPresenter do
 
         it "populates the access_limited hash" do
           expect(result[:access_limited][:users].length).to eq(1)
+          expect(result[:access_limited][:fact_check_ids].length).to eq(0)
         end
       end
 

--- a/spec/support/request_helpers/mocks.rb
+++ b/spec/support/request_helpers/mocks.rb
@@ -54,6 +54,7 @@ module RequestHelpers
           "bf3e4b4f-f02d-4658-95a7-df7c74cd0f50",
           "74c7d700-5b4a-0131-7a8e-005056030037",
         ],
+        fact_check_ids: [],
       }
     end
 


### PR DESCRIPTION
It appears we aren't storing fact_check_ids that can be received, it looks like this was just a missing piece of the fact_check_id work. 

Custom are hoping to start using these and hit an issue that they couldn't store these.

Migration takes 0.13 seconds
```
*** [err :: backend-1.backend.integration.publishing.service.gov.uk] Migrating to AddFactCheckIds (20170208172603)
*** [err :: backend-1.backend.integration.publishing.service.gov.uk] == 20170208172603 AddFactCheckIds: migrating ==================================
*** [err :: backend-1.backend.integration.publishing.service.gov.uk] -- add_column(:access_limits, :fact_check_ids, :json, {:null=>false, :default=>[]})
*** [err :: backend-1.backend.integration.publishing.service.gov.uk] -> 0.1345s
*** [err :: backend-1.backend.integration.publishing.service.gov.uk] == 20170208172603 AddFactCheckIds: migrated (0.1347s) =========================
*** [err :: backend-1.backend.integration.publishing.service.gov.uk] 
```