### PR TITLE
Ignore editions without a base path

### DIFF
--- a/lib/content_consistency_checker.rb
+++ b/lib/content_consistency_checker.rb
@@ -34,6 +34,8 @@ private
   end
 
   def check_edition(prefix, edition, content_store)
+    return unless edition.base_path
+
     content_item = item_from_content_store(edition.base_path, content_store)
 
     if edition.gone? && content_item


### PR DESCRIPTION
They won't appear in the content store directly but through links.