### PR TITLE
Fix documents reverse link name

### DIFF
--- a/lib/link_expansion/rules.rb
+++ b/lib/link_expansion/rules.rb
@@ -21,7 +21,7 @@ module LinkExpansion::Rules
 
   REVERSE_LINKS = {
     parent: :children,
-    documents: :documents_collections,
+    documents: :document_collections,
     working_groups: :policies,
     parent_taxons: :child_taxons,
   }.freeze


### PR DESCRIPTION
An 's' was accidentally added making it 'documents_collections'
when it should actually be 'document_collections'.