### PR TITLE
Refactor GetLinkables to be a single query

### DIFF
--- a/app/queries/get_linkables.rb
+++ b/app/queries/get_linkables.rb
@@ -1,5 +1,5 @@
 module Queries
-  LinkablePresenter = Struct.new(:title, :content_id, :publication_state, :base_path, :internal_name)
+  LinkablePresenter = Struct.new(:content_id, :title, :publication_state, :base_path, :internal_name)
 
   class GetLinkables
     def initialize(document_type:)
@@ -15,30 +15,31 @@ module Queries
         .last
 
       Rails.cache.fetch ["linkables", document_type, latest_updated_at] do
-        edition_ids = Queries::GetEditionIdsWithFallbacks.(
-          Edition.with_document.distinct.where(
-            document_type: [document_type, "placeholder_#{document_type}"]
-          ).pluck('documents.content_id'),
-          state_fallback_order: [:published, :draft]
-        )
-
-        Edition.with_document
-          .where(id: edition_ids)
-          .pluck(:title, :content_id, :state, :base_path, "COALESCE(details->>'internal_name', title)")
-          .map do |(title, content_id, state, base_path, internal_name)|
-            LinkablePresenter.new(
-              title,
-              content_id,
-              state,
-              base_path,
-              internal_name,
-            )
-          end
+        linkables_query(document_type)
+          .map { |result| LinkablePresenter.new(*result) }
       end
     end
 
   private
 
     attr_reader :document_type
+
+    def linkables_query(document_type)
+      Edition.with_document
+        .where(
+          document_type: [document_type, "placeholder_#{document_type}"],
+          state: %w(published draft),
+          "documents.locale": "en",
+        )
+        .order("documents.content_id ASC")
+        .order("CASE editions.state WHEN 'published' THEN 0 ELSE 1 END")
+        .pluck(
+          "DISTINCT ON (documents.content_id) documents.content_id",
+          :title,
+          :state,
+          :base_path,
+          "COALESCE(details->>'internal_name', title)"
+        )
+    end
   end
 end

--- a/spec/queries/get_linkables.rb
+++ b/spec/queries/get_linkables.rb
@@ -1,0 +1,175 @@
+require "rails_helper"
+
+RSpec.describe Queries::GetLinkables do
+  let(:document_type) { "contact" }
+
+  describe "#call" do
+    before { Rails.cache.clear }
+
+    subject(:linkables) { described_class.new(document_type: document_type).call }
+
+    context "when there is a single edition" do
+      let(:base_path) { "/path" }
+      let(:content_id) { SecureRandom.uuid }
+      let(:internal_name) { "Internal Name" }
+      let(:title) { "Title" }
+      before do
+        FactoryGirl.create(:live_edition,
+          base_path: base_path,
+          details: { internal_name: internal_name },
+          document: FactoryGirl.create(:document, content_id: content_id),
+          document_type: document_type,
+          title: title,
+        )
+      end
+
+      it "returns an array of linkable presenters" do
+        expect(linkables).to match_array([
+          an_instance_of(Queries::LinkablePresenter)
+        ])
+      end
+
+      it "returns the expected linkable" do
+        expect(linkables.first.to_h).to eq(
+          base_path: base_path,
+          content_id: content_id,
+          internal_name: internal_name,
+          publication_state: "published",
+          title: title,
+        )
+      end
+
+      context "and there isn't an internal name given" do
+        let(:internal_name) { nil }
+
+        it "returns title instead of internal_name" do
+          expect(linkables.first.to_h).to match(
+            a_hash_including(internal_name: title)
+          )
+        end
+      end
+    end
+
+    context "when there are a number of editions matching a document_type" do
+      let!(:editions) do
+        3.times.map { FactoryGirl.create(:live_edition, document_type: document_type) }
+      end
+      let(:edition_content_ids) { editions.map { |e| e.document.content_id } }
+
+      it "returns an array of LinkablePresenter" do
+        expect(linkables).to match_array([
+          an_instance_of(Queries::LinkablePresenter),
+          an_instance_of(Queries::LinkablePresenter),
+          an_instance_of(Queries::LinkablePresenter),
+        ])
+      end
+
+      it "returns the editions" do
+        expect(linkables.map(&:content_id)).to match_array(edition_content_ids)
+      end
+    end
+
+    context "when there is a an edition with a placeholder of the document_type" do
+      let!(:editions) do
+        [
+          FactoryGirl.create(:live_edition, document_type: "contact"),
+          FactoryGirl.create(:live_edition, document_type: "placeholder_contact"),
+        ]
+      end
+      let(:edition_content_ids) { editions.map { |e| e.document.content_id } }
+
+      it "returns both linkables" do
+        expect(linkables.length).to be(2)
+      end
+
+      it "returns the editions" do
+        expect(linkables.map(&:content_id)).to match_array(edition_content_ids)
+      end
+    end
+
+    context "when there is a an edition with a different document_type" do
+      before do
+        FactoryGirl.create(:live_edition, document_type: "different")
+      end
+
+      it { is_expected.to be_empty }
+    end
+
+    context "when the edition is not available in English" do
+      before do
+        FactoryGirl.create(:live_edition,
+          document_type: document_type,
+          document: FactoryGirl.create(:document, locale: "fr"),
+        )
+      end
+
+      it { is_expected.to be_empty }
+    end
+
+    context "when the edition is available in English and French" do
+      let(:content_id) { SecureRandom.uuid }
+      before do
+        FactoryGirl.create(:live_edition,
+          document_type: document_type,
+          title: "Hello",
+          document: FactoryGirl.create(:document, content_id: content_id)
+        )
+        FactoryGirl.create(:live_edition,
+          document_type: document_type,
+          title: "Salut",
+          document: FactoryGirl.create(:document, content_id: content_id, locale: "fr"),
+        )
+      end
+
+      it "has the english title" do
+        expect(linkables.map(&:title)).to match_array(["Hello"])
+      end
+    end
+
+    context "when the edition is available in draft" do
+      let(:document) { FactoryGirl.create(:document) }
+      let!(:draft_edition) do
+        FactoryGirl.create(:draft_edition,
+          document_type: document_type,
+          title: "Draft",
+          document: document,
+          user_facing_version: 2,
+        )
+      end
+
+      it "has the draft edition" do
+        expect(linkables.map(&:title)).to match_array(["Draft"])
+      end
+
+      context "and there is a published edition" do
+        let!(:published_edition) do
+          FactoryGirl.create(:live_edition,
+            document_type: document_type,
+            title: "Published",
+            document: document,
+          )
+        end
+
+        it "has the published edition" do
+          expect(linkables.map(&:title)).to match_array(["Published"])
+        end
+      end
+    end
+
+    context "when an edition is unpublished" do
+      before do
+        FactoryGirl.create(:unpublished_edition, document_type: document_type)
+      end
+
+      it { is_expected.to be_empty }
+    end
+
+    context "when an edition is superseded" do
+      before do
+        FactoryGirl.create(:superseded_edition, document_type: document_type)
+      end
+
+      it { is_expected.to be_empty }
+    end
+  end
+end


### PR DESCRIPTION
With tests for GetLinkables

Before:
```
vm  publishing-api git:(e93e614) ruby bench/linkables.rb
mainstream_browse_page
..........  0.270000   0.160000   0.430000 (  1.822024)
queries: 45

need
..........  2.630000   0.340000   2.970000 (  6.390978)
queries: 40

organisation
..........  0.790000   0.140000   0.930000 (  2.792776)
queries: 40

policy
..........  0.340000   0.070000   0.410000 (  1.613873)
queries: 40

taxon
..........  0.260000   0.090000   0.350000 (  1.552737)
queries: 40

topic
..........  0.440000   0.080000   0.520000 (  1.929325)
queries: 40
```

After:
```
vm  publishing-api git:(single-linkables-query) ruby bench/linkables.rb
mainstream_browse_page
..........  0.080000   0.020000   0.100000 (  0.240875)
queries: 22

need
..........  0.900000   0.120000   1.020000 (  1.402184)
queries: 20

organisation
..........  0.220000   0.030000   0.250000 (  0.408201)
queries: 20

policy
..........  0.060000   0.010000   0.070000 (  0.162763)
queries: 20

taxon
..........  0.040000   0.000000   0.040000 (  0.075444)
queries: 20

topic
..........  0.100000   0.010000   0.110000 (  0.233104)
queries: 20
```