### PR TITLE
Set the publishing_request_id when publishing an edition

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,7 @@ else
 end
 
 gem "gds-sso", "13.0.0"
-gem "govuk_schemas", require: false
+gem "govuk_schemas", "~> 2.1.1"
 gem "govuk_document_types", "~> 0.1.4"
 
 gem 'bunny', '~> 2.6'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -124,7 +124,7 @@ GEM
       rubocop (~> 0.39.0)
       scss_lint
     govuk_document_types (0.1.4)
-    govuk_schemas (2.0.0)
+    govuk_schemas (2.1.1)
       json-schema (~> 2.5.0)
     govuk_sidekiq (1.0.3)
       airbrake (>= 3.1.0)
@@ -412,7 +412,7 @@ DEPENDENCIES
   govspeak (~> 5.0.2)
   govuk-lint
   govuk_document_types (~> 0.1.4)
-  govuk_schemas
+  govuk_schemas (~> 2.1.1)
   govuk_sidekiq (~> 1.0.3)
   hashdiff
   json-schema

--- a/app/commands/v2/publish.rb
+++ b/app/commands/v2/publish.rb
@@ -29,6 +29,7 @@ module Commands
 
         set_public_updated_at
         set_first_published_at
+        set_publishing_request_id
         edition.publish
         remove_access_limit
         create_publish_action
@@ -168,6 +169,12 @@ module Commands
 
       def default_datetime
         @default_datetime ||= Time.zone.now
+      end
+
+      def set_publishing_request_id
+        edition.update_attributes!(
+          publishing_request_id: GdsApi::GovukHeaders.headers[:govuk_request_id]
+        )
       end
 
       def publish_redirect(previous_base_path, locale)

--- a/app/presenters/edition_presenter.rb
+++ b/app/presenters/edition_presenter.rb
@@ -14,6 +14,7 @@ module Presenters
       :user_facing_version,
       :web_url,
       :withdrawn,
+      :publishing_request_id,
     ].freeze
 
     def initialize(edition, draft: false)
@@ -42,6 +43,7 @@ module Presenters
         .merge(schema_name_and_document_type)
         .merge(document_supertypes)
         .merge(withdrawal_notice)
+        .merge(publishing_request_id)
     end
 
     def rendered_details
@@ -126,6 +128,16 @@ module Presenters
             explanation: unpublishing.explanation,
             withdrawn_at: withdrawn_at
           },
+        }
+      else
+        {}
+      end
+    end
+
+    def publishing_request_id
+      if edition.publishing_request_id
+        {
+          publishing_request_id: edition.publishing_request_id
         }
       else
         {}

--- a/db/migrate/20170510135557_add_publishing_request_id_field.rb
+++ b/db/migrate/20170510135557_add_publishing_request_id_field.rb
@@ -1,0 +1,5 @@
+class AddPublishingRequestIdField < ActiveRecord::Migration[5.0]
+  def change
+    add_column :editions, :publishing_request_id, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -82,6 +82,7 @@ ActiveRecord::Schema.define(version: 20170519112024) do
     t.string "content_store"
     t.integer "document_id", null: false
     t.string "description"
+    t.string "publishing_request_id"
     t.index ["base_path", "content_store"], name: "index_editions_on_base_path_and_content_store", unique: true
     t.index ["document_id", "content_store"], name: "index_editions_on_document_id_and_content_store", unique: true
     t.index ["document_id", "state"], name: "index_editions_on_document_id_and_state"

--- a/spec/controllers/v2/content_items_controller_spec.rb
+++ b/spec/controllers/v2/content_items_controller_spec.rb
@@ -463,10 +463,12 @@ RSpec.describe V2::ContentItemsController do
 
   describe "publish" do
     context "for an existing draft edition" do
+      let(:body) { { update_type: "major" } }
+      let(:govuk_request_id) { "test" }
       before do
-        request.env["CONTENT_TYPE"] = "application/json"
-        request.env["RAW_POST_DATA"] = { update_type: "major" }.to_json
-        post :publish, params: { content_id: content_id }
+        request.set_header("HTTP_GOVUK_REQUEST_ID", govuk_request_id)
+        GdsApi::GovukHeaders.set_header(:govuk_request_id, govuk_request_id)
+        put :publish, params: { content_id: content_id }, body: body.to_json
       end
 
       it "is successful" do
@@ -477,6 +479,11 @@ RSpec.describe V2::ContentItemsController do
         parsed_response_body = parsed_response
         expect(parsed_response_body.keys).to include("content_id")
         expect(parsed_response_body["content_id"]).not_to be_nil
+      end
+
+      it "updates the publishing_request_id" do
+        edition = Edition.last
+        expect(edition.publishing_request_id).to eq(govuk_request_id)
       end
     end
 


### PR DESCRIPTION
This will be send down to the Content Store so it is usable by frontend apps.

This shouldn't be merged until https://github.com/alphagov/content-store/pull/290 has gone though.

[Trello Card](https://trello.com/c/JZ5Zabe9/702-remove-publishing-request-id-from-travel-advice-publisher-details-hash-2)