### PR TITLE
Fix n+1 query issue on link expansion.

### DIFF
--- a/lib/link_expansion/content_cache.rb
+++ b/lib/link_expansion/content_cache.rb
@@ -32,7 +32,7 @@ private
       locale_fallback_order: locale_fallback_order,
       state_fallback_order: state_fallback_order,
     )
-    Edition.where(id: edition_ids)
+    Edition.with_document.includes(:document).where(id: edition_ids)
       .each_with_object(results) { |item, memo| memo[item.content_id] = item }
   end
 


### PR DESCRIPTION
Benchmarks (from bench/get_expanded_links.rb)

Before:

Many reverse dependencies: 4bda0be5-3e65-4cc1-850c-0541e95a40ca
..........191.290000  15.530000 206.820000 (220.334644)
queries: {"LinkSet Load"=>10, nil=>70, "SCHEMA"=>3, "Edition Load"=>20, "Document Load"=>15670}
total: 15773
query time: {"LinkSet Load"=>0.011229717000000002, nil=>9.352159802000005, "SCHEMA"=>0.007067406, "Edition Load"=>1.0278217400000003, "Document Load"=>13.041198452999964}

log file written to log/many-reverse-dependencies.output
Many forward dependencies: 5f4f1e91-7631-11e4-a3cb-005056011aef
.......... 41.880000   4.050000  45.930000 ( 52.448071)
queries: {"LinkSet Load"=>10, nil=>80, "Edition Load"=>20, "Document Load"=>9000}
total: 9110
query time: {"LinkSet Load"=>0.011633751, nil=>4.045429631000002, "Edition Load"=>1.076095221, "Document Load"=>6.94957432600001}

log file written to log/many-forward-dependencies.output
No dependencies: cacd92c1-42ef-4e2d-9ed4-817c8f03ff23
..........  0.170000   0.010000   0.180000 (  0.240705)
queries: {"LinkSet Load"=>10, nil=>50, "Edition Load"=>10, "Document Load"=>10}
total: 80
query time: {"LinkSet Load"=>0.012469598, nil=>0.08083045400000001, "Edition Load"=>0.012296095, "Document Load"=>0.010742818999999999}

log file written to log/no-dependencies.output
Single link each way: 00012147-49f6-4e90-be1f-e50bb719f53d
..........  0.420000   0.040000   0.460000 (  0.605475)
queries: {"LinkSet Load"=>10, nil=>60, "Edition Load"=>20, "Document Load"=>50}
total: 140
query time: {"LinkSet Load"=>0.011485203999999999, nil=>0.16677465799999996, "Edition Load"=>0.022849809999999998, "Document Load"=>0.05654972}

log file written to log/single-link-each-way.output



After:

Many reverse dependencies: 4bda0be5-3e65-4cc1-850c-0541e95a40ca
..........164.570000  11.130000 175.700000 (176.582229)
queries: {"LinkSet Load"=>10, nil=>70, "SCHEMA"=>3, "SQL"=>10, "Edition Load"=>10, "Document Load"=>10}
total: 113
query time: {"LinkSet Load"=>0.010689761999999997, nil=>1.1857171599999998, "SCHEMA"=>0.004245719, "SQL"=>0.5618977810000001, "Edition Load"=>0.016878386000000002, "Document Load"=>0.01035659}

log file written to log/many-reverse-dependencies.output
Many forward dependencies: 5f4f1e91-7631-11e4-a3cb-005056011aef
.......... 32.800000   4.400000  37.200000 ( 37.685448)
queries: {"LinkSet Load"=>10, nil=>80, "SQL"=>10, "Edition Load"=>10, "Document Load"=>10}
total: 120
query time: {"LinkSet Load"=>0.009931244, nil=>0.6579279839999999, "SQL"=>0.47850329, "Edition Load"=>0.011937168, "Document Load"=>0.010049168}

log file written to log/many-forward-dependencies.output
No dependencies: cacd92c1-42ef-4e2d-9ed4-817c8f03ff23
..........  0.150000   0.030000   0.180000 (  0.231159)
queries: {"LinkSet Load"=>10, nil=>50, "Edition Load"=>10, "Document Load"=>10}
total: 80
query time: {"LinkSet Load"=>0.010585292, nil=>0.080511656, "Edition Load"=>0.010415471, "Document Load"=>0.011111201}

log file written to log/no-dependencies.output
Single link each way: 00012147-49f6-4e90-be1f-e50bb719f53d
..........  0.400000   0.030000   0.430000 (  0.501341)
queries: {"LinkSet Load"=>10, nil=>60, "SQL"=>10, "Edition Load"=>10, "Document Load"=>10}
total: 100
query time: {"LinkSet Load"=>0.01126876, nil=>0.109529448, "SQL"=>0.016674166, "Edition Load"=>0.010611595000000001, "Document Load"=>0.009380688999999998}

log file written to log/single-link-each-way.output