### PR TITLE
Expand taxons of related_items_overrides

### DIFF
--- a/lib/link_expansion/rules.rb
+++ b/lib/link_expansion/rules.rb
@@ -17,6 +17,7 @@ module LinkExpansion::Rules
     [:parent_taxons.recurring],
     [:taxons, :parent_taxons.recurring],
     [:ordered_related_items, :mainstream_browse_pages, :parent.recurring],
+    [:ordered_related_items_overrides, :taxons]
   ].freeze
 
   REVERSE_LINKS = {


### PR DESCRIPTION
We've added a new link type to allow publishers to override the autogenerated
sidebar on beta education pages with a curated one.

This lets us organise the related links into sections by taxon.

Trello: https://trello.com/c/vM6Kaw9B/505-ias-and-content-designers-can-curate-related-links-for-any-content-type