### PR TITLE
Expose an endpoint for document actions

### DIFF
--- a/app/controllers/v2/actions_controller.rb
+++ b/app/controllers/v2/actions_controller.rb
@@ -1,6 +1,8 @@
 module V2
   class ActionsController < ApplicationController
     def index
+      TimedFeature.check!(owner: "Tijmen", expires: "2017-04-22")
+
       actions = Action
         .where(content_id: params[:content_id])
         .as_json(only: %i[action user_uid created_at])

--- a/app/controllers/v2/actions_controller.rb
+++ b/app/controllers/v2/actions_controller.rb
@@ -4,7 +4,9 @@ module V2
       TimedFeature.check!(owner: "Tijmen", expires: "2017-04-22")
 
       actions = Action
+        .order("created_at DESC")
         .where(content_id: params[:content_id])
+        .limit(100)
         .as_json(only: %i[action user_uid created_at])
 
       render json: actions

--- a/app/controllers/v2/actions_controller.rb
+++ b/app/controllers/v2/actions_controller.rb
@@ -1,5 +1,13 @@
 module V2
   class ActionsController < ApplicationController
+    def index
+      actions = Action
+        .where(content_id: params[:content_id])
+        .as_json(only: %i[action user_uid created_at])
+
+      render json: actions
+    end
+
     def create
       response = Commands::V2::PostAction.call(action_params)
       render status: response.code, json: response

--- a/app/errors/command_error.rb
+++ b/app/errors/command_error.rb
@@ -56,7 +56,7 @@ class CommandError < StandardError
   end
 
   def valid_code?(code)
-    [400, 404, 409, 422, 500].include?(code)
+    [400, 404, 409, 410, 422, 500].include?(code)
   end
 
   def as_json(_options = nil)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,6 +34,7 @@ Rails.application.routes.draw do
       get "/new-linkables", to: "content_items#new_linkables"
 
       post "/actions/:content_id", to: "actions#create"
+      get "/actions/:content_id", to: "actions#index"
     end
   end
 

--- a/lib/timed_feature.rb
+++ b/lib/timed_feature.rb
@@ -1,0 +1,18 @@
+class TimedFeature
+  def self.check!(owner:, expires:)
+    return unless Date.today > Date.parse(expires)
+
+    message = <<~HEREDOC
+      Expired feature!
+
+      The feature you are attempting to use has expired.
+
+      Please ask #{owner} to remove the code or extend the feature period.
+    HEREDOC
+
+    raise CommandError.new(
+      code: 410,
+      error_details: { error: { code: 410, message: message } },
+    )
+  end
+end

--- a/spec/lib/timed_feature_spec.rb
+++ b/spec/lib/timed_feature_spec.rb
@@ -1,0 +1,21 @@
+require "rails_helper"
+
+RSpec.describe TimedFeature do
+  describe ".check!" do
+    it "does nothing if the feature hasn't expired" do
+      Timecop.freeze "2016-01-01" do
+        expect {
+          TimedFeature.check!(owner: "Me", expires: "2017-01-01")
+        }.not_to raise_error
+      end
+    end
+
+    it "raises a command error if the feature has expired" do
+      Timecop.freeze "2018-01-01" do
+        expect {
+          TimedFeature.check!(owner: "Me", expires: "2017-01-01")
+        }.to raise_error(CommandError)
+      end
+    end
+  end
+end

--- a/spec/requests/actions_requests_spec.rb
+++ b/spec/requests/actions_requests_spec.rb
@@ -1,0 +1,30 @@
+require "rails_helper"
+
+RSpec.describe "Actions", type: :request do
+  include RandomContentHelpers
+
+  it "returns the actions" do
+    base_path = "/#{SecureRandom.hex}"
+    stub_content_store_calls(base_path)
+    edition = generate_random_edition(base_path)
+
+    Timecop.freeze "2017-01-01" do
+      put "/v2/content/#{content_id}", params: edition.to_json
+      post "/v2/content/#{content_id}/publish", params: { locale: edition["locale"], update_type: "major" }.to_json
+    end
+
+    get "/v2/actions/#{content_id}"
+
+    expect(parsed_response).to eql([
+      { "action" => "PutContent", "user_uid" => nil, "created_at" => "2017-01-01T00:00:00.000Z" },
+      { "action" => "Publish", "user_uid" => nil, "created_at" => "2017-01-01T00:00:00.000Z" },
+    ])
+  end
+
+  def stub_content_store_calls(base_path)
+    stub_request(:put, "http://draft-content-store.dev.gov.uk/content#{base_path}")
+      .to_return(status: 200)
+    stub_request(:put, "http://content-store.dev.gov.uk/content#{base_path}")
+      .to_return(status: 200)
+  end
+end


### PR DESCRIPTION
This adds an experimental endpoint to expose the "actions" (update, publish, etc) of a document. We'll use it in content-tagger to show a rudimentary content history.

Inspired by @commuterjoy's excellent talk yesterday about sustainable development, this feature will stop working on April 22nd. This will make sure that we'll either properly build this endpoint (with documentation) or remove the code.

https://trello.com/c/HQ28fhrF