### PR TITLE
Rabbitmq issues

### DIFF
--- a/config/initializers/services.rb
+++ b/config/initializers/services.rb
@@ -28,7 +28,7 @@ PublishingAPI.register_service(
 if ENV['DISABLE_QUEUE_PUBLISHER'] || (Rails.env.test? && ENV['ENABLE_QUEUE_IN_TEST_MODE'].blank?)
   rabbitmq_config = { noop: true }
 elsif ENV["RABBITMQ_URL"] && ENV["RABBITMQ_EXCHANGE"]
-  rabbitmq_config = { url: ENV["RABBITMQ_URL"], exchange: ENV["RABBITMQ_EXCHANGE"] }
+  rabbitmq_config = { exchange: ENV["RABBITMQ_EXCHANGE"] }
 else
   rabbitmq_config = Rails.application.config_for(:rabbitmq).symbolize_keys
 end

--- a/lib/queue_publisher.rb
+++ b/lib/queue_publisher.rb
@@ -8,8 +8,8 @@ class QueuePublisher
   end
 
   def connection
-    establish_connection if @connection.nil?
-    @connection
+    @connection ||= Bunny.new(@options)
+    @connection.start
   end
 
   class PublishFailedError < StandardError
@@ -65,10 +65,5 @@ private
     ensure
       channel.close if channel.open?
     end
-  end
-
-  def establish_connection
-    @connection = Bunny.new(@options)
-    @connection.start
   end
 end

--- a/lib/queue_publisher.rb
+++ b/lib/queue_publisher.rb
@@ -8,7 +8,7 @@ class QueuePublisher
   end
 
   def connection
-    @connection ||= Bunny.new(@options)
+    @connection ||= Bunny.new(ENV["RABBITMQ_URL"], @options)
     @connection.start
   end
 

--- a/spec/lib/queue_publisher_spec.rb
+++ b/spec/lib/queue_publisher_spec.rb
@@ -14,16 +14,17 @@ RSpec.describe QueuePublisher do
     end
     let(:queue_publisher) { QueuePublisher.new(options) }
 
-    let(:mock_session) { instance_double("Bunny::Session", start: nil, create_channel: mock_channel) }
+    let(:mock_session) { instance_double("Bunny::Session", create_channel: mock_channel) }
     let(:mock_channel) { instance_double("Bunny::Channel", confirm_select: nil, topic: mock_exchange, open?: false) }
     let(:mock_exchange) { instance_double("Bunny::Exchange", publish: nil, wait_for_confirms: true) }
     before :each do
       allow(Bunny).to receive(:new) { mock_session }
+      allow(mock_session).to receive(:start) { mock_session }
     end
 
     describe "setting up the connection etc" do
       it "connects to rabbitmq using the given parameters" do
-        expect(Bunny).to receive(:new).with(options.except(:exchange)).and_return(mock_session)
+        expect(Bunny).to receive(:new).with(anything, options.except(:exchange)).and_return(mock_session)
         expect(mock_session).to receive(:start)
 
         queue_publisher.connection


### PR DESCRIPTION
Hopefully a fix for the `undefined method `next_channel_id' for nil:NilClass` error and fixes configuration for e2e tests