### PR TITLE
Stop using content id with change notes

### DIFF
--- a/app/models/change_note.rb
+++ b/app/models/change_note.rb
@@ -30,7 +30,6 @@ private
       .find_or_create_by!(edition: edition)
       .update!(
         document: edition.document,
-        content_id: edition.document.content_id,
         public_timestamp: Time.zone.now,
         note: change_note,
       )
@@ -42,7 +41,6 @@ private
       .find_or_create_by!(edition: edition)
       .update!(
         document: edition.document,
-        content_id: edition.document.content_id,
         public_timestamp: edition.updated_at,
         note: note,
       )
@@ -55,7 +53,6 @@ private
       .find_or_create_by!(edition: edition)
       .update!(
         document: edition.document,
-        content_id: edition.document.content_id,
         public_timestamp: history_element.fetch(:public_timestamp),
         note: history_element.fetch(:note),
       )

--- a/app/presenters/change_history_presenter.rb
+++ b/app/presenters/change_history_presenter.rb
@@ -18,7 +18,7 @@ module Presenters
 
     def change_notes_for_content_item
       change_notes = ChangeNote
-        .where(content_id: content_id)
+        .where(document: document)
         .where("edition_id IS NULL OR edition_id IN (?)", edition_ids)
         .order(:public_timestamp)
         .pluck(:note, :public_timestamp)
@@ -27,8 +27,8 @@ module Presenters
     end
 
     def edition_ids
-      Edition.with_document
-        .where("documents.content_id": content_id)
+      Edition
+        .where(document: document)
         .where("user_facing_version <= ?", version_number)
         .pluck(:id)
     end
@@ -37,8 +37,8 @@ module Presenters
       edition.user_facing_version
     end
 
-    def content_id
-      edition.content_id
+    def document
+      edition.document
     end
   end
 end

--- a/spec/presenters/change_history_presenter_spec.rb
+++ b/spec/presenters/change_history_presenter_spec.rb
@@ -1,8 +1,7 @@
 require "rails_helper"
 
 RSpec.describe Presenters::ChangeHistoryPresenter do
-  let(:content_id) { SecureRandom.uuid }
-  let(:document) { FactoryGirl.create(:document, content_id: content_id) }
+  let(:document) { FactoryGirl.create(:document) }
   let(:edition) do
     FactoryGirl.create(:edition,
       document: document,
@@ -30,7 +29,7 @@ RSpec.describe Presenters::ChangeHistoryPresenter do
         2.times do |i|
           ChangeNote.create(
             edition: edition,
-            content_id: content_id,
+            document: document,
             note: i.to_s,
             public_timestamp: Time.now.utc
           )
@@ -45,7 +44,7 @@ RSpec.describe Presenters::ChangeHistoryPresenter do
       [1, 3, 2].to_a.each do |i|
         ChangeNote.create(
           edition: edition,
-          content_id: content_id,
+          document: document,
           note: i.to_s,
           public_timestamp: i.days.ago
         )
@@ -69,9 +68,9 @@ RSpec.describe Presenters::ChangeHistoryPresenter do
         )
       end
       before do
-        ChangeNote.create(edition: item1, content_id: content_id)
-        ChangeNote.create(edition: item2, content_id: content_id)
-        ChangeNote.create(content_id: content_id)
+        ChangeNote.create(edition: item1, document: document)
+        ChangeNote.create(edition: item2, document: document)
+        ChangeNote.create(document: document)
       end
 
       context "reviewing latest version of a edition" do

--- a/spec/presenters/edition_presenter_spec.rb
+++ b/spec/presenters/edition_presenter_spec.rb
@@ -200,7 +200,7 @@ RSpec.describe Presenters::EditionPresenter do
           details: details.slice(:body))
       end
       before do
-        ChangeNote.create(change_history.merge(edition: edition, content_id: edition.document.content_id))
+        ChangeNote.create(change_history.merge(edition: edition, document: edition.document))
       end
 
       it "constructs the change history" do


### PR DESCRIPTION
This is the third part of linking change notes with documents. It should not be deployed until #921 has been deployed.

[Trello Card](https://trello.com/c/7GRaupoY/919-since-changehistory-is-associated-with-a-content-id-it-should-be-associated-with-a-locale-1)