### PR TITLE
Add migration to fix parted Publisher redirects

### DIFF
--- a/db/migrate/20170309165912_fix_redirects_for_publisher_multipart_content.rb
+++ b/db/migrate/20170309165912_fix_redirects_for_publisher_multipart_content.rb
@@ -1,0 +1,46 @@
+class FixRedirectsForPublisherMultipartContent < ActiveRecord::Migration[5.0]
+  disable_ddl_transaction!
+
+  BASE_PATHS_FOR_PARTED_CONTENT_WITH_EXACT_REDIRECT_TYPE = [
+    "/accredited-electrical-and-electronic-equipment-producer-compliance-scheme-scotland",
+    "/air-conditioning-system-energy-assessor-accreditation-england-wales",
+    "/business-legal-structures",
+    "/domestic-energy-assessor-existing-buildings",
+    "/energy-assessor-england-and-wales",
+    "/family-visit-visa",
+    "/insolvency-practitioner-authorisation-ni",
+    "/insolvency-practitioner-authorisations-england-scotland-wales",
+    "/non-domestic-energy-assessor-accreditation",
+    "/on-construction-dea-accreditation",
+    "/operational-ratings-assessor-accreditation-england-wales",
+    "/set-up-and-run-limited-liability-partnership",
+    "/set-up-and-run-limited-partnership",
+    "/set-up-business-uk",
+    "/tv-dealer-notifications",
+  ].freeze
+
+  def unpublishings
+    unpublished_editions.map(&:unpublishing)
+  end
+
+  def unpublished_editions
+    Edition
+      .where('base_path IN (?)', BASE_PATHS_FOR_PARTED_CONTENT_WITH_EXACT_REDIRECT_TYPE)
+      .where(state: "unpublished")
+      .where(publishing_app: "publisher")
+      .where("updated_at > '2017-01-20'")
+      .where("updated_at < '2017-02-27'")
+  end
+
+  def up
+    unpublishings.each do |u|
+      prefix_redirects = u.redirects
+      prefix_redirects.each { |r| r[:type] = "prefix" }
+      u.update_attributes!(redirects: prefix_redirects)
+    end
+
+    if Rails.env.production?
+      Commands::V2::RepresentDownstream.new.call(unpublished_editions.map(&:content_id))
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170306135152) do
+ActiveRecord::Schema.define(version: 20170313184559) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
A while back we switched Publisher to use the Publishing API for unpublishing with redirects. At that point the Publishing API did not support unpublishing with prefix routes, so the routes were set incorrectly to 'exact'. This issue has since been fixed, however we added a CSV to router-data to fix these routes (to make absolutely sure, we just included ALL routes for unpublished parted formats, but the list of affected items is much smaller). This migration aims to fix the affected content items so that we can remove the CSV from router-data.

See https://github.gds/gds/router-data/pull/619