### PR TITLE
Change search_in to array

### DIFF
--- a/app/controllers/v2/content_items_controller.rb
+++ b/app/controllers/v2/content_items_controller.rb
@@ -10,7 +10,7 @@ module V2
         filters: filters,
         pagination: pagination,
         search_query: query_params.fetch("q", ""),
-        search_in: query_params["search_in"]
+        search_in: query_params[:search_in]
       )
 
       render json: Presenters::ResultsPresenter.new(results, pagination, request.original_url).present

--- a/app/queries/get_content_collection.rb
+++ b/app/queries/get_content_collection.rb
@@ -84,8 +84,8 @@ module Queries
 
     def search_fields
       return default_search_fields if search_in.blank?
-      search_in.split(',').map do |field|
-        elements = field.strip.split('.')
+      search_in.map do |field|
+        elements = field.split('.')
         unless permitted_fields.include?(elements.first) && elements.length <= 2
           raise_error("Invalid search field: #{field}")
         end

--- a/bench/get_content_items.rb
+++ b/bench/get_content_items.rb
@@ -14,7 +14,7 @@ params = {
   document_types: ['taxon', 'organisation', 'topic', 'mainstream_browse_page', 'policy'],
   fields: ['content_id', 'document_type', 'title', 'base_path']
 }
-params.merge(q: "school", search_in: "details.internal_name") if search
+params.merge(q: "school", search_in: ["details.internal_name"]) if search
 
 queries = 0
 ActiveSupport::Notifications.subscribe("sql.active_record") { |_| queries += 1 }

--- a/doc/api.md
+++ b/doc/api.md
@@ -347,11 +347,11 @@ and a state has been specified, the draft is returned.
 - `per_page` *(optional, default: 50)*
   - The number of results to be shown on a given page.
 - `q` *(optional)*
-  - Search term to match against the fields in `search_in`.
-- `search_in` *(optional)*
-  - Comma-seperated list of fields to search against. Each field can indicate a
-    single level of nesting via the dot operator. If not provided, will default
-    to `title` and `base_path`.
+  - Search term to match against the fields in `search_in[]`.
+- `search_in[]` *(optional)*
+  - Array of fields to search against. Each field can indicate a single level
+    of nesting via the dot operator. If not provided, will default to
+    `title` and `base_path`.
 - `publishing_app` *(optional)*
   - Used to restrict editions to those for a given publishing app.
 - `states` *(optional)*

--- a/spec/controllers/v2/content_items_controller_spec.rb
+++ b/spec/controllers/v2/content_items_controller_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe V2::ContentItemsController do
 
       context "specifying fields to search" do
         it "returns the item" do
-          get :index, params: { document_type: "topic", q: "stuff", search_in: "description.value", fields: %w(title) }
+          get :index, params: { document_type: "topic", q: "stuff", search_in: ["description.value"], fields: %w(title) }
           expect(parsed_response["results"].map { |i| i["title"] }).to eq(['bar'])
         end
       end

--- a/spec/queries/get_content_collection_spec.rb
+++ b/spec/queries/get_content_collection_spec.rb
@@ -429,7 +429,7 @@ RSpec.describe Queries::GetContentCollection do
 
     context "search in" do
       context "with a single nested field" do
-        let(:search_in) { "details.body" }
+        let(:search_in) { ["details.body"] }
         let(:search_query) { 'doors' }
         it "finds the edition" do
           expect(subject.call.map(&:to_hash)).to eq([{ "base_path" => "/baz" }])
@@ -437,7 +437,7 @@ RSpec.describe Queries::GetContentCollection do
       end
 
       context "with multiple nested fields" do
-        let(:search_in) { "details.body,details.internal_name" }
+        let(:search_in) { ["details.body", "details.internal_name"] }
         let(:search_query) { 'newtopic' }
         it "finds the edition" do
           expect(subject.call.map(&:to_hash)).to eq([{ "base_path" => "/bar/foo" }])
@@ -445,7 +445,7 @@ RSpec.describe Queries::GetContentCollection do
       end
 
       context "with a mixture of nested and non-nested fields" do
-        let(:search_in) { "title,details.internal_name" }
+        let(:search_in) { ["title", "details.internal_name"] }
         let(:search_query) { 'baz' }
         it "finds the edition" do
           expect(subject.call.map(&:to_hash)).to eq([{ "base_path" => "/bar/foo" }, { "base_path" => "/baz" }])
@@ -453,7 +453,7 @@ RSpec.describe Queries::GetContentCollection do
       end
 
       context "with invalid top-level fields" do
-        let(:search_in) { "nonexistent_field" }
+        let(:search_in) { ["nonexistent_field"] }
         let(:search_query) { 'baz' }
         it "raises a CommandError" do
           expect { subject.call }.to raise_error(CommandError)
@@ -461,14 +461,14 @@ RSpec.describe Queries::GetContentCollection do
       end
 
       context "with fields nested more than one level deep" do
-        let(:search_in) { "details.foo.bar" }
+        let(:search_in) { ["details.foo.bar"] }
         let(:search_query) { 'baz' }
         it "raises a CommandError" do
           expect { subject.call }.to raise_error(CommandError)
         end
 
         context "with SQL injection in nested fields" do
-          let(:search_in) { "details.foo' = '') OR 1=1--" }
+          let(:search_in) { ["details.foo' = '') OR 1=1--"] }
           let(:search_query) { 'baz' }
           it "returns an empty result" do
             expect(subject.call.to_a).to eq([])


### PR DESCRIPTION
This commit changes the `search_in` param to accept an array rather than a comma-separated string, in order to be consistent with other similar params like `fields[]`.

Depends on https://github.com/alphagov/gds-api-adapters/pull/664.