### PR TITLE
Lookup by base paths v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ You can run the pact verification tests on their own using:
 $ bundle exec rake pact:verify
 ```
 
-See [doc/pacts.md](doc/pacts.md) for more details about the pacts and the pact
+See [doc/pact_testing.md](doc/pact_testing.md) for more details about the pacts and the pact
 broker.
 
 ## Example API requests

--- a/app/controllers/v2/lookups_controller.rb
+++ b/app/controllers/v2/lookups_controller.rb
@@ -1,0 +1,17 @@
+module V2
+  class LookupsController < ApplicationController
+    def lookup_by_base_paths
+      if base_paths.length > 100
+        raise CommandError.new(code: 400, message: "base_paths must contain less than 100 items")
+      end
+
+      render json: Queries::LookupByBasePaths.call(base_paths)
+    end
+
+  private
+
+    def base_paths
+      params.fetch(:base_paths)
+    end
+  end
+end

--- a/app/controllers/v2/lookups_controller.rb
+++ b/app/controllers/v2/lookups_controller.rb
@@ -11,7 +11,11 @@ module V2
   private
 
     def base_paths
-      params.fetch(:base_paths)
+      permitted_params.require(:base_paths)
+    end
+
+    def permitted_params
+      params.permit(base_paths: [])
     end
   end
 end

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -38,6 +38,7 @@ class Edition < ApplicationRecord
   has_one :unpublishing
   has_one :change_note
   has_many :links
+  has_many :access_limit
 
   scope :renderable_content, -> { where.not(document_type: NON_RENDERABLE_FORMATS) }
   scope :with_document, -> { joins(:document) }

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -43,6 +43,7 @@ class Edition < ApplicationRecord
   scope :renderable_content, -> { where.not(document_type: NON_RENDERABLE_FORMATS) }
   scope :with_document, -> { joins(:document) }
   scope :with_unpublishing, -> { left_outer_joins(:unpublishing) }
+  scope :with_access_limit, -> { left_outer_joins(:access_limit) }
   scope :with_change_note, -> { left_outer_joins(:change_note) }
 
   validates :document, presence: true

--- a/app/queries/lookup_by_base_paths.rb
+++ b/app/queries/lookup_by_base_paths.rb
@@ -1,0 +1,57 @@
+module Queries
+  module LookupByBasePaths
+    def self.call(base_paths)
+      base_paths_and_content_ids = Edition.with_document
+        .left_outer_joins(:unpublishing)
+        .left_outer_joins(:access_limit)
+        .where(base_path: base_paths)
+        .where("access_limits.edition_id IS NULL")
+        .where("state != 'superseded'")
+        .order(:base_path)
+        .order(:state)
+        .order(user_facing_version: :desc)
+        .pluck(
+          %{
+            DISTINCT ON (editions.base_path, editions.state)
+            editions.base_path,
+            documents.content_id,
+            documents.locale,
+            editions.document_type,
+            CASE editions.state WHEN 'draft' THEN 'draft' ELSE 'live' END,
+            unpublishings.type,
+            unpublishings.alternative_path
+          }
+        )
+
+      lookups = base_paths_and_content_ids.group_by(&:first)
+
+      lookups.each_with_object({}) do |group, result|
+        base_path, rows = group
+        result[base_path] = build_lookup(rows)
+      end
+    end
+
+    def self.build_lookup(rows)
+      rows.each_with_object({}) do |row, lookup|
+        _, content_id, locale, document_type, state, unpublishing_type, alternative_path = row
+
+        content_item = {
+          "content_id" => content_id,
+          "locale" => locale,
+          "document_type" => document_type,
+        }
+
+        if unpublishing_type.present?
+          content_item["unpublishing"] = {
+            "type" => unpublishing_type,
+            "alternative_path" => alternative_path
+          }.compact
+        end
+
+        lookup[state] = content_item
+      end
+    end
+
+    private_class_method :build_lookup
+  end
+end

--- a/bench/lookup_by_base_path.rb
+++ b/bench/lookup_by_base_path.rb
@@ -8,8 +8,20 @@ require 'stackprof'
 
 abort "Refusing to run outside of development" unless Rails.env.development?
 
-benchmarks = Location.order("RANDOM()").limit(10).pluck(:base_path)
+benchmarks = Edition.order("RANDOM()").limit(10).pluck(:base_path)
 states = %w(published unpublished)
+
+def reference_implementation(base_paths, states)
+  base_paths_and_content_ids = Edition.with_document
+    .left_outer_joins(:unpublishing)
+    .where(state: states, base_path: base_paths)
+    .where("state = 'published' OR unpublishings.type = 'withdrawal'")
+    .where("document_type NOT IN ('gone', 'redirect')")
+    .pluck(:base_path, 'documents.content_id')
+    .uniq
+
+  Hash[base_paths_and_content_ids]
+end
 
 benchmarks.each do |base_path|
   queries = 0
@@ -18,14 +30,22 @@ benchmarks.each do |base_path|
   StackProf.run(mode: :wall, out: "tmp/lookup_by_base_path_#{base_path.gsub(/\//, '_').downcase}_wall.dump") do
     puts Benchmark.measure {
       10.times do
-        Edition
-          .where(state: states, base_path: [base_path])
-          .pluck(:base_path, :content_id)
-          .uniq
+        reference_implementation([base_path], states)
         print "."
       end
     }
   end
   puts "queries: #{queries}"
   puts ""
+end
+
+batch = Edition.order("RANDOM()").limit(100).pluck(:base_path)
+StackProf.run(mode: :wall, out: "tmp/lookup_by_base_path_many}_wall.dump") do
+  puts "Batch of 100 base paths"
+  puts Benchmark.measure {
+    10.times do
+      reference_implementation(batch, states)
+      print "."
+    end
+  }
 end

--- a/bench/lookup_by_base_path_v2.rb
+++ b/bench/lookup_by_base_path_v2.rb
@@ -1,0 +1,38 @@
+# /usr/bin/env ruby
+
+require ::File.expand_path('../../config/environment', __FILE__)
+
+require 'benchmark'
+
+require 'stackprof'
+
+abort "Refusing to run outside of development" unless Rails.env.development?
+
+benchmarks = Edition.order("RANDOM()").limit(10).pluck(:base_path)
+
+benchmarks.each do |base_path|
+  queries = 0
+  ActiveSupport::Notifications.subscribe("sql.active_record") { |_| queries += 1 }
+  puts base_path
+  StackProf.run(mode: :wall, out: "tmp/lookup_by_base_path_v2_#{base_path.gsub(/\//, '_').downcase}_wall.dump") do
+    puts Benchmark.measure {
+      10.times do
+        Queries::LookupByBasePaths.call([base_path])
+        print "."
+      end
+    }
+  end
+  puts "queries: #{queries}"
+  puts ""
+end
+
+batch = Edition.order("RANDOM()").limit(100).pluck(:base_path)
+StackProf.run(mode: :wall, out: "tmp/lookup_by_base_path_v2_many}_wall.dump") do
+  puts "Batch of 100 base paths"
+  puts Benchmark.measure {
+    10.times do
+      Queries::LookupByBasePaths.call(batch)
+      print "."
+    end
+  }
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,6 +30,11 @@ Rails.application.routes.draw do
         get "/linked/:content_id", to: "link_sets#get_linked"
       end
 
+      # post is provided for querying multiple base paths without hitting URI
+      # size limits.
+      get "/lookup-by-base-path", to: "lookups#lookup_by_base_paths"
+      post "/lookup-by-base-path", to: "lookups#lookup_by_base_paths"
+
       get "/linkables", to: "content_items#linkables"
       get "/new-linkables", to: "content_items#new_linkables"
 

--- a/doc/api.md
+++ b/doc/api.md
@@ -24,6 +24,7 @@ message queue for other apps (e.g. `email-alert-service`) to consume.
 - [`GET /v2/linked/:content_id`](#get-v2linkedcontent_id)
 - [`GET /v2/linkables`](#get-v2linkables)
 - [`POST /lookup-by-base-path`](#post-lookup-by-base-path)
+- [`GET /v2/lookup-by-base-path`](#get-v2lookup-by-base-path)
 - [`GET /debug/:content_id`](#get-debugcontent_id)
 - [`PUT /paths/:base_path`](#put-pathsbase_path)
 
@@ -528,6 +529,9 @@ which is `details.internal_name` and falls back to `title`.
 
  [Request/Response detail][lookup-by-base-path-pact]
 
+** Deprecated: **
+Use [GET /v2/lookup-by-base-path](#get-v2lookup-by-base-path) instead.
+
 Retrieves live editions for a given collection of base paths. Returns
 a mapping of `base_path` to `content_id`.
 
@@ -535,6 +539,26 @@ a mapping of `base_path` to `content_id`.
 
 - `base_paths[]` *(required)*
   - An array of `base_path`s to query by.
+
+## `GET /v2/lookup-by-base-path`
+
+ [Request/Response detail][lookup-by-base-path-v2-pact]
+
+Returns the current draft and/or the current live edition matching a base path
+or set of base paths.
+
+"draft" and "live" refer to the content stores, rather than edition states. The live edition contains an `unpublishing` object if the edition is unpublished.
+
+If a base path has never been used, it will be omitted from the response.
+
+There is a limit of 100 base paths per request. This endpoint also responds to `POST` requests, which can be used if the query params would otherwise make the
+URI too long.
+
+### GET parameters:
+
+- `base_paths[]` *(required)*
+  - An array of `base_path`s to query by.
+
 
 ## `PUT /paths/:base_path`
 
@@ -610,5 +634,6 @@ http://publishing-api.integration.publishing.service.gov.uk:8888/debug/f141fa95-
 [show-linked-pact]: https://pact-broker.cloudapps.digital/pacts/provider/Publishing%20API/consumer/GDS%20API%20Adapters/latest#a_request_to_return_the_items_linked_to_it_given_no_content_exists
 [index-linkables-pact]: https://pact-broker.cloudapps.digital/pacts/provider/Publishing%20API/consumer/GDS%20API%20Adapters/latest#a_get_linkables_request_given_there_is_content_with_format_'topic'
 [lookup-by-base-path-pact]: https://pact-broker.cloudapps.digital/pacts/provider/Publishing%20API/consumer/GDS%20API%20Adapters/latest#a_/lookup-by-base-path-request_given_there_are_live_content_items_with_base_paths_/foo_and_/bar
+[lookup-by-base-path-v2-pact]: https://pact-broker.dev.publishing.service.gov.uk/pacts/provider/Publishing%20API/consumer/GDS%20API%20Adapters/latest#a_/v2/lookup-by-base-path-request_given_there_are_live_content_items_with_base_paths_/foo_and_/bar
 [reserve-path-pact]: https://pact-broker.cloudapps.digital/pacts/provider/Publishing%20API/consumer/GDS%20API%20Adapters/latest#a_request_to_put_a_path_given_no_content_exists
 [rfc-3339]: https://www.ietf.org/rfc/rfc3339.txt

--- a/doc/api.md
+++ b/doc/api.md
@@ -542,22 +542,39 @@ a mapping of `base_path` to `content_id`.
 
 ## `GET /v2/lookup-by-base-path`
 
- [Request/Response detail][lookup-by-base-path-v2-pact]
-
 Returns the current draft and/or the current live edition matching a base path
 or set of base paths.
 
 "draft" and "live" refer to the content stores, rather than edition states. The live edition contains an `unpublishing` object if the edition is unpublished.
 
-If a base path has never been used, it will be omitted from the response.
+
+The response contains both `live` and `draft` when a document has a live edition as well as a new draft:
+
+```json
+{
+  "/register-to-vote":{
+    "draft": {
+      "content_id":"834a7921-260b-4061-9de1-edda3e998c68",
+      "locale":"en",
+      "document_type":"transaction"
+    },
+    "live": {
+      "content_id":"834a7921-260b-4061-9de1-edda3e998c68",
+      "locale":"en",
+      "document_type":"transaction"
+    }
+  }
+}
+```
+If a base path has never been used, or belongs to an access-limited draft, its value will be `null` in the response.
 
 There is a limit of 100 base paths per request. This endpoint also responds to `POST` requests, which can be used if the query params would otherwise make the
 URI too long.
-
 ### GET parameters:
 
 - `base_paths[]` *(required)*
   - An array of `base_path`s to query by.
+
 
 
 ## `PUT /paths/:base_path`

--- a/spec/factories/unpublished_edition.rb
+++ b/spec/factories/unpublished_edition.rb
@@ -14,6 +14,7 @@ FactoryGirl.define do
         edition: edition,
         type: evaluator.unpublishing_type,
         explanation: evaluator.explanation,
+        alternative_path: evaluator.alternative_path,
         redirects: [{ path: edition.base_path, type: :exact, destination: evaluator.alternative_path }],
         unpublished_at: evaluator.unpublished_at,
       )

--- a/spec/factories/unpublished_edition.rb
+++ b/spec/factories/unpublished_edition.rb
@@ -10,12 +10,16 @@ FactoryGirl.define do
     end
 
     after(:create) do |edition, evaluator|
+      redirects = [
+        { path: edition.base_path, type: :exact, destination: evaluator.alternative_path }
+      ] if evaluator.unpublishing_type == 'redirect'
+
       FactoryGirl.create(:unpublishing,
         edition: edition,
         type: evaluator.unpublishing_type,
         explanation: evaluator.explanation,
         alternative_path: evaluator.alternative_path,
-        redirects: [{ path: edition.base_path, type: :exact, destination: evaluator.alternative_path }],
+        redirects: redirects,
         unpublished_at: evaluator.unpublished_at,
       )
     end

--- a/spec/queries/lookup_by_base_paths_spec.rb
+++ b/spec/queries/lookup_by_base_paths_spec.rb
@@ -1,0 +1,207 @@
+require "rails_helper"
+
+RSpec.describe Queries::LookupByBasePaths do
+  describe "#call" do
+    before { Rails.cache.clear }
+
+    context "with draft, superseded, published and unpublished editions" do
+      let(:published_with_new_draft) { FactoryGirl.create(:document, content_id: "aa491126-77ed-4e81-91fa-8dc7f74e9657") }
+      let(:published_with_no_drafts) { FactoryGirl.create(:document, content_id: "bbabcd3c-7c45-4403-8490-db51e4bfc4f6") }
+      let(:two_initial_drafts) { FactoryGirl.create(:document, content_id: "dd1bf833-f91c-4e45-9f97-87b165808176") }
+      let(:redirected) { FactoryGirl.create(:document, content_id: "ee491126-77ed-4e81-91fa-8dc7f74e9657") }
+      let(:gone) { FactoryGirl.create(:document, content_id: "ffabcd3c-7c45-4403-8490-db51e4bfc4f6") }
+      let(:withdrawn) { FactoryGirl.create(:document, content_id: "00abcd3c-7c45-4403-8490-db51e4bfc4f6") }
+      let(:initial_draft) { FactoryGirl.create(:document, content_id: "01abcd3c-7c45-4403-8490-db51e4bfc4f6") }
+      let(:unpublished_without_draft) { FactoryGirl.create(:document, content_id: "02abcd3c-7c45-4403-8490-db51e4bfc4f6") }
+      let(:reused_base_path) { FactoryGirl.create(:document, content_id: "03abcd3c-7c45-4403-8490-db51e4bfc4f6") }
+
+      before do
+        FactoryGirl.create(:live_edition, state: "published", base_path: "/published-and-draft-page", document: published_with_new_draft, user_facing_version: 1, document_type: "publication")
+        FactoryGirl.create(:edition, state: "draft", base_path: "/published-and-draft-page", document: published_with_new_draft, user_facing_version: 2, document_type: "publication")
+        FactoryGirl.create(:live_edition, state: "published", base_path: "/only-published-page", document: published_with_no_drafts, document_type: "publication")
+        FactoryGirl.create(:edition, state: "draft", base_path: "/draft-and-superseded-page", document: two_initial_drafts, user_facing_version: 2, document_type: "publication")
+        FactoryGirl.create(:superseded_edition, state: "superseded", base_path: "/draft-and-superseded-page", document: two_initial_drafts, user_facing_version: 1, document_type: "publication")
+        FactoryGirl.create(:edition, state: "draft", base_path: "/only-draft-page", document: initial_draft, user_facing_version: 1, document_type: "publication")
+        FactoryGirl.create(:unpublished_edition, base_path: "/redirected-from-page", document: redirected, user_facing_version: 1, unpublishing_type: "redirect", alternative_path: "/redirected-to-page", document_type: "publication")
+        FactoryGirl.create(:unpublished_edition, base_path: "/gone-page", document: gone, user_facing_version: 1, unpublishing_type: "gone", alternative_path: nil, document_type: "publication")
+        FactoryGirl.create(:unpublished_edition, base_path: "/withdrawn-page", document: withdrawn, user_facing_version: 1, unpublishing_type: "withdrawal", explanation: "Consolidated into another page", alternative_path: nil, document_type: "publication")
+      end
+
+      it "returns published pages" do
+        response = Queries::LookupByBasePaths.call(%w(/only-published-page))
+
+        expect(response).to eql(
+          "/only-published-page" => {
+            "live" => {
+              "content_id" => published_with_no_drafts.content_id,
+              "locale" => "en",
+              "document_type" => "publication",
+            }
+          }
+        )
+      end
+
+      it "returns draft pages" do
+        response = Queries::LookupByBasePaths.call(%w(/only-draft-page))
+
+        expect(response).to eql(
+          "/only-draft-page" => {
+            "draft" => {
+              "content_id" => initial_draft.content_id,
+              "locale" => "en",
+              "document_type" => "publication",
+            }
+          }
+        )
+      end
+
+      it "includes withdrawn pages" do
+        response = Queries::LookupByBasePaths.call(%w(/withdrawn-page))
+
+        expect(response).to eql(
+          "/withdrawn-page" => {
+            "live" => {
+              "content_id" => withdrawn.content_id,
+              "locale" => "en",
+              "document_type" => "publication",
+              "unpublishing" => {
+                "type" => "withdrawal",
+              }
+            }
+          }
+        )
+      end
+
+      it "returns different content ids if the base path has been reused" do
+        replacement_content_id = "ab491126-77ed-4e81-91fa-8dc7f74e9657"
+        replacement = FactoryGirl.create(:document, content_id: replacement_content_id)
+        FactoryGirl.create(:edition, state: "draft", base_path: "/withdrawn-page", document: replacement, user_facing_version: 1, document_type: "publication")
+
+        response = Queries::LookupByBasePaths.call(%w(/withdrawn-page))
+
+        expect(response).to eql(
+          "/withdrawn-page" => {
+            "draft" => {
+              "content_id" => replacement_content_id,
+              "locale" => "en",
+              "document_type" => "publication",
+            },
+            "live" => {
+              "content_id" => withdrawn.content_id,
+              "locale" => "en",
+              "document_type" => "publication",
+              "unpublishing" => {
+                "type" => "withdrawal",
+              }
+            },
+          }
+        )
+      end
+
+      it "returns unpublished content" do
+        response = Queries::LookupByBasePaths.call(%w(/redirected-from-page /gone-page /withdrawn-page))
+
+        expect(response).to eql(
+          "/gone-page" => {
+            "live" => {
+              "content_id" => gone.content_id,
+              "locale" => "en",
+              "document_type" => "publication",
+              "unpublishing" => {
+                "type" => "gone",
+              }
+            },
+          },
+          "/redirected-from-page" => {
+            "live" => {
+              "content_id" => redirected.content_id,
+              "locale" => "en",
+              "document_type" => "publication",
+              "unpublishing" => {
+                "type" => "redirect",
+                "alternative_path" => "/redirected-to-page"
+              }
+            },
+          },
+          "/withdrawn-page" => {
+            "live" => {
+              "content_id" => withdrawn.content_id,
+              "locale" => "en",
+              "document_type" => "publication",
+              "unpublishing" => {
+                "type" => "withdrawal",
+              }
+            }
+          }
+        )
+      end
+
+      it "ignores paths that do not match" do
+        test_base_paths = [
+          "/only-published-page",
+          "/does-not-exist",
+          "/only-draft-page"
+        ]
+
+        response = Queries::LookupByBasePaths.call(test_base_paths)
+
+        expect(response).to eql(
+          "/only-published-page" => {
+            "live" => {
+              "content_id" => published_with_no_drafts.content_id,
+              "locale" => "en",
+              "document_type" => "publication"
+            },
+          },
+          "/only-draft-page" => {
+            "draft" => {
+              "content_id" => initial_draft.content_id,
+              "locale" => "en",
+              "document_type" => "publication"
+            }
+          }
+        )
+      end
+    end
+
+    it "returns content items with document_type redirect" do
+      edition = FactoryGirl.create(:redirect_edition, state: "published", base_path: "/redirect-page")
+
+      response = Queries::LookupByBasePaths.call(edition.base_path)
+
+      expect(response).to eql(
+        "/redirect-page" => {
+          "live" => {
+            "content_id" => edition.content_id,
+            "locale" => "en",
+            "document_type" => "redirect"
+          }
+        }
+      )
+    end
+
+    it "returns content items with document_type gone" do
+      edition = FactoryGirl.create(:gone_edition, state: "published", base_path: "/gone-page")
+
+      response = Queries::LookupByBasePaths.call(edition.base_path)
+
+      expect(response).to eql(
+        "/gone-page" => {
+          "live" => {
+            "content_id" => edition.content_id,
+            "locale" => "en",
+            "document_type" => "gone"
+          }
+        }
+      )
+    end
+
+    it "excludes access-limited editions" do
+      FactoryGirl.create(:access_limited_edition, base_path: "/access-limited")
+
+      response = Queries::LookupByBasePaths.call(%w(/access-limited))
+
+      expect(response).to eql({})
+    end
+  end
+end

--- a/spec/requests/lookups_v2_spec.rb
+++ b/spec/requests/lookups_v2_spec.rb
@@ -1,0 +1,70 @@
+require "rails_helper"
+
+RSpec.describe "/v2/lookup-by-base-path", type: :request do
+  let(:content_id) { SecureRandom.uuid }
+  let(:base_path) { "/document" }
+  let(:document) { FactoryGirl.create(:document, content_id: content_id) }
+
+  before do
+    FactoryGirl.create(:draft_edition, document: document, base_path: base_path)
+  end
+
+  context "GET" do
+    it "requires a base path param" do
+      expected_error_response = { "error" => { "code" => 422, "message" => "param is missing or the value is empty: base_paths" } }
+
+      get "/v2/lookup-by-base-path"
+
+      expect(parsed_response).to eq(expected_error_response)
+    end
+
+    it "rejects requests with more than 100 base paths" do
+      base_paths = 1.upto(101).map { |i| "/foo-#{i}" }
+
+      get v2_lookup_by_base_path_path, params: { base_paths: base_paths }
+
+      expected_error_response = { "error" => { "code" => 400, "message" => "base_paths must contain less than 100 items" } }
+      expect(parsed_response).to eq(expected_error_response)
+    end
+
+    it "queries content matching the base_paths" do
+      get v2_lookup_by_base_path_path, params: { base_paths: [base_path] }
+
+      expect(response.status).to eq(200)
+      expect(parsed_response.keys).to eq([base_path])
+
+      parsed_content_id = parsed_response.dig(
+        base_path,
+        "draft",
+        "content_id"
+      )
+
+      expect(parsed_content_id).to eq(content_id)
+    end
+  end
+
+  context "called with POST" do
+    it "requires a base path param" do
+      expected_error_response = { "error" => { "code" => 422, "message" => "param is missing or the value is empty: base_paths" } }
+
+      post "/v2/lookup-by-base-path"
+
+      expect(parsed_response).to eq(expected_error_response)
+    end
+
+    it "queries content matching the base_paths" do
+      post v2_lookup_by_base_path_path, params: { base_paths: [base_path] }
+
+      expect(response.status).to eq(200)
+      expect(parsed_response.keys).to eq([base_path])
+
+      parsed_content_id = parsed_response.dig(
+        base_path,
+        "draft",
+        "content_id"
+      )
+
+      expect(parsed_content_id).to eq(content_id)
+    end
+  end
+end

--- a/spec/requests/lookups_v2_spec.rb
+++ b/spec/requests/lookups_v2_spec.rb
@@ -18,6 +18,14 @@ RSpec.describe "/v2/lookup-by-base-path", type: :request do
       expect(parsed_response).to eq(expected_error_response)
     end
 
+    it "requires a base path param to be an array" do
+      expected_error_response = { "error" => { "code" => 422, "message" => "param is missing or the value is empty: base_paths" } }
+
+      get "/v2/lookup-by-base-path", params: { base_paths: "/foo" }
+
+      expect(parsed_response).to eq(expected_error_response)
+    end
+
     it "rejects requests with more than 100 base paths" do
       base_paths = 1.upto(101).map { |i| "/foo-#{i}" }
 


### PR DESCRIPTION
This request replaces `/lookup-by-base-path`. It allows draft and unpublished documents to be looked up in addition to live content.

More background in https://github.com/alphagov/publishing-api/issues/812

Trello: https://trello.com/c/MHBTiA65/544-publishing-api-support-for-lookups-of-draft-content-split-from-allow-users-to-tag-draft-content