### PR TITLE
Ensure all documents have link sets

### DIFF
--- a/app/queries/get_expanded_links.rb
+++ b/app/queries/get_expanded_links.rb
@@ -1,31 +1,42 @@
 module Queries
   class GetExpandedLinks
     def self.call(content_id, locale)
-      link_set = find_link_set(content_id)
+      if (link_set = LinkSet.find_by(content_id: content_id))
+        expanded_link_set(link_set, locale)
+      elsif Document.where(content_id: content_id).exists?
+        empty_expanded_link_set(content_id)
+      else
+        error_details = {
+          error: {
+            code: 404,
+            message: "Could not find link set with content_id: #{content_id}"
+          }
+        }
+
+        raise CommandError.new(code: 404, error_details: error_details)
+      end
+    end
+
+    def self.expanded_link_set(link_set, locale)
       expanded_link_set = Presenters::Queries::ExpandedLinkSet.new(
-        content_id: content_id,
+        content_id: link_set.content_id,
         draft: true,
         locale: locale,
       )
 
       {
-        content_id: content_id,
+        content_id: link_set.content_id,
         expanded_links: expanded_link_set.links,
         version: link_set.stale_lock_version,
       }
     end
 
-    def self.find_link_set(content_id)
-      LinkSet.find_by!(content_id: content_id)
-    rescue ActiveRecord::RecordNotFound
-      error_details = {
-        error: {
-          code: 404,
-          message: "Could not find link set with content_id: #{content_id}"
-        }
+    def self.empty_expanded_link_set(content_id)
+      {
+        content_id: content_id,
+        expanded_links: {},
+        version: 0
       }
-
-      raise CommandError.new(code: 404, error_details: error_details)
     end
   end
 end

--- a/app/queries/get_link_set.rb
+++ b/app/queries/get_link_set.rb
@@ -3,6 +3,12 @@ module Queries
     def self.call(content_id)
       if (link_set = LinkSet.find_by(content_id: content_id))
         Presenters::Queries::LinkSetPresenter.present(link_set)
+      elsif Document.where(content_id: content_id).exists?
+        {
+          content_id: content_id,
+          links: {},
+          version: 0,
+        }
       else
         error_details = {
           error: {

--- a/spec/queries/get_expanded_links_spec.rb
+++ b/spec/queries/get_expanded_links_spec.rb
@@ -1,0 +1,29 @@
+require "rails_helper"
+
+RSpec.describe Queries::GetExpandedLinks do
+  let(:content_id) { SecureRandom.uuid }
+
+  context "when the document does not exist" do
+    it "raises a command error" do
+      expect {
+        described_class.call(content_id, "en")
+      }.to raise_error(CommandError, /could not find link set/i)
+    end
+  end
+
+  context "when a document exists without a link set" do
+    before do
+      FactoryGirl.create(:document, content_id: content_id)
+    end
+
+    it "returns an empty response" do
+      result = described_class.call(content_id, "en")
+
+      expect(result).to eq(
+        content_id: content_id,
+        version: 0,
+        expanded_links: {},
+      )
+    end
+  end
+end

--- a/spec/queries/get_link_set_spec.rb
+++ b/spec/queries/get_link_set_spec.rb
@@ -59,11 +59,27 @@ RSpec.describe Queries::GetLinkSet do
     end
   end
 
-  context "when the link set does not exist" do
+  context "when the document does not exist" do
     it "raises a command error" do
       expect {
         subject.call(content_id)
       }.to raise_error(CommandError, /could not find link set/i)
+    end
+  end
+
+  context "when a document exists without a link set" do
+    before do
+      FactoryGirl.create(:document, content_id: content_id)
+    end
+
+    it "returns an empty response" do
+      result = subject.call(content_id)
+
+      expect(result).to eq(
+        content_id: content_id,
+        version: 0,
+        links: {},
+      )
     end
   end
 end


### PR DESCRIPTION
 PutContent used to create a LinkSet when creating a draft, but this got removed in 050ca98b44f2460b1668061a2d5f4dfe4bfcf01a.

This affects `GET links` and `GET expanded-links`

Both of these now return 404 for documents that have never had links set, which complicates building tagging interfaces that work with draft content.

`LinkSet` is an implementation detail: we expect to be able to get links at any time regardless of publishing status of the document.

There are different ways this could work.

- Rather than create the `LinkSet`s, the requests that read them could handle the case where the `LinkSet` is missing, but the document exists.
- We could eliminate `LinkSet` completely: I think now that we have a `Document` model, we don't need it: conceptually a `Link` belongs to either an `Edition` or a `Document` (via its `content_id`).
- Or we could just restore the previous implementation, which is what I've done in this PR.

https://trello.com/c/6VPQcc7C/507-content-tagger-should-be-able-to-tag-to-the-first-draft-of-a-document