### PR TITLE
Add instrumentation for cache hit/miss

### DIFF
--- a/config/initializers/instrumentation.rb
+++ b/config/initializers/instrumentation.rb
@@ -1,0 +1,7 @@
+statsd = Statsd.new
+statsd.namespace = "govuk.app.publishing-api"
+
+ActiveSupport::Notifications.subscribe("cache_read.active_support") do |_name, _start, _finish, _id, payload|
+  hit_or_miss = payload[:hit] ? "cache_hit" : "cache_miss"
+  statsd.increment("cache.#{hit_or_miss}", 1)
+end


### PR DESCRIPTION
This subscribes to the active support notifications to increment a cache hit/miss counter. We can use this to see whether or not our linkables cache is doing anything useful, and how often the cache is invalidated.

Tested by running the tests in the VM and listening to UDP 8125 (statsd) in another terminal:

```
vagrant@development:~/govuk/publishing-api$ nc -u -l 8125
govuk.app.publishing-api.cache.cache_miss:1|c
```

Part of an effort to speed up content-tagger.