### PR TITLE
Capture orphaned links before we delete them

### DIFF
--- a/app/workers/dependency_resolution_worker.rb
+++ b/app/workers/dependency_resolution_worker.rb
@@ -11,6 +11,8 @@ class DependencyResolutionWorker
       send_downstream(content_id, locale)
     end
 
+    # FIXME: we need to do all locales not just 'en'
+    # make sure we update this when we come to edition level implementation.
     orphaned_content_ids.each { |content_id| send_downstream(content_id, "en") }
   end
 

--- a/app/workers/dependency_resolution_worker.rb
+++ b/app/workers/dependency_resolution_worker.rb
@@ -8,17 +8,15 @@ class DependencyResolutionWorker
     assign_attributes(args.deep_symbolize_keys)
 
     dependencies.each do |(content_id, locale)|
-      if draft?
-        downstream_draft(content_id, locale)
-      else
-        downstream_live(content_id, locale)
-      end
+      send_downstream(content_id, locale)
     end
+
+    orphaned_content_ids.each { |content_id| send_downstream(content_id, "en") }
   end
 
 private
 
-  attr_reader :content_id, :locale, :fields, :content_store, :payload_version
+  attr_reader :content_id, :locale, :fields, :content_store, :payload_version, :orphaned_content_ids
 
   def assign_attributes(args)
     @content_id = args.fetch(:content_id)
@@ -27,6 +25,12 @@ private
     @locale = args[:locale]
     @content_store = args.fetch(:content_store).constantize
     @payload_version = args.fetch(:payload_version)
+    @orphaned_content_ids = args.fetch(:orphaned_content_ids, [])
+  end
+
+  def send_downstream(content_id, locale)
+    downstream_draft(content_id, locale)
+    downstream_live(content_id, locale)
   end
 
   def dependencies
@@ -42,6 +46,8 @@ private
   end
 
   def downstream_draft(dependent_content_id, locale)
+    return unless draft?
+
     DownstreamDraftWorker.perform_async_in_queue(
       DownstreamDraftWorker::LOW_QUEUE,
       content_id: dependent_content_id,
@@ -53,6 +59,8 @@ private
   end
 
   def downstream_live(dependent_content_id, locale)
+    return if draft?
+
     DownstreamLiveWorker.perform_async_in_queue(
       DownstreamLiveWorker::LOW_QUEUE,
       content_id: dependent_content_id,

--- a/app/workers/downstream_draft_worker.rb
+++ b/app/workers/downstream_draft_worker.rb
@@ -50,12 +50,13 @@ class DownstreamDraftWorker
 private
 
   attr_reader :content_id, :locale, :edition, :payload_version,
-    :update_dependencies, :dependency_resolution_source_content_id
+    :update_dependencies, :dependency_resolution_source_content_id, :orphaned_content_ids
 
   def assign_attributes(attributes)
     assign_backwards_compatible_content_item(attributes)
     @edition = Queries::GetEditionForContentStore.(content_id, locale, true)
     @payload_version = attributes.fetch(:payload_version)
+    @orphaned_content_ids = attributes.fetch(:orphaned_content_ids, [])
     @update_dependencies = attributes.fetch(:update_dependencies, true)
     @dependency_resolution_source_content_id = attributes.fetch(
       :dependency_resolution_source_content_id,
@@ -83,7 +84,8 @@ private
       fields: [:content_id],
       content_id: content_id,
       locale: locale,
-      payload_version: payload_version
+      payload_version: payload_version,
+      orphaned_content_ids: orphaned_content_ids,
     )
   end
 

--- a/app/workers/downstream_live_worker.rb
+++ b/app/workers/downstream_live_worker.rb
@@ -55,12 +55,13 @@ private
 
   attr_reader :content_id, :locale, :edition, :payload_version,
     :message_queue_update_type, :update_dependencies,
-    :dependency_resolution_source_content_id
+    :dependency_resolution_source_content_id, :orphaned_content_ids
 
   def assign_attributes(attributes)
     assign_backwards_compatible_content_item(attributes)
     @edition = Queries::GetEditionForContentStore.(content_id, locale, false)
     @payload_version = attributes.fetch(:payload_version)
+    @orphaned_content_ids = attributes.fetch(:orphaned_content_ids, [])
     @message_queue_update_type = attributes.fetch(:message_queue_update_type, nil)
     @update_dependencies = attributes.fetch(:update_dependencies, true)
     @dependency_resolution_source_content_id = attributes.fetch(
@@ -90,6 +91,7 @@ private
       content_id: content_id,
       locale: locale,
       payload_version: payload_version,
+      orphaned_content_ids: orphaned_content_ids,
     )
   end
 

--- a/lib/dependency_resolution/link_reference.rb
+++ b/lib/dependency_resolution/link_reference.rb
@@ -26,14 +26,18 @@ private
 
   def descendant_links(content_id, link_types_path, parent_content_ids)
     descendant_link_types = rules.next_dependency_resolution_link_types(link_types_path)
+
     return {} if descendant_link_types.empty?
+
     reverse_types, direct_types = descendant_link_types.partition do |link_type|
       rules.is_reverse_link_type?(link_type)
     end
+
     direct = direct_links(content_id,
       allowed_link_types: direct_types,
       parent_content_ids: parent_content_ids,
     )
+
     reverse = reverse_links(content_id,
       allowed_reverse_link_types: reverse_types,
       parent_content_ids: parent_content_ids,

--- a/lib/link_expansion/link_reference.rb
+++ b/lib/link_expansion/link_reference.rb
@@ -3,16 +3,13 @@ class LinkExpansion::LinkReference
     if link_types_path.empty?
       root_links(content_id)
     else
-      descendant_links(
-        content_id,
-        link_types_path,
-        parent_content_ids
-      )
+      descendant_links(content_id, link_types_path, parent_content_ids)
     end
   end
 
   def valid_link_node?(node)
     return true if node.link_types_path.length == 1
+
     rules.valid_link_expansion_link_types_path?(node.link_types_path)
   end
 
@@ -28,7 +25,9 @@ private
 
   def descendant_links(content_id, link_types_path, parent_content_ids)
     descendant_link_types = rules.next_link_expansion_link_types(link_types_path)
+
     return {} if descendant_link_types.empty?
+
     reverse_types, direct_types = descendant_link_types.partition do |link_type|
       rules.is_reverse_link_type?(link_type)
     end

--- a/spec/commands/v2/patch_link_set_spec.rb
+++ b/spec/commands/v2/patch_link_set_spec.rb
@@ -332,8 +332,9 @@ RSpec.describe Commands::V2::PatchLinkSet do
               "downstream_high",
               content_id: content_id,
               locale: locale,
-              payload_version: an_instance_of(Fixnum),
               message_queue_update_type: "links",
+              payload_version: an_instance_of(Fixnum),
+              orphaned_content_ids: [],
             )
         end
 


### PR DESCRIPTION
Given a -> b, if we change a -> c, b still thinks it has a child of a,
but since we severed this relation, b has no reference to a, which means
that it is missed by dependency resolution.

This captures those relations before we remove them, and passes them
down into the dependency resolution worker.