### PR TITLE
Allow substitutions of unpublished content

### DIFF
--- a/app/commands/v2/publish.rb
+++ b/app/commands/v2/publish.rb
@@ -142,7 +142,7 @@ module Commands
         SubstitutionHelper.clear!(
           new_item_document_type: edition.document_type,
           new_item_content_id: document.content_id,
-          state: "published",
+          state: %w[published unpublished],
           locale: document.locale,
           base_path: edition.base_path,
           downstream: downstream,


### PR DESCRIPTION
We recently updated the substitution helper to support unpublished
content: https://github.com/alphagov/publishing-api/pull/845 however we
did not update the helper to include unpublished items in the checks.

This has caused a problem for smart-answers.