### PR TITLE
Make change notes document field not nullable

### DIFF
--- a/app/models/change_note.rb
+++ b/app/models/change_note.rb
@@ -1,5 +1,5 @@
 class ChangeNote < ActiveRecord::Base
-  belongs_to :document, optional: true
+  belongs_to :document
   belongs_to :edition, optional: true
 
   def self.create_from_edition(payload, edition)
@@ -27,9 +27,8 @@ private
   def create_from_top_level_change_note
     return unless change_note
     ChangeNote
-      .find_or_create_by!(edition: edition)
+      .find_or_create_by!(document: document, edition: edition)
       .update!(
-        document: edition.document,
         public_timestamp: Time.zone.now,
         note: change_note,
       )
@@ -38,9 +37,8 @@ private
   def create_from_details_hash_change_note
     return unless note
     ChangeNote
-      .find_or_create_by!(edition: edition)
+      .find_or_create_by!(document: document, edition: edition)
       .update!(
-        document: edition.document,
         public_timestamp: edition.updated_at,
         note: note,
       )
@@ -50,9 +48,8 @@ private
     return unless change_history.present?
     history_element = change_history.max_by { |h| h[:public_timestamp] }
     ChangeNote
-      .find_or_create_by!(edition: edition)
+      .find_or_create_by!(document: document, edition: edition)
       .update!(
-        document: edition.document,
         public_timestamp: history_element.fetch(:public_timestamp),
         note: history_element.fetch(:note),
       )
@@ -72,5 +69,9 @@ private
 
   def change_history
     edition.details[:change_history]
+  end
+
+  def document
+    edition.document
   end
 end

--- a/db/migrate/20170519121140_make_change_notes_document_field_not_nullable.rb
+++ b/db/migrate/20170519121140_make_change_notes_document_field_not_nullable.rb
@@ -1,0 +1,5 @@
+class MakeChangeNotesDocumentFieldNotNullable < ActiveRecord::Migration[5.1]
+  def change
+    change_column_null :change_notes, :document_id, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170519120114) do
+ActiveRecord::Schema.define(version: 20170519121140) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -45,7 +45,7 @@ ActiveRecord::Schema.define(version: 20170519120114) do
     t.integer "edition_id"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.integer "document_id"
+    t.integer "document_id", null: false
     t.index ["edition_id"], name: "index_change_notes_on_edition_id"
   end
 

--- a/spec/commands/v2/publish_spec.rb
+++ b/spec/commands/v2/publish_spec.rb
@@ -345,7 +345,7 @@ RSpec.describe Commands::V2::Publish do
         before do
           draft_item.update(update_type: "major")
           payload[:update_type] = "minor"
-          ChangeNote.create(edition: draft_item)
+          ChangeNote.create!(document: draft_item.document, edition: draft_item)
         end
         it "deletes associated ChangeNote records" do
           expect { described_class.call(payload) }


### PR DESCRIPTION
This is the fifth part of linking change notes with documents. It should not be deployed until #923 has been deployed.

[Trello Card](https://trello.com/c/7GRaupoY/919-since-changehistory-is-associated-with-a-content-id-it-should-be-associated-with-a-locale-1)