### PR TITLE
Remove Land Registry Corporate Information Page

### DIFF
--- a/db/migrate/20170328122051_remove_land_registry.rb
+++ b/db/migrate/20170328122051_remove_land_registry.rb
@@ -1,0 +1,12 @@
+require_relative "helpers/delete_content"
+
+class RemoveLandRegistry < ActiveRecord::Migration[5.0]
+  def up
+    land_registry_content_ids = [
+      "4ac6acfd-2ff4-427b-b952-eca13bb14d88",
+      "5fe3c59c-7631-11e4-a3cb-005056011aef",
+    ]
+
+    Helpers::DeleteContent.destroy_documents_with_links(land_registry_content_ids)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170322172057) do
+ActiveRecord::Schema.define(version: 20170328122051) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
Adds a migration to remove Land Registry Corporate Information Page.
There are two content ids associated with the same base path, so these are both removed. When Whitehall republishes the document, it should push everything through correctly.

Corresponding PRs 

* Content Store: https://github.com/alphagov/content-store/pull/281
* Whitehall: https://github.com/alphagov/whitehall/pull/3145