### PR TITLE
Optimise get content

### DIFF
--- a/app/models/change_note.rb
+++ b/app/models/change_note.rb
@@ -4,12 +4,6 @@ class ChangeNote < ActiveRecord::Base
   def self.create_from_edition(payload, edition)
     ChangeNoteFactory.new(payload, edition).build
   end
-
-  def self.join_editions(edition_scope)
-    edition_scope.joins(
-      "LEFT JOIN change_notes ON change_notes.edition_id = editions.id"
-    )
-  end
 end
 
 class ChangeNoteFactory

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -36,11 +36,13 @@ class Edition < ApplicationRecord
 
   belongs_to :document
   has_one :unpublishing
+  has_one :change_note
   has_many :links
 
   scope :renderable_content, -> { where.not(document_type: NON_RENDERABLE_FORMATS) }
   scope :with_document, -> { joins(:document) }
   scope :with_unpublishing, -> { left_outer_joins(:unpublishing) }
+  scope :with_change_note, -> { left_outer_joins(:change_note) }
 
   validates :document, presence: true
 

--- a/app/pagination.rb
+++ b/app/pagination.rb
@@ -39,7 +39,6 @@ private
     end
 
     raise_unless_valid_order_field(field)
-    field = disambiguate_field(field)
 
     { field => direction }
   end
@@ -78,9 +77,5 @@ private
       :rendering_app,
       :updated_at,
     ]
-  end
-
-  def disambiguate_field(field)
-    field == :updated_at ? :"editions.updated_at" : field
   end
 end

--- a/app/presenters/queries/content_item_presenter.rb
+++ b/app/presenters/queries/content_item_presenter.rb
@@ -1,7 +1,7 @@
 module Presenters
   module Queries
     class ContentItemPresenter
-      attr_accessor :edition_scope, :fields, :order, :limit, :offset,
+      attr_reader :edition_scope, :fields, :order, :limit, :offset,
         :search_query, :search_in, :states, :include_warnings
 
       DEFAULT_FIELDS = ([
@@ -33,15 +33,15 @@ module Presenters
       end
 
       def initialize(edition_scope, params = {})
-        self.edition_scope = edition_scope
-        self.fields = (params[:fields] || DEFAULT_FIELDS).map(&:to_sym)
-        self.order = params[:order] || { id: "asc" }
-        self.limit = params[:limit]
-        self.offset = params[:offset]
-        self.search_query = params[:search_query]
-        self.search_in = params[:search_in] || DEFAULT_SEARCH_FIELDS
-        self.states = params[:states].present? ? Array(params[:states]) : %i(draft published unpublished)
-        self.include_warnings = params[:include_warnings] || false
+        @edition_scope = edition_scope
+        @fields = (params[:fields] || DEFAULT_FIELDS).map(&:to_sym)
+        @order = params[:order] || { id: "asc" }
+        @limit = params[:limit]
+        @offset = params[:offset]
+        @search_query = params[:search_query]
+        @search_in = params[:search_in] || DEFAULT_SEARCH_FIELDS
+        @states = params[:states].present? ? Array(params[:states]) : %i(draft published unpublished)
+        @include_warnings = params[:include_warnings] || false
       end
 
       def present_many

--- a/app/queries/get_content.rb
+++ b/app/queries/get_content.rb
@@ -5,11 +5,13 @@ module Queries
 
       editions = Edition.with_document
         .where(documents: { content_id: content_id, locale: locale_to_use })
+
       editions = editions.where(user_facing_version: version) if version
 
       response = Presenters::Queries::ContentItemPresenter.present_many(
         editions,
-        include_warnings: include_warnings
+        include_warnings: include_warnings,
+        states: %i(draft published unpublished superseded),
       ).first
 
       if response.present?

--- a/app/queries/get_content_collection.rb
+++ b/app/queries/get_content_collection.rb
@@ -16,7 +16,7 @@ module Queries
       self.document_types = Array(document_types)
       self.fields = (fields || default_fields) + ["total"]
       self.publishing_app = filters[:publishing_app]
-      self.states = filters[:states]
+      self.states = filters[:states] || %i(draft published unpublished)
       self.link_filters = filters[:links]
       self.locale = filters[:locale] || "en"
       self.pagination = pagination
@@ -51,7 +51,6 @@ module Queries
     def editions
       scope = Edition.where(document_type: lookup_document_types)
       scope = scope.where(publishing_app: publishing_app) if publishing_app
-      scope = scope.where(state: states) if states.present?
       scope = scope.with_document.where("documents.locale": locale) unless locale == "all"
       scope = Link.filter_editions(scope, link_filters) unless link_filters.blank?
       scope
@@ -125,6 +124,7 @@ module Queries
         limit: pagination.per_page,
         search_query: search_query,
         search_in: search_fields,
+        states: states,
       )
     end
 

--- a/bench/content_item_presenter.rb
+++ b/bench/content_item_presenter.rb
@@ -10,12 +10,14 @@ ActiveSupport::Notifications.subscribe "sql.active_record" do |name, started, fi
 end
 
 def present(number_of_items)
-  scope = Edition.limit(number_of_items).order(id: :desc)
+  scope = Edition.where(id: Edition.limit(number_of_items).order(id: :asc))
   $queries = 0
 
   puts "Presenting #{number_of_items} content items"
   StackProf.run(mode: :wall, out: "tmp/content_item_presenter_#{number_of_items}_wall.dump") do
-    puts Benchmark.measure { Presenters::Queries::ContentItemPresenter.present_many(scope).to_a }
+    puts Benchmark.measure { Presenters::Queries::ContentItemPresenter.present_many(
+      scope, limit: number_of_items
+    ).to_a }
   end
   puts "  Queries: #{$queries}"
 end

--- a/bench/specialist_publisher_index_content.rb
+++ b/bench/specialist_publisher_index_content.rb
@@ -1,0 +1,29 @@
+# /usr/bin/env ruby
+
+require ::File.expand_path('../../config/environment', __FILE__)
+
+require 'benchmark'
+
+abort "Refusing to run outside of development" unless Rails.env.development?
+
+document_types = Edition
+  .where(publishing_app: "specialist-publisher")
+  .distinct.pluck(:document_type)
+
+document_types.each do |document_type|
+  puts document_type.to_s
+
+  tms = Benchmark.measure do
+    10.times do
+      Queries::GetContentCollection.new(
+        document_types: document_type,
+        fields: %w(base_path content_id last_edited_at title publication_state state_history),
+        filters: { publishing_app: "specialist-publisher" },
+        pagination: Pagination.new(per_page: 50, page: 1, order: "-last_edited_at"),
+      ).call
+      print "."
+    end
+  end
+  puts tms
+  puts ""
+end

--- a/spec/queries/get_content_spec.rb
+++ b/spec/queries/get_content_spec.rb
@@ -90,23 +90,22 @@ RSpec.describe Queries::GetContent do
 
   context "when editions exist in non-draft, non-live states" do
     before do
-      FactoryGirl.create(:edition,
+      FactoryGirl.create(:superseded_edition,
         document: document,
         user_facing_version: 1,
-        title: "Published Title",
-        state: "published",
+        title: "Older Title",
       )
 
       FactoryGirl.create(:superseded_edition,
         document: document,
         user_facing_version: 2,
-        title: "Submitted Title",
+        title: "Newer Title",
       )
     end
 
     it "includes these editions" do
       result = subject.call(content_id)
-      expect(result.fetch("title")).to eq("Submitted Title")
+      expect(result.fetch("title")).to eq("Newer Title")
     end
   end
 


### PR DESCRIPTION
This is to try reduce the Specialist Publisher timeouts that are a pain /cc @NeilvB
It's all a bit ugly and messy, suggestions to clean up the code (or even better speed up the queries are very welcome)

tl;dr

Benchmarks between this and fcd37be show a speed up in accessing the
slower Specialist Publisher index pages

from:

```
dfid_research_output
..........  5.620000   0.020000   5.640000 ( 49.909101)

aaib_report
..........  1.900000   0.000000   1.900000 ( 18.333954)
```

to:

```
dfid_research_output
..........  0.010000   0.010000   0.020000 (  6.626270)

aaib_report
..........  0.020000   0.000000   0.020000 (  2.608745)
```

Full benchmarks at the end.

anyway...

This changes the way the ContentItemPresenter works so that it no longer
pulls out a large collection of ids that can be queried and instead does
a single query that pulls out everything, while making use of state to
reduce data set size.

To group by latest items in the query we use `DISTINCT ON` which
unfortunately means that to do ordering we need to run that as a
subquery inside a `SELECT * FROM subquery`.

This can give us some nice performance gains for a document_type that
has many editions - although the query is 4 or 5 times faster than the
previous iteration it still is quite slow, in the region of 600ms.

Digging into the presenters/queries/content_item_presenter class is
particularly difficult, and it looks like it's got way over complicated
and is used in too many cases. This trello card:
https://trello.com/c/m7PFbmGt/399-remove-state-history-from-get-content-and-rethink-endpoint
suggests steps.

Full benchmarks:

master:
```
vm  publishing-api git:(fcd37be) ruby bench/get_content_items.rb
..........  0.640000   0.250000   0.890000 (  2.645056)
queries: 30

vm  publishing-api git:(fcd37be) ruby bench/content_item_presenter.rb
Presenting 64 content items
  0.030000   0.010000   0.040000 (  0.078049)
  Queries: 4
Presenting 128 content items
  0.000000   0.000000   0.000000 (  0.020408)
  Queries: 2
Presenting 256 content items
  0.020000   0.010000   0.030000 (  0.041716)
  Queries: 2
Presenting 512 content items
  0.030000   0.000000   0.030000 (  0.077993)
  Queries: 2
Presenting 1024 content items
  0.080000   0.010000   0.090000 (  0.152250)
  Queries: 2
vm  publishing-api git:(fcd37be) ruby bench/specialist_publisher_index_content.rb
countryside_stewardship_grant
..........  0.090000   0.020000   0.110000 (  0.378548)

gone
..........  0.020000   0.000000   0.020000 (  0.224220)

redirect
..........  0.160000   0.010000   0.170000 (  2.241235)

esi_fund
..........  0.110000   0.000000   0.110000 (  0.487870)

international_development_fund
..........  0.040000   0.000000   0.040000 (  0.245753)

service_standard_report
..........  0.060000   0.000000   0.060000 (  0.287343)

medical_safety_alert
..........  0.110000   0.020000   0.130000 (  0.463453)

specialist_document
..........  0.120000   0.000000   0.120000 (  0.489946)

employment_appeal_tribunal_decision
..........  0.020000   0.010000   0.030000 (  0.199861)

finder_email_signup
..........  0.020000   0.000000   0.020000 (  0.215405)

finder
..........  0.030000   0.000000   0.030000 (  0.220461)

vehicle_recalls_and_faults_alert
..........  0.030000   0.000000   0.030000 (  0.208663)

asylum_support_decision
..........  0.030000   0.000000   0.030000 (  0.229216)

dfid_research_output
..........  5.620000   0.020000   5.640000 ( 49.909101)

aaib_report
..........  1.900000   0.000000   1.900000 ( 18.333954)

raib_report
..........  0.120000   0.000000   0.120000 (  0.429986)

cma_case
..........  0.340000   0.010000   0.350000 (  1.843951)

drug_safety_update
..........  0.110000   0.010000   0.120000 (  0.445271)

utaac_decision
..........  0.110000   0.000000   0.110000 (  0.368779)

maib_report
..........  0.180000   0.000000   0.180000 (  0.966065)

tax_tribunal_decision
..........  0.140000   0.010000   0.150000 (  0.697152)

employment_tribunal_decision
..........  0.100000   0.000000   0.100000 (  0.383149)
```

this branch:
```
vm  publishing-api git:(refactor-get-content) ruby bench/get_content_items.rb
..........  0.320000   0.240000   0.560000 (  2.722570)
queries: 19

vm  publishing-api git:(refactor-get-content) ruby bench/content_item_presenter.rb
Presenting 64 content items
  0.020000   0.010000   0.030000 (  0.048117)
  Queries: 3
Presenting 128 content items
  0.000000   0.000000   0.000000 (  0.007047)
  Queries: 1
Presenting 256 content items
  0.000000   0.000000   0.000000 (  0.007677)
  Queries: 1
Presenting 512 content items
  0.000000   0.000000   0.000000 (  0.010066)
  Queries: 1
Presenting 1024 content items
  0.010000   0.000000   0.010000 (  0.024324)
  Queries: 1
vm  publishing-api git:(refactor-get-content) ruby bench/specialist_publisher_index_content.rb
countryside_stewardship_grant
..........  0.030000   0.020000   0.050000 (  0.301340)

gone
..........  0.010000   0.000000   0.010000 (  0.202118)

redirect
..........  0.030000   0.000000   0.030000 (  0.553600)

esi_fund
..........  0.020000   0.000000   0.020000 (  0.309609)

international_development_fund
..........  0.020000   0.000000   0.020000 (  0.209377)

service_standard_report
..........  0.020000   0.010000   0.030000 (  0.226802)

medical_safety_alert
..........  0.010000   0.000000   0.010000 (  0.289368)

specialist_document
..........  0.020000   0.000000   0.020000 (  0.208020)

employment_appeal_tribunal_decision
..........  0.010000   0.010000   0.020000 (  0.192036)

finder_email_signup
..........  0.020000   0.000000   0.020000 (  0.208976)

finder
..........  0.020000   0.010000   0.030000 (  0.203342)

vehicle_recalls_and_faults_alert
..........  0.010000   0.000000   0.010000 (  0.195428)

asylum_support_decision
..........  0.020000   0.000000   0.020000 (  0.205268)

dfid_research_output
..........  0.010000   0.010000   0.020000 (  6.626270)

aaib_report
..........  0.020000   0.000000   0.020000 (  2.608745)

raib_report
..........  0.010000   0.000000   0.010000 (  0.275698)

cma_case
..........  0.020000   0.010000   0.030000 (  0.587719)

drug_safety_update
..........  0.010000   0.000000   0.010000 (  0.295200)

utaac_decision
..........  0.030000   0.000000   0.030000 (  0.258562)

maib_report
..........  0.020000   0.000000   0.020000 (  0.393338)

tax_tribunal_decision
..........  0.020000   0.000000   0.020000 (  0.308831)

employment_tribunal_decision
..........  0.020000   0.000000   0.020000 (  0.245689)
```