### PR TITLE
Add fallback OAuth ID and secret

### DIFF
--- a/config/initializers/gds-sso.rb
+++ b/config/initializers/gds-sso.rb
@@ -1,7 +1,7 @@
 GDS::SSO.config do |config|
   config.user_model = "User"
-  config.oauth_id = ENV['OAUTH_ID']
-  config.oauth_secret = ENV['OAUTH_SECRET']
+  config.oauth_id = ENV['OAUTH_ID'] || "abcdefg"
+  config.oauth_secret = ENV['OAUTH_SECRET'] || "secret"
   config.oauth_root_url = Plek.find("signon")
   config.cache = Rails.cache
 end


### PR DESCRIPTION
This commit adds a fallback OAuth ID and secret. This will allow the signon-munging script for development to configure signon for this app locally.