### PR TITLE
Use the change note time if earlier than first published at

### DIFF
--- a/db/migrate/20170510090933_sync_specialist_publisher_first_published_at.rb
+++ b/db/migrate/20170510090933_sync_specialist_publisher_first_published_at.rb
@@ -1,0 +1,16 @@
+class SyncSpecialistPublisherFirstPublishedAt < ActiveRecord::Migration[5.0]
+  def up
+    sql = <<-SQL
+      UPDATE editions AS e
+      SET first_published_at = cn.public_timestamp
+      FROM change_notes AS cn
+      WHERE e.id = cn.edition_id
+      AND e.publishing_app = 'specialist-publisher'
+      AND e.schema_name = 'specialist_document'
+      AND e.state NOT IN ('draft', 'unpublished')
+      AND e.first_published_at < cn.public_timestamp
+    SQL
+
+    ActiveRecord::Base.connection.execute(sql)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170509133559) do
+ActiveRecord::Schema.define(version: 20170510090933) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
https://trello.com/c/Or794AhX/903-fix-incorrect-first-published-at-values-where-possible-2

There are around 300 specialist-publisher editions which have a first published time
later than the timestamp recorded in their corresponding change note. Update these
to use the time from the change note.