### PR TITLE
Update govuk_document_types to 1.0.4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,7 @@ end
 
 gem "gds-sso", "13.0.0"
 gem "govuk_schemas", require: false
-gem "govuk_document_types", "~> 0.1.3"
+gem "govuk_document_types", "~> 0.1.4"
 
 gem 'bunny', '2.5.1'
 gem 'whenever', '0.9.4', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -124,7 +124,7 @@ GEM
     govuk-lint (1.2.1)
       rubocop (~> 0.39.0)
       scss_lint
-    govuk_document_types (0.1.3)
+    govuk_document_types (0.1.4)
     govuk_schemas (2.0.0)
       json-schema (~> 2.5.0)
     govuk_sidekiq (1.0.3)
@@ -408,7 +408,7 @@ DEPENDENCIES
   gds-sso (= 13.0.0)
   govspeak (~> 5.0.2)
   govuk-lint
-  govuk_document_types (~> 0.1.3)
+  govuk_document_types (~> 0.1.4)
   govuk_schemas
   govuk_sidekiq (~> 1.0.3)
   hashdiff


### PR DESCRIPTION
This add email_document_supertype and government_document_supertype
fields.