### PR TITLE
Add a migration to republish manuals documents

### DIFF
--- a/db/migrate/20170320104726_republish_manuals_documents.rb
+++ b/db/migrate/20170320104726_republish_manuals_documents.rb
@@ -1,0 +1,20 @@
+class RepublishManualsDocuments < ActiveRecord::Migration[5.0]
+  disable_ddl_transaction!
+
+  def editions
+    Edition
+      .with_document
+      .where(publishing_app: "manuals-publisher")
+      .where.not(content_store: nil)
+  end
+
+  def content_ids_to_represent
+    editions.pluck(:content_id)
+  end
+
+  def up
+    if Rails.env.production?
+      Commands::V2::RepresentDownstream.new.(content_ids_to_represent)
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170313184559) do
+ActiveRecord::Schema.define(version: 20170320104726) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
This is required as a result of alphagov/manuals-publisher@23eb39f31f7516296288dad0706dddfe1b3746dd.

[Trello card](https://trello.com/c/dN27kLGQ/898-resolve-inconsistent-documents-2)