### PR TITLE
Verify pacts against production content store

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,7 @@
 
 REPOSITORY = "publishing-api"
 DEFAULT_SCHEMA_BRANCH = "deployed-to-production"
-DEFAULT_CONTENT_STORE_BRANCH = "master"
+DEFAULT_CONTENT_STORE_BRANCH = "deployed-to-production"
 
 node {
   def govuk = load("/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy")


### PR DESCRIPTION
This seems a more cautious default path to take than running against
master. This would have caught the issue we had earlier where we could
not deploy to production as
https://github.com/alphagov/content-store/pull/272 was not deployed.

In situations where we want to get greens against merged branches we can
always build against master build with the parameter.

I wasn't sure if something similar should be done for GDS API Adapters
or not since that's a gem rather than something that's deployed :-/