### PR TITLE
Include orphaned_content_ids in worker unique credentials

### DIFF
--- a/app/workers/downstream_draft_worker.rb
+++ b/app/workers/downstream_draft_worker.rb
@@ -14,6 +14,7 @@ class DownstreamDraftWorker
       args.first["content_id"],
       args.first["locale"],
       args.first.fetch("update_dependencies", true),
+      args.first.fetch("orphaned_content_ids", []),
       name,
     ]
   end

--- a/app/workers/downstream_live_worker.rb
+++ b/app/workers/downstream_live_worker.rb
@@ -15,6 +15,7 @@ class DownstreamLiveWorker
       args.first["locale"],
       args.first["message_queue_update_type"],
       args.first.fetch("update_dependencies", true),
+      args.first.fetch("orphaned_content_ids", []),
       name,
     ]
   end


### PR DESCRIPTION
It was reported that our clearing of orphaned_content_ids was behaving
inconsistently. A reason this could be happening is that jobs to clear
them could be rejected as orphaned_content_ids do not appear in the
sidekiq uniq jobs criteria.

This adds them in so they will not be discarded.