### PR TITLE
Reduce the number of historical builds in Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,6 +7,11 @@ node {
   def govuk = load '/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy'
 
   properties([
+    buildDiscarder(
+      logRotator(
+        numToKeepStr: '10'
+      )
+    ),
     [$class: 'ParametersDefinitionProperty',
       parameterDefinitions: [
         [$class: 'BooleanParameterDefinition',


### PR DESCRIPTION
Our CI server is running low on disk space, and this will help.

It will affect the number of historical builds of the master and
deployed-to-production branches.