### PR TITLE
Update dependencies only when certain fields have changed

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,7 @@ gem 'bunny', '2.5.1'
 gem 'whenever', '0.9.4', require: false
 gem "govuk_sidekiq", "~> 1.0.3"
 gem "json-schema", require: false
-gem "hashdiff"
+gem "hashdiff", require: false
 gem "sidekiq-unique-jobs", git: "https://github.com/alphagov/sidekiq-unique-jobs", require: false
 gem "govspeak", "~> 5.0.2"
 gem "diffy", "~> 3.1", require: false

--- a/app/commands/v2/publish.rb
+++ b/app/commands/v2/publish.rb
@@ -168,11 +168,7 @@ module Commands
       end
 
       def update_dependencies?
-        (dependency_fields & EditionDiff.new(edition).field_diff).present?
-      end
-
-      def dependency_fields
-        LinkExpansion::Rules.expansion_fields(edition.document_type)
+        EditionDiff.new(edition).field_diff.present?
       end
 
       def send_downstream(content_id, locale, update_type)

--- a/app/commands/v2/publish.rb
+++ b/app/commands/v2/publish.rb
@@ -167,6 +167,14 @@ module Commands
         ) if draft_redirect
       end
 
+      def update_dependencies?
+        (dependency_fields & EditionDiff.new(edition).field_diff).present?
+      end
+
+      def dependency_fields
+        Queries::DependentExpansionRules.expansion_fields(edition.document_type)
+      end
+
       def send_downstream(content_id, locale, update_type)
         return unless downstream
 
@@ -178,6 +186,7 @@ module Commands
           locale: locale,
           message_queue_update_type: update_type,
           payload_version: event.id,
+          update_dependencies: update_dependencies?,
         )
       end
     end

--- a/app/commands/v2/publish.rb
+++ b/app/commands/v2/publish.rb
@@ -172,7 +172,7 @@ module Commands
       end
 
       def dependency_fields
-        Queries::DependentExpansionRules.expansion_fields(edition.document_type)
+        LinkExpansion::Rules.expansion_fields(edition.document_type)
       end
 
       def send_downstream(content_id, locale, update_type)

--- a/app/commands/v2/put_content.rb
+++ b/app/commands/v2/put_content.rb
@@ -99,7 +99,7 @@ module Commands
       def create_or_update_edition
         if previous_drafted_edition
           @links_before_update = previous_drafted_edition.links.map(&:target_content_id)
-          updated_item, @previous_edition, @presented_old_edition = UpdateExistingDraftEdition.new(previous_drafted_edition, self, payload).call
+          updated_item, @previous_edition = UpdateExistingDraftEdition.new(previous_drafted_edition, self, payload).call
         else
           @links_before_update = previously_published_edition.links.map(&:target_content_id)
           new_draft_edition = CreateDraftEdition.new(self, payload, previously_published_edition).call
@@ -147,11 +147,7 @@ module Commands
       end
 
       def update_dependencies?(edition)
-        (dependency_fields(edition) & EditionDiff.new(edition, previous_edition: @presented_old_edition).field_diff).present?
-      end
-
-      def dependency_fields(edition)
-        LinkExpansion::Rules.expansion_fields(edition.document_type)
+        EditionDiff.new(edition, previous_edition: @previous_edition).field_diff.present?
       end
 
       def send_downstream(content_id, locale, update_dependencies, orphaned_links)

--- a/app/models/update_existing_draft_edition.rb
+++ b/app/models/update_existing_draft_edition.rb
@@ -35,6 +35,7 @@ private
 
   def update_edition
     old_edition = edition.dup
+    presented_old_edition = presented_old_edition(edition.id)
     assign_attributes_with_defaults
 
     # The links are deleted here and then recreated from a payload in the
@@ -43,7 +44,14 @@ private
     edition.links.delete_all
 
     edition.save!
-    [edition, old_edition]
+    [edition, old_edition, presented_old_edition]
+  end
+
+  def presented_old_edition(id)
+    Presenters::DownstreamPresenter.present(
+      Queries::GetWebContentItems.find(id),
+      state_fallback_order: [:draft, :published]
+    ).deep_stringify_keys
   end
 
   def assign_attributes_with_defaults

--- a/app/models/update_existing_draft_edition.rb
+++ b/app/models/update_existing_draft_edition.rb
@@ -35,7 +35,7 @@ private
 
   def update_edition
     old_edition = edition.dup
-    presented_old_edition = presented_old_edition(edition.id)
+    presented_old_edition = presented_old_edition(edition)
     assign_attributes_with_defaults
 
     # The links are deleted here and then recreated from a payload in the
@@ -47,11 +47,8 @@ private
     [edition, old_edition, presented_old_edition]
   end
 
-  def presented_old_edition(id)
-    Presenters::DownstreamPresenter.present(
-      Queries::GetWebContentItems.find(id),
-      state_fallback_order: [:draft, :published]
-    ).deep_stringify_keys
+  def presented_old_edition(edition)
+    Presenters::EditionPresenter.new(edition).present.deep_stringify_keys
   end
 
   def assign_attributes_with_defaults

--- a/app/models/update_existing_draft_edition.rb
+++ b/app/models/update_existing_draft_edition.rb
@@ -35,7 +35,6 @@ private
 
   def update_edition
     old_edition = edition.dup
-    presented_old_edition = presented_old_edition(edition)
     assign_attributes_with_defaults
 
     # The links are deleted here and then recreated from a payload in the
@@ -44,11 +43,7 @@ private
     edition.links.delete_all
 
     edition.save!
-    [edition, old_edition, presented_old_edition]
-  end
-
-  def presented_old_edition(edition)
-    Presenters::EditionPresenter.new(edition).present.deep_stringify_keys
+    [edition, old_edition]
   end
 
   def assign_attributes_with_defaults

--- a/app/presenters/edition_presenter.rb
+++ b/app/presenters/edition_presenter.rb
@@ -33,16 +33,6 @@ module Presenters
       )
     end
 
-  private
-
-    attr_reader :draft, :edition
-
-    def unexpanded_links
-      Queries::LinkSetPresenter.new(
-        LinkSet.find_by(content_id: edition.content_id)
-      ).links
-    end
-
     def present
       edition.to_h
         .except(*NON_PRESENTED_PROPERTIES)
@@ -51,6 +41,16 @@ module Presenters
         .merge(access_limited)
         .merge(format)
         .merge(withdrawal_notice)
+    end
+
+  private
+
+    attr_reader :draft, :edition
+
+    def unexpanded_links
+      Queries::LinkSetPresenter.new(
+        LinkSet.find_by(content_id: edition.content_id)
+      ).links
     end
 
     def links

--- a/lib/edition_diff.rb
+++ b/lib/edition_diff.rb
@@ -10,21 +10,23 @@ class EditionDiff
   end
 
   def field_diff
-    diff.map { |_, field, _| field.to_sym }
+    LinkExpansion::Rules.expansion_fields(current_edition.document_type) &
+      diff.map { |_, field, _| field.to_sym }
   end
 
 private
 
   def diff
     HashDiff.best_diff(
-      @previous_edition ? @previous_edition : presented_item(previous_edition),
-      presented_item(current_edition))
+      @previous_edition ? @previous_edition.to_h.deep_symbolize_keys : previous_edition.to_h.deep_symbolize_keys,
+      current_edition.to_h.deep_symbolize_keys)
   end
 
   def previous_edition
     @previous_edition ||
-      current_edition.document.editions.find_by(user_facing_version:
-                                                previous_user_version)
+      current_edition.document.editions.find_by(
+        user_facing_version: previous_user_version
+    )
   end
 
   def previous_user_version
@@ -33,10 +35,5 @@ private
 
   def current_user_version
     version || current_edition.user_facing_version
-  end
-
-  def presented_item(edition)
-    return {} unless edition
-    Presenters::EditionPresenter.new(edition).present.deep_stringify_keys
   end
 end

--- a/lib/edition_diff.rb
+++ b/lib/edition_diff.rb
@@ -1,0 +1,44 @@
+require 'hashdiff'
+
+class EditionDiff
+  attr_reader :current_edition, :version
+  NullEdition = Struct.new(:id)
+
+  def initialize(current_edition, version: nil, previous_edition: nil)
+    @current_edition = current_edition
+    @previous_edition = previous_edition
+    @version = version
+  end
+
+  def field_diff
+    diff.map { |_, field, _| field.to_sym }
+  end
+
+private
+
+  def diff
+    HashDiff.best_diff(
+      @previous_edition ? @previous_edition : presented_item(previous_edition.id),
+      presented_item(current_edition.id))
+  end
+
+  def previous_edition
+    @previous_edition || Document.find_by(content_id: current_edition.document.content_id)
+      .editions.find_by(user_facing_version: previous_user_version) || NullEdition.new
+  end
+
+  def previous_user_version
+    current_user_version - 1
+  end
+
+  def current_user_version
+    version || current_edition.user_facing_version
+  end
+
+  def presented_item(id)
+    Presenters::DownstreamPresenter.present(
+      Queries::GetWebContentItems.find(id),
+      state_fallback_order: [:draft, :published]
+    ).deep_stringify_keys
+  end
+end

--- a/spec/commands/v2/publish_spec.rb
+++ b/spec/commands/v2/publish_spec.rb
@@ -71,6 +71,67 @@ RSpec.describe Commands::V2::Publish do
       end
     end
 
+    context "publishing draft edition" do
+      let(:existing_base_path) { base_path }
+
+      let!(:draft_item) do
+        FactoryGirl.create(:draft_edition,
+          document: document,
+          base_path: existing_base_path,
+          title: "foo",
+        )
+      end
+
+      it "updates the dependencies" do
+        expect(DownstreamLiveWorker)
+          .to receive(:perform_async_in_queue)
+          .with("downstream_high", a_hash_including(update_dependencies: true))
+
+        described_class.call(payload)
+      end
+    end
+
+    context "dependency fields change on new publication" do
+      let(:existing_base_path) { base_path }
+
+      let!(:live_item) do
+        FactoryGirl.create(:live_edition,
+          document: document,
+          base_path: existing_base_path,
+          title: "foo",
+          user_facing_version: user_facing_version - 1,
+        )
+      end
+
+      it "updates the dependencies" do
+        expect(DownstreamLiveWorker)
+          .to receive(:perform_async_in_queue)
+          .with("downstream_high", a_hash_including(update_dependencies: true))
+
+        described_class.call(payload)
+      end
+    end
+
+    context "dependency fields don't change between publications" do
+      let(:existing_base_path) { base_path }
+
+      let!(:live_item) do
+        FactoryGirl.create(:live_edition,
+          document: document,
+          base_path: existing_base_path,
+          user_facing_version: user_facing_version - 1,
+        )
+      end
+
+      it "doesn't updates the dependencies" do
+        expect(DownstreamLiveWorker)
+          .to receive(:perform_async_in_queue)
+          .with("downstream_high", a_hash_including(update_dependencies: false))
+
+        described_class.call(payload)
+      end
+    end
+
     context "when the edition was previously published" do
       let(:existing_base_path) { base_path }
 

--- a/spec/commands/v2/put_content_spec.rb
+++ b/spec/commands/v2/put_content_spec.rb
@@ -884,5 +884,16 @@ RSpec.describe Commands::V2::PutContent do
         expect { described_class.call(payload) }.not_to raise_error
       end
     end
+
+    context "field doesn't change between drafts" do
+      it "doesn't update the dependencies" do
+        expect(DownstreamDraftWorker).to receive(:perform_async_in_queue)
+          .with(anything, a_hash_including(update_dependencies: true))
+        expect(DownstreamDraftWorker).to receive(:perform_async_in_queue)
+          .with(anything, a_hash_including(update_dependencies: false))
+        described_class.call(payload)
+        described_class.call(payload)
+      end
+    end
   end
 end

--- a/spec/lib/edition_diff_spec.rb
+++ b/spec/lib/edition_diff_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe EditionDiff do
     end
 
     let(:presented_item) do
-      Presenters::EditionPresenter.new(new_draft_edition).present.deep_stringify_keys
+      new_draft_edition.to_h.deep_stringify_keys
     end
 
     it "compares the two given editions" do

--- a/spec/lib/edition_diff_spec.rb
+++ b/spec/lib/edition_diff_spec.rb
@@ -1,0 +1,85 @@
+require 'rails_helper'
+
+RSpec.describe EditionDiff do
+  let(:content_id) { SecureRandom.uuid }
+  let(:document) { FactoryGirl.create(:document, content_id: content_id) }
+
+  let!(:previous_edition) do
+    FactoryGirl.create(:superseded_edition, document: document,
+                       title: "Foo", base_path: "/foo")
+  end
+
+  let!(:current_edition) do
+    FactoryGirl.create(:live_edition, document: document,
+                       title: "Bar", base_path: "/foo",
+                       user_facing_version: 2)
+  end
+
+  let(:new_draft_edition) do
+    FactoryGirl.create(:draft_edition, document: document,
+                       title: "Bar", base_path: "/foo",
+                       user_facing_version: 3)
+  end
+
+  subject { described_class.new(current_edition) }
+
+  context "diff in title" do
+    it "returns the diff between two versions" do
+      expect(subject.field_diff).to eq([:title])
+    end
+  end
+
+  context "diff in title, document_type and base_path" do
+    let!(:current_edition) do
+      FactoryGirl.create(
+        :live_edition,
+        document: document,
+        title: "Bar",
+        base_path: "/bar",
+        user_facing_version: 2,
+        document_type: "new_type"
+      )
+    end
+
+    it "returns the diff between two versions" do
+      expect(subject.field_diff).to include(:base_path, :title, :document_type)
+    end
+  end
+
+  context "multiple versions" do
+    it "compares between the previous version" do
+      current_edition.supersede
+      expect(described_class.new(new_draft_edition).field_diff).to eq([])
+    end
+  end
+
+  context "no previous item" do
+    let!(:previous_edition) { nil }
+    it "returns the diff between two versions" do
+      expect(subject.field_diff).to include(:base_path, :title, :document_type)
+    end
+  end
+
+  context "provide the edition to compare" do
+    it "compares the two given editions" do
+      expect(
+        EditionDiff.new(new_draft_edition,
+                        previous_edition: {}).field_diff
+      ).to include(:document_type, :title)
+    end
+
+    let(:presented_item) do
+      Presenters::DownstreamPresenter.present(
+        Queries::GetWebContentItems.find(new_draft_edition.id),
+        state_fallback_order: [:draft, :published]
+      ).deep_stringify_keys
+    end
+
+    it "compares the two given editions" do
+      expect(
+        EditionDiff.new(new_draft_edition,
+                        previous_edition: presented_item).field_diff
+      ).to eq([])
+    end
+  end
+end

--- a/spec/lib/edition_diff_spec.rb
+++ b/spec/lib/edition_diff_spec.rb
@@ -69,10 +69,7 @@ RSpec.describe EditionDiff do
     end
 
     let(:presented_item) do
-      Presenters::DownstreamPresenter.present(
-        Queries::GetWebContentItems.find(new_draft_edition.id),
-        state_fallback_order: [:draft, :published]
-      ).deep_stringify_keys
+      Presenters::EditionPresenter.new(new_draft_edition).present.deep_stringify_keys
     end
 
     it "compares the two given editions" do

--- a/spec/requests/content_item_requests/downstream_requests_spec.rb
+++ b/spec/requests/content_item_requests/downstream_requests_spec.rb
@@ -212,7 +212,7 @@ RSpec.describe "Downstream requests", type: :request do
         .with(a_hash_including(base_path: '/a'))
       expect(PublishingAPI.service(:draft_content_store)).to receive(:put_content_item)
         .with(a_hash_including(base_path: '/b'))
-      params = v2_content_item.merge(base_path: "/a", content_id: a,
+      params = v2_content_item.merge(base_path: "/a", content_id: a, title: "foo",
                                      routes: [{ path: '/a', type: 'exact' }]).to_json
       put "/v2/content/#{a}", params: params
     end

--- a/spec/requests/logging_requests_spec.rb
+++ b/spec/requests/logging_requests_spec.rb
@@ -41,6 +41,7 @@ RSpec.describe "Logging requests", type: :request do
       v2_content_item.merge(
         content_id: a,
         base_path: "/a",
+        title: "foo",
         routes: [{ path: "/a", type: "exact" }],
       )
     end


### PR DESCRIPTION
The whole presented diff of an edition is unnecessary when comparing for
dependency resolution, so just compare the hash of the edition.

Before:
....................................................................................................
  4.890000   0.310000   5.200000 (  5.991872)
2523 SQL queries

After:
....................................................................................................
  4.870000   0.340000   5.210000 (  5.974374)
2623 SQL queries