### PR TITLE
Increase DB pool size

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -1,7 +1,7 @@
 default: &default
   adapter: postgresql
   encoding: unicode
-  pool: 5
+  pool: 10
   template: template0
 
 development:


### PR DESCRIPTION
We now have increased number of sidekiq workers from 2 to 6 so this
would require an increase in the pooled connections. 6 should be all
that is required here but 10 gives us a little wiggle room.

I've given this a spin on integration and no problems have occurred, of
course I said that on the PR that this is to fix. This time I've sent 6000
things downstream though