### PR TITLE
Test that reverse links are consistent with content schemas

### DIFF
--- a/spec/lib/link_expansion/rules_spec.rb
+++ b/spec/lib/link_expansion/rules_spec.rb
@@ -84,4 +84,30 @@ RSpec.describe LinkExpansion::Rules do
       expect(subject.potential_expansion_fields("nested_doc")).to eq([:title, :details])
     end
   end
+
+  describe "REVERSE_LINKS" do
+    let(:reverse_links) { described_class::REVERSE_LINKS.values.map(&:to_s) }
+
+    describe "are defined in necessary frontend schemas" do
+      schemas_of_type("frontend/schema").each do |path, schema|
+        links = schema["properties"]["links"]
+        next unless links
+        context "when the schema is #{path}" do
+          subject { links["properties"].keys }
+          it { is_expected.to include(*reverse_links) }
+        end
+      end
+    end
+
+    describe "are not defined in publisher schemas" do
+      schemas_of_type("publisher_v2/links").each do |path, schema|
+        links = schema["properties"]["links"]
+        next unless links
+        context "when the schema is #{path}" do
+          subject { links["properties"].keys }
+          it { is_expected.not_to include(*reverse_links) }
+        end
+      end
+    end
+  end
 end

--- a/spec/lib/link_expansion_spec.rb
+++ b/spec/lib/link_expansion_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe LinkExpansion do
 
   let(:content_id) { SecureRandom.uuid }
 
-  describe "#links_with_contetn" do
+  describe "#links_with_content" do
     subject do
       described_class.new(content_id,
         locale: :en,

--- a/spec/support/content_store_helpers.rb
+++ b/spec/support/content_store_helpers.rb
@@ -1,0 +1,10 @@
+module ContentStoreHelpers
+  def schemas_of_type(schema_type)
+    GovukSchemas::Schema.all
+      .select { |path, _| path.ends_with? "#{schema_type}.json" }
+  end
+end
+
+RSpec.configure do |c|
+  c.extend ContentStoreHelpers
+end


### PR DESCRIPTION
For some link types such as child and parent taxons, when a publishing app sends a patch links request to the publishing API, the publishing API updates the links for that document in the content store, and then updates the _reverse_ links in the linked document. This has a couple of implications:
- The publishing API adds extra, reverse links to documents, so these must be defined by the frontend schemas
- The publishing API is solely responsible for these reverse links, so they must _not_ be defined in the publisher schemas

This PR adds tests of those two conditions. I've added them in preparation for adding some more reverse link types.

The second test currently _fails_, which I wasn't expecting. There are collisions with existing links defined in a few of the schema:

 - case_study: policies
 - consultation: policies
 - detailed_guide: policies
 - news_article: policies
 - publication: policies
 - speech: policies
 - topic: children

I'll leave this PR open while we figure out whether we can fix these collisions. It'd still be good to get feedback on the tests, and whether they're worth adding to the project.

Trello: https://trello.com/c/eR1fhzlD/443-test-that-reverse-links-don-t-conflict-with-links-defined-in-publisher-schemas