### PR TITLE
[DO NOT MERGE] Allow lookup requests to return draft content

### DIFF
--- a/app/controllers/lookups_controller.rb
+++ b/app/controllers/lookups_controller.rb
@@ -9,7 +9,9 @@ class LookupsController < ApplicationController
 
     base_paths_and_content_ids = Edition.with_document
       .left_outer_joins(:unpublishing)
+      .left_outer_joins(:access_limit)
       .where(base_path: base_paths)
+      .where("access_limits.edition_id IS NULL")
       .where("state IN ('published', 'draft') OR (state = 'unpublished' AND unpublishings.type = 'withdrawal')")
       .where("document_type NOT IN ('gone', 'redirect')")
       .order(:base_path)

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -37,6 +37,7 @@ class Edition < ApplicationRecord
   belongs_to :document
   has_one :unpublishing
   has_many :links
+  has_many :access_limit
 
   scope :renderable_content, -> { where.not(document_type: NON_RENDERABLE_FORMATS) }
   scope :with_document, -> { joins(:document) }

--- a/spec/requests/lookups_spec.rb
+++ b/spec/requests/lookups_spec.rb
@@ -11,69 +11,125 @@ RSpec.describe "POST /lookup-by-base-path", type: :request do
     end
   end
 
-  context "returning content_ids" do
-    it "returns content_ids for user-visible states (published, withdrawn)" do
-      create_test_content
+  context "with content in different states" do
+    let(:published_with_new_draft) {FactoryGirl.create(:document, content_id: "aa491126-77ed-4e81-91fa-8dc7f74e9657")}
+    let(:published_with_no_drafts) {FactoryGirl.create(:document, content_id: "bbabcd3c-7c45-4403-8490-db51e4bfc4f6")}
+    let(:two_initial_drafts) {FactoryGirl.create(:document, content_id: "dd1bf833-f91c-4e45-9f97-87b165808176")}
+    let(:redirected) {FactoryGirl.create(:document, content_id: "ee491126-77ed-4e81-91fa-8dc7f74e9657")}
+    let(:gone) {FactoryGirl.create(:document, content_id: "ffabcd3c-7c45-4403-8490-db51e4bfc4f6")}
+    let(:withdrawn) {FactoryGirl.create(:document, content_id: "00abcd3c-7c45-4403-8490-db51e4bfc4f6")}
+    let(:initial_draft) {FactoryGirl.create(:document, content_id: "01abcd3c-7c45-4403-8490-db51e4bfc4f6")}
+    let(:unpublished_without_draft) {FactoryGirl.create(:document, content_id: "02abcd3c-7c45-4403-8490-db51e4bfc4f6")}
+    let(:reused_base_path) {FactoryGirl.create(:document, content_id: "03abcd3c-7c45-4403-8490-db51e4bfc4f6")}
+
+    before do
+      FactoryGirl.create(:live_edition, state: "published", base_path: "/published-and-draft-page", document: published_with_new_draft, user_facing_version: 1)
+      FactoryGirl.create(:edition, state: "draft", base_path: "/published-and-draft-page", document: published_with_new_draft, user_facing_version: 2)
+      FactoryGirl.create(:live_edition, state: "published", base_path: "/only-published-page", document: published_with_no_drafts)
+      FactoryGirl.create(:edition, state: "draft", base_path: "/draft-and-superseded-page", document: two_initial_drafts, user_facing_version: 2)
+      FactoryGirl.create(:superseded_edition, state: "superseded", base_path: "/draft-and-superseded-page", document: two_initial_drafts, user_facing_version: 1)
+      FactoryGirl.create(:edition, state: "draft", base_path: "/only-draft-page", document: initial_draft, user_facing_version: 1)
+
+      unpublished1 = FactoryGirl.create(:live_edition, state: "published", base_path: "/redirected-from-page", document: redirected, user_facing_version: 1)
+      unpublished1.unpublish(type: "redirect", alternative_path: "/redirected-to-page")
+
+      unpublished2 = FactoryGirl.create(:live_edition, state: "published", base_path: "/gone-page", document: gone, user_facing_version: 1)
+      unpublished2.unpublish(type: "gone")
+
+      unpublished3 = FactoryGirl.create(:live_edition, state: "published", base_path: "/withdrawn-page", document: withdrawn, user_facing_version: 1)
+      unpublished3.unpublish(type: "withdrawal", explanation: "Consolidated into another page")
+    end
+
+    it "includes published pages" do
+      post "/lookup-by-base-path", params: { base_paths: %w(/only-published-page) }
+
+      expect(parsed_response).to eql(
+        "/only-published-page" => published_with_no_drafts.content_id,
+      )
+    end
+
+    it "includes draft pages" do
+      post "/lookup-by-base-path", params: { base_paths: %w(/only-draft-page) }
+
+      expect(parsed_response).to eql(
+        "/only-draft-page" => initial_draft.content_id,
+      )
+    end
+
+    it "includes withdrawn pages" do
+      post "/lookup-by-base-path", params: { base_paths: %w(/withdrawn-page) }
+
+      expect(parsed_response).to eql(
+        "/withdrawn-page" => withdrawn.content_id
+      )
+    end
+
+    it "picks withdrawn editions over drafts if the base path has been reused" do
+      replacement = FactoryGirl.create(:document, content_id: "ab491126-77ed-4e81-91fa-8dc7f74e9657")
+      FactoryGirl.create(:edition, state: "draft", base_path: "/withdrawn-page", document: replacement, user_facing_version: 1)
+
+      post "/lookup-by-base-path", params: { base_paths: %w(/withdrawn-page) }
+
+      expect(parsed_response).to eql(
+        "/withdrawn-page" => withdrawn.content_id
+      )
+    end
+
+    it "picks published editions over drafts if the base path has been reused" do
+      replacement = FactoryGirl.create(:document, content_id: "ab491126-77ed-4e81-91fa-8dc7f74e9657")
+      FactoryGirl.create(:edition, state: "draft", base_path: "/only-published-page", document: replacement, user_facing_version: 1)
+
+      post "/lookup-by-base-path", params: { base_paths: %w(/only-published-page) }
+
+      expect(parsed_response).to eql(
+        "/only-published-page" => published_with_no_drafts.content_id
+      )
+    end
+
+    it "excludes unpublished content that is not withdrawn" do
+      post "/lookup-by-base-path", params: { base_paths: %w(redirected-from-page gone-page) }
+
+      expect(parsed_response).to eql({})
+    end
+
+    it "looks up multiple base paths and returns the ones that match" do
+      test_base_paths = [
+        "/published-and-draft-page",
+        "/only-published-page",
+        "/draft-and-superseded-page",
+        "/does-not-exist",
+        "/redirected-from-page",
+        "/gone-page",
+        "/withdrawn-page",
+        "/only-draft-page"
+      ]
 
       post "/lookup-by-base-path", params: { base_paths: test_base_paths }
 
       expect(parsed_response).to eql(
-        "/published-and-draft-page" => "aa491126-77ed-4e81-91fa-8dc7f74e9657",
-        "/only-published-page" => "bbabcd3c-7c45-4403-8490-db51e4bfc4f6",
-        "/withdrawn-page" => "00abcd3c-7c45-4403-8490-db51e4bfc4f6"
+        "/draft-and-superseded-page" => two_initial_drafts.content_id,
+        "/published-and-draft-page" => published_with_new_draft.content_id,
+        "/only-published-page" => published_with_no_drafts.content_id,
+        "/withdrawn-page" => withdrawn.content_id,
+        "/only-draft-page" => initial_draft.content_id,
       )
     end
-
-    it "excludes redirect content items" do
-      FactoryGirl.create(:redirect_edition, state: "published", base_path: "/redirect-page", user_facing_version: 1)
-
-      post "/lookup-by-base-path", params: { base_paths: %w(/redirect-page) }
-
-      expect(parsed_response).to eql({})
-    end
-
-    it "excludes gone content items" do
-      FactoryGirl.create(:gone_edition, state: "published", base_path: "/gone-page", user_facing_version: 1)
-
-      post "/lookup-by-base-path", params: { base_paths: %w(/gone-page) }
-
-      expect(parsed_response).to eql({})
-    end
   end
 
-  def create_test_content
-    doc1 = FactoryGirl.create(:document, content_id: "aa491126-77ed-4e81-91fa-8dc7f74e9657")
-    doc2 = FactoryGirl.create(:document, content_id: "bbabcd3c-7c45-4403-8490-db51e4bfc4f6")
-    doc3 = FactoryGirl.create(:document, content_id: "dd1bf833-f91c-4e45-9f97-87b165808176")
-    doc4 = FactoryGirl.create(:document, content_id: "ee491126-77ed-4e81-91fa-8dc7f74e9657")
-    doc5 = FactoryGirl.create(:document, content_id: "ffabcd3c-7c45-4403-8490-db51e4bfc4f6")
-    doc6 = FactoryGirl.create(:document, content_id: "00abcd3c-7c45-4403-8490-db51e4bfc4f6")
+  it "excludes content items with document_type redirect" do
+    FactoryGirl.create(:redirect_edition, state: "published", base_path: "/redirect-page", user_facing_version: 1)
 
-    FactoryGirl.create(:live_edition, state: "published", base_path: "/published-and-draft-page", document: doc1, user_facing_version: 1)
-    FactoryGirl.create(:edition, state: "draft", base_path: "/published-and-draft-page", document: doc1, user_facing_version: 2)
-    FactoryGirl.create(:live_edition, state: "published", base_path: "/only-published-page", document: doc2)
-    FactoryGirl.create(:edition, state: "draft", base_path: "/draft-and-superseded-page", document: doc3, user_facing_version: 2)
-    FactoryGirl.create(:superseded_edition, state: "superseded", base_path: "/draft-and-superseded-page", document: doc3, user_facing_version: 1)
+    post "/lookup-by-base-path", params: { base_paths: %w(/redirect-page) }
 
-    unpublished1 = FactoryGirl.create(:live_edition, state: "published", base_path: "/redirected-from-page", document: doc4, user_facing_version: 1)
-    unpublished1.unpublish(type: "redirect", alternative_path: "/redirected-to-page")
-
-    unpublished2 = FactoryGirl.create(:live_edition, state: "published", base_path: "/gone-page", document: doc5, user_facing_version: 1)
-    unpublished2.unpublish(type: "gone")
-
-    unpublished3 = FactoryGirl.create(:live_edition, state: "published", base_path: "/withdrawn-page", document: doc6, user_facing_version: 1)
-    unpublished3.unpublish(type: "withdrawal", explanation: "Consolidated into another page")
+    expect(parsed_response).to eql({})
   end
 
-  def test_base_paths
-    [
-      "/published-and-draft-page",
-      "/only-published-page",
-      "/draft-and-superseded-page",
-      "/does-not-exist",
-      "/redirected-from-page",
-      "/gone-page",
-      "/withdrawn-page"
-    ]
+  it "excludes content items with document_type gone" do
+    FactoryGirl.create(:gone_edition, state: "published", base_path: "/gone-page", user_facing_version: 1)
+
+    post "/lookup-by-base-path", params: { base_paths: %w(/gone-page) }
+
+    expect(parsed_response).to eql({})
   end
+
 end

--- a/spec/requests/lookups_spec.rb
+++ b/spec/requests/lookups_spec.rb
@@ -12,15 +12,15 @@ RSpec.describe "POST /lookup-by-base-path", type: :request do
   end
 
   context "with content in different states" do
-    let(:published_with_new_draft) {FactoryGirl.create(:document, content_id: "aa491126-77ed-4e81-91fa-8dc7f74e9657")}
-    let(:published_with_no_drafts) {FactoryGirl.create(:document, content_id: "bbabcd3c-7c45-4403-8490-db51e4bfc4f6")}
-    let(:two_initial_drafts) {FactoryGirl.create(:document, content_id: "dd1bf833-f91c-4e45-9f97-87b165808176")}
-    let(:redirected) {FactoryGirl.create(:document, content_id: "ee491126-77ed-4e81-91fa-8dc7f74e9657")}
-    let(:gone) {FactoryGirl.create(:document, content_id: "ffabcd3c-7c45-4403-8490-db51e4bfc4f6")}
-    let(:withdrawn) {FactoryGirl.create(:document, content_id: "00abcd3c-7c45-4403-8490-db51e4bfc4f6")}
-    let(:initial_draft) {FactoryGirl.create(:document, content_id: "01abcd3c-7c45-4403-8490-db51e4bfc4f6")}
-    let(:unpublished_without_draft) {FactoryGirl.create(:document, content_id: "02abcd3c-7c45-4403-8490-db51e4bfc4f6")}
-    let(:reused_base_path) {FactoryGirl.create(:document, content_id: "03abcd3c-7c45-4403-8490-db51e4bfc4f6")}
+    let(:published_with_new_draft) { FactoryGirl.create(:document, content_id: "aa491126-77ed-4e81-91fa-8dc7f74e9657") }
+    let(:published_with_no_drafts) { FactoryGirl.create(:document, content_id: "bbabcd3c-7c45-4403-8490-db51e4bfc4f6") }
+    let(:two_initial_drafts) { FactoryGirl.create(:document, content_id: "dd1bf833-f91c-4e45-9f97-87b165808176") }
+    let(:redirected) { FactoryGirl.create(:document, content_id: "ee491126-77ed-4e81-91fa-8dc7f74e9657") }
+    let(:gone) { FactoryGirl.create(:document, content_id: "ffabcd3c-7c45-4403-8490-db51e4bfc4f6") }
+    let(:withdrawn) { FactoryGirl.create(:document, content_id: "00abcd3c-7c45-4403-8490-db51e4bfc4f6") }
+    let(:initial_draft) { FactoryGirl.create(:document, content_id: "01abcd3c-7c45-4403-8490-db51e4bfc4f6") }
+    let(:unpublished_without_draft) { FactoryGirl.create(:document, content_id: "02abcd3c-7c45-4403-8490-db51e4bfc4f6") }
+    let(:reused_base_path) { FactoryGirl.create(:document, content_id: "03abcd3c-7c45-4403-8490-db51e4bfc4f6") }
 
     before do
       FactoryGirl.create(:live_edition, state: "published", base_path: "/published-and-draft-page", document: published_with_new_draft, user_facing_version: 1)
@@ -117,7 +117,7 @@ RSpec.describe "POST /lookup-by-base-path", type: :request do
   end
 
   it "excludes content items with document_type redirect" do
-    FactoryGirl.create(:redirect_edition, state: "published", base_path: "/redirect-page", user_facing_version: 1)
+    FactoryGirl.create(:redirect_edition, state: "published", base_path: "/redirect-page")
 
     post "/lookup-by-base-path", params: { base_paths: %w(/redirect-page) }
 
@@ -125,11 +125,18 @@ RSpec.describe "POST /lookup-by-base-path", type: :request do
   end
 
   it "excludes content items with document_type gone" do
-    FactoryGirl.create(:gone_edition, state: "published", base_path: "/gone-page", user_facing_version: 1)
+    FactoryGirl.create(:gone_edition, state: "published", base_path: "/gone-page")
 
     post "/lookup-by-base-path", params: { base_paths: %w(/gone-page) }
 
     expect(parsed_response).to eql({})
   end
 
+  it "excludes access-limited editions" do
+    FactoryGirl.create(:access_limited_edition, base_path: "/access-limited")
+
+    post "/lookup-by-base-path", params: { base_paths: %w(/access-limited) }
+
+    expect(parsed_response).to eql({})
+  end
 end


### PR DESCRIPTION
We want to be able to tag to draft content in content tagger.

For example, content tagger is now the only way to tag certain things to mainstream content (eg need ids).

This breaks at the moment because we can't lookup the content, which affects both bulk tagging and the regular tagging workflow.

I've made it return all drafts that don't have an access limit.

https://trello.com/c/6VPQcc7C/507-content-tagger-should-be-able-to-tag-to-the-first-draft-of-a-document

We shouldn't merge this until we've made content tagger handle drafts (show the state, and replace live links with draft-origin links).