### PR TITLE
Add Jenkins build parameters to support schema tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,17 +1,41 @@
 #!/usr/bin/env groovy
 
 REPOSITORY = 'publishing-api'
+DEFAULT_SCHEMA_BRANCH = 'deployed-to-production'
 
 node {
   def govuk = load '/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy'
 
+  properties([
+    [$class: 'ParametersDefinitionProperty',
+      parameterDefinitions: [
+        [$class: 'BooleanParameterDefinition',
+          name: 'IS_SCHEMA_TEST',
+          defaultValue: false,
+          description: 'Identifies whether this build is being triggered to test a change to the content schemas'],
+        [$class: 'StringParameterDefinition',
+          name: 'SCHEMA_BRANCH',
+          defaultValue: DEFAULT_SCHEMA_BRANCH,
+          description: 'The branch of govuk-content-schemas to test against']]
+    ],
+  ])
+
   try {
+    govuk.initializeParameters([
+      'IS_SCHEMA_TEST': 'false',
+      'SCHEMA_BRANCH': DEFAULT_SCHEMA_BRANCH,
+    ])
+
+    if (!govuk.isAllowedBranchBuild(env.BRANCH_NAME)) {
+      return
+    }
+
     stage("Build") {
       checkout scm
       govuk.cleanupGit()
       govuk.mergeMasterBranch()
       govuk.bundleApp()
-      govuk.contentSchemaDependency()
+      govuk.contentSchemaDependency(env.SCHEMA_BRANCH)
       govuk.setEnvar("GOVUK_CONTENT_SCHEMAS_PATH", "tmp/govuk-content-schemas")
       govuk.setEnvar("RAILS_ENV", "test")
       govuk.setEnvar("RCOV", "1")


### PR DESCRIPTION
Add build parameters to allow two types of builds:
 - Regular master and branch builds, which run against the deployed-to-production version of the content schemas.
 - Content schema downstream builds, which run the publishing-api deployed-to-production branch against a dev branch of the content schemas.

This will enable us to add publishing-api to the list of content schema downstream builds, so that it will not be possible to push a change to the content schemas which breaks the publishing-api tests.