### PR TITLE
Send an Airbrake error when inconsistent documents are found

### DIFF
--- a/lib/tasks/check_content_consistency.rake
+++ b/lib/tasks/check_content_consistency.rake
@@ -4,8 +4,14 @@ namespace :check_content_consistency do
     errors = checker.call
 
     if errors.any?
-      puts "#{content_id} #{locale} 😱"
-      puts errors
+      Airbrake.notify(
+        "Found an inconsistent document: #{content_id} #{locale} 😱",
+        parameters: {
+          content_id: content_id,
+          locale: locale,
+          errors: errors,
+        }
+      )
     end
 
     errors.none?


### PR DESCRIPTION
This will allow the task to run automatically and send us an alert when inconsistent documents are found.