### PR TITLE
Delete fact check attribute

### DIFF
--- a/db/migrate/20170322172057_remove_fact_check_ids_from_access_limits.rb
+++ b/db/migrate/20170322172057_remove_fact_check_ids_from_access_limits.rb
@@ -1,0 +1,5 @@
+class RemoveFactCheckIdsFromAccessLimits < ActiveRecord::Migration[5.0]
+  def change
+    remove_column :access_limits, :fact_check_ids, :json, null: false, default: []
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170316160949) do
+ActiveRecord::Schema.define(version: 20170322172057) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -20,7 +20,6 @@ ActiveRecord::Schema.define(version: 20170316160949) do
     t.datetime "created_at",                   null: false
     t.datetime "updated_at",                   null: false
     t.integer  "edition_id"
-    t.json     "fact_check_ids",  default: [], null: false
     t.json     "auth_bypass_ids", default: [], null: false
     t.index ["edition_id"], name: "index_access_limits_on_edition_id", using: :btree
   end


### PR DESCRIPTION
Removes fact-check-ids from AccessLimits table. They are no longer necessary as they have been replaced by auth_bypass_ids.

[DO NOT MERGE] Do not merge until https://github.com/alphagov/publishing-api/pull/842 and its related PRs have been deployed.

https://trello.com/c/7oRBYwnn/690-rename-fact-check-id-to-auth-bypass-id