### PR TITLE
Throw an error if the first publish does not use a 'major' update_type

### DIFF
--- a/app/commands/v2/publish.rb
+++ b/app/commands/v2/publish.rb
@@ -104,7 +104,15 @@ module Commands
           raise_command_error(422, "An update_type of '#{update_type}' is invalid", fields: {
             update_type: ["must be one of #{valid_update_types.inspect}"],
           })
+        elsif first_publication_and_not_major_update?
+          raise_command_error(422, "An update_type of major is required the first time an edition is published", fields: {
+            update_type: ["must be major on first publication"],
+          })
         end
+      end
+
+      def first_publication_and_not_major_update?
+        !previous_item && update_type != "major"
       end
 
       def delete_change_notes

--- a/spec/requests/logging_requests_spec.rb
+++ b/spec/requests/logging_requests_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe "Logging requests", type: :request do
     expect(PublishingAPI.service(:queue_publisher)).to receive(:send_message)
       .with(hash_including(govuk_request_id: govuk_request_id))
 
-    post("/v2/content/#{draft_edition.document.content_id}/publish", params: { update_type: "minor" }.to_json,
+    post("/v2/content/#{draft_edition.document.content_id}/publish", params: { update_type: "major" }.to_json,
       headers: { "HTTP_GOVUK_REQUEST_ID" => "12345-67890" }
     )
   end


### PR DESCRIPTION
Trello card: https://trello.com/c/3S4m5wAJ

Only accept an update type of `major` if a document is being published for the first time

Related to: PR https://github.com/alphagov/gds-api-adapters/pull/698