### PR TITLE
Set public_updated_at for auto published items

### DIFF
--- a/app/commands/v2/publish.rb
+++ b/app/commands/v2/publish.rb
@@ -154,7 +154,7 @@ module Commands
       def set_public_updated_at
         return if edition.public_updated_at.present?
 
-        if update_type == "major"
+        if update_type == "major" || previous_item.blank?
           edition.update_attributes!(public_updated_at: Time.zone.now)
         elsif update_type == "minor"
           edition.update_attributes!(public_updated_at: previous_item.public_updated_at)

--- a/spec/commands/v2/publish_spec.rb
+++ b/spec/commands/v2/publish_spec.rb
@@ -312,6 +312,12 @@ RSpec.describe Commands::V2::Publish do
 
             expect(Edition.last.public_updated_at.iso8601).to eq(public_updated_at.iso8601)
           end
+
+          it "updates the public_updated_at time to now if no previous item" do
+            described_class.call(payload)
+
+            expect(draft_item.reload.public_updated_at).to be_within(1.second).of(Time.zone.now)
+          end
         end
 
         context "for a republish" do


### PR DESCRIPTION
Trello card: https://trello.com/c/3S4m5wAJ
Supersedes: PR #893 

## Changes

Stop the publishing-api from crashing in cases where an Edition has never had a `major` update (the `public_updated_at` value has never been set) and the update type is `minor`.

## Context

If an Edition is published in batches by an application rather than a human then the update_type is usually set to minor.

See [Smartanswers](https://github.com/alphagov/smart-answers/blob/master/app/services/content_item_publisher.rb#L6), where all Smartanswers are republished when a single smart answer is updated.

Setting the update_type to minor stop users from receiving multiple emails, potentially about topics they have no interest in.

The `publish` function expects that the Edition has a value in `public_updated_at` if a minor update is being published. If it doesn’t, the publishing-api crashes.

Most applications get around this my setting `public_updated_at` themselves.