### PR TITLE
Populate change history for specialist docs without it

### DIFF
--- a/db/migrate/20170517091731_remove_empty_specialist_publisher_change_history.rb
+++ b/db/migrate/20170517091731_remove_empty_specialist_publisher_change_history.rb
@@ -1,0 +1,52 @@
+class RemoveEmptySpecialistPublisherChangeHistory < ActiveRecord::Migration[5.0]
+  def up
+    scope = Edition.where(publishing_app: "specialist-publisher",
+                          schema_name: "specialist_document")
+                   .where.not(state: "draft")
+                   .where("details ->> 'change_history' = '[]'")
+                   .order("user_facing_version ASC")
+
+    scope.each do |edition|
+      change_notes = ChangeNote
+        .where(content_id: edition.content_id)
+        .where("edition_id IS NULL OR edition_id IN (?)", edition_ids(edition))
+        .order(:public_timestamp)
+        .pluck(:note, :public_timestamp)
+        .map { |note, timestamp| { note: note, public_timestamp: timestamp } }
+
+      if change_notes.empty?
+        change_notes = [
+          ChangeNote.create!(edition: edition,
+                           content_id: edition.content_id,
+                           public_timestamp: earliest_date_for(edition),
+                           note: "First published.")
+        ]
+      end
+
+      edition_details = edition.details
+      edition_details[:change_history] = SymbolizeJSON.symbolize(change_notes.as_json)
+      edition.update!(details: edition_details)
+    end
+
+    if Rails.env.production?
+      Commands::V2::RepresentDownstream.new.call(scope.all.map(&:content_id))
+    end
+  end
+
+private
+
+  def earliest_date_for(edition)
+    pub_date = earliest(edition.first_published_at, edition.public_updated_at)
+    earliest(pub_date, edition.created_at)
+  end
+
+  def earliest(d1, d2)
+    [d1, d2].compact.min
+  end
+
+  def edition_ids(edition)
+    Edition.with_document
+      .where("documents.content_id": edition.content_id)
+      .pluck(:id)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,157 +10,157 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170512090530) do
+ActiveRecord::Schema.define(version: 20170517091731) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "access_limits", force: :cascade do |t|
-    t.json     "users",           default: [], null: false
-    t.datetime "created_at",                   null: false
-    t.datetime "updated_at",                   null: false
-    t.integer  "edition_id"
-    t.json     "auth_bypass_ids", default: [], null: false
-    t.index ["edition_id"], name: "index_access_limits_on_edition_id", using: :btree
+    t.json "users", default: [], null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.integer "edition_id"
+    t.json "auth_bypass_ids", default: [], null: false
+    t.index ["edition_id"], name: "index_access_limits_on_edition_id"
   end
 
   create_table "actions", force: :cascade do |t|
-    t.uuid     "content_id",  null: false
-    t.string   "locale"
-    t.string   "action",      null: false
-    t.uuid     "user_uid"
-    t.integer  "edition_id"
-    t.integer  "link_set_id"
-    t.integer  "event_id",    null: false
-    t.datetime "created_at",  null: false
-    t.datetime "updated_at",  null: false
-    t.index ["edition_id"], name: "index_actions_on_edition_id", using: :btree
-    t.index ["event_id"], name: "index_actions_on_event_id", using: :btree
-    t.index ["link_set_id"], name: "index_actions_on_link_set_id", using: :btree
+    t.uuid "content_id", null: false
+    t.string "locale"
+    t.string "action", null: false
+    t.uuid "user_uid"
+    t.integer "edition_id"
+    t.integer "link_set_id"
+    t.integer "event_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["edition_id"], name: "index_actions_on_edition_id"
+    t.index ["event_id"], name: "index_actions_on_event_id"
+    t.index ["link_set_id"], name: "index_actions_on_link_set_id"
   end
 
   create_table "change_notes", force: :cascade do |t|
-    t.string   "note",             default: ""
+    t.string "note", default: ""
     t.datetime "public_timestamp"
-    t.integer  "edition_id"
+    t.integer "edition_id"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "content_id"
-    t.index ["content_id"], name: "index_change_notes_on_content_id", using: :btree
-    t.index ["edition_id"], name: "index_change_notes_on_edition_id", using: :btree
+    t.string "content_id"
+    t.index ["content_id"], name: "index_change_notes_on_content_id"
+    t.index ["edition_id"], name: "index_change_notes_on_edition_id"
   end
 
   create_table "documents", force: :cascade do |t|
-    t.uuid    "content_id",                     null: false
-    t.string  "locale",                         null: false
+    t.uuid "content_id", null: false
+    t.string "locale", null: false
     t.integer "stale_lock_version", default: 0, null: false
-    t.index ["content_id", "locale"], name: "index_documents_on_content_id_and_locale", unique: true, using: :btree
+    t.index ["content_id", "locale"], name: "index_documents_on_content_id_and_locale", unique: true
   end
 
   create_table "editions", force: :cascade do |t|
-    t.string   "title"
+    t.string "title"
     t.datetime "public_updated_at"
-    t.json     "details",              default: {}
-    t.json     "routes",               default: []
-    t.json     "redirects",            default: []
-    t.string   "publishing_app"
-    t.string   "rendering_app"
-    t.json     "need_ids",             default: []
-    t.string   "update_type"
-    t.string   "phase",                default: "live"
-    t.string   "analytics_identifier"
-    t.datetime "created_at",                            null: false
-    t.datetime "updated_at",                            null: false
-    t.string   "document_type"
-    t.string   "schema_name"
+    t.json "details", default: {}
+    t.json "routes", default: []
+    t.json "redirects", default: []
+    t.string "publishing_app"
+    t.string "rendering_app"
+    t.json "need_ids", default: []
+    t.string "update_type"
+    t.string "phase", default: "live"
+    t.string "analytics_identifier"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "document_type"
+    t.string "schema_name"
     t.datetime "first_published_at"
     t.datetime "last_edited_at"
-    t.string   "state",                                 null: false
-    t.integer  "user_facing_version",  default: 1,      null: false
-    t.string   "base_path"
-    t.string   "content_store"
-    t.integer  "document_id",                           null: false
-    t.string   "description"
-    t.index ["base_path", "content_store"], name: "index_editions_on_base_path_and_content_store", unique: true, using: :btree
-    t.index ["document_id", "content_store"], name: "index_editions_on_document_id_and_content_store", unique: true, using: :btree
-    t.index ["document_id", "state"], name: "index_editions_on_document_id_and_state", using: :btree
-    t.index ["document_id", "user_facing_version"], name: "index_editions_on_document_id_and_user_facing_version", unique: true, using: :btree
-    t.index ["document_id"], name: "index_editions_on_document_id", using: :btree
-    t.index ["document_type", "updated_at"], name: "index_editions_on_document_type_and_updated_at", using: :btree
-    t.index ["last_edited_at"], name: "index_editions_on_last_edited_at", using: :btree
-    t.index ["public_updated_at"], name: "index_editions_on_public_updated_at", using: :btree
-    t.index ["publishing_app"], name: "index_editions_on_publishing_app", using: :btree
-    t.index ["rendering_app"], name: "index_editions_on_rendering_app", using: :btree
-    t.index ["state", "base_path"], name: "index_editions_on_state_and_base_path", using: :btree
-    t.index ["updated_at"], name: "index_editions_on_updated_at", using: :btree
+    t.string "state", null: false
+    t.integer "user_facing_version", default: 1, null: false
+    t.string "base_path"
+    t.string "content_store"
+    t.integer "document_id", null: false
+    t.string "description"
+    t.index ["base_path", "content_store"], name: "index_editions_on_base_path_and_content_store", unique: true
+    t.index ["document_id", "content_store"], name: "index_editions_on_document_id_and_content_store", unique: true
+    t.index ["document_id", "state"], name: "index_editions_on_document_id_and_state"
+    t.index ["document_id", "user_facing_version"], name: "index_editions_on_document_id_and_user_facing_version", unique: true
+    t.index ["document_id"], name: "index_editions_on_document_id"
+    t.index ["document_type", "updated_at"], name: "index_editions_on_document_type_and_updated_at"
+    t.index ["last_edited_at"], name: "index_editions_on_last_edited_at"
+    t.index ["public_updated_at"], name: "index_editions_on_public_updated_at"
+    t.index ["publishing_app"], name: "index_editions_on_publishing_app"
+    t.index ["rendering_app"], name: "index_editions_on_rendering_app"
+    t.index ["state", "base_path"], name: "index_editions_on_state_and_base_path"
+    t.index ["updated_at"], name: "index_editions_on_updated_at"
   end
 
   create_table "events", force: :cascade do |t|
-    t.string   "action",                  null: false
-    t.json     "payload",    default: {}
-    t.string   "user_uid"
+    t.string "action", null: false
+    t.json "payload", default: {}
+    t.string "user_uid"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "request_id"
-    t.uuid     "content_id"
-    t.index ["content_id"], name: "index_events_on_content_id", using: :btree
+    t.string "request_id"
+    t.uuid "content_id"
+    t.index ["content_id"], name: "index_events_on_content_id"
   end
 
   create_table "link_sets", force: :cascade do |t|
-    t.uuid     "content_id"
+    t.uuid "content_id"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.integer  "stale_lock_version", default: 0
-    t.index ["content_id"], name: "index_link_sets_on_content_id", unique: true, using: :btree
+    t.integer "stale_lock_version", default: 0
+    t.index ["content_id"], name: "index_link_sets_on_content_id", unique: true
   end
 
   create_table "links", force: :cascade do |t|
-    t.integer  "link_set_id"
-    t.uuid     "target_content_id"
-    t.string   "link_type",                     null: false
-    t.datetime "created_at",                    null: false
-    t.datetime "updated_at",                    null: false
-    t.integer  "position",          default: 0, null: false
-    t.integer  "edition_id"
-    t.index ["edition_id"], name: "index_links_on_edition_id", using: :btree
-    t.index ["link_set_id", "target_content_id"], name: "index_links_on_link_set_id_and_target_content_id", using: :btree
-    t.index ["link_set_id"], name: "index_links_on_link_set_id", using: :btree
-    t.index ["link_type"], name: "index_links_on_link_type", using: :btree
-    t.index ["target_content_id", "link_type"], name: "index_links_on_target_content_id_and_link_type", using: :btree
-    t.index ["target_content_id"], name: "index_links_on_target_content_id", using: :btree
+    t.integer "link_set_id"
+    t.uuid "target_content_id"
+    t.string "link_type", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.integer "position", default: 0, null: false
+    t.integer "edition_id"
+    t.index ["edition_id"], name: "index_links_on_edition_id"
+    t.index ["link_set_id", "target_content_id"], name: "index_links_on_link_set_id_and_target_content_id"
+    t.index ["link_set_id"], name: "index_links_on_link_set_id"
+    t.index ["link_type"], name: "index_links_on_link_type"
+    t.index ["target_content_id", "link_type"], name: "index_links_on_target_content_id_and_link_type"
+    t.index ["target_content_id"], name: "index_links_on_target_content_id"
   end
 
   create_table "path_reservations", force: :cascade do |t|
-    t.string   "base_path",      null: false
-    t.string   "publishing_app", null: false
+    t.string "base_path", null: false
+    t.string "publishing_app", null: false
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.index ["base_path"], name: "index_path_reservations_on_base_path", unique: true, using: :btree
+    t.index ["base_path"], name: "index_path_reservations_on_base_path", unique: true
   end
 
   create_table "unpublishings", force: :cascade do |t|
-    t.integer  "edition_id",       null: false
-    t.string   "type",             null: false
-    t.string   "explanation"
-    t.string   "alternative_path"
+    t.integer "edition_id", null: false
+    t.string "type", null: false
+    t.string "explanation"
+    t.string "alternative_path"
     t.datetime "created_at"
     t.datetime "updated_at"
     t.datetime "unpublished_at"
-    t.json     "redirects"
-    t.index ["edition_id", "type"], name: "index_unpublishings_on_edition_id_and_type", using: :btree
-    t.index ["edition_id"], name: "index_unpublishings_on_edition_id", using: :btree
+    t.json "redirects"
+    t.index ["edition_id", "type"], name: "index_unpublishings_on_edition_id_and_type"
+    t.index ["edition_id"], name: "index_unpublishings_on_edition_id"
   end
 
   create_table "users", force: :cascade do |t|
-    t.string   "name"
-    t.string   "email"
-    t.string   "uid"
-    t.string   "organisation_slug"
-    t.string   "organisation_content_id"
-    t.string   "app_name"
-    t.text     "permissions"
-    t.boolean  "remotely_signed_out",     default: false
-    t.boolean  "disabled",                default: false
+    t.string "name"
+    t.string "email"
+    t.string "uid"
+    t.string "organisation_slug"
+    t.string "organisation_content_id"
+    t.string "app_name"
+    t.text "permissions"
+    t.boolean "remotely_signed_out", default: false
+    t.boolean "disabled", default: false
     t.datetime "created_at"
     t.datetime "updated_at"
   end


### PR DESCRIPTION
https://trello.com/c/hBz4UCa3/936-add-change-notes-for-specialist-documents-that-are-missing-them

There are ~200,000 specialist documents which have an empty change history, this won't
get presented downstream because a memoizing clause in how the change history is presented.
So identify these records (they can be anything but draft), generate an initial change note
if none exists, then update the change history in the details hash from the change notes
for the edition.
This is a modification of the migration in https://github.com/alphagov/publishing-api/commit/c29d05b19dc2c89c21c9dabbaf29dbad2fa54373
it now finds all edition_ids for a given content id and retrieves change notes for them,
this gets round the earlier problem of duplicates being created.

As this is the first migration since we've upgraded to Rails 5.1 there's a significant amount of noise in the schema file.
See https://github.com/rails/rails/commit/6d37cd918dba5b492194afbc1094a6503c88f379 and https://github.com/rails/rails/commit/df84e9867219e9311aef6f4efd5dd9ec675bee5c?short_path=1ed2907#diff-e0d63791fb8e00fc467e7c47b74fb6d6 for changes to how schemas are dumped.