### PR TITLE
Update old redirect unpublishings

### DIFF
--- a/db/migrate/20170221093606_update_old_redirect_unpublishings.rb
+++ b/db/migrate/20170221093606_update_old_redirect_unpublishings.rb
@@ -1,0 +1,13 @@
+class UpdateOldRedirectUnpublishings < ActiveRecord::Migration[5.0]
+  def up
+    Unpublishing
+      .where(type: :redirect)
+      .where(redirects: nil)
+      .find_each do |unpublishing|
+        # this magical line works because the 'redirects' getter is overriden
+        # to generate a JSON blob automatically if it is nil within the
+        # database
+        unpublishing.update_attribute(:redirects, unpublishing.redirects)
+      end
+  end
+end


### PR DESCRIPTION
This should be deployed after #782 to migrate old-style `alternative_path` redirect unpublishings.

Takes about 85 seconds to run on my machine.