### PR TITLE
Allow setting first_published_at when updating a draft edition

### DIFF
--- a/app/models/update_existing_draft_edition.rb
+++ b/app/models/update_existing_draft_edition.rb
@@ -6,7 +6,6 @@ class UpdateExistingDraftEdition
     :locale,
     :created_at,
     :updated_at,
-    :first_published_at,
     :last_edited_at,
   ].freeze
 
@@ -42,13 +41,25 @@ private
   end
 
   def assign_attributes_with_defaults
-    edition.assign_attributes(new_attributes)
+    edition.assign_attributes(attributes_from_payload)
   end
 
-  def new_attributes
+  def remove_first_published_at_if_not_explicitly_set(attributes)
+    attributes.tap do |x|
+      x.delete(:first_published_at) unless payload.include?(:first_published_at)
+    end
+  end
+
+  def without_protected_attributes
     edition.class.column_defaults.symbolize_keys
       .merge(attributes.symbolize_keys)
       .except(*ATTRIBUTES_PROTECTED_FROM_RESET)
+  end
+
+  def attributes_from_payload
+    remove_first_published_at_if_not_explicitly_set(
+      without_protected_attributes
+    )
   end
 
   def attributes

--- a/spec/commands/v2/put_content_spec.rb
+++ b/spec/commands/v2/put_content_spec.rb
@@ -332,7 +332,17 @@ RSpec.describe Commands::V2::PutContent do
         expect(previously_drafted_item.content_store).to eq("draft")
       end
 
-      it "keeps the first_published_at timestamp if present" do
+      it "allows the setting of first_published_at" do
+        explicit_first_published = DateTime.new(2016, 05, 23, 1, 1, 1).rfc3339
+        payload[:first_published_at] = explicit_first_published
+
+        described_class.call(payload)
+
+        expect(previously_drafted_item.reload.first_published_at)
+          .to eq(explicit_first_published)
+      end
+
+      it "keeps the first_published_at timestamp if not set in payload" do
         first_published_at = 1.year.ago
         previously_drafted_item.update_attributes(first_published_at: first_published_at)
 


### PR DESCRIPTION
[Related Trello card][trello].

[trello]: https://trello.com/c/GuXm7xI1/884-allow-updating-first-published-at-blocking-core