### PR TITLE
Use the same datetime when setting default public_updated_at and firs…

### DIFF
--- a/app/commands/v2/publish.rb
+++ b/app/commands/v2/publish.rb
@@ -155,7 +155,7 @@ module Commands
         return if edition.public_updated_at.present?
 
         if update_type == "major" || previous_item.blank?
-          edition.update_attributes!(public_updated_at: Time.zone.now)
+          edition.update_attributes!(public_updated_at: default_datetime)
         elsif update_type == "minor"
           edition.update_attributes!(public_updated_at: previous_item.public_updated_at)
         end
@@ -163,7 +163,11 @@ module Commands
 
       def set_first_published_at
         return if edition.first_published_at.present?
-        edition.update_attributes!(first_published_at: Time.zone.now)
+        edition.update_attributes!(first_published_at: default_datetime)
+      end
+
+      def default_datetime
+        @default_datetime ||= Time.zone.now
       end
 
       def publish_redirect(previous_base_path, locale)

--- a/spec/commands/v2/publish_spec.rb
+++ b/spec/commands/v2/publish_spec.rb
@@ -380,6 +380,18 @@ RSpec.describe Commands::V2::Publish do
       end
     end
 
+    context "with no first_published_at and no public_updated_at set on the draft edition" do
+      before do
+        draft_item.update_attributes!(first_published_at: nil, public_updated_at: nil)
+      end
+
+      it "updates both fields with the same value" do
+        described_class.call(payload)
+
+        expect(draft_item.first_published_at).to eq(draft_item.public_updated_at)
+      end
+    end
+
     context "when the base_path differs from the previously published item" do
       let!(:live_item) do
         FactoryGirl.create(:live_edition,


### PR DESCRIPTION
…t_published_at

https://trello.com/c/sC7n41TO/941-reorder-default-date-assignments-1

Memoize the default datetime we use to set `first_published_at` and `public_updated_at` when not present to avoid fractional differences, we could reorder the `set_...` method calls but in terms of data it makes sense to use the same value.