### PR TITLE
Allow search_in only in specific fields

### DIFF
--- a/app/presenters/queries/content_item_presenter.rb
+++ b/app/presenters/queries/content_item_presenter.rb
@@ -20,6 +20,9 @@ module Presenters
 
       DEFAULT_SEARCH_FIELDS = %w(title base_path).freeze
 
+      SEARCH_FIELDS = %w(title base_path description).freeze
+      NESTED_SEARCH_FIELDS = %w(details).freeze
+
       def self.present_many(scope, params = {})
         new(scope, params).present_many
       end

--- a/doc/api.md
+++ b/doc/api.md
@@ -348,10 +348,10 @@ and a state has been specified, the draft is returned.
   - The number of results to be shown on a given page.
 - `q` *(optional)*
   - Search term to match against the fields in `search_in[]`.
-- `search_in[]` *(optional)*
-  - Array of fields to search against. Each field can indicate a single level
-    of nesting via the dot operator. If not provided, will default to
-    `title` and `base_path`.
+- `search_in[]` *(optional, default: [title, base_path])*
+  - Array of fields to search against.
+  - Fields supported are `title`, `base_path`, `description`, and `details.*` -
+    where * indicates a field within details, e.g. `details.internal_name`.
 - `publishing_app` *(optional)*
   - Used to restrict editions to those for a given publishing app.
 - `states` *(optional)*

--- a/spec/controllers/v2/content_items_controller_spec.rb
+++ b/spec/controllers/v2/content_items_controller_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe V2::ContentItemsController do
 
       context "specifying fields to search" do
         it "returns the item" do
-          get :index, params: { document_type: "topic", q: "stuff", search_in: ["description.value"], fields: %w(title) }
+          get :index, params: { document_type: "topic", q: "stuff", search_in: ["description"], fields: %w(title) }
           expect(parsed_response["results"].map { |i| i["title"] }).to eq(['bar'])
         end
       end

--- a/spec/queries/get_content_collection_spec.rb
+++ b/spec/queries/get_content_collection_spec.rb
@@ -395,6 +395,7 @@ RSpec.describe Queries::GetContentCollection do
         document_type: "topic",
         schema_name: "topic",
         title: "zip",
+        description: "foo",
         details: {
           body: "A page all about doors.",
           internal_name: "baz"
@@ -457,6 +458,22 @@ RSpec.describe Queries::GetContentCollection do
         let(:search_query) { 'baz' }
         it "raises a CommandError" do
           expect { subject.call }.to raise_error(CommandError)
+        end
+      end
+
+      context "with a nested field as a top-level fields" do
+        let(:search_in) { ["details"] }
+        let(:search_query) { "baz" }
+        it "raises a CommandError" do
+          expect { subject.call }.to raise_error(CommandError)
+        end
+      end
+
+      context "with description among the fields" do
+        let(:search_in) { ["description"] }
+        let(:search_query) { "foo" }
+        it "finds the edition" do
+          expect(subject.call.map(&:to_hash)).to eq([{ "base_path" => "/baz" }])
         end
       end
 

--- a/spec/queries/get_content_collection_spec.rb
+++ b/spec/queries/get_content_collection_spec.rb
@@ -99,7 +99,7 @@ RSpec.describe Queries::GetContentCollection do
 
       expect(
         Queries::GetContentCollection.new(
-          document_types: 'topic',
+          document_types: "topic",
           fields: %w(base_path publication_state unpublishing),
         ).call
       ).to match_array(
@@ -431,7 +431,7 @@ RSpec.describe Queries::GetContentCollection do
     context "search in" do
       context "with a single nested field" do
         let(:search_in) { ["details.body"] }
-        let(:search_query) { 'doors' }
+        let(:search_query) { "doors" }
         it "finds the edition" do
           expect(subject.call.map(&:to_hash)).to eq([{ "base_path" => "/baz" }])
         end
@@ -439,7 +439,7 @@ RSpec.describe Queries::GetContentCollection do
 
       context "with multiple nested fields" do
         let(:search_in) { ["details.body", "details.internal_name"] }
-        let(:search_query) { 'newtopic' }
+        let(:search_query) { "newtopic" }
         it "finds the edition" do
           expect(subject.call.map(&:to_hash)).to eq([{ "base_path" => "/bar/foo" }])
         end
@@ -447,7 +447,7 @@ RSpec.describe Queries::GetContentCollection do
 
       context "with a mixture of nested and non-nested fields" do
         let(:search_in) { ["title", "details.internal_name"] }
-        let(:search_query) { 'baz' }
+        let(:search_query) { "baz" }
         it "finds the edition" do
           expect(subject.call.map(&:to_hash)).to eq([{ "base_path" => "/bar/foo" }, { "base_path" => "/baz" }])
         end
@@ -455,7 +455,7 @@ RSpec.describe Queries::GetContentCollection do
 
       context "with invalid top-level fields" do
         let(:search_in) { ["nonexistent_field"] }
-        let(:search_query) { 'baz' }
+        let(:search_query) { "baz" }
         it "raises a CommandError" do
           expect { subject.call }.to raise_error(CommandError)
         end
@@ -479,14 +479,14 @@ RSpec.describe Queries::GetContentCollection do
 
       context "with fields nested more than one level deep" do
         let(:search_in) { ["details.foo.bar"] }
-        let(:search_query) { 'baz' }
+        let(:search_query) { "baz" }
         it "raises a CommandError" do
           expect { subject.call }.to raise_error(CommandError)
         end
 
         context "with SQL injection in nested fields" do
           let(:search_in) { ["details.foo' = '') OR 1=1--"] }
-          let(:search_query) { 'baz' }
+          let(:search_query) { "baz" }
           it "returns an empty result" do
             expect(subject.call.to_a).to eq([])
           end


### PR DESCRIPTION
This specifies which fields can be searched in for GetContentCollection
as root level fields and nested fields. These are limited since using
search_in on a field type that doesn't support `ilike` will result in a
500 error.

/cc @rubenarakelyan 