### PR TITLE
Remove backwards compatible interfaces to workers

### DIFF
--- a/app/workers/dependency_resolution_worker.rb
+++ b/app/workers/dependency_resolution_worker.rb
@@ -22,9 +22,7 @@ private
 
   def assign_attributes(args)
     @content_id = args.fetch(:content_id)
-    # FIXME: As of December 2016 locale is a optional field to be backwards
-    # compatible. By January 2017 it will be safe to make locale required.
-    @locale = args[:locale]
+    @locale = args.fetch(:locale)
     @content_store = args.fetch(:content_store).constantize
     @payload_version = args.fetch(:payload_version)
     @orphaned_content_ids = args.fetch(:orphaned_content_ids, [])

--- a/app/workers/downstream_draft_worker.rb
+++ b/app/workers/downstream_draft_worker.rb
@@ -11,18 +11,13 @@ class DownstreamDraftWorker
 
   def self.uniq_args(args)
     [
-      args.first["content_id"] || args.first["content_item_id"],
+      args.first["content_id"],
       args.first["locale"],
       args.first.fetch("update_dependencies", true),
       name,
     ]
   end
 
-  # FIXME: This worker can be initialised using a legacy interface with
-  # "content_item_id" and the updated interface which uses "content_id" and
-  # "locale". Both interfaces are supported until we are confident there are
-  # no longer items in the sidekiq queue. They should all be long gone by
-  # January 2017 and probably sooner.
   def perform(args = {})
     assign_attributes(args.symbolize_keys)
 
@@ -53,7 +48,8 @@ private
     :update_dependencies, :dependency_resolution_source_content_id, :orphaned_content_ids
 
   def assign_attributes(attributes)
-    assign_backwards_compatible_content_item(attributes)
+    @content_id = attributes.fetch(:content_id)
+    @locale = attributes.fetch(:locale)
     @edition = Queries::GetEditionForContentStore.(content_id, locale, true)
     @payload_version = attributes.fetch(:payload_version)
     @orphaned_content_ids = attributes.fetch(:orphaned_content_ids, [])
@@ -62,20 +58,6 @@ private
       :dependency_resolution_source_content_id,
       nil
     )
-  end
-
-  def assign_backwards_compatible_content_item(attributes)
-    if attributes[:content_item_id]
-      edition = Edition.find(attributes[:content_item_id])
-      unless edition
-        raise AbortWorkerError.new("A content item was not found for content_item_id: #{attributes[:content_item_id]}")
-      end
-      @content_id = edition.content_id
-      @locale = edition.locale
-    else
-      @content_id = attributes.fetch(:content_id)
-      @locale = attributes.fetch(:locale)
-    end
   end
 
   def enqueue_dependencies

--- a/spec/workers/dependency_resolution_worker_spec.rb
+++ b/spec/workers/dependency_resolution_worker_spec.rb
@@ -69,6 +69,7 @@ RSpec.describe DependencyResolutionWorker, :perform do
 
       described_class.new.perform(
         content_id: "123",
+        locale: "en",
         content_store: "Adapters::ContentStore",
         payload_version: "123",
       )
@@ -85,6 +86,7 @@ RSpec.describe DependencyResolutionWorker, :perform do
 
       described_class.new.perform(
         content_id: "123",
+        locale: "en",
         content_store: "Adapters::DraftContentStore",
         payload_version: "123",
       )
@@ -134,6 +136,7 @@ RSpec.describe DependencyResolutionWorker, :perform do
         described_class.new.perform(
           content_id: content_id,
           content_store: "Adapters::ContentStore",
+          locale: "en",
           payload_version: "123",
         )
       end

--- a/spec/workers/downstream_discard_draft_worker_spec.rb
+++ b/spec/workers/downstream_discard_draft_worker_spec.rb
@@ -40,10 +40,10 @@ RSpec.describe DownstreamDiscardDraftWorker do
       }.to raise_error(KeyError)
     end
 
-    it "doesn't requires locale" do
+    it "requires locale" do
       expect {
         subject.perform(arguments.except("locale"))
-      }.not_to raise_error
+      }.to raise_error(KeyError)
     end
 
     it "requires payload_version" do


### PR DESCRIPTION
Since we are now into January 2017 by a fair margin it's safe to remove
this backwards compatible code.