### PR TITLE
Delete some corrupt content items

### DIFF
--- a/db/migrate/20170227130411_clear_some_content_to_allow_whitehall_republishing.rb
+++ b/db/migrate/20170227130411_clear_some_content_to_allow_whitehall_republishing.rb
@@ -1,0 +1,13 @@
+require_relative "helpers/delete_content"
+class ClearSomeContentToAllowWhitehallRepublishing < ActiveRecord::Migration[5.0]
+  def up
+    content_ids = [
+      #/government/statistics/how-he-statistics-are-used
+      "5c848d93-7631-11e4-a3cb-005056011aef",
+      #/government/publications/mod-desg-graduate-trainee
+      "5c9034ed-7631-11e4-a3cb-005056011aef",
+    ]
+
+    Helpers::DeleteContent.destroy_documents_with_links(content_ids)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170223160956) do
+ActiveRecord::Schema.define(version: 20170227130411) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
This commit adds a migration to delete two content items that have become corrupt leading to Whitehall not being able to republish them.

The associated Whitehall documents will be republished once this migration has run.