### PR TITLE
Check that there is data to migrate

### DIFF
--- a/db/migrate/20170419125440_repair_missing_attachment_urls.rb
+++ b/db/migrate/20170419125440_repair_missing_attachment_urls.rb
@@ -2,6 +2,7 @@ class RepairMissingAttachmentUrls < ActiveRecord::Migration[5.0]
   def up
     ATTACHMENT_URLS.each do |item|
       edition = Edition.where(base_path: item[:edition_slug]).order(:created_at).last
+      next unless edition
 
       edition_details = edition.details
 
@@ -25,6 +26,7 @@ class RepairMissingAttachmentUrls < ActiveRecord::Migration[5.0]
   def down
     ATTACHMENT_URLS.each do |item|
       edition = Edition.where(base_path: item[:edition_slug]).order(:created_at).last
+      next unless edition
 
       edition_details = edition.details
 


### PR DESCRIPTION
If you are running database migrations for the first time, this
migration was failing because there were no Editions to migrate.