### PR TITLE
Remove duplicate change notes from specialist editions

### DIFF
--- a/db/migrate/20170517161719_remove_duplicate_specialist_change_notes.rb
+++ b/db/migrate/20170517161719_remove_duplicate_specialist_change_notes.rb
@@ -1,0 +1,23 @@
+class RemoveDuplicateSpecialistChangeNotes < ActiveRecord::Migration[5.1]
+  disable_ddl_transaction!
+
+  def up
+    specialist_editions = Edition.where(publishing_app: "specialist-publisher",
+                                        schema_name: "specialist_document")
+                                 .where.not(state: "draft")
+
+    duplicates = ChangeNote.where(edition: specialist_editions)
+                           .group(:content_id, :note, :public_timestamp)
+                           .having("count(*) > 1")
+                           .pluck("max(edition_id)")
+
+    puts "Removing #{duplicates.size} duplicate change notes for edition ids: #{duplicates.join(',')}"
+
+    ChangeNote.where(edition_id: duplicates).delete_all
+
+    if Rails.env.production?
+      content_ids = Edition.with_document.where(id: duplicates).pluck("documents.content_id")
+      Commands::V2::RepresentDownstream.new.call(content_ids)
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170517091731) do
+ActiveRecord::Schema.define(version: 20170517161719) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
https://trello.com/c/iI3rOMy8/946-investigate-fix-duplicate-change-notes-for-specialist-publisher

Approx 300 duplicate change notes were created at 2017-03-17 15:55 (ish).
Identify these and remove the latter duplicate.