### PR TITLE
Add missing change notes for specialist documents

### DIFF
--- a/db/migrate/20170508101720_add_missing_change_notes_to_specialist_documents.rb
+++ b/db/migrate/20170508101720_add_missing_change_notes_to_specialist_documents.rb
@@ -1,0 +1,28 @@
+class AddMissingChangeNotesToSpecialistDocuments < ActiveRecord::Migration[5.0]
+  def up
+    scope = Edition.where(publishing_app: "specialist-publisher",
+                          schema_name: "specialist_document",
+                          state: "published")
+      .with_document
+      .where("NOT EXISTS (SELECT * FROM change_notes WHERE content_id::uuid = documents.content_id)")
+
+    scope.each do |edition|
+      oldest_edition = Edition.where(document_id: edition.document_id).order(:created_at).first
+      ChangeNote.create!(edition: edition,
+                         content_id: edition.content_id,
+                         public_timestamp: earliest_date_for(oldest_edition),
+                         note: "First published.")
+    end
+  end
+
+private
+
+  def earliest_date_for(edition)
+    pub_date = earliest(edition.first_published_at, edition.public_updated_at)
+    earliest(pub_date, edition.created_at)
+  end
+
+  def earliest(d1, d2)
+    [d1, d2].min
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170504075801) do
+ActiveRecord::Schema.define(version: 20170508101720) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
https://trello.com/c/hBz4UCa3/936-add-change-notes-for-specialist-documents-that-are-missing-them

Adds a migration to create missing change notes for specialist documents.
Uses the earliest relevant timestamp from the earliest edition in the document sequence.
Took 47 seconds to run on a dev VM.