### PR TITLE
Replace N queries with a join in linkables query

### DIFF
--- a/app/queries/get_linkables.rb
+++ b/app/queries/get_linkables.rb
@@ -33,7 +33,7 @@ module Queries
           state_fallback_order: [:published, :draft]
         )
 
-        Edition.where(id: edition_ids).map do |edition|
+        Edition.with_document.includes(:document).where(id: edition_ids).map do |edition|
           LinkablePresenter.from_hash(edition.to_h.deep_symbolize_keys)
         end
       end

--- a/bench/linkables.rb
+++ b/bench/linkables.rb
@@ -17,6 +17,7 @@ benchmarks.each do |document_type|
   StackProf.run(mode: :wall, out: "tmp/linkable_mediator_#{document_type.gsub(/ +/, '_').downcase}_wall.dump") do
     puts Benchmark.measure {
       10.times do
+        Rails.cache.clear
         Queries::GetLinkables.new(
           document_type: document_type
         ).call


### PR DESCRIPTION
This request performs very badly on the initial load, before it is cached.

This has a large impact on content tagger, because content tagger queries multiple document types in succession, to render various autocomplete fields for tagging. So if the data isn't in cache, content tagger times out on each successive request until it's all in cache. I tested this behaviour on dev by repeatedly requesting the content tagger page after the server starts up.

This PR prevents the request from making a bunch of "select ... from documents where id=$1" queries, when it could just join to the table.

This probably won't solve the problem on its own, but it's an improvement.

I've also changed the benchmark to avoid cache hits.

Before:

    mainstream_browse_page
    ..........  2.180000   0.180000   2.360000 (  6.114330)
    queries: 1586

    organisation
    .......... 12.730000   1.090000  13.820000 ( 18.425612)
    queries: 10240

    policy
    ..........  4.010000   0.360000   4.370000 (  8.642484)
    queries: 2280

    taxon
    ..........  1.940000   0.280000   2.220000 (  3.994576)
    queries: 1460

    topic
    ..........  6.220000   0.430000   6.650000 (  9.721289)
    queries: 4100

After:

    ..........  1.120000   0.150000   1.270000 (  3.900343)
    queries: 45

    organisation
    ..........  5.730000   0.400000   6.130000 (  8.142727)
    queries: 40

    policy
    ..........  2.480000   0.370000   2.850000 (  6.634938)
    queries: 40

    taxon
    ..........  0.960000   0.110000   1.070000 (  2.366947)
    queries: 40

    topic
    ..........  2.720000   0.240000   2.960000 (  4.777198)
    queries: 40

https://trello.com/c/OJHS5mzw/495-investigate-get-linkables-timeouts-in-content-tagger