### PR TITLE
Remove links from randomly generated edition

### DIFF
--- a/spec/integration/message_queue_publishing_spec.rb
+++ b/spec/integration/message_queue_publishing_spec.rb
@@ -14,11 +14,11 @@ RSpec.describe "Message queue publishing" do
 
       put "/v2/content/#{content_id}", params: edition.to_json
 
-      expect(response).to be_ok
+      expect(response).to be_ok, "failed to put-content a randomly generated edition"
 
       post "/v2/content/#{content_id}/publish", params: { locale: edition["locale"] }.to_json
 
-      expect(response).to be_ok
+      expect(response).to be_ok, "failed to publish a randomly generated edition"
 
       ensure_message_queue_payload_validates_against_notification_schema
     end

--- a/spec/integration/message_queue_publishing_spec.rb
+++ b/spec/integration/message_queue_publishing_spec.rb
@@ -8,7 +8,9 @@ RSpec.describe "Message queue publishing" do
 
       stub_content_store_calls(base_path)
 
-      edition = generate_random_edition(base_path, change_note)
+      # FIXME: this without("links") should be removed once Edition links are
+      # supported: https://github.com/alphagov/publishing-api/pull/749
+      edition = generate_random_edition(base_path, change_note).without("links")
 
       put "/v2/content/#{content_id}", params: edition.to_json
 


### PR DESCRIPTION
Links were causing this test to fail intermittently. This will fix the links issue.

I think this might well have been already an intermittent test so I've updated the errors so it's clearer what happened and hopefully we can look into fixing it fully if it occurs again. 