### PR TITLE
Only respond with JSON for exceptions

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,11 +5,6 @@ class ApplicationController < ActionController::Base
   rescue_from JSON::ParserError, with: :json_parse_error
   rescue_from CommandError, with: :respond_with_command_error
 
-  before_action do
-    # Force Rails to show text-error pages
-    request.env['HTTP_X_REQUESTED_WITH'] = 'XMLHttpRequest'
-  end
-
   before_action :require_signin_permission!
 
   Warden::Manager.after_authentication do |user, _, _|

--- a/config/application.rb
+++ b/config/application.rb
@@ -36,5 +36,7 @@ module PublishingAPI
       bucket: ENV["EVENT_LOG_AWS_BUCKETNAME"],
       events_key_prefix: "events/",
     )
+
+    config.debug_exception_response_format = :api
   end
 end


### PR DESCRIPTION
This makes Rails return a JSON error instead of a HTML page when it encounters an error. This makes it a lot easier to find the error when in development. Kinda like https://github.com/alphagov/publishing-api/pull/123, but better (it's a new feature in Rails 5).

## Before

![screen shot 2017-03-08 at 20 47 38](https://cloud.githubusercontent.com/assets/233676/23723441/1c8c0a6a-0441-11e7-986a-bde527492752.png)

## After

![screen shot 2017-03-08 at 20 47 08](https://cloud.githubusercontent.com/assets/233676/23723448/23280b1c-0441-11e7-8342-3b8b3c353d08.png)
