### PR TITLE
Add auth_bypass_id

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ gem 'dalli'
 if ENV["API_DEV"]
   gem "gds-api-adapters", path: "../gds-api-adapters"
 else
-  gem "gds-api-adapters", "38.1.0"
+  gem 'gds-api-adapters', "~> 41.0"
 end
 
 gem "gds-sso", "13.0.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -81,7 +81,7 @@ GEM
     diff-lcs (1.2.5)
     diffy (3.1.0)
     docile (1.1.5)
-    domain_name (0.5.20160826)
+    domain_name (0.5.20170223)
       unf (>= 0.0.5, < 1.0.0)
     erubis (2.7.0)
     factory_girl (4.7.0)
@@ -94,7 +94,7 @@ GEM
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
     find_a_port (1.0.1)
-    gds-api-adapters (38.1.0)
+    gds-api-adapters (41.0.0)
       link_header
       lrucache (~> 0.1.1)
       null_logger
@@ -245,7 +245,7 @@ GEM
     pry-rails (0.3.4)
       pry (>= 0.9.10)
     rack (2.0.1)
-    rack-cache (1.6.1)
+    rack-cache (1.7.0)
       rack (>= 0.4)
     rack-protection (1.5.3)
       rack
@@ -282,7 +282,7 @@ GEM
     redis-namespace (1.5.2)
       redis (~> 3.0, >= 3.0.4)
     request_store (1.3.1)
-    rest-client (2.0.0)
+    rest-client (2.0.1)
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
@@ -404,7 +404,7 @@ DEPENDENCIES
   diffy (~> 3.1)
   factory_girl_rails (= 4.7.0)
   faker
-  gds-api-adapters (= 38.1.0)
+  gds-api-adapters (~> 41.0)
   gds-sso (= 13.0.0)
   govspeak (~> 5.0.2)
   govuk-lint

--- a/app/commands/v2/put_content.rb
+++ b/app/commands/v2/put_content.rb
@@ -88,7 +88,7 @@ module Commands
           AccessLimit.find_or_create_by(edition: edition).tap do |access_limit|
             access_limit.update_attributes!(
               users: (payload[:access_limited][:users] || []),
-              fact_check_ids: (payload[:access_limited][:fact_check_ids] || []),
+              auth_bypass_ids: (payload[:access_limited][:auth_bypass_ids] || []),
             )
           end
         else

--- a/app/models/access_limit.rb
+++ b/app/models/access_limit.rb
@@ -2,7 +2,7 @@ class AccessLimit < ApplicationRecord
   belongs_to :edition
 
   validate :user_uids_are_strings
-  validate :fact_check_ids_are_uuids
+  validate :auth_bypass_ids_are_uuids
 
 private
 
@@ -12,9 +12,9 @@ private
     end
   end
 
-  def fact_check_ids_are_uuids
-    unless fact_check_ids.all? { |id| UuidValidator.valid?(id) }
-      errors.add(:fact_check_ids, ["contains invalid UUIDs"])
+  def auth_bypass_ids_are_uuids
+    unless auth_bypass_ids.all? { |id| UuidValidator.valid?(id) }
+      errors.add(:auth_bypass_ids, ["contains invalid UUIDs"])
     end
   end
 end

--- a/app/presenters/edition_presenter.rb
+++ b/app/presenters/edition_presenter.rb
@@ -72,7 +72,7 @@ module Presenters
         {
           access_limited: {
             users: access_limit.users,
-            fact_check_ids: access_limit.fact_check_ids,
+            auth_bypass_ids: access_limit.auth_bypass_ids,
           }
         }
       end

--- a/db/migrate/20170316160949_add_auth_bypass_id.rb
+++ b/db/migrate/20170316160949_add_auth_bypass_id.rb
@@ -1,0 +1,5 @@
+class AddAuthBypassId < ActiveRecord::Migration[5.0]
+  def change
+    add_column :access_limits, :auth_bypass_ids, :json, null: false, default: []
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -20,7 +20,8 @@ ActiveRecord::Schema.define(version: 20170313184559) do
     t.datetime "created_at",                  null: false
     t.datetime "updated_at",                  null: false
     t.integer  "edition_id"
-    t.json     "fact_check_ids", default: [], null: false
+    t.json     "fact_check_ids",  default: [], null: false
+    t.json     "auth_bypass_ids", default: [], null: false
     t.index ["edition_id"], name: "index_access_limits_on_edition_id", using: :btree
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,15 +10,15 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170313184559) do
+ActiveRecord::Schema.define(version: 20170316160949) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "access_limits", force: :cascade do |t|
-    t.json     "users",          default: [], null: false
-    t.datetime "created_at",                  null: false
-    t.datetime "updated_at",                  null: false
+    t.json     "users",           default: [], null: false
+    t.datetime "created_at",                   null: false
+    t.datetime "updated_at",                   null: false
     t.integer  "edition_id"
     t.json     "fact_check_ids",  default: [], null: false
     t.json     "auth_bypass_ids", default: [], null: false

--- a/spec/commands/v2/post_action_spec.rb
+++ b/spec/commands/v2/post_action_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Commands::V2::PostAction do
         stale_lock_version: 6,
       )
     end
-    let(:action) { "FactCheck" }
+    let(:action) { "AuthBypass" }
     let(:draft) { nil }
 
     let(:payload) do

--- a/spec/commands/v2/put_content_spec.rb
+++ b/spec/commands/v2/put_content_spec.rb
@@ -534,12 +534,12 @@ RSpec.describe Commands::V2::PutContent do
         end
 
         context "when the params includes an access limit" do
-          let(:fact_check_id) { SecureRandom.uuid }
+          let(:auth_bypass_id) { SecureRandom.uuid }
           before do
             payload.merge!(
               access_limited: {
                 users: ["new-user"],
-                fact_check_ids: [fact_check_id],
+                auth_bypass_ids: [auth_bypass_id],
               }
             )
           end
@@ -549,7 +549,7 @@ RSpec.describe Commands::V2::PutContent do
             access_limit.reload
 
             expect(access_limit.users).to eq(["new-user"])
-            expect(access_limit.fact_check_ids).to eq([fact_check_id])
+            expect(access_limit.auth_bypass_ids).to eq([auth_bypass_id])
           end
         end
 
@@ -564,12 +564,12 @@ RSpec.describe Commands::V2::PutContent do
 
       context "when the previously drafted item does not have an access limit" do
         context "when the params includes an access limit" do
-          let(:fact_check_id) { SecureRandom.uuid }
+          let(:auth_bypass_id) { SecureRandom.uuid }
           before do
             payload.merge!(
               access_limited: {
                 users: ["new-user"],
-                fact_check_ids: [fact_check_id],
+                auth_bypass_ids: [auth_bypass_id],
               }
             )
           end
@@ -581,7 +581,7 @@ RSpec.describe Commands::V2::PutContent do
 
             access_limit = AccessLimit.find_by!(edition: previously_drafted_item)
             expect(access_limit.users).to eq(["new-user"])
-            expect(access_limit.fact_check_ids).to eq([fact_check_id])
+            expect(access_limit.auth_bypass_ids).to eq([auth_bypass_id])
           end
         end
       end

--- a/spec/controllers/v2/actions_controller_spec.rb
+++ b/spec/controllers/v2/actions_controller_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe V2::ActionsController do
         stale_lock_version: 5,
       )
     end
-    let(:action) { "FactCheck" }
+    let(:action) { "AuthBypass" }
 
     let(:params) { { content_id: document.content_id, format: :json } }
     let(:payload) do

--- a/spec/models/access_limit_spec.rb
+++ b/spec/models/access_limit_spec.rb
@@ -4,12 +4,12 @@ RSpec.describe AccessLimit do
   subject do
     FactoryGirl.build(:access_limit,
       users: users,
-      fact_check_ids: fact_check_ids,
+      auth_bypass_ids: auth_bypass_ids,
     )
   end
 
   let(:users) { [SecureRandom.uuid] }
-  let(:fact_check_ids) { [] }
+  let(:auth_bypass_ids) { [] }
 
   it { is_expected.to be_valid }
 
@@ -25,19 +25,19 @@ RSpec.describe AccessLimit do
     end
   end
 
-  describe "validates fact_check_ids" do
-    context "where fact_check_ids has an array with a uuids" do
-      let(:fact_check_ids) { [SecureRandom.uuid, SecureRandom.uuid] }
+  describe "validates auth_bypass_ids" do
+    context "where auth_bypass_ids has an array with a uuids" do
+      let(:auth_bypass_ids) { [SecureRandom.uuid, SecureRandom.uuid] }
       it { is_expected.to be_valid }
     end
 
-    context "where fact_check_ids has an array with non uuids" do
-      let(:fact_check_ids) { ["not-a-uuid"] }
+    context "where auth_bypass_ids has an array with non uuids" do
+      let(:auth_bypass_ids) { ["not-a-uuid"] }
       it { is_expected.to be_invalid }
     end
 
     context "where users has an array with an integer" do
-      let(:fact_check_ids) { [123] }
+      let(:auth_bypass_ids) { [123] }
       it { is_expected.to be_invalid }
     end
   end

--- a/spec/presenters/edition_presenter_spec.rb
+++ b/spec/presenters/edition_presenter_spec.rb
@@ -240,7 +240,7 @@ RSpec.describe Presenters::EditionPresenter do
 
         it "populates the access_limited hash" do
           expect(result[:access_limited][:users].length).to eq(1)
-          expect(result[:access_limited][:fact_check_ids].length).to eq(0)
+          expect(result[:access_limited][:auth_bypass_ids].length).to eq(0)
         end
       end
 

--- a/spec/support/request_helpers/mocks.rb
+++ b/spec/support/request_helpers/mocks.rb
@@ -54,7 +54,7 @@ module RequestHelpers
           "bf3e4b4f-f02d-4658-95a7-df7c74cd0f50",
           "74c7d700-5b4a-0131-7a8e-005056030037",
         ],
-        fact_check_ids: [],
+        auth_bypass_ids: [],
       }
     end
 


### PR DESCRIPTION
Content needs to be previewable by users without signon accounts in most
stages of a publishers workflow, not just during fact check.

This adds a migration that renames the fact_check_ids column in the AccessLimits
table to auth_bypass_ids.

Also renames occurrences of fact_check_ids to auth_bypass_ids.

https://trello.com/c/7oRBYwnn/690-rename-fact-check-id-to-auth-bypass-id