### PR TITLE
Add a document field to change notes

### DIFF
--- a/db/migrate/20170519111706_add_document_field_to_change_notes.rb
+++ b/db/migrate/20170519111706_add_document_field_to_change_notes.rb
@@ -1,0 +1,6 @@
+class AddDocumentFieldToChangeNotes < ActiveRecord::Migration[5.1]
+  def change
+    add_column :change_notes, :document_id, :integer
+    add_foreign_key :change_notes, :documents, on_delete: :cascade
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170517161719) do
+ActiveRecord::Schema.define(version: 20170519111706) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -46,6 +46,7 @@ ActiveRecord::Schema.define(version: 20170517161719) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.string "content_id"
+    t.integer "document_id"
     t.index ["content_id"], name: "index_change_notes_on_content_id"
     t.index ["edition_id"], name: "index_change_notes_on_edition_id"
   end
@@ -165,6 +166,7 @@ ActiveRecord::Schema.define(version: 20170517161719) do
     t.datetime "updated_at"
   end
 
+  add_foreign_key "change_notes", "documents", on_delete: :cascade
   add_foreign_key "change_notes", "editions"
   add_foreign_key "editions", "documents"
   add_foreign_key "links", "editions", on_delete: :cascade


### PR DESCRIPTION
This will eventually replace the content_id field.

[Trello Card](https://trello.com/c/7GRaupoY/919-since-changehistory-is-associated-with-a-content-id-it-should-be-associated-with-a-locale-1)