### PR TITLE
Resolve orphaned edition links

### DIFF
--- a/app/workers/dependency_resolution_worker.rb
+++ b/app/workers/dependency_resolution_worker.rb
@@ -11,9 +11,7 @@ class DependencyResolutionWorker
       send_downstream(content_id, locale)
     end
 
-    # FIXME: we need to do all locales not just 'en'
-    # make sure we update this when we come to edition level implementation.
-    orphaned_content_ids.each { |content_id| send_downstream(content_id, "en") }
+    orphaned_content_ids.each { |content_id| send_downstream(content_id, locale) }
   end
 
 private


### PR DESCRIPTION
Make sure we update the dependencies of the edition links that we have
removed and pass them down to the dependency resolution worker.

https://trello.com/c/zEnaap6p/882-bug-dependency-resolution-misses-reverse-links-in-orphaned-nodes-blocking-finding-things