### PR TITLE
Ignore recent documents when performing a consistency check

### DIFF
--- a/lib/content_consistency_checker.rb
+++ b/lib/content_consistency_checker.rb
@@ -3,9 +3,10 @@ require 'gds_api/content_store'
 class ContentConsistencyChecker
   attr_reader :errors
 
-  def initialize(content_id, locale = "en")
+  def initialize(content_id, locale = "en", ignore_recent = false)
     @content_id = content_id
     @locale = locale
+    @ignore_recent = ignore_recent
     @errors = []
   end
 
@@ -23,10 +24,12 @@ class ContentConsistencyChecker
 
 private
 
-  attr_reader :content_id, :locale
+  attr_reader :content_id, :locale, :ignore_recent
 
   def check_edition(prefix, edition, content_store)
     return unless edition.base_path
+
+    return if ignore_recent && edition.updated_at < 1.day.ago
 
     path = edition.base_path
 


### PR DESCRIPTION
This means we don't find issues where the data has not yet copied
across to integration.

This does not affect the default behaviour.