### PR TITLE
Distributed lock when writing to content store

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,6 +31,7 @@ gem "sidekiq-unique-jobs", git: "https://github.com/alphagov/sidekiq-unique-jobs
 gem "govspeak", "~> 5.0.2"
 gem "diffy", "~> 3.1", require: false
 gem "aws-sdk", "~> 2"
+gem "with_advisory_lock", "~> 3.1"
 
 group :development do
   # Access an IRB console on exception pages or by using <%= console %> in views

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -389,6 +389,9 @@ GEM
     websocket-extensions (0.1.2)
     whenever (0.9.4)
       chronic (>= 0.6.3)
+    with_advisory_lock (3.1.0)
+      activerecord (>= 3.2)
+      thread_safe
 
 PLATFORMS
   ruby
@@ -437,6 +440,7 @@ DEPENDENCIES
   web-console (~> 2.0)
   webmock
   whenever (= 0.9.4)
+  with_advisory_lock (~> 3.1)
 
 BUNDLED WITH
    1.14.5

--- a/lib/distributed_lock.rb
+++ b/lib/distributed_lock.rb
@@ -1,0 +1,35 @@
+class DistributedLock
+  attr_reader :name, :timeout_seconds, :has_run
+
+  def self.lock(name, timeout_seconds: 30, &block)
+    self.new(name, timeout_seconds: timeout_seconds).run(&block)
+  end
+
+  def initialize(name, timeout_seconds:)
+    @name = name
+    @timeout_seconds = timeout_seconds
+    @has_run = false
+  end
+
+  def run
+    @has_run = false
+    # Run this inside a transaction so lock can be automatically released
+    # when tranasction completes - seems a less deadlock prone situation than
+    # creating a lock and the releasing it later
+    result = ActiveRecord::Base.transaction do
+      ActiveRecord::Base.with_advisory_lock(
+        name,
+        timeout_seconds: timeout_seconds,
+        transaction: true
+      ) do
+        @has_run = true
+        yield
+      end
+    end
+
+    raise FailedToAcquireLock unless @has_run
+    result
+  end
+
+  class FailedToAcquireLock < StandardError; end
+end

--- a/spec/lib/distributed_lock_spec.rb
+++ b/spec/lib/distributed_lock_spec.rb
@@ -1,0 +1,24 @@
+require "rails_helper"
+
+RSpec.describe DistributedLock do
+  describe ".lock" do
+    context "when it runs successfully" do
+      it "returns the block value" do
+        result = described_class.lock("lock_name") { :complete }
+        expect(result).to eq(:complete)
+      end
+    end
+
+    context "when it fails to acquire a lock within the timeout" do
+      before do
+        allow(ActiveRecord::Base).to receive(:with_advisory_lock).and_return(false)
+      end
+
+      it "raises DistributedLock::FailedToAcquireLock" do
+        run = -> { described_class.lock("lock_name") { :complete } }
+
+        expect { run.call }.to raise_error(DistributedLock::FailedToAcquireLock)
+      end
+    end
+  end
+end


### PR DESCRIPTION
https://trello.com/c/T9OE6SSJ/916-distributed-lock-to-resolve-race-conditions-updating-content-store

This uses the [with_advisory_lock](https://github.com/mceachen/with_advisory_lock) gem to use PostgreSQL's advisory lock feature to perform a distributed lock when writing to the content store.

See individual commits for further details.