### PR TITLE
Better support for republish update_type

### DIFF
--- a/app/commands/v2/publish.rb
+++ b/app/commands/v2/publish.rb
@@ -157,7 +157,7 @@ module Commands
 
         if update_type == "major" || previous_item.blank?
           edition.update_attributes!(public_updated_at: default_datetime)
-        elsif update_type == "minor"
+        else
           edition.update_attributes!(public_updated_at: previous_item.public_updated_at)
         end
       end

--- a/app/models/create_draft_edition.rb
+++ b/app/models/create_draft_edition.rb
@@ -39,6 +39,7 @@ private
   def fill_out_new_edition
     document.increment!(:stale_lock_version)
     set_first_published_at
+    set_last_edited_at
   end
 
   def set_first_published_at
@@ -46,6 +47,14 @@ private
     return if edition.first_published_at
     edition.update_attributes(
       first_published_at: previously_published_item.first_published_at,
+    )
+  end
+
+  def set_last_edited_at
+    return unless previously_published_item.set_last_edited_at?
+    return if edition.last_edited_at
+    edition.update_attributes(
+      last_edited_at: previously_published_item.last_edited_at,
     )
   end
 

--- a/app/models/create_draft_edition.rb
+++ b/app/models/create_draft_edition.rb
@@ -43,7 +43,7 @@ private
   end
 
   def set_first_published_at
-    return unless previously_published_item.set_first_published_at?
+    return unless previously_published_item.has_first_published_at?
     return if edition.first_published_at
     edition.update_attributes(
       first_published_at: previously_published_item.first_published_at,
@@ -51,7 +51,7 @@ private
   end
 
   def set_last_edited_at
-    return unless previously_published_item.set_last_edited_at?
+    return unless previously_published_item.has_last_edited_at?
     return if edition.last_edited_at
     edition.update_attributes(
       last_edited_at: previously_published_item.last_edited_at,

--- a/app/models/previously_published_item.rb
+++ b/app/models/previously_published_item.rb
@@ -19,7 +19,7 @@ class PreviouslyPublishedItem
     previously_published_item.user_facing_version + 1
   end
 
-  def set_first_published_at?
+  def has_first_published_at?
     true
   end
 
@@ -27,7 +27,7 @@ class PreviouslyPublishedItem
     previously_published_item.first_published_at
   end
 
-  def set_last_edited_at?
+  def has_last_edited_at?
     true
   end
 
@@ -60,11 +60,11 @@ class PreviouslyPublishedItem
       []
     end
 
-    def set_first_published_at?
+    def has_first_published_at?
       false
     end
 
-    def set_last_edited_at?
+    def has_last_edited_at?
       false
     end
 

--- a/app/models/previously_published_item.rb
+++ b/app/models/previously_published_item.rb
@@ -27,6 +27,14 @@ class PreviouslyPublishedItem
     previously_published_item.first_published_at
   end
 
+  def set_last_edited_at?
+    true
+  end
+
+  def last_edited_at
+    previously_published_item.last_edited_at
+  end
+
   def previous_base_path
     previously_published_item.base_path
   end
@@ -53,6 +61,10 @@ class PreviouslyPublishedItem
     end
 
     def set_first_published_at?
+      false
+    end
+
+    def set_last_edited_at?
       false
     end
 

--- a/spec/commands/v2/publish_spec.rb
+++ b/spec/commands/v2/publish_spec.rb
@@ -296,7 +296,7 @@ RSpec.describe Commands::V2::Publish do
 
             described_class.call(payload)
 
-            expect(Edition.last.public_updated_at.iso8601).to eq(public_updated_at.iso8601)
+            expect(draft_item.reload.public_updated_at.iso8601).to eq(public_updated_at.iso8601)
           end
 
           it "preserves the public_updated_at value from the last unpublished item" do
@@ -310,7 +310,7 @@ RSpec.describe Commands::V2::Publish do
 
             described_class.call(payload)
 
-            expect(Edition.last.public_updated_at.iso8601).to eq(public_updated_at.iso8601)
+            expect(draft_item.reload.public_updated_at.iso8601).to eq(public_updated_at.iso8601)
           end
 
           it "updates the public_updated_at time to now if no previous item" do

--- a/spec/commands/v2/put_content_spec.rb
+++ b/spec/commands/v2/put_content_spec.rb
@@ -921,5 +921,37 @@ RSpec.describe Commands::V2::PutContent do
         described_class.call(payload)
       end
     end
+
+    context "when the update_type is 'republish'" do
+      before { payload[:update_type] = "republish" }
+
+      context "and there is a previous edition" do
+        let(:document) do
+          FactoryGirl.create(:document, content_id: content_id)
+        end
+
+        let!(:previous_edition) do
+          FactoryGirl.create(:live_edition,
+            document: document,
+            base_path: base_path,
+            last_edited_at: Time.zone.now
+          )
+        end
+
+        it "uses the last_edited_at value from the previous edition" do
+          described_class.call(payload)
+          edition = Edition.last
+          expect(edition.last_edited_at.iso8601).to eq previous_edition.last_edited_at.iso8601
+        end
+      end
+
+      context "but there is not a previous edition" do
+        it "has a last_edited_at of nil" do
+          described_class.call(payload)
+          edition = Edition.last
+          expect(edition.last_edited_at).to be_nil
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
This band aids a couple of the holes that we have in the system for using an update_type of republish - as evidenced from running the specialist publisher republish task. 

I think we should aim to remove this update_type as it adds junk to the history and all feels complicated and prone to bugs, but until then it's probably best to keep it going.
