### PR TITLE
Pluck linkables

### DIFF
--- a/bench/linkables.rb
+++ b/bench/linkables.rb
@@ -8,7 +8,7 @@ require 'stackprof'
 
 abort "Refusing to run outside of development" unless Rails.env.development?
 
-benchmarks = Edition.where(document_type: ['taxon', 'organisation', 'topic', 'mainstream_browse_page', 'policy']).pluck(:document_type).uniq
+benchmarks = Edition.where(document_type: ['taxon', 'organisation', 'topic', 'mainstream_browse_page', 'policy', 'need']).pluck(:document_type).uniq
 
 benchmarks.each do |document_type|
   queries = 0


### PR DESCRIPTION
For a linkable type with lots of results the process of instantiating
thousands of ActiveRecord objects can add significantly to the time.

This changes this to pluck from the database rather than instantiate the
objects.

Benchmark before this:
```
vm  publishing-api git:(pluck-linkables) ruby bench/linkables.rb
organisation
..........  5.710000   0.430000   6.140000 (  9.272327)
queries: 45

topic
..........  2.360000   0.280000   2.640000 (  5.321053)
queries: 40

mainstream_browse_page
..........  1.150000   0.210000   1.360000 (  3.970612)
queries: 40

taxon
..........  1.000000   0.160000   1.160000 (  2.466987)
queries: 40

need
.......... 19.180000   1.500000  20.680000 ( 27.322240)
queries: 40

policy
..........  2.220000   0.210000   2.430000 (  4.896295)
queries: 40
```

Benchmark after this:
```
vm  publishing-api git:(pluck-linkables) ✗ ruby bench/linkables.rb
organisation
..........  0.930000   0.280000   1.210000 (  4.082884)
queries: 45

topic
..........  0.600000   0.220000   0.820000 (  3.356793)
queries: 40

mainstream_browse_page
..........  0.470000   0.210000   0.680000 (  3.127825)
queries: 40

taxon
..........  0.270000   0.140000   0.410000 (  1.736428)
queries: 40

need
..........  2.980000   0.600000   3.580000 (  9.859130)
queries: 40

policy
..........  0.390000   0.230000   0.620000 (  3.079350)
queries: 40
```

/cc @cbaines @matmoore