### PR TITLE
Don't allow random redirect placeholder schemas

### DIFF
--- a/spec/support/random_content_helpers.rb
+++ b/spec/support/random_content_helpers.rb
@@ -3,29 +3,20 @@ require "govuk_schemas"
 module RandomContentHelpers
   def generate_random_edition(base_path)
     random = GovukSchemas::RandomExample.for_schema(publisher_schema: "placeholder")
-
-    item = random.merge_and_validate(
+    payload = random.payload
+    random.merge_and_validate(
       base_path: base_path,
-
-      # TODOs:
+      # TODO: don't allow placeholder redirect, it doesn't make sense
+      document_type: payload["document_type"] == "redirect" ? "guide" : payload["document_type"],
+      # TODO: random schemas should generate valid routes and redirects
+      routes: [
+        { "path" => base_path, "type" => "prefix" }
+      ],
+      redirects: [],
       title: "Something not empty", # TODO: make schemas validate title length
       rendering_app: "government-frontend", # TODO: remove after https://github.com/alphagov/govuk-content-schemas/pull/575
       publishing_app: "publisher", # TODO: remove after https://github.com/alphagov/govuk-content-schemas/pull/575
     )
-
-    if item["document_type"] == "redirect"
-      item[:routes] = []
-      item[:redirects] = [
-        { path: base_path, type: "exact", destination: "/some-redirect" }
-      ]
-    else
-      item[:routes] = [
-        { path: base_path, type: "prefix" }
-      ]
-      item[:redirects] = []
-    end
-
-    item
   end
 
   def random_content_failure_message(response, edition)


### PR DESCRIPTION
These don't really work as placeholder isn't suitable for a redirect
document type and cause intermittent test failures.