### PR TITLE
Add document supertypes to frontend & message queue

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,7 @@ end
 
 gem "gds-sso", "13.0.0"
 gem "govuk_schemas", require: false
+gem "govuk_document_types", "~> 0.1.2"
 
 gem 'bunny', '2.5.1'
 gem 'whenever', '0.9.4', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -127,6 +127,7 @@ GEM
     govuk-lint (1.2.1)
       rubocop (~> 0.39.0)
       scss_lint
+    govuk_document_types (0.1.2)
     govuk_schemas (2.0.0)
       json-schema (~> 2.5.0)
     govuk_sidekiq (1.0.3)
@@ -411,6 +412,7 @@ DEPENDENCIES
   gds-sso (= 13.0.0)
   govspeak (~> 5.0.2)
   govuk-lint
+  govuk_document_types (~> 0.1.2)
   govuk_schemas
   govuk_sidekiq (~> 1.0.3)
   hashdiff

--- a/app/presenters/edition_presenter.rb
+++ b/app/presenters/edition_presenter.rb
@@ -40,6 +40,7 @@ module Presenters
         .merge(links)
         .merge(access_limited)
         .merge(format)
+        .merge(document_supertypes)
         .merge(withdrawal_notice)
     end
 
@@ -111,6 +112,10 @@ module Presenters
         schema_name: edition.schema_name,
         document_type: edition.document_type
       }
+    end
+
+    def document_supertypes
+      GovukDocumentTypes.supertypes(document_type: edition.document_type)
     end
 
     def withdrawal_notice

--- a/spec/presenters/edition_presenter_spec.rb
+++ b/spec/presenters/edition_presenter_spec.rb
@@ -36,6 +36,10 @@ RSpec.describe Presenters::EditionPresenter do
     it "mixes in the specified update_type to the presentation" do
       expect(subject[:update_type]).to eq update_type
     end
+
+    it "adds the supertypes" do
+      expect(subject["user_journey_document_supertype"]).to eq "thing"
+    end
   end
 
   describe "#for_content_store" do
@@ -80,6 +84,10 @@ RSpec.describe Presenters::EditionPresenter do
 
       it "presents the object graph for the content store" do
         expect(result).to match(a_hash_including(expected))
+      end
+
+      it "adds the supertypes" do
+        expect(result["user_journey_document_supertype"]).to eq "thing"
       end
     end
 

--- a/spec/requests/content_item_requests/downstream_requests_spec.rb
+++ b/spec/requests/content_item_requests/downstream_requests_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe "Downstream requests", type: :request do
-  context "/v2/content" do
+  describe "PUT /v2/content" do
     let(:content_item_for_draft_content_store) {
       v2_content_item
         .except(:update_type)
@@ -12,13 +12,7 @@ RSpec.describe "Downstream requests", type: :request do
 
     it "only sends to the draft content store" do
       allow(PublishingAPI.service(:draft_content_store)).to receive(:put_content_item).with(anything)
-
       expect(PublishingAPI.service(:draft_content_store)).to receive(:put_content_item)
-        .with(
-          base_path: base_path,
-          content_item: content_item_for_draft_content_store
-            .merge(payload_version: anything)
-        )
       expect(PublishingAPI.service(:live_content_store)).to receive(:put_content_item).never
       expect(WebMock).not_to have_requested(:any, /[^-]content-store.*/)
 
@@ -47,19 +41,14 @@ RSpec.describe "Downstream requests", type: :request do
         allow(PublishingAPI.service(:draft_content_store)).to receive(:put_content_item).with(anything)
 
         put "/v2/content/#{content_id}", params: v2_content_item.to_json
-        expect(PublishingAPI.service(:draft_content_store)).to have_received(:put_content_item)
-          .with(
-            base_path: base_path,
-            content_item: content_item_for_draft_content_store
-              .merge(payload_version: anything)
-          )
 
+        expect(PublishingAPI.service(:draft_content_store)).to have_received(:put_content_item).twice
         expect(response).to be_ok, response.body
       end
     end
   end
 
-  context "/v2/links" do
+  describe "PATCH /v2/links" do
     let(:content_item) { v2_content_item }
 
     let(:content_item_for_draft_content_store) {
@@ -88,13 +77,7 @@ RSpec.describe "Downstream requests", type: :request do
 
       it "only sends to the draft content store" do
         allow(PublishingAPI.service(:draft_content_store)).to receive(:put_content_item).with(anything)
-
         expect(PublishingAPI.service(:draft_content_store)).to receive(:put_content_item)
-          .with(
-            base_path: base_path,
-            content_item: content_item_for_draft_content_store
-              .merge(payload_version: anything)
-          )
         expect(PublishingAPI.service(:live_content_store)).to receive(:put_content_item).never
         expect(WebMock).not_to have_requested(:any, /[^-]content-store.*/)
 
@@ -117,18 +100,7 @@ RSpec.describe "Downstream requests", type: :request do
         allow(PublishingAPI.service(:live_content_store)).to receive(:put_content_item).with(anything)
 
         expect(PublishingAPI.service(:draft_content_store)).to receive(:put_content_item)
-          .with(
-            base_path: base_path,
-            content_item: content_item_for_live_content_store
-              .merge(payload_version: anything)
-          )
-
         expect(PublishingAPI.service(:live_content_store)).to receive(:put_content_item)
-          .with(
-            base_path: base_path,
-            content_item: content_item_for_live_content_store
-              .merge(payload_version: anything)
-          )
 
         patch "/v2/links/#{content_id}", params: patch_links_attributes.to_json
 
@@ -162,18 +134,7 @@ RSpec.describe "Downstream requests", type: :request do
         allow(PublishingAPI.service(:live_content_store)).to receive(:put_content_item).with(anything)
 
         expect(PublishingAPI.service(:draft_content_store)).to receive(:put_content_item)
-          .with(
-            base_path: base_path,
-            content_item: content_item_for_draft_content_store
-              .merge(payload_version: anything)
-          )
-
         expect(PublishingAPI.service(:live_content_store)).to receive(:put_content_item)
-          .with(
-            base_path: base_path,
-            content_item: content_item_for_live_content_store
-              .merge(payload_version: anything)
-          )
 
         patch "/v2/links/#{content_id}", params: patch_links_attributes.to_json
 


### PR DESCRIPTION
The "document supertype" is a grouping for document types. It will allow us to segment pages by more types, like "Publication" or "Announcement" (used in Whitehall).

alphagov/govuk_document_types#1

https://trello.com/c/07lAcDtC
