### PR TITLE
Solve the case of the missing change notes

### DIFF
--- a/app/commands/v2/publish.rb
+++ b/app/commands/v2/publish.rb
@@ -32,10 +32,15 @@ module Commands
         edition.publish
         remove_access_limit
         create_publish_action
+        create_change_note if payload[:update_type].present?
       end
 
       def create_publish_action
         Action.create_publish_action(edition, document.locale, event)
+      end
+
+      def create_change_note
+        ChangeNote.create_from_edition(payload, edition)
       end
 
       def access_limit

--- a/app/models/change_note.rb
+++ b/app/models/change_note.rb
@@ -28,9 +28,9 @@ private
     ChangeNote
       .find_or_create_by!(edition: edition)
       .update!(
-        note: change_note,
         content_id: edition.document.content_id,
-        public_timestamp: Time.zone.now
+        public_timestamp: Time.zone.now,
+        note: change_note,
       )
   end
 
@@ -51,7 +51,9 @@ private
     ChangeNote
       .find_or_create_by!(edition: edition)
       .update!(
-        history_element.merge(content_id: edition.document.content_id)
+        content_id: edition.document.content_id,
+        public_timestamp: history_element.fetch(:public_timestamp),
+        note: history_element.fetch(:note),
       )
   end
 

--- a/app/models/change_note.rb
+++ b/app/models/change_note.rb
@@ -25,9 +25,9 @@ private
 
   def create_from_top_level_change_note
     return unless change_note
-    ChangeNote.
-      find_or_create_by!(edition: edition).
-      update!(
+    ChangeNote
+      .find_or_create_by!(edition: edition)
+      .update!(
         note: change_note,
         content_id: edition.document.content_id,
         public_timestamp: Time.zone.now
@@ -36,23 +36,23 @@ private
 
   def create_from_details_hash_change_note
     return unless note
-    ChangeNote.create!(
-      edition: edition,
-      content_id: edition.document.content_id,
-      public_timestamp: edition.updated_at,
-      note: note,
-    )
+    ChangeNote
+      .find_or_create_by!(edition: edition)
+      .update!(
+        content_id: edition.document.content_id,
+        public_timestamp: edition.updated_at,
+        note: note,
+      )
   end
 
   def create_from_details_hash_change_history
     return unless change_history.present?
     history_element = change_history.max_by { |h| h[:public_timestamp] }
-    ChangeNote.create!(
-      history_element.merge(
-        edition: edition,
-        content_id: edition.document.content_id
+    ChangeNote
+      .find_or_create_by!(edition: edition)
+      .update!(
+        history_element.merge(content_id: edition.document.content_id)
       )
-    )
   end
 
   def change_note

--- a/app/models/change_note.rb
+++ b/app/models/change_note.rb
@@ -13,7 +13,7 @@ class ChangeNoteFactory
   end
 
   def build
-    return unless edition.update_type == "major"
+    return unless update_type == "major"
     create_from_top_level_change_note ||
       create_from_details_hash_change_note ||
       create_from_details_hash_change_history
@@ -53,6 +53,10 @@ private
       .update!(
         history_element.merge(content_id: edition.document.content_id)
       )
+  end
+
+  def update_type
+    @update_type ||= payload[:update_type] || edition.update_type
   end
 
   def change_note

--- a/db/migrate/20170313142432_ensure_change_notes_exist.rb
+++ b/db/migrate/20170313142432_ensure_change_notes_exist.rb
@@ -1,0 +1,24 @@
+class EnsureChangeNotesExist < ActiveRecord::Migration[5.0]
+  disable_ddl_transaction!
+
+  def up
+    payload = {} # fake payload, imagine nothing was given
+
+    Edition
+      .where(%q(
+        NOT EXISTS (
+          SELECT 1
+          FROM change_notes
+          WHERE change_notes.edition_id = editions.id
+        )
+        AND (
+          (details->'change_history') IS NOT NULL
+          OR
+          (details->'change_note') IS NOT NULL
+        )
+      ))
+      .find_each do |edition|
+        ChangeNote.create_from_edition(payload, edition)
+      end
+  end
+end

--- a/spec/commands/v2/publish_spec.rb
+++ b/spec/commands/v2/publish_spec.rb
@@ -71,6 +71,21 @@ RSpec.describe Commands::V2::Publish do
       end
     end
 
+    context "with a change note in the details" do
+      before do
+        draft_item.update(
+          details: {
+            change_history: [{ note: "Info", public_timestamp: Time.now }]
+          }
+        )
+      end
+
+      it "creates associated ChangeNote records" do
+        expect { described_class.call(payload) }
+          .to change { ChangeNote.count }.by(1)
+      end
+    end
+
     context "publishing draft edition" do
       let(:existing_base_path) { base_path }
 

--- a/spec/models/change_note_spec.rb
+++ b/spec/models/change_note_spec.rb
@@ -52,14 +52,14 @@ RSpec.describe ChangeNote do
       end
     end
 
-    context "edition has change_note entry in details hash" do
+    context "edition has an empty change_history entry in details hash" do
       let(:details) { { change_history: [] } }
       it "populates change note from details hash" do
         expect { subject }.to_not change { ChangeNote.count }
       end
     end
 
-    context "edition has change_note entry in details hash" do
+    context "edition has a nil change_history entry in details hash" do
       let(:details) { { change_history: nil } }
       it "populates change note from details hash" do
         expect { subject }.to_not change { ChangeNote.count }
@@ -68,12 +68,15 @@ RSpec.describe ChangeNote do
 
     context "edition has change_history entry in details hash" do
       let(:details) do
-        { change_history: [
-          { public_timestamp: 3.day.ago.to_s, note: "note 3" },
-          { public_timestamp: 1.day.ago.to_s, note: "note 1" },
-          { public_timestamp: 2.days.ago.to_s, note: "note 2" },
-        ] }
+        {
+          change_history: [
+            { public_timestamp: 3.day.ago.to_s, note: "note 3" },
+            { public_timestamp: 1.day.ago.to_s, note: "note 1" },
+            { public_timestamp: 2.days.ago.to_s, note: "note 2" },
+          ]
+        }
       end
+
       it "populates change note from most recent history item" do
         expect { subject }.to change { ChangeNote.count }.by(1)
         expect(ChangeNote.last.note).to eq "note 1"


### PR DESCRIPTION
We were previously only adding change notes during a put content request when the `update_type` was set to `major`. However, in our API docs we state that `update_type` can be left out, meaning no change notes would be created.

This PR changes the behaviour by also creating change notes on publish, where the `update_type` is not an optional field.