### PR TITLE
Support expanding nested fields

### DIFF
--- a/lib/link_expansion/rules.rb
+++ b/lib/link_expansion/rules.rb
@@ -109,13 +109,16 @@ module LinkExpansion::Rules
   end
 
   def potential_expansion_fields(document_type)
-    find_custom_expansion_fields(document_type) || DEFAULT_FIELDS
+    (find_custom_expansion_fields(document_type) || DEFAULT_FIELDS).map do |field|
+      Array(field).first
+    end
   end
 
   def expand_fields(edition, link_type)
-    edition.to_h.slice(
-      *expansion_fields(edition.document_type, link_type)
-    )
+    expansion_fields(edition.document_type, link_type).each_with_object({}) do |field, expanded|
+      field = Array(field)
+      expanded[field.last] = edition.to_h.dig(*field)
+    end
   end
 
   def valid_link_expansion_link_types_path?(link_types_path)

--- a/lib/link_expansion/rules.rb
+++ b/lib/link_expansion/rules.rb
@@ -54,6 +54,7 @@ module LinkExpansion::Rules
     { document_type: :taxon,                      fields: DEFAULT_FIELDS_WITH_DETAILS },
     { document_type: :need,                       fields: DEFAULT_FIELDS_WITH_DETAILS },
     { document_type: :finder, link_type: :finder, fields: DEFAULT_FIELDS_WITH_DETAILS },
+    { document_type: :travel_advice,              fields: DEFAULT_FIELDS + [[:details, :country], [:details, :change_description]] },
   ].freeze
 
   def root_reverse_links


### PR DESCRIPTION
This came out of an investigation about how we would render the travel advice index via link expansion. To do that, we would need the country and change description elements from the details hashes to be present in the expanded links - but we wouldn't want the entire details, as that would result in 225 entire documents being embedded in the index.

The proposal is to allow elements in the list of CUSTOM_FIELDS_FOR_DOCUMENT_TYPE to be arrays; the expand_fields method would then follow the array and extract the element, using the last name in the array as the key in the expanded hash.

Opinions welcome (on the principle, not necessarily the implementation).