### PR TITLE
Stop representing `format`

### DIFF
--- a/app/presenters/edition_presenter.rb
+++ b/app/presenters/edition_presenter.rb
@@ -39,7 +39,7 @@ module Presenters
         .merge(rendered_details)
         .merge(expanded_links)
         .merge(access_limited)
-        .merge(format)
+        .merge(schema_name_and_document_type)
         .merge(document_supertypes)
         .merge(withdrawal_notice)
     end
@@ -105,9 +105,8 @@ module Presenters
       @access_limit ||= AccessLimit.find_by(edition_id: edition.id)
     end
 
-    def format
+    def schema_name_and_document_type
       {
-        format: edition.schema_name,
         schema_name: edition.schema_name,
         document_type: edition.document_type
       }

--- a/spec/presenters/edition_presenter_spec.rb
+++ b/spec/presenters/edition_presenter_spec.rb
@@ -59,7 +59,6 @@ RSpec.describe Presenters::EditionPresenter do
         description: "VAT rates for goods and services",
         details: details,
         document_type: "nonexistent-schema",
-        format: "nonexistent-schema",
         locale: "en",
         need_ids: %w(100123 100124),
         phase: "beta",

--- a/spec/requests/content_item_requests/downstream_requests_spec.rb
+++ b/spec/requests/content_item_requests/downstream_requests_spec.rb
@@ -215,7 +215,6 @@ RSpec.describe "Downstream requests", type: :request do
           locale: "en",
           document_type: "nonexistent-schema",
           schema_name: "nonexistent-schema",
-          format: "nonexistent-schema",
         )
         .except(
           :id,
@@ -245,7 +244,6 @@ RSpec.describe "Downstream requests", type: :request do
           content_item: a_hash_including(
             content_id: content_id,
             locale: "en",
-            format: "nonexistent-schema",
             payload_version: anything,
           )
         )

--- a/spec/support/request_helpers/mocks.rb
+++ b/spec/support/request_helpers/mocks.rb
@@ -22,7 +22,6 @@ module RequestHelpers
         description: "VAT rates for goods and services",
         document_type: "nonexistent-schema",
         schema_name: "nonexistent-schema",
-        format: "nonexistent-schema",
         need_ids: %w(100123 100124),
         first_published_at: DateTime.parse("2014-01-02T03:04:05.000Z"),
         public_updated_at: DateTime.parse("2014-05-14T13:00:06.000Z"),


### PR DESCRIPTION
This attribute has been deprecated (long ago). This stops it from being sent to the content store and message queue.