### PR TITLE
Repair attachments with missing content_type

### DIFF
--- a/db/migrate/20170509133559_repair_missing_attachment_content_type.rb
+++ b/db/migrate/20170509133559_repair_missing_attachment_content_type.rb
@@ -1,0 +1,28 @@
+class RepairMissingAttachmentContentType < ActiveRecord::Migration[5.0]
+  def change
+    BASE_PATHS.each do |base_path|
+      edition = Edition.where(base_path: base_path).last
+      edition_details = edition.details
+
+      updated_attachments = edition_details[:attachments].map do |attachment|
+        attachment[:content_type] = "application/pdf" if attachment[:content_type] == nil
+        attachment
+      end
+
+      edition_details[:attachments] = updated_attachments
+      edition.details = edition_details
+      edition.save!
+    end
+  end
+
+  BASE_PATHS = [
+    "/cma-cases/private-motor-insurance-market-investigation",
+    "/aaib-reports/piper-pa-28-180e-g-ayar-9-may-1985",
+    "/aaib-reports/stampe-sv4a-g-bhyi-24-september-1989",
+    "/cma-cases/baa-airports-market-investigation-cc",
+    "/aaib-reports/bae-146-300-g-oinv-8-november-2006",
+    "/aaib-reports/dh82a-tiger-moth-g-anoh-28-august-1983",
+    "/aaib-reports/eaa-biplane-g-bbmh-15-april-2012",
+    "/aaib-reports/jetstream-4100-g-maji-1-may-1998"
+  ]
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170508101720) do
+ActiveRecord::Schema.define(version: 20170509133559) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
A bug was discovered in Specialist Publisher where a CMA case could not be
saved as it included attachments that did not have a `content_type`, causing a
`HTTPUnprocessableEntity` error in the Publishing API.  This adds the correct
`content_type` for all attachments that had it set to nil.