### PR TITLE
Link expansion on document type

### DIFF
--- a/lib/link_expansion.rb
+++ b/lib/link_expansion.rb
@@ -46,7 +46,7 @@ private
   def link_content(node)
     edition = content_cache.find(node.content_id)
     return if !edition || !should_link?(node.link_type, edition)
-    rules.expand_fields(edition).tap do |expanded|
+    rules.expand_fields(edition, node.link_type).tap do |expanded|
       links = populate_links(node.links)
       auto_reverse = auto_reverse_link(node)
       expanded.merge!(links: (auto_reverse || {}).merge(links))
@@ -60,7 +60,7 @@ private
     edition = content_cache.find(content_id)
     return if !edition || !should_link?(node.link_type, edition)
     un_reverse_link_type = rules.un_reverse_link_type(node.link_types_path.first)
-    { un_reverse_link_type => [rules.expand_fields(edition).merge(links: {})] }
+    { un_reverse_link_type => [rules.expand_fields(edition, un_reverse_link_type).merge(links: {})] }
   end
 
   def should_link?(link_type, edition)

--- a/lib/link_expansion/rules.rb
+++ b/lib/link_expansion/rules.rb
@@ -53,6 +53,7 @@ module LinkExpansion::Rules
     { document_type: :placeholder_organisation,   fields: DEFAULT_FIELDS_WITH_DETAILS },
     { document_type: :taxon,                      fields: DEFAULT_FIELDS_WITH_DETAILS },
     { document_type: :need,                       fields: DEFAULT_FIELDS_WITH_DETAILS },
+    { document_type: :finder, link_type: :finder, fields: DEFAULT_FIELDS_WITH_DETAILS },
   ].freeze
 
   def root_reverse_links

--- a/lib/link_expansion/rules.rb
+++ b/lib/link_expansion/rules.rb
@@ -42,16 +42,18 @@ module LinkExpansion::Rules
     :withdrawn,
   ].freeze
 
-  CUSTOM_FIELDS_FOR_DOCUMENT_TYPE = {
-    redirect: [],
-    gone: [],
-    topical_event: DEFAULT_FIELDS + [:details],
-    placeholder_topical_event: DEFAULT_FIELDS + [:details],
-    organisation: DEFAULT_FIELDS + [:details],
-    placeholder_organisation: DEFAULT_FIELDS + [:details],
-    taxon: DEFAULT_FIELDS + [:details],
-    need: DEFAULT_FIELDS + [:details],
-  }.freeze
+  DEFAULT_FIELDS_WITH_DETAILS = (DEFAULT_FIELDS + [:details]).freeze
+
+  CUSTOM_EXPANSION_FIELDS = [
+    { document_type: :redirect,                   fields: [] },
+    { document_type: :gone,                       fields: [] },
+    { document_type: :topical_event,              fields: DEFAULT_FIELDS_WITH_DETAILS },
+    { document_type: :placeholder_topical_event,  fields: DEFAULT_FIELDS_WITH_DETAILS },
+    { document_type: :organisation,               fields: DEFAULT_FIELDS_WITH_DETAILS },
+    { document_type: :placeholder_organisation,   fields: DEFAULT_FIELDS_WITH_DETAILS },
+    { document_type: :taxon,                      fields: DEFAULT_FIELDS_WITH_DETAILS },
+    { document_type: :need,                       fields: DEFAULT_FIELDS_WITH_DETAILS },
+  ].freeze
 
   def root_reverse_links
     REVERSE_LINKS.values
@@ -89,13 +91,21 @@ module LinkExpansion::Rules
     next_link_type(link_types_path, reverse: true)
   end
 
-  def expansion_fields(document_type)
-    CUSTOM_FIELDS_FOR_DOCUMENT_TYPE[document_type] || DEFAULT_FIELDS
+  def find_custom_expansion_fields(document_type, link_type)
+    condition = CUSTOM_EXPANSION_FIELDS.find do |cond|
+      cond[:document_type] == document_type &&
+        cond.fetch(:link_type, link_type) == link_type
+    end
+    condition[:fields] if condition
   end
 
-  def expand_fields(edition)
+  def expansion_fields(document_type, link_type = nil)
+    find_custom_expansion_fields(document_type, link_type) || DEFAULT_FIELDS
+  end
+
+  def expand_fields(edition, link_type)
     edition.to_h.slice(
-      *expansion_fields(edition.document_type.to_sym)
+      *expansion_fields(edition.document_type.to_sym, link_type)
     )
   end
 

--- a/spec/lib/link_expansion/rules_spec.rb
+++ b/spec/lib/link_expansion/rules_spec.rb
@@ -39,8 +39,11 @@ RSpec.describe LinkExpansion::Rules do
   describe ".expansion_fields" do
     let(:default_fields) { subject::DEFAULT_FIELDS }
     let(:organisation_fields) { default_fields + [:details] }
+    let(:finder_fields) { default_fields + [:details] }
     specify { expect(subject.expansion_fields(:redirect)).to eq([]) }
     specify { expect(subject.expansion_fields(:parent)).to eq(default_fields) }
     specify { expect(subject.expansion_fields(:organisation)).to eq(organisation_fields) }
+    specify { expect(subject.expansion_fields(:finder, :finder)).to eq(finder_fields) }
+    specify { expect(subject.expansion_fields(:parent, :finder)).to eq(default_fields) }
   end
 end


### PR DESCRIPTION
Allow ability to perform custom field link expansion based on the link type. Also, expand the finder details hash on `finder` link types.