### PR TITLE
Sent the govuk_request_id field to the Content Store

### DIFF
--- a/app/presenters/edition_presenter.rb
+++ b/app/presenters/edition_presenter.rb
@@ -28,7 +28,6 @@ module Presenters
     def for_message_queue(update_type)
       present.merge(
         update_type: update_type,
-        govuk_request_id: GdsApi::GovukHeaders.headers[:govuk_request_id],
         links: unexpanded_links
       )
     end
@@ -42,6 +41,7 @@ module Presenters
         .merge(format)
         .merge(document_supertypes)
         .merge(withdrawal_notice)
+        .merge(govuk_request_id)
     end
 
     def rendered_details
@@ -131,6 +131,12 @@ module Presenters
       else
         {}
       end
+    end
+
+    def govuk_request_id
+      {
+        govuk_request_id: GdsApi::GovukHeaders.headers[:govuk_request_id]
+      }
     end
   end
 end


### PR DESCRIPTION
Currently it is only sent to the message queue but it was decided
that it would be useful to have in the Content Store as well.

Not to be merged until after https://github.com/alphagov/govuk-content-schemas/pull/613 has gone in.

[Trello Card](https://trello.com/c/JZ5Zabe9/702-remove-publishing-request-id-from-travel-advice-publisher-details-hash-2)