### PR TITLE
Allow exclusion of drafts from GetExpandedLinks

### DIFF
--- a/app/controllers/v2/link_sets_controller.rb
+++ b/app/controllers/v2/link_sets_controller.rb
@@ -5,7 +5,11 @@ module V2
     end
 
     def expanded_links
-      render json: Queries::GetExpandedLinks.call(content_id, params[:locale])
+      render json: Queries::GetExpandedLinks.call(
+        content_id,
+        params[:locale],
+        with_drafts: with_drafts?,
+      )
     end
 
     def patch_links
@@ -22,6 +26,12 @@ module V2
     end
 
   private
+
+    def with_drafts?
+      # Cast the `with_drafts` query param to a real boolean, and default to
+      # `true` to preserve existing behaviour
+      ActiveModel::Type::Boolean.new.cast(params.fetch(:with_drafts, true))
+    end
 
     def links_params
       payload.merge(content_id: content_id)

--- a/app/queries/get_expanded_links.rb
+++ b/app/queries/get_expanded_links.rb
@@ -1,8 +1,8 @@
 module Queries
   class GetExpandedLinks
-    def self.call(content_id, locale)
+    def self.call(content_id, locale, with_drafts: true)
       if (link_set = LinkSet.find_by(content_id: content_id))
-        expanded_link_set(link_set, locale)
+        expanded_link_set(link_set, locale, with_drafts: with_drafts)
       elsif Document.where(content_id: content_id).exists?
         empty_expanded_link_set(content_id)
       else
@@ -17,10 +17,10 @@ module Queries
       end
     end
 
-    def self.expanded_link_set(link_set, locale)
+    def self.expanded_link_set(link_set, locale, with_drafts:)
       expanded_link_set = Presenters::Queries::ExpandedLinkSet.new(
         content_id: link_set.content_id,
-        draft: true,
+        draft: with_drafts,
         locale: locale,
       )
 

--- a/doc/api.md
+++ b/doc/api.md
@@ -488,6 +488,11 @@ details for each linked edition in groupings of `link_type`.
 - [`content_id`](model.md#content_id)
   - Identifies the link set links will be retrieved for.
 
+### Query string parameters:
+
+- `with_drafts` *(optional, default: true)*
+  - Whether links to draft editions should be included in the response.
+
 ## `GET /v2/linked/:content_id`
 
  [Request/Response detail][show-linked-pact]

--- a/spec/queries/get_expanded_links_spec.rb
+++ b/spec/queries/get_expanded_links_spec.rb
@@ -2,6 +2,8 @@ require "rails_helper"
 
 RSpec.describe Queries::GetExpandedLinks do
   let(:content_id) { SecureRandom.uuid }
+  let(:live_child_taxon_content_id) { SecureRandom.uuid }
+  let(:draft_child_taxon_content_id) { SecureRandom.uuid }
 
   context "when the document does not exist" do
     it "raises a command error" do
@@ -23,6 +25,60 @@ RSpec.describe Queries::GetExpandedLinks do
         content_id: content_id,
         version: 0,
         expanded_links: {},
+      )
+    end
+  end
+
+  context "when a document exists with a link set" do
+    before do
+      document = FactoryGirl.create(:document, content_id: content_id)
+      FactoryGirl.create(:live_edition, document: document, base_path: '/foo')
+
+      FactoryGirl.create(:live_edition,
+        document: Document.find_or_create_by(
+          content_id: live_child_taxon_content_id,
+          locale: "en"
+        ),
+        base_path: "/foo/bar",
+        user_facing_version: 1,
+        links_hash: {
+          parent_taxons: [content_id]
+        },
+      )
+      FactoryGirl.create(:draft_edition,
+        document: Document.find_or_create_by(
+          content_id: draft_child_taxon_content_id,
+          locale: "en"
+        ),
+        base_path: "/foo/baz",
+        user_facing_version: 1,
+        links_hash: {
+          parent_taxons: [content_id]
+        },
+      )
+      FactoryGirl.create(:link_set,
+        content_id: content_id,
+        links_hash: {},
+      )
+    end
+
+    it "returns all links by default" do
+      result = described_class.call(content_id, "en")
+      expect(result[:expanded_links][:child_taxons]).to match_array(
+        [
+          hash_including(content_id: live_child_taxon_content_id),
+          hash_including(content_id: draft_child_taxon_content_id),
+        ]
+      )
+    end
+
+    it "returns only links to live editions when with_drafts is false" do
+      result = described_class.call(content_id, "en", with_drafts: false)
+
+      expect(result[:expanded_links][:child_taxons]).to match_array(
+        [
+          hash_including(content_id: live_child_taxon_content_id),
+        ]
       )
     end
   end


### PR DESCRIPTION
Currently, GetExpandedLinks returns all links, whether live or draft. This commit adds a `with_drafts` option, mirroring that already available on `LinkSetExpansion`, to allow the user to choose whether or not drafts should be returned.

Trello: https://trello.com/c/LmVHv7Jv/537-build-design-for-tagging-to-draft-taxons-in-whitehall

cc @kevindew 