### PR TITLE
Fix flakiness caused by random content 

### DIFF
--- a/spec/integration/random_content_spec.rb
+++ b/spec/integration/random_content_spec.rb
@@ -1,0 +1,28 @@
+require "rails_helper"
+
+RSpec.describe "Randomised content" do
+  include RandomContentHelpers
+
+  50.times do |i|
+    it "it can publish randomly generated content #{i+1}/50" do
+      base_path = "/#{SecureRandom.hex}"
+      stub_content_store_calls(base_path)
+      edition = generate_random_edition(base_path)
+
+      put "/v2/content/#{content_id}", params: edition.to_json
+
+      expect(response).to be_ok, random_content_failure_message(response, edition)
+
+      post "/v2/content/#{content_id}/publish", params: { locale: edition["locale"], update_type: "major" }.to_json
+
+      expect(response).to be_ok, random_content_failure_message(response, edition)
+    end
+  end
+
+  def stub_content_store_calls(base_path)
+    stub_request(:put, "http://draft-content-store.dev.gov.uk/content#{base_path}")
+      .to_return(status: 200)
+    stub_request(:put, "http://content-store.dev.gov.uk/content#{base_path}")
+      .to_return(status: 200)
+  end
+end

--- a/spec/integration/random_content_spec.rb
+++ b/spec/integration/random_content_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe "Randomised content" do
   include RandomContentHelpers
 
   50.times do |i|
-    it "it can publish randomly generated content #{i+1}/50" do
+    it "it can publish randomly generated content #{i + 1}/50" do
       base_path = "/#{SecureRandom.hex}"
       stub_content_store_calls(base_path)
       edition = generate_random_edition(base_path)

--- a/spec/support/random_content_helpers.rb
+++ b/spec/support/random_content_helpers.rb
@@ -1,0 +1,31 @@
+require "govuk_schemas"
+
+module RandomContentHelpers
+  def generate_random_edition(base_path)
+    random = GovukSchemas::RandomExample.for_schema(publisher_schema: "placeholder")
+
+    random.merge_and_validate(
+      routes: [
+        { path: base_path, type: "prefix" } # hard to do in schemas
+      ],
+      base_path: base_path,
+
+      # TODOs:
+      rendering_app: "something", # TODO: make schemas validate rendering_app
+      publishing_app: "something", # TODO: make schemas validate rendering_app
+      redirects: [], # TODO: make schemas validate redirects
+    )
+  end
+
+  def random_content_failure_message(response, edition)
+    <<-DOC
+    Failed #{response.request.method} #{response.request.fullpath}
+
+    Content:
+    #{JSON.pretty_generate(edition)}
+
+    Response:
+    #{JSON.pretty_generate(parsed_response)}"
+    DOC
+  end
+end

--- a/spec/support/random_content_helpers.rb
+++ b/spec/support/random_content_helpers.rb
@@ -12,6 +12,7 @@ module RandomContentHelpers
 
       # TODOs:
       title: "Something not empty", # TODO: make schemas validate title length
+      document_type: "guide", # TODO: remove after https://github.com/alphagov/govuk-content-schemas/pull/550 deployed
       rendering_app: "something", # TODO: make schemas validate rendering_app
       publishing_app: "something", # TODO: make schemas validate rendering_app
       redirects: [], # TODO: make schemas validate redirects

--- a/spec/support/random_content_helpers.rb
+++ b/spec/support/random_content_helpers.rb
@@ -11,6 +11,7 @@ module RandomContentHelpers
       base_path: base_path,
 
       # TODOs:
+      title: "Something not empty", # TODO: make schemas validate title length
       rendering_app: "something", # TODO: make schemas validate rendering_app
       publishing_app: "something", # TODO: make schemas validate rendering_app
       redirects: [], # TODO: make schemas validate redirects


### PR DESCRIPTION
This PR fixes the flakiness caused by the random content generation. 

To do we first add a proper error message that outputs the failures. With that I found two cases where the random content, which is valid according to the schema, is not valid according to this app. I've put in temporary fixes.

Also added an explicit test that tests 50 random items against the put content & publish endpoints. To verify there are no more issues I've run it 2000 times.

More details in the commits.