### PR TITLE
Remove the requirement to filter content by document_type

### DIFF
--- a/app/controllers/v2/content_items_controller.rb
+++ b/app/controllers/v2/content_items_controller.rb
@@ -1,11 +1,10 @@
 module V2
   class ContentItemsController < ApplicationController
     def index
-      doc_types = query_params.fetch(:document_type) { query_params.fetch(:content_format) }
       pagination = Pagination.new(query_params)
 
       results = Queries::GetContentCollection.new(
-        document_types: doc_types,
+        document_types: document_types,
         fields: query_params[:fields],
         filters: filters,
         pagination: pagination,
@@ -70,6 +69,10 @@ module V2
 
     def states
       query_params[:states]
+    end
+
+    def document_types
+      query_params[:document_type] || query_params[:content_format] || []
     end
 
     def filters

--- a/doc/api.md
+++ b/doc/api.md
@@ -334,7 +334,7 @@ and a state has been specified, the draft is returned.
 
 ### Query string parameters
 
-- `document_type` *(required)*
+- `document_type` *(optional)*
   - The type of editions to return.
 - `fields[]` *(optional)*
   - Accepts an array of: "analytics_identifier", "base_path",

--- a/spec/controllers/v2/content_items_controller_spec.rb
+++ b/spec/controllers/v2/content_items_controller_spec.rb
@@ -182,19 +182,6 @@ RSpec.describe V2::ContentItemsController do
       end
     end
 
-    context "with all_items param" do
-      before do
-        get :index, params: { content_format: "topic", fields: ["content_id"], all_items: "true" }
-      end
-      it "is successful" do
-        expect(response.status).to eq(200)
-      end
-      it "responds with the edition as json" do
-        parsed_response_body = parsed_response["results"]
-        expect(parsed_response_body.first.fetch("content_id")).to eq(content_id.to_s)
-      end
-    end
-
     context "with an order param" do
       before do
         @en_draft_content.update!(

--- a/spec/controllers/v2/content_items_controller_spec.rb
+++ b/spec/controllers/v2/content_items_controller_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe V2::ContentItemsController do
       @en_live_content = FactoryGirl.create(:live_edition,
         document: document_en,
         base_path: "/content.en",
-        document_type: "topic",
+        document_type: "guide",
         schema_name: "topic",
         user_facing_version: 1,
       )
@@ -75,32 +75,50 @@ RSpec.describe V2::ContentItemsController do
 
       context "when there is a valid query" do
         it "returns the item when searching for base_path" do
-          get :index, params: { document_type: "topic", q: "foo", locale: "all" }
+          get :index, params: { q: "foo", locale: "all" }
           expect(parsed_response["results"].map { |i| i["base_path"] }).to eq(["/foo"])
         end
 
         it "returns the item when searching for title" do
-          get :index, params: { document_type: "topic", q: "bar", locale: "all" }
+          get :index, params: { q: "bar", locale: "all" }
           expect(parsed_response["results"].map { |i| i["base_path"] }).to eq(["/foo"])
         end
 
         it "doesn't return items that are no longer the latest version" do
-          get :index, params: { document_type: "topic", q: "zip", fields: %w(title) }
+          get :index, params: { q: "zip", fields: %w(title) }
           expect(parsed_response["results"].map { |i| i["title"] }).to eq([])
         end
       end
 
       context "specifying fields to search" do
         it "returns the item" do
-          get :index, params: { document_type: "topic", q: "stuff", search_in: ["description"], fields: %w(title) }
+          get :index, params: { q: "stuff", search_in: ["description"], fields: %w(title) }
           expect(parsed_response["results"].map { |i| i["title"] }).to eq(['bar'])
         end
       end
     end
 
+    context "with a document_type param" do
+      before do
+        get :index, params: { document_type: "guide" }
+      end
+
+      it "is successful" do
+        expect(response.status).to eq(200)
+      end
+
+      it "responds with the guide edition as json" do
+        parsed_response_body = parsed_response["results"]
+        expect(parsed_response_body.length).to eq(1)
+
+        base_paths = parsed_response_body.map { |item| item.fetch("base_path") }
+        expect(base_paths).to eq ["/content.en"]
+      end
+    end
+
     context "without providing a locale parameter" do
       before do
-        get :index, params: { document_type: "topic", fields: %w(base_path) }
+        get :index, params: { fields: %w(base_path) }
       end
 
       it "is successful" do
@@ -118,7 +136,7 @@ RSpec.describe V2::ContentItemsController do
 
     context "providing a specific locale parameter" do
       before do
-        get :index, params: { document_type: "topic", fields: %w(base_path), locale: "ar" }
+        get :index, params: { fields: %w(base_path), locale: "ar" }
       end
 
       it "is successful" do
@@ -136,7 +154,7 @@ RSpec.describe V2::ContentItemsController do
 
     context "providing a locale parameter set to 'all'" do
       before do
-        get :index, params: { document_type: "topic", fields: %w(base_path), locale: "all" }
+        get :index, params: { fields: %w(base_path), locale: "all" }
       end
 
       let(:parsed_response_body) { parsed_response["results"] }
@@ -193,7 +211,7 @@ RSpec.describe V2::ContentItemsController do
           last_edited_at: Date.new(2016, 2, 2),
         )
 
-        get :index, params: { document_type: "topic", locale: "all", order: order, fields: fields }
+        get :index, params: { locale: "all", order: order, fields: fields }
       end
 
       context "when ordering by updated_at ascending" do
@@ -361,7 +379,6 @@ RSpec.describe V2::ContentItemsController do
         FactoryGirl.create(:draft_edition,
           document: document_ar,
           base_path: "/content.ar",
-          document_type: "topic",
           schema_name: "topic",
           user_facing_version: 2,
         )

--- a/spec/queries/get_content_collection_spec.rb
+++ b/spec/queries/get_content_collection_spec.rb
@@ -25,6 +25,17 @@ RSpec.describe Queries::GetContentCollection do
       )
     end
 
+    it "returns the requested fields for all editions" do
+      expect(Queries::GetContentCollection.new(
+        fields: %w(base_path),
+      ).call).to match_array([
+        hash_including("base_path" => "/a"),
+        hash_including("base_path" => "/b"),
+        hash_including("base_path" => "/c"),
+        hash_including("base_path" => "/d"),
+      ])
+    end
+
     it "returns the editions matching the type" do
       expect(Queries::GetContentCollection.new(
         document_types: "topic",

--- a/spec/requests/index_spec.rb
+++ b/spec/requests/index_spec.rb
@@ -20,24 +20,16 @@ RSpec.describe "GET /v2/content", type: :request do
     )
   }
 
-  it "accepts either 'content_format' or 'document_type'" do
+  it "responds with a list of content items" do
     expected_result = [
       hash_including(title: "Policy 1"),
       hash_including(title: "Policy 2"),
     ]
 
-    get "/v2/content", params: { document_type: "policy", fields: ["title"] }
+    get "/v2/content", params: { fields: ["title"] }
     expect(JSON.parse(response.body, symbolize_names: true)[:results]).to match_array(expected_result)
 
-    get "/v2/content", params: { content_format: "policy", fields: ["title"] }
+    get "/v2/content", params: { fields: ["title"] }
     expect(JSON.parse(response.body, symbolize_names: true)[:results]).to match_array(expected_result)
-  end
-
-  context "without a format" do
-    it "422s" do
-      get "/v2/content", params: { fields: ["title"] }
-
-      expect(response.status).to eq(422)
-    end
   end
 end


### PR DESCRIPTION
We’d like to paginate through all content items in
the content performance manager application. This
change removes the requirement that a document_type
be provided to the index endpoint.