### PR TITLE
Remove content id from change notes

### DIFF
--- a/db/migrate/20170519120114_remove_content_ids_from_change_notes.rb
+++ b/db/migrate/20170519120114_remove_content_ids_from_change_notes.rb
@@ -1,0 +1,5 @@
+class RemoveContentIdsFromChangeNotes < ActiveRecord::Migration[5.1]
+  def change
+    remove_column :change_notes, :content_id, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170519112024) do
+ActiveRecord::Schema.define(version: 20170519120114) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -45,9 +45,7 @@ ActiveRecord::Schema.define(version: 20170519112024) do
     t.integer "edition_id"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string "content_id"
     t.integer "document_id"
-    t.index ["content_id"], name: "index_change_notes_on_content_id"
     t.index ["edition_id"], name: "index_change_notes_on_edition_id"
   end
 


### PR DESCRIPTION
This is the fourth part of linking change notes with documents. It should not be deployed until #922 has been deployed.

[Trello Card](https://trello.com/c/7GRaupoY/919-since-changehistory-is-associated-with-a-content-id-it-should-be-associated-with-a-locale-1)