### PR TITLE
Use a realistic document type in tests

### DIFF
--- a/spec/commands/v2/import_spec.rb
+++ b/spec/commands/v2/import_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Commands::V2::Import, type: :request do
 
     let(:content_item) do
       {
-        document_type: "foo1",
+        document_type: "organisation",
         schema_name: "generic",
         publishing_app: "foo",
         title: "foo",


### PR DESCRIPTION
This will make it possible to lock down the types to a defined set (https://github.com/alphagov/govuk-content-schemas/pull/550).

https://trello.com/c/07lAcDtC