### PR TITLE
Link to withdrawn available translations

### DIFF
--- a/app/presenters/queries/available_translations.rb
+++ b/app/presenters/queries/available_translations.rb
@@ -16,16 +16,15 @@ module Presenters
       attr_reader :content_id, :with_drafts, :expanded_translations
 
       def grouped_translations
-        Edition.with_document
-          .where("documents.content_id": content_id, state: state_fallback_order)
-          .pluck(:id, "documents.locale", :state)
-          .sort_by { |(_, _, state)| state_fallback_order.index(state.to_sym) }
-          .group_by { |(_, locale)| locale }
+        pluck_and_sort_editions(edition_scope)
       end
 
       def expand_translation(id)
-        expansion_rules = LinkExpansion::Rules
-        web_item(id).select { |f| expansion_rules.expansion_fields(:available_translations).include?(f) }
+        web_item(id).select do |field|
+          LinkExpansion::Rules
+            .expansion_fields(:available_translations)
+            .include?(field)
+        end
       end
 
       def web_item(id)
@@ -33,11 +32,29 @@ module Presenters
       end
 
       def expanded_translations
-        @expanded_translations ||= grouped_translations.map { |_, (id)| expand_translation(id) }
+        @expanded_translations ||= grouped_translations.map do |_, (id)|
+          expand_translation(id)
+        end
       end
 
       def state_fallback_order
         with_drafts ? %i[draft published] : %i[published]
+      end
+
+      def edition_scope
+        Edition
+          .with_document
+          .with_unpublishing
+          .where(
+            documents: { content_id: content_id },
+            state: state_fallback_order,
+          )
+      end
+
+      def pluck_and_sort_editions(scope)
+        scope.pluck(:id, :locale, :state)
+          .sort_by { |(_, _, state)| state_fallback_order.index(state.to_sym) }
+          .group_by { |(_, locale)| locale }
       end
     end
   end

--- a/spec/presenters/queries/available_translations_spec.rb
+++ b/spec/presenters/queries/available_translations_spec.rb
@@ -38,6 +38,41 @@ RSpec.describe Presenters::Queries::AvailableTranslations do
     end
   end
 
+  context "with withdrawn editions" do
+    let(:with_drafts) { true }
+
+    before do
+      create_edition("/a", "published").unpublish(type: "withdrawal", explanation: "Withdrawn for a test.")
+      create_edition("/a.ar", "published", "ar")
+      create_edition("/a.es", "draft", "es")
+    end
+
+    it "returns all the items" do
+      expect(translations).to match_array([
+        a_hash_including(base_path: "/a", locale: "en"),
+        a_hash_including(base_path: "/a.ar", locale: "ar"),
+        a_hash_including(base_path: "/a.es", locale: "es"),
+      ])
+    end
+  end
+
+  context "with gone editions" do
+    let(:with_drafts) { false }
+
+    before do
+      create_edition("/a", "published")
+      create_edition("/a.ar", "published", "ar")
+      create_edition("/a.es", "published", "es").unpublish(type: "gone", explanation: "Removed for a test.")
+    end
+
+    it "returns the items which are not gone" do
+      expect(translations).to match_array([
+        a_hash_including(base_path: "/a", locale: "en"),
+        a_hash_including(base_path: "/a.ar", locale: "ar"),
+      ])
+    end
+  end
+
   context "with items in more than one state" do
     let!(:en) { create_edition("/a", "published") }
     let!(:ar) { create_edition("/a.ar", "draft", "ar") }


### PR DESCRIPTION
This PR adds the ability to allow editions to link to withdrawn available translations.

[Trello card](https://trello.com/c/EWBxn7q6/931-can-t-link-to-withdrawn-available-translations-2)