### PR TITLE
Upgrade govuk_document_types gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,7 @@ end
 
 gem "gds-sso", "13.0.0"
 gem "govuk_schemas", require: false
-gem "govuk_document_types", "~> 0.1.2"
+gem "govuk_document_types", "~> 0.1.3"
 
 gem 'bunny', '2.5.1'
 gem 'whenever', '0.9.4', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -127,7 +127,7 @@ GEM
     govuk-lint (1.2.1)
       rubocop (~> 0.39.0)
       scss_lint
-    govuk_document_types (0.1.2)
+    govuk_document_types (0.1.3)
     govuk_schemas (2.0.0)
       json-schema (~> 2.5.0)
     govuk_sidekiq (1.0.3)
@@ -412,7 +412,7 @@ DEPENDENCIES
   gds-sso (= 13.0.0)
   govspeak (~> 5.0.2)
   govuk-lint
-  govuk_document_types (~> 0.1.2)
+  govuk_document_types (~> 0.1.3)
   govuk_schemas
   govuk_sidekiq (~> 1.0.3)
   hashdiff
@@ -443,4 +443,4 @@ DEPENDENCIES
   whenever (= 0.9.4)
 
 BUNDLED WITH
-   1.13.1
+   1.14.5


### PR DESCRIPTION
Pick up the latest document supertypes: `notice` has been removed from the `guidance` supertype.

https://trello.com/c/RhEocgyj/42-remove-notices-from-guidance-list