### PR TITLE
Dual populate change notes with documents

### DIFF
--- a/app/models/change_note.rb
+++ b/app/models/change_note.rb
@@ -1,4 +1,5 @@
 class ChangeNote < ActiveRecord::Base
+  belongs_to :document, optional: true
   belongs_to :edition, optional: true
 
   def self.create_from_edition(payload, edition)
@@ -28,6 +29,7 @@ private
     ChangeNote
       .find_or_create_by!(edition: edition)
       .update!(
+        document: edition.document,
         content_id: edition.document.content_id,
         public_timestamp: Time.zone.now,
         note: change_note,
@@ -39,6 +41,7 @@ private
     ChangeNote
       .find_or_create_by!(edition: edition)
       .update!(
+        document: edition.document,
         content_id: edition.document.content_id,
         public_timestamp: edition.updated_at,
         note: note,
@@ -51,6 +54,7 @@ private
     ChangeNote
       .find_or_create_by!(edition: edition)
       .update!(
+        document: edition.document,
         content_id: edition.document.content_id,
         public_timestamp: history_element.fetch(:public_timestamp),
         note: history_element.fetch(:note),

--- a/db/migrate/20170519112024_link_change_notes_with_documents.rb
+++ b/db/migrate/20170519112024_link_change_notes_with_documents.rb
@@ -1,0 +1,27 @@
+class LinkChangeNotesWithDocuments < ActiveRecord::Migration[5.1]
+  def up
+    sql1 = <<-SQL
+      UPDATE change_notes
+      SET document_id = editions.document_id
+      FROM editions
+      WHERE editions.id = change_notes.edition_id
+    SQL
+
+    ActiveRecord::Base.connection.execute(sql1)
+
+    sql2 = <<-SQL
+      UPDATE change_notes
+      SET document_id = documents.id
+      FROM documents
+      WHERE documents.content_id = change_notes.content_id::uuid
+        AND documents.locale = 'en'
+        AND change_notes.edition_id IS NULL
+    SQL
+
+    ActiveRecord::Base.connection.execute(sql2)
+  end
+
+  def down
+    ChangeNote.update_all(document_id: nil)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170519111706) do
+ActiveRecord::Schema.define(version: 20170519112024) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/spec/factories/edition.rb
+++ b/spec/factories/edition.rb
@@ -37,7 +37,12 @@ FactoryGirl.define do
 
     after(:create) do |item, evaluator|
       unless item.update_type == "minor" || evaluator.change_note.nil?
-        FactoryGirl.create(:change_note, note: evaluator.change_note, edition: item)
+        FactoryGirl.create(
+          :change_note,
+          note: evaluator.change_note,
+          edition: item,
+          document: item.document,
+        )
       end
 
       if evaluator.links_hash


### PR DESCRIPTION
This is the second part of linked change notes with documents. It should not be deployed until #920 has been deployed.

[Trello Card](https://trello.com/c/7GRaupoY/919-since-changehistory-is-associated-with-a-content-id-it-should-be-associated-with-a-locale-1)