### PR TITLE
Mark draft expanded links

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -483,6 +483,9 @@ were created.
 Retrieves the expanded link set for the given `content_id`. Returns arrays of
 details for each linked edition in groupings of `link_type`.
 
+Expanded links from both the live and draft content stores are returned.
+Links to draft editions are marked with `draft: true`.
+
 ### Path parameters
 
 - [`content_id`](model.md#content_id)

--- a/lib/link_expansion.rb
+++ b/lib/link_expansion.rb
@@ -49,7 +49,10 @@ private
     rules.expand_fields(edition, node.link_type).tap do |expanded|
       links = populate_links(node.links)
       auto_reverse = auto_reverse_link(node)
-      expanded.merge!(links: (auto_reverse || {}).merge(links))
+      expanded.merge!(
+        links: (auto_reverse || {}).merge(links),
+        draft: draft?(edition),
+      )
     end
   end
 
@@ -70,6 +73,10 @@ private
     # this requires we assess impact on the rendering applications first.
     %i(children parent related_statistical_data_sets).include?(link_type) ||
       edition.state != "unpublished"
+  end
+
+  def draft?(edition)
+    edition.content_store == "draft"
   end
 
   def rules

--- a/spec/requests/expanded_links_endpoint_spec.rb
+++ b/spec/requests/expanded_links_endpoint_spec.rb
@@ -70,6 +70,7 @@ RSpec.describe "GET /v2/expanded-links/:id", type: :request do
             "title" => "VAT rates",
             "withdrawn" => false,
             "links" => {},
+            "draft" => true,
             "details" => { "body" => "<p>Something about VAT</p>\n" },
           }
         ],


### PR DESCRIPTION
This commit marks expanded links to draft editions with `draft: true` so that they can be differentiated from links to live editions.

Trello: https://trello.com/c/LmVHv7Jv/537-build-design-for-tagging-to-draft-taxons-in-whitehall

Paired with @Davidslv 

cc @kevindew 