### PR TITLE
Give Edition links equal precedence with Link Set links in Dependency Resolution

### DIFF
--- a/lib/dependency_resolution/link_reference.rb
+++ b/lib/dependency_resolution/link_reference.rb
@@ -1,28 +1,19 @@
 class DependencyResolution::LinkReference
   def links_by_link_type(
     content_id:,
+    parent_is_edition: false,
+    locale: nil,
+    with_drafts: false,
     link_types_path: [],
     parent_content_ids: []
   )
+    return {} if parent_is_edition
+
     if link_types_path.empty?
-      root_links(content_id)
+      merged_root_links(content_id, locale, with_drafts)
     else
       descendant_links(content_id, link_types_path, parent_content_ids)
     end
-  end
-
-  def edition_links_by_link_type(
-    content_id:,
-    locale:,
-    with_drafts:,
-    link_types_path: []
-  )
-    return {} unless link_types_path.empty?
-
-    edition_links(content_id,
-      locale: locale,
-      with_drafts: with_drafts
-    )
   end
 
   def valid_link_node?(node)
@@ -33,6 +24,14 @@ class DependencyResolution::LinkReference
   end
 
 private
+
+  def merged_root_links(content_id, locale, with_drafts)
+    root = root_links(content_id)
+    edition = edition_links(content_id, locale: locale, with_drafts: with_drafts)
+    root.merge(edition) do |_key, old, new|
+      new + old
+    end
+  end
 
   def root_links(content_id)
     direct = direct_links(content_id)

--- a/lib/link_expansion/link_reference.rb
+++ b/lib/link_expansion/link_reference.rb
@@ -1,11 +1,16 @@
 class LinkExpansion::LinkReference
   def links_by_link_type(
     content_id:,
+    parent_is_edition: false,
+    locale: nil,
+    with_drafts: false,
     link_types_path: [],
     parent_content_ids: []
   )
+    return {} if parent_is_edition
+
     if link_types_path.empty?
-      root_links(content_id)
+      merged_root_links(content_id, locale, with_drafts)
     else
       descendant_links(
         content_id,
@@ -15,20 +20,6 @@ class LinkExpansion::LinkReference
     end
   end
 
-  def edition_links_by_link_type(
-    content_id:,
-    locale:,
-    with_drafts:,
-    link_types_path: []
-  )
-    return {} unless link_types_path.empty?
-
-    edition_links(content_id,
-      locale: locale,
-      with_drafts: with_drafts
-    )
-  end
-
   def valid_link_node?(node)
     return true if node.link_types_path.length == 1
 
@@ -36,6 +27,14 @@ class LinkExpansion::LinkReference
   end
 
 private
+
+  def merged_root_links(content_id, locale, with_drafts)
+    edition = edition_links(content_id,
+      locale: locale,
+      with_drafts: with_drafts
+    )
+    root_links(content_id).merge(edition)
+  end
 
   def root_links(content_id)
     direct = direct_links(content_id)

--- a/spec/integration/dependency_resolution_spec.rb
+++ b/spec/integration/dependency_resolution_spec.rb
@@ -222,7 +222,7 @@ RSpec.describe "Dependency Resolution" do
     before do
       create_link_set(link_content_id, links_hash: { link_type => [content_id] })
       create_edition(edition_content_id, "/edition-links",
-        links_hash: { link_type => [edition_content_id] },
+        links_hash: { link_type => [link_content_id] },
       )
     end
 

--- a/spec/integration/dependency_resolution_spec.rb
+++ b/spec/integration/dependency_resolution_spec.rb
@@ -208,8 +208,8 @@ RSpec.describe "Dependency Resolution" do
         )
       end
 
-      it "has the edition links which take precedence over link set links" do
-        expect(dependency_resolution).to match_array([edition_content_id])
+      it "merges the links to return both" do
+        expect(dependency_resolution).to match_array([edition_content_id, links_to_content_id])
       end
     end
   end


### PR DESCRIPTION
This is to fix an issue encountered by @andrewgarner earlier today where: [`/government/organisations/highways-england/about/procurement`](https://www.gov.uk/api/content/government/organisations/highways-england/about/procurement) was not getting updated when [`/government/organisations/highways-england`](https://www.gov.uk/api/content/government/organisations/highways-england) was updated. 

It turned out that the reason this was occurring was that a number of documents have edition links to `/government/organisations/highways-england` with type `organisations` and there a number of documents with link set links to it. We however were superseding the link set links with edition links, as per LinkExpansion.

This was intended behaviour as we didn't anticipate that the same link types would be used in both edition and link set links, and this should ideally be avoided. However it does seem like a case dependency resolution should handle so this has modified for this.