### PR TITLE
Revert to using sidekiq-unique-jobs gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,7 +29,7 @@ gem 'whenever', '0.9.4', require: false
 gem "govuk_sidekiq", "~> 1.0.3"
 gem "json-schema", require: false
 gem "hashdiff", require: false
-gem "sidekiq-unique-jobs", git: "https://github.com/alphagov/sidekiq-unique-jobs", require: false
+gem "sidekiq-unique-jobs", "~> 5.0", require: false
 gem "govspeak", "~> 5.0.2"
 gem "diffy", "~> 3.1", require: false
 gem "aws-sdk", "~> 2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,3 @@
-GIT
-  remote: https://github.com/alphagov/sidekiq-unique-jobs
-  revision: 6c03e39c3ad6ba1468d567c22bb99908f6fdb317
-  specs:
-    sidekiq-unique-jobs (4.0.18)
-      sidekiq (>= 2.6)
-      thor
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -245,7 +237,7 @@ GEM
     rack (2.0.3)
     rack-cache (1.7.0)
       rack (>= 0.4)
-    rack-protection (1.5.3)
+    rack-protection (2.0.0)
       rack
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -276,7 +268,7 @@ GEM
     raindrops (0.17.0)
     rake (11.3.0)
     randexp (0.1.7)
-    redis (3.3.2)
+    redis (3.3.3)
     redis-namespace (1.5.2)
       redis (~> 3.0, >= 3.0.4)
     request_store (1.3.1)
@@ -319,7 +311,7 @@ GEM
     scss_lint (0.50.2)
       rake (>= 0.9, < 12)
       sass (~> 3.4.20)
-    sidekiq (4.2.8)
+    sidekiq (4.2.10)
       concurrent-ruby (~> 1.0)
       connection_pool (~> 2.2, >= 2.2.0)
       rack-protection (>= 1.5.0)
@@ -330,6 +322,9 @@ GEM
       activesupport
       sidekiq (>= 2.6)
       statsd-ruby (>= 1.1.0)
+    sidekiq-unique-jobs (5.0.8)
+      sidekiq (>= 4.0, <= 6.0)
+      thor (~> 0)
     simplecov (0.10.0)
       docile (~> 1.1.0)
       json (~> 1.8)
@@ -427,7 +422,7 @@ DEPENDENCIES
   rails (= 5.1)
   rspec
   rspec-rails (~> 3.5)
-  sidekiq-unique-jobs!
+  sidekiq-unique-jobs (~> 5.0)
   simplecov (= 0.10.0)
   simplecov-rcov (= 0.2.3)
   spring


### PR DESCRIPTION
We were previously using a fork of it for a bug fix.

I've given it a spin on integration and has been running without issues.