### PR TITLE
1) Add description2 to Edition temporarily

### DIFF
--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -232,6 +232,7 @@ class Edition < ApplicationRecord
   # be removed when the column is fixed.
   def description=(value)
     super("value" => value)
+    self.description2 = value
   end
 
   def description

--- a/db/migrate/20170419132005_add_description2_to_edition.rb
+++ b/db/migrate/20170419132005_add_description2_to_edition.rb
@@ -1,0 +1,5 @@
+class AddDescription2ToEdition < ActiveRecord::Migration[5.0]
+  def change
+    add_column :editions, :description2, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170419125440) do
+ActiveRecord::Schema.define(version: 20170419132931) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -81,6 +81,7 @@ ActiveRecord::Schema.define(version: 20170419125440) do
     t.string   "base_path"
     t.string   "content_store"
     t.integer  "document_id",                                   null: false
+    t.string   "description2"
     t.index ["base_path", "content_store"], name: "index_editions_on_base_path_and_content_store", unique: true, using: :btree
     t.index ["document_id", "content_store"], name: "index_editions_on_document_id_and_content_store", unique: true, using: :btree
     t.index ["document_id", "state"], name: "index_editions_on_document_id_and_state", using: :btree


### PR DESCRIPTION
In order to prepare for converting `description`'s type to string, we
temporarily create a string attribute called `description2`.

NOTE: This will fail due to `description2` failing the schema validation.

https://trello.com/c/Fpgjdydt/915-sort-out-the-json-description-field-on-edition