### PR TITLE
Compress memcache so we can store a bit more data

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -47,7 +47,7 @@ Rails.application.configure do
   # config.log_formatter = ::Logger::Formatter.new
 
   # use memcached on production
-  config.cache_store = :dalli_store, nil, { namespace: :publishing_api }
+  config.cache_store = :dalli_store, nil, { namespace: :publishing_api, compress: true }
 
   # Use a different logger for distributed setups.
   # config.logger = ActiveSupport::TaggedLogging.new(SyslogLogger.new)


### PR DESCRIPTION
We have a problem that we're limited to 1MB of cache storage for
Memcache and we're trying to cache > 1MB of needs. This adds compression
that reduces our cache sizes to be below 1MB. It's not really an ideal
as if the payload increases this cache will fail but it can be done
without having to investigate any infrastructure changes.