### PR TITLE
Add support for deep-nested govspeak fields

### DIFF
--- a/app/presenters/details_presenter.rb
+++ b/app/presenters/details_presenter.rb
@@ -32,7 +32,7 @@ module Presenters
       return render_govspeak(value) if govspeak?(wrapped_array)
       return value if value.is_a?(String)
       return value if value.respond_to?(:has_key?) && value.has_key?(:content)
-      value.map {|o| recursively_transform_govspeak(o) }
+      value.map { |o| recursively_transform_govspeak(o) }
     end
 
     def recursively_transform_govspeak(obj)

--- a/spec/presenters/details_presenter_spec.rb
+++ b/spec/presenters/details_presenter_spec.rb
@@ -129,5 +129,45 @@ RSpec.describe Presenters::DetailsPresenter do
         expect { subject }.to_not raise_error
       end
     end
+
+    context "when we're passed a deeply-nested hash with govspeak" do
+      let(:edition_details) do
+        {
+          parts: [
+            {
+              body: [
+                {
+                  content_type: 'text/govspeak',
+                  content: 'foo'
+                }
+              ]
+            }
+          ]
+        }
+      end
+
+      let(:expected_details) do
+        {
+          parts: [
+            {
+              body: [
+                {
+                  content_type: 'text/govspeak',
+                  content: 'foo'
+                },
+                {
+                  content_type: 'text/html',
+                  content: "<p>foo</p>\n"
+                }
+              ]
+            }
+          ]
+        }
+      end
+
+      it "converts from govspeak appropriately" do
+        expect(subject).to eq expected_details
+      end
+    end
   end
 end


### PR DESCRIPTION
Documents with govspeak parts that are nested mutliple levels deep
in the details hash weren't getting rendered by publishing-api.

This adds recursion to the rendering presentor, so that these schema
types can be accomodated.

Pair-coded with @emmabeynon 

Trello: https://trello.com/c/r2gA1lxN/640-migrate-guide-format-to-rendered