### PR TITLE
Another bunny battle

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,7 @@ gem "gds-sso", "13.0.0"
 gem "govuk_schemas", require: false
 gem "govuk_document_types", "~> 0.1.4"
 
-gem 'bunny', '2.5.1'
+gem 'bunny', '~> 2.6'
 gem 'whenever', '0.9.4', require: false
 gem "govuk_sidekiq", "~> 1.0.3"
 gem "json-schema", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -51,7 +51,7 @@ GEM
     airbrake (5.5.0)
       airbrake-ruby (~> 1.5)
     airbrake-ruby (1.5.0)
-    amq-protocol (2.0.1)
+    amq-protocol (2.1.0)
     arel (7.1.4)
     ast (2.3.0)
     awesome_print (1.7.0)
@@ -64,8 +64,8 @@ GEM
     binding_of_caller (0.7.2)
       debug_inspector (>= 0.0.1)
     builder (3.2.2)
-    bunny (2.5.1)
-      amq-protocol (>= 2.0.1)
+    bunny (2.6.5)
+      amq-protocol (>= 2.1.0)
     byebug (9.0.6)
     chronic (0.10.2)
     coderay (1.1.1)
@@ -398,7 +398,7 @@ DEPENDENCIES
   airbrake-ruby (= 1.5)
   arel (= 7.1.4)
   aws-sdk (~> 2)
-  bunny (= 2.5.1)
+  bunny (~> 2.6)
   dalli
   database_cleaner
   diffy (~> 3.1)

--- a/lib/queue_publisher.rb
+++ b/lib/queue_publisher.rb
@@ -5,11 +5,14 @@ class QueuePublisher
 
     @exchange_name = options.fetch(:exchange)
     @options = options.except(:exchange)
+    @connection_mutex = Mutex.new
   end
 
   def connection
-    @connection ||= Bunny.new(ENV["RABBITMQ_URL"], @options)
-    @connection.start
+    @connection_mutex.synchronize do
+      @connection ||= Bunny.new(ENV["RABBITMQ_URL"], @options)
+      @connection.start
+    end
   end
 
   class PublishFailedError < StandardError


### PR DESCRIPTION
Wrap Bunny connection in a mutex

Starting a connection on Bunny is not threadsafe - hopefully this
problem is why we have seen the "NoMethodError: undefined method
'next_channel_id' for nil:NilClass"

see: https://github.com/ruby-amqp/bunny/issues/498 for further information.