### PR TITLE
Append EXECUTOR_NUMBER to test database name

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -45,8 +45,9 @@ node {
       govuk.setEnvar("RAILS_ENV", "test")
       govuk.setEnvar("RCOV", "1")
       govuk.setEnvar("PACT_BROKER_BASE_URL", "https://pact-broker.cloudapps.digital")
+      sh('bundle exec rake db:drop db:create')
       sh('bin/rails db:environment:set')
-      sh('bundle exec rake db:drop db:create db:schema:load')
+      sh('bundle exec rake db:schema:load')
     }
 
     stage("Lint") {

--- a/config/database.yml
+++ b/config/database.yml
@@ -7,12 +7,14 @@ default: &default
 development:
   <<: *default
   database: publishing_api_development
-  url: <%= ENV["DATABASE_URL"]%>
+  url: <%= ENV["DATABASE_URL"] %>
 
 test:
   <<: *default
-  database: publishing_api_test
-  url: <%= ENV["DATABASE_URL"].try(:sub, /([-_]development)?$/, '_test')%>
+  # EXECUTOR_NUMBER is a env var added by Jenkins, this allows concurrent builds
+  # on the same box without the database colliding.
+  database: publishing_api_test<%= "_executor_#{ENV['EXECUTOR_NUMBER']}" if ENV["EXECUTOR_NUMBER"] %>
+  url: <%= ENV["DATABASE_URL"].try(:sub, /([-_]development)?$/, "_test") %>
 
 production:
   <<: *default


### PR DESCRIPTION
This is to allow for concurrent builds in Jenkins without the database
name colliding.

There was an example failure of this but sadly that's out of our recent history now.

/cc @tijmenb 