### PR TITLE
Fix dependency resolution difference on finder link types

### DIFF
--- a/lib/edition_diff.rb
+++ b/lib/edition_diff.rb
@@ -1,5 +1,3 @@
-require 'hashdiff'
-
 class EditionDiff
   attr_reader :current_edition, :version
 
@@ -10,16 +8,21 @@ class EditionDiff
   end
 
   def field_diff
-    LinkExpansion::Rules.expansion_fields(current_edition.document_type) &
-      diff.map { |_, field, _| field.to_sym }
+    LinkExpansion::Rules.finder_expansion_fields(current_edition.document_type) &
+      diff.map(&:first)
   end
 
 private
 
   def diff
-    HashDiff.best_diff(
+    hash_diff(
       @previous_edition ? @previous_edition.to_h.deep_symbolize_keys : previous_edition.to_h.deep_symbolize_keys,
-      current_edition.to_h.deep_symbolize_keys)
+      current_edition.to_h.deep_symbolize_keys
+    )
+  end
+
+  def hash_diff(a, b)
+    a.size > b.size ? a.to_a - b.to_a : b.to_a - a.to_a
   end
 
   def previous_edition

--- a/lib/link_expansion/rules.rb
+++ b/lib/link_expansion/rules.rb
@@ -104,6 +104,13 @@ module LinkExpansion::Rules
     find_custom_expansion_fields(document_type, link_type) || DEFAULT_FIELDS
   end
 
+  # FIXME this is too much of a special case, called from EditionDiff, needs fixing
+  def finder_expansion_fields(document_type)
+    expansion_fields(document_type).dup.tap do |fields|
+      fields << :details if document_type == "finder"
+    end
+  end
+
   def expand_fields(edition, link_type)
     edition.to_h.slice(
       *expansion_fields(edition.document_type.to_sym, link_type)

--- a/spec/lib/edition_diff_spec.rb
+++ b/spec/lib/edition_diff_spec.rb
@@ -46,6 +46,23 @@ RSpec.describe EditionDiff do
     end
   end
 
+  context "diff in details when a finder" do
+    let!(:current_edition) do
+      FactoryGirl.create(
+        :live_edition,
+        document: document,
+        user_facing_version: 2,
+        document_type: "finder",
+        base_path: "/foo",
+        details: { facets: [2] },
+      )
+    end
+
+    it "returns the diff between two versions" do
+      expect(subject.field_diff).to include(:details, :document_type)
+    end
+  end
+
   context "multiple versions" do
     it "compares between the previous version" do
       current_edition.supersede


### PR DESCRIPTION
This is a bug that was accidentally missed by early merge of #808 .