### PR TITLE
Validate routes and redirects based off schema_name

### DIFF
--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -63,7 +63,7 @@ class Edition < ApplicationRecord
   validate :user_facing_version_must_increase
   validate :draft_cannot_be_behind_live
 
-  validates :routes, absence: true, if: :redirect?
+  validates :routes, absence: true, if: -> (e) { e.schema_name == "redirect" }
 
   validates_with VersionForDocumentValidator
   validates_with BasePathForStateValidator

--- a/app/validators/routes_and_redirects_validator.rb
+++ b/app/validators/routes_and_redirects_validator.rb
@@ -18,7 +18,7 @@ class RoutesAndRedirectsValidator < ActiveModel::Validator
 
     must_have_unique_paths(record, routes, redirects)
 
-    if record.redirect?
+    if check_redirects?(record)
       redirects_must_include_base_path(record, base_path, redirects)
     else
       routes_must_include_base_path(record, base_path, routes)
@@ -26,6 +26,11 @@ class RoutesAndRedirectsValidator < ActiveModel::Validator
   end
 
 private
+
+  def check_redirects?(record)
+    return record.schema_name == "redirect" if record.respond_to?(:schema_name)
+    record.redirect?
+  end
 
   def must_have_unique_paths(record, routes, redirects)
     paths = routes.map { |r| r[:path] }

--- a/spec/support/random_content_helpers.rb
+++ b/spec/support/random_content_helpers.rb
@@ -4,28 +4,18 @@ module RandomContentHelpers
   def generate_random_edition(base_path)
     random = GovukSchemas::RandomExample.for_schema(publisher_schema: "placeholder")
 
-    item = random.merge_and_validate(
+    random.merge_and_validate(
       base_path: base_path,
 
       # TODOs:
       title: "Something not empty", # TODO: make schemas validate title length
       rendering_app: "government-frontend", # TODO: remove after https://github.com/alphagov/govuk-content-schemas/pull/575
       publishing_app: "publisher", # TODO: remove after https://github.com/alphagov/govuk-content-schemas/pull/575
+      routes: [
+        { path: base_path, type: "prefix" },
+      ],
+      redirects: []
     )
-
-    if item["document_type"] == "redirect"
-      item[:routes] = []
-      item[:redirects] = [
-        { path: base_path, type: "exact", destination: "/some-redirect" }
-      ]
-    else
-      item[:routes] = [
-        { path: base_path, type: "prefix" }
-      ]
-      item[:redirects] = []
-    end
-
-    item
   end
 
   def random_content_failure_message(response, edition)


### PR DESCRIPTION
We were using a check of `redirect?` before which was incorrect for two
reasons:

1. It was including unpublishing type redirect when the redirects that
   would be validated were those of the edition.
2. It was checking on document_type whereas you can be a valid schema of
   document_type redirect and have a schema_name of placeholder and you
   would not have redirects (crazy but schema allowed) whereas
   schema_name restricts this to actual redirects.