### PR TITLE
Fix typo in method name

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ require_relative "helpers/delete_content"
 class RemoveYourDocument < ActiveRecord::Migration
   # Remove /some/base-path
   def up
-    Helpers::DeleteContent.destroy_document_with_links("some-content-id")
+    Helpers::DeleteContent.destroy_documents_with_links("some-content-id")
   end
 end
 ```

--- a/db/migrate/helpers/delete_content.rb
+++ b/db/migrate/helpers/delete_content.rb
@@ -1,6 +1,6 @@
 module Helpers
   module DeleteContent
-    def self.destroy_document_with_links(content_ids)
+    def self.destroy_documents_with_links(content_ids)
       content_ids = Array(content_ids)
 
       Document.where(content_id: content_ids).each do |document|


### PR DESCRIPTION
We destroy documents plural with this method not just singular.