### PR TITLE
Update Substitution Helper

### DIFF
--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -209,6 +209,10 @@ class Edition < ApplicationRecord
     unpublished? && unpublishing.withdrawal?
   end
 
+  def substitute?
+    unpublished? && unpublishing.substitute?
+  end
+
   def api_path
     return unless base_path
     "/api/content" + base_path

--- a/app/models/unpublishing.rb
+++ b/app/models/unpublishing.rb
@@ -35,6 +35,10 @@ class Unpublishing < ApplicationRecord
     type == "redirect"
   end
 
+  def substitute?
+    type == "substitute"
+  end
+
   def self.is_substitute?(edition)
     where(edition: edition).pluck(:type).first == "substitute"
   end

--- a/app/substitution_helper.rb
+++ b/app/substitution_helper.rb
@@ -1,4 +1,6 @@
 module SubstitutionHelper
+  extend self
+
   SUBSTITUTABLE_DOCUMENT_TYPES = %w(
     coming_soon
     gone
@@ -7,48 +9,55 @@ module SubstitutionHelper
     special_route
   ).freeze
 
-  class << self
-    def clear!(
-      new_item_document_type:,
-      new_item_content_id:,
-      base_path:,
-      locale:,
-      state:,
-      downstream: true,
-      callbacks: [],
-      nested: false
-    )
-      raise NilBasePathError if base_path.nil?
+  def clear!(
+    new_item_document_type:,
+    new_item_content_id:,
+    base_path:,
+    locale:,
+    state:,
+    downstream: true,
+    callbacks: [],
+    nested: false
+  )
+    raise NilBasePathError if base_path.nil?
 
-      blocking_items = Edition.with_document
-        .where(base_path: base_path, state: state, "documents.locale": locale)
-
-      blocking_items.each do |blocking_item|
-        mismatch = (blocking_item.document.content_id != new_item_content_id)
-        allowed_to_substitute = (substitute?(new_item_document_type) || substitute?(blocking_item.document_type))
-
-        if mismatch && allowed_to_substitute
-          if state == "draft"
-            Commands::V2::DiscardDraft.call({
-                content_id: blocking_item.document.content_id,
-                locale: blocking_item.document.locale,
-              },
-              downstream: downstream,
-              nested: nested,
-              callbacks: callbacks,
-            )
-          else
-            blocking_item.substitute
-          end
-        end
+    blocking_editions(
+      base_path, state, locale, new_item_content_id, new_item_document_type
+    ).each do |blocking_edition|
+      if state == "draft"
+        discard_draft(blocking_edition, downstream, nested, callbacks)
+      else
+        blocking_edition.substitute
       end
     end
+  end
 
-  private
+private
 
-    def substitute?(document_type)
-      SUBSTITUTABLE_DOCUMENT_TYPES.include?(document_type)
-    end
+  def discard_draft(blocking_edition, downstream, nested, callbacks)
+    Commands::V2::DiscardDraft.call(
+      {
+        content_id: blocking_edition.document.content_id,
+        locale: blocking_edition.document.locale,
+      },
+      downstream: downstream,
+      nested: nested,
+      callbacks: callbacks
+    )
+  end
+
+  def blocking_editions(base_path, state, locale, new_item_content_id, new_item_document_type)
+    Edition
+      .with_document
+      .where(base_path: base_path, state: state, documents: { locale: locale })
+      .where.not(documents: { content_id: new_item_content_id })
+      .select do |item|
+        can_substitute?(new_item_document_type) || can_substitute?(item.document_type)
+      end
+  end
+
+  def can_substitute?(document_type)
+    SUBSTITUTABLE_DOCUMENT_TYPES.include?(document_type)
   end
 
   class NilBasePathError < StandardError; end

--- a/app/substitution_helper.rb
+++ b/app/substitution_helper.rb
@@ -51,8 +51,10 @@ private
       .with_document
       .where(base_path: base_path, state: state, documents: { locale: locale })
       .where.not(documents: { content_id: new_item_content_id })
-      .select do |item|
-        can_substitute?(new_item_document_type) || can_substitute?(item.document_type)
+      .select do |edition|
+        can_substitute?(new_item_document_type) ||
+          can_substitute?(edition.document_type) ||
+          (edition.unpublished? ? edition.unpublishing.type : false)
       end
   end
 

--- a/spec/commands/v2/put_content_spec.rb
+++ b/spec/commands/v2/put_content_spec.rb
@@ -233,7 +233,7 @@ RSpec.describe Commands::V2::PutContent do
           thread1.join
           thread2.join
 
-          expect(Edition.all.pluck(:state)).to eq %w(superseded published draft)
+          expect(Edition.all.pluck(:state)).to match_array(%w(superseded published draft))
         end
       end
     end

--- a/spec/substitution_helper_spec.rb
+++ b/spec/substitution_helper_spec.rb
@@ -52,9 +52,17 @@ RSpec.describe SubstitutionHelper do
     end
 
     context "when the existing edition is unpublished" do
-      let(:unpublished_edition) { FactoryGirl.create(:gone_unpublished_edition) }
+      let(:existing_item) do
+        FactoryGirl.create(
+          :gone_unpublished_edition,
+          base_path: existing_base_path,
+        )
+      end
 
-      it "" do
+      let(:new_content_id) { SecureRandom.uuid }
+
+      it "substitutes the draft" do
+        expect(existing_item.reload.substitute?).to be
       end
     end
 

--- a/spec/substitution_helper_spec.rb
+++ b/spec/substitution_helper_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe SubstitutionHelper do
       let(:new_content_id) { existing_item.document.content_id }
 
       it "does not discard the existing draft" do
-        expect(Edition.exists?(id: existing_item.id)).to eq(true)
+        expect(Edition.exists?(id: existing_item.id)).to be true
       end
 
       context "when the existing item is published" do
@@ -46,7 +46,7 @@ RSpec.describe SubstitutionHelper do
         }
 
         it "does not unpublish the existing published item" do
-          expect(existing_item.reload.substitute?).to_not be
+          expect(existing_item.reload.substitute?).to be false
         end
       end
     end
@@ -62,7 +62,7 @@ RSpec.describe SubstitutionHelper do
       let(:new_content_id) { SecureRandom.uuid }
 
       it "substitutes the draft" do
-        expect(existing_item.reload.substitute?).to be
+        expect(existing_item.reload.substitute?).to be true
       end
     end
 
@@ -73,7 +73,7 @@ RSpec.describe SubstitutionHelper do
         let(:existing_document_type) { "gone" }
 
         it "discards the existing draft" do
-          expect(Edition.exists?(id: existing_item.id)).to eq(false)
+          expect(Edition.exists?(id: existing_item.id)).to be false
         end
 
         it "doesn't unpublish any other items" do
@@ -107,7 +107,7 @@ RSpec.describe SubstitutionHelper do
           }
 
           it "unpublishes the existing published item" do
-            expect(existing_item.reload.substitute?).to be
+            expect(existing_item.reload.substitute?).to be true
           end
         end
       end
@@ -116,7 +116,7 @@ RSpec.describe SubstitutionHelper do
         let(:new_document_type) { "gone" }
 
         it "discards the existing draft" do
-          expect(Edition.exists?(id: existing_item.id)).to eq(false)
+          expect(Edition.exists?(id: existing_item.id)).to be false
         end
 
         it "doesn't unpublish any other items" do
@@ -150,14 +150,14 @@ RSpec.describe SubstitutionHelper do
           }
 
           it "unpublishes the existing published item" do
-            expect(existing_item.reload.substitute?).to be
+            expect(existing_item.reload.substitute?).to be true
           end
         end
       end
 
       context "when neither item has a document_type that is substitutable" do
         it "does not discard the existing draft" do
-          expect(Edition.exists?(id: existing_item.id)).to eq(true)
+          expect(Edition.exists?(id: existing_item.id)).to be true
         end
 
         context "when the existing item is published" do
@@ -169,7 +169,7 @@ RSpec.describe SubstitutionHelper do
           }
 
           it "does not unpublish the existing item" do
-            expect(existing_item.reload.substitute?).to_not be
+            expect(existing_item.reload.substitute?).to be false
           end
         end
       end

--- a/spec/substitution_helper_spec.rb
+++ b/spec/substitution_helper_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe SubstitutionHelper do
         }
 
         it "does not unpublish the existing published item" do
-          expect(existing_item.state).not_to eq("unpublished")
+          expect(existing_item.reload.substitute?).to_not be
         end
       end
     end
@@ -99,7 +99,7 @@ RSpec.describe SubstitutionHelper do
           }
 
           it "unpublishes the existing published item" do
-            expect(existing_item.reload.state).to eq("unpublished")
+            expect(existing_item.reload.substitute?).to be
           end
         end
       end
@@ -142,7 +142,7 @@ RSpec.describe SubstitutionHelper do
           }
 
           it "unpublishes the existing published item" do
-            expect(existing_item.reload.state).to eq("unpublished")
+            expect(existing_item.reload.substitute?).to be
           end
         end
       end
@@ -161,7 +161,7 @@ RSpec.describe SubstitutionHelper do
           }
 
           it "does not unpublish the existing item" do
-            expect(existing_item.state).not_to eq("unpublished")
+            expect(existing_item.reload.substitute?).to_not be
           end
         end
       end

--- a/spec/substitution_helper_spec.rb
+++ b/spec/substitution_helper_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe SubstitutionHelper do
   before do
     stub_request(
       :delete,
-      Plek.find('draft-content-store') + "/content#{existing_base_path}"
+      Plek.find("draft-content-store") + "/content#{existing_base_path}"
     )
   end
 
@@ -48,6 +48,13 @@ RSpec.describe SubstitutionHelper do
         it "does not unpublish the existing published item" do
           expect(existing_item.state).not_to eq("unpublished")
         end
+      end
+    end
+
+    context "when the existing edition is unpublished" do
+      let(:unpublished_edition) { FactoryGirl.create(:gone_unpublished_edition) }
+
+      it "" do
       end
     end
 


### PR DESCRIPTION
Currently we substitute items with a document type of coming_soon, redirect, gone, and unpublishing. 

This PR enables us to also allow substitution of content items with unpublished states of gone and redirect.

[Trello Card](https://trello.com/c/4RRvSMeQ/867-update-substitution-helper-2)