### PR TITLE
Make sure random "redirect" items are always valid

### DIFF
--- a/spec/support/random_content_helpers.rb
+++ b/spec/support/random_content_helpers.rb
@@ -4,18 +4,28 @@ module RandomContentHelpers
   def generate_random_edition(base_path)
     random = GovukSchemas::RandomExample.for_schema(publisher_schema: "placeholder")
 
-    random.merge_and_validate(
-      routes: [
-        { path: base_path, type: "prefix" } # hard to do in schemas
-      ],
+    item = random.merge_and_validate(
       base_path: base_path,
 
       # TODOs:
       title: "Something not empty", # TODO: make schemas validate title length
       rendering_app: "government-frontend", # TODO: remove after https://github.com/alphagov/govuk-content-schemas/pull/575
       publishing_app: "publisher", # TODO: remove after https://github.com/alphagov/govuk-content-schemas/pull/575
-      redirects: [], # TODO: make schemas validate redirects
     )
+
+    if item["document_type"] == "redirect"
+      item[:routes] = []
+      item[:redirects] = [
+        { path: base_path, type: "exact", destination: "/some-redirect" }
+      ]
+    else
+      item[:routes] = [
+        { path: base_path, type: "prefix" }
+      ]
+      item[:redirects] = []
+    end
+
+    item
   end
 
   def random_content_failure_message(response, edition)


### PR DESCRIPTION
We currently don't validate `redirects` and `routes` in the `redirect` schema. This causes some data to be generated that's invalid according to the publishing-api. This PR makes sure that we obey the publishing-api validation rules.

https://ci.integration.publishing.service.gov.uk/job/publishing-api/job/deployed-to-production/322/console