### PR TITLE
Add validation for redirect destination for a specific segments mode

### DIFF
--- a/spec/support/routes_and_redirects_validator.rb
+++ b/spec/support/routes_and_redirects_validator.rb
@@ -205,6 +205,34 @@ RSpec.shared_examples_for RoutesAndRedirectsValidator do
       end
     end
 
+    context "when the segments_mode is 'preserve'" do
+      it "must not contain query parameters in the destination" do
+        edition.redirects = [
+          {
+            path: "#{subject.base_path}/foo",
+            type: "exact",
+            segments_mode: "preserve",
+            destination: "/bar?baz=4"
+          }
+        ]
+
+        expect(subject).to be_invalid
+      end
+
+      it "must not contain a fragment in the destination" do
+        edition.redirects = [
+          {
+            path: "#{subject.base_path}/foo",
+            type: "prefix",
+            segments_mode: "preserve",
+            destination: "/bar#baz"
+          }
+        ]
+
+        expect(subject).to be_invalid
+      end
+    end
+
     context "when the type is 'prefix'" do
       it "must contain valid absolute paths for destinations" do
         edition.redirects = [{ path: "#{subject.base_path}/foo", type: "prefix", destination: "not valid" }]


### PR DESCRIPTION
When the segments mode is preserve, the query parameters from the
incoming url will be appended on to the destination. If the route type
is prefix, in addition to the query parameters, part of the incoming
path may also be appended.

This validation prevents the introduction of redirects where the
destination contains a fragment or where the destination has query
parameters, as its unlikely that these are appropriate to use when the
segments mode is preserve.