### PR TITLE
Index edition on (document_type, updated_at)

### DIFF
--- a/db/migrate/20170223160956_index_document_type_updated_at.rb
+++ b/db/migrate/20170223160956_index_document_type_updated_at.rb
@@ -1,0 +1,8 @@
+class IndexDocumentTypeUpdatedAt < ActiveRecord::Migration[5.0]
+  disable_ddl_transaction!
+
+  def change
+    add_index :editions, [:document_type, :updated_at], algorithm: :concurrently
+    remove_index :editions, :document_type
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170223082047) do
+ActiveRecord::Schema.define(version: 20170223160956) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -86,7 +86,7 @@ ActiveRecord::Schema.define(version: 20170223082047) do
     t.index ["document_id", "state"], name: "index_editions_on_document_id_and_state", using: :btree
     t.index ["document_id", "user_facing_version"], name: "index_editions_on_document_id_and_user_facing_version", unique: true, using: :btree
     t.index ["document_id"], name: "index_editions_on_document_id", using: :btree
-    t.index ["document_type"], name: "index_editions_on_document_type", using: :btree
+    t.index ["document_type", "updated_at"], name: "index_editions_on_document_type_and_updated_at", using: :btree
     t.index ["last_edited_at"], name: "index_editions_on_last_edited_at", using: :btree
     t.index ["public_updated_at"], name: "index_editions_on_public_updated_at", using: :btree
     t.index ["publishing_app"], name: "index_editions_on_publishing_app", using: :btree


### PR DESCRIPTION
In `GET linkables` we check to see when the latest updated was to documents of a
particular type. This query can take some time to complete at the moment
because the document_type may not be updated very frequently, so the database
would have to scan through a lot of records if just using the updated_at index.

I think this means we can also remove the `document_type` index

cc @kevindew 