### PR TITLE
Add a migration which fixes a nil public_updated_at

### DIFF
--- a/db/migrate/20170504075801_fix_highway_code_public_updated_at.rb
+++ b/db/migrate/20170504075801_fix_highway_code_public_updated_at.rb
@@ -1,0 +1,15 @@
+class FixHighwayCodePublicUpdatedAt < ActiveRecord::Migration[5.0]
+  def up
+    document = Document.find_by(content_id: content_id)
+    edition = document.editions.last
+    edition.update!(public_updated_at: "2017-03-01T00:00:00.000+00:00")
+
+    if Rails.env.production?
+      Commands::V2::RepresentDownstream.new.([content_id])
+    end
+  end
+
+  def content_id
+    "bbf6c11a-7dc6-4fe6-8dd8-68c09bdbe562"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170503130640) do
+ActiveRecord::Schema.define(version: 20170504075801) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
This edition ended up with a nil public_updated_at which needs fixing.

[Trello card](https://trello.com/c/JGuGBZD2/913-1901209-fix-update-date-in-manuals-publisher-gofreerange-team)