### PR TITLE
Orphaned content ids fixes

### DIFF
--- a/app/commands/v2/patch_link_set.rb
+++ b/app/commands/v2/patch_link_set.rb
@@ -22,6 +22,9 @@ module Commands
           end
         end
 
+        # we need to reload the link_set as the links association will be stale
+        link_set.reload
+
         orphaned_content_ids = link_diff_between(links_before_patch, link_set.links.map(&:target_content_id))
 
         after_transaction_commit do

--- a/app/commands/v2/publish.rb
+++ b/app/commands/v2/publish.rb
@@ -35,6 +35,13 @@ module Commands
         create_change_note if payload[:update_type].present?
       end
 
+      def orphaned_content_ids
+        return [] unless previous_item
+        previous_links = previous_item.links.map(&:target_content_id)
+        current_links = edition.links.map(&:target_content_id)
+        previous_links - current_links
+      end
+
       def create_publish_action
         Action.create_publish_action(edition, document.locale, event)
       end
@@ -202,7 +209,8 @@ module Commands
       def live_worker_params
         {
           message_queue_update_type: update_type,
-          update_dependencies: update_dependencies?
+          update_dependencies: update_dependencies?,
+          orphaned_content_ids: orphaned_content_ids,
         }.merge(worker_params)
       end
 

--- a/app/commands/v2/put_content.rb
+++ b/app/commands/v2/put_content.rb
@@ -161,7 +161,7 @@ module Commands
           locale: locale,
           payload_version: event.id,
           update_dependencies: update_dependencies,
-          orphaned_links: orphaned_links,
+          orphaned_content_ids: orphaned_links,
         )
       end
     end

--- a/app/commands/v2/unpublish.rb
+++ b/app/commands/v2/unpublish.rb
@@ -121,11 +121,19 @@ module Commands
           locale: document.locale,
           payload_version: event.id,
           update_dependencies: true,
+          orphaned_content_ids: orphaned_content_ids,
         )
       end
 
       def previous_version_number
         payload[:previous_version].to_i if payload[:previous_version]
+      end
+
+      def orphaned_content_ids
+        return [] if !payload[:allow_draft] || !previous
+        previous_links = previous.links.map(&:target_content_id)
+        current_links = find_unpublishable_edition.links.map(&:target_content_id)
+        previous_links - current_links
       end
 
       def find_unpublishable_edition

--- a/spec/commands/v2/put_content_spec.rb
+++ b/spec/commands/v2/put_content_spec.rb
@@ -646,7 +646,7 @@ RSpec.describe Commands::V2::PutContent do
           it "passes the old link to dependency resolution" do
             expect(DownstreamDraftWorker).to receive(:perform_async_in_queue).with(
               "downstream_high",
-              a_hash_including(orphaned_links: [content_id])
+              a_hash_including(orphaned_content_ids: [content_id])
             )
             described_class.call(payload)
           end
@@ -658,7 +658,7 @@ RSpec.describe Commands::V2::PutContent do
           it "passes the old link to dependency resolution" do
             expect(DownstreamDraftWorker).to receive(:perform_async_in_queue).with(
               "downstream_high",
-              a_hash_including(orphaned_links: [content_id])
+              a_hash_including(orphaned_content_ids: [content_id])
             )
             described_class.call(payload)
           end


### PR DESCRIPTION
There were still problems with our orphaned_content_ids implementation. It turned out it wasn't working with `patch_link_set` as links needed to be reloaded and that we had the wrong parameter for `put_content`. So the question is more "how did it ever work intermittently?" than "why didn't it work?"

I've added some tests in and added the checking into publish and unpublishing endpoints. 

/cc @suzannehamilton - yet another spin at fixing these