### PR TITLE
Sync public_updated_at with first_published_at on specific Whitehall formats

### DIFF
--- a/db/migrate/20170512090530_sync_whitehall_public_updated_at.rb
+++ b/db/migrate/20170512090530_sync_whitehall_public_updated_at.rb
@@ -1,0 +1,31 @@
+class SyncWhitehallPublicUpdatedAt < ActiveRecord::Migration[5.0]
+  disable_ddl_transaction!
+
+  def up
+    schema_names = %w(gone redirect special_route speech statistical_data_set take_part topical_event_about_page)
+
+    schema_names.each do |schema_name|
+      scope = Edition.where(publishing_app: "whitehall")
+                     .where(schema_name: schema_name)
+                     .where("first_published_at AT TIME ZONE 'Europe/London' > public_updated_at")
+
+      # Sync all the timestamps
+      scope.update_all("public_updated_at = first_published_at")
+      puts "#{scope.count} records updated for schema '#{schema_name}'"
+      puts "(#{scope.pluck(:id).join(",")})"
+
+      # Narrow the scope to find current content
+      current_editions_scope = scope.where(state: %w(draft published))
+      current_edition_content_ids = current_editions_scope.map(&:content_id)
+
+      if Rails.env.production? && current_editions_scope.any?
+        # Represent current editions downstream
+        Commands::V2::RepresentDownstream.new.call(current_edition_content_ids, with_drafts: true)
+
+        # Output what has been updated downstream
+        puts "The following items have been represented downstream:"
+        puts current_editions_scope.map(&:base_path).uniq.sort
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170510090933) do
+ActiveRecord::Schema.define(version: 20170512090530) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
https://trello.com/c/Or794AhX/903-fix-incorrect-first-published-at-values-where-possible-2

This migration updates the low risk formats/schema types which can use the `first_published_at` value as the `public_updated_at` timestamp where it currently has an older time.

There's some additional work to be done in Whitehall to shore up invalid date combinations so that more bad data isn't sent to the Publishing API.
Trello card here: https://trello.com/c/TPwh5GYI/491-whitehall-should-provide-a-public-updated-at-value-if-when-sending-a-first-published-at-value-to-the-publishing-api


