### PR TITLE
Up sidekiq to a concurrency of 6

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,6 +1,6 @@
 ---
 :verbose: false
-:concurrency:  2
+:concurrency:  6
 :logfile: ./log/sidekiq.json.log
 :queues:
   - downstream_high


### PR DESCRIPTION
Currently we use ~95 connections of 200 on production, with less on
staging (seems a little strange) and less still on integration.

Publishing API currently uses 16 connections on prod/staging and 13 on
integration. This will increase its usage to 28 on prod/staging and 21
on integration. Which still be well below the 200 connections limit.

Seems to have run fine on tests with integration, but may need to throw a
bit more at it to open all the connections.