### PR TITLE
Fix `links` subquery in `ContentItemPresenter`

### DIFF
--- a/app/presenters/queries/content_item_presenter.rb
+++ b/app/presenters/queries/content_item_presenter.rb
@@ -180,10 +180,9 @@ module Presenters
 
       LINKS_SQL = <<-SQL.freeze
         (
-          SELECT json_agg((links.link_type, target_content_id))
+          SELECT json_agg((links.link_type, links.target_content_id))
           FROM links
           WHERE links.edition_id = editions.id
-          GROUP BY links.link_type
         )
       SQL
 

--- a/spec/presenters/queries/content_item_presenter_spec.rb
+++ b/spec/presenters/queries/content_item_presenter_spec.rb
@@ -120,6 +120,26 @@ RSpec.describe Presenters::Queries::ContentItemPresenter do
         expect(result).to eq expected
       end
     end
+
+    context "when we have multiple links" do
+      let(:other_content_id) { SecureRandom.uuid }
+      let(:and_another_content_id) { SecureRandom.uuid }
+      before do
+        edition.links.create(link_type: "test", target_content_id: content_id)
+        edition.links.create(link_type: "test", target_content_id: and_another_content_id)
+        edition.links.create(link_type: "ers", target_content_id: other_content_id)
+      end
+
+      it "presents the item including the links" do
+        expected = expected_output.merge(
+          "links" => {
+            "test" => [content_id, and_another_content_id],
+            "ers" => [other_content_id],
+          }
+        )
+        expect(result).to eq expected
+      end
+    end
   end
 
   describe "#present_many" do


### PR DESCRIPTION
When an edition has links of more than one type the current sub-query in `ContentItemPresenter` was raising as the sub-query returned multiple rows.

This commit fixes the SQL to return the expected result by removing the `group by` clause. The JSON aggregation already seems to do the necessary grouping by type.