### PR TITLE
Track document owner

### DIFF
--- a/app/helpers/redirect_helper.rb
+++ b/app/helpers/redirect_helper.rb
@@ -19,7 +19,10 @@ module RedirectHelper
         publishing_app: payload[:publishing_app]
       ).merge(content_id: SecureRandom.uuid)
 
-      Commands::V2::PutContent.call(redirect_payload, callbacks: callbacks, nested: true)
+      Commands::V2::PutContent.call(redirect_payload,
+                                    callbacks: callbacks,
+                                    nested: true,
+                                    owning_document_id: owning_document.id)
     end
 
   private
@@ -53,6 +56,11 @@ module RedirectHelper
           destination: route[:path].gsub(old_base_path, new_base_path)
         }
       end
+    end
+
+    def owning_document
+      previously_published_item.try(:document) ||
+        previously_drafted_item.document
     end
   end
 end

--- a/app/helpers/redirect_helper.rb
+++ b/app/helpers/redirect_helper.rb
@@ -1,28 +1,7 @@
 module RedirectHelper
-  extend self
-
-  def create_redirect(old_base_path:, new_base_path:, publishing_app:, callbacks:, content_id: nil, routes: [])
-    payload = RedirectPresenter.present(
-      base_path: old_base_path,
-      public_updated_at: Time.zone.now,
-      redirects: redirects_for(routes, old_base_path, new_base_path),
-      publishing_app: publishing_app
-    ).merge(content_id: content_id || SecureRandom.uuid)
-
-    Commands::V2::PutContent.call(payload, callbacks: callbacks, nested: true)
-  end
-
-  def redirects_for(routes, old_base_path, new_base_path)
-    routes.map do |route|
-      {
-        path: route[:path],
-        type: route[:type],
-        destination: route[:path].gsub(old_base_path, new_base_path)
-      }
-    end
-  end
-
   class Redirect
+    attr_reader :previously_published_item, :previously_drafted_item, :payload, :callbacks
+
     def initialize(previously_published_item, previously_drafted_item, payload, callbacks)
       @previously_published_item = previously_published_item
       @previously_drafted_item = previously_drafted_item
@@ -32,16 +11,19 @@ module RedirectHelper
 
     def create
       return unless path_has_changed?
-      create_redirect(
-        from_path: previous_base_path,
-        to_path: payload[:base_path],
-        routes: previous_routes,
-      )
+
+      redirect_payload = RedirectPresenter.present(
+        base_path: previous_base_path,
+        public_updated_at: Time.zone.now,
+        redirects: redirects_for(previous_routes, previous_base_path, payload[:base_path]),
+        publishing_app: payload[:publishing_app]
+      ).merge(content_id: SecureRandom.uuid)
+
+      Commands::V2::PutContent.call(redirect_payload, callbacks: callbacks, nested: true)
     end
 
   private
 
-    attr_reader :previously_published_item, :previously_drafted_item, :payload, :callbacks
 
     def path_has_changed?
       previously_published_item.path_has_changed? ||
@@ -63,14 +45,14 @@ module RedirectHelper
         previously_drafted_item.base_path
     end
 
-    def create_redirect(from_path:, to_path:, routes:)
-      RedirectHelper.create_redirect(
-        publishing_app: payload[:publishing_app],
-        old_base_path: from_path,
-        new_base_path: to_path,
-        routes: routes,
-        callbacks: callbacks,
-      )
+    def redirects_for(routes, old_base_path, new_base_path)
+      routes.map do |route|
+        {
+          path: route[:path],
+          type: route[:type],
+          destination: route[:path].gsub(old_base_path, new_base_path)
+        }
+      end
     end
   end
 end

--- a/app/models/create_draft_edition.rb
+++ b/app/models/create_draft_edition.rb
@@ -40,6 +40,7 @@ private
     document.increment!(:stale_lock_version)
     set_first_published_at
     set_last_edited_at
+    set_document_owner
   end
 
   def set_first_published_at
@@ -56,6 +57,11 @@ private
     edition.update_attributes(
       last_edited_at: previously_published_item.last_edited_at,
     )
+  end
+
+  def set_document_owner
+    owner_id = put_content.options[:owning_document_id]
+    edition.document.update_attributes(owning_document_id: owner_id) if owner_id
   end
 
   def edition_attributes_from_payload

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -1,6 +1,7 @@
 class Document < ApplicationRecord
   include FindOrCreateLocked
 
+  belongs_to :owning_document, class_name: "Document", optional: true
   has_many :editions
   has_one :draft, -> { where(content_store: "draft") }, class_name: 'Edition'
   has_one :live, -> { where(content_store: "live") }, class_name: 'Edition'

--- a/db/migrate/20170606102023_add_owning_document_id_to_documents.rb
+++ b/db/migrate/20170606102023_add_owning_document_id_to_documents.rb
@@ -1,0 +1,9 @@
+class AddOwningDocumentIdToDocuments < ActiveRecord::Migration[5.1]
+  def up
+    add_column :documents, :owning_document_id, :integer, index: true
+  end
+
+  def down
+    remove_column :documents, :owning_document_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170602111120) do
-
+ActiveRecord::Schema.define(version: 20170606102023) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -55,6 +54,7 @@ ActiveRecord::Schema.define(version: 20170602111120) do
     t.integer "stale_lock_version", default: 0, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "owning_document_id"
     t.index ["content_id", "locale"], name: "index_documents_on_content_id_and_locale", unique: true
   end
 

--- a/spec/integration/put_content/content_with_a_previous_draft_spec.rb
+++ b/spec/integration/put_content/content_with_a_previous_draft_spec.rb
@@ -105,6 +105,7 @@ RSpec.describe "PUT /v2/content when the payload is for an already drafted editi
           destination: "#{base_path}.atom"
         }
       ])
+      expect(redirect.document.owning_document).to eq(previously_drafted_item.document)
     end
 
     it "sends a create request to the draft content store for the redirect" do

--- a/spec/integration/put_content/content_with_a_previously_published_edition_spec.rb
+++ b/spec/integration/put_content/content_with_a_previously_published_edition_spec.rb
@@ -83,6 +83,8 @@ RSpec.describe "PUT /v2/content when creating a draft for a previously published
         type: "exact",
         destination: "/moved",
       }])
+
+      expect(redirect.document.owning_document).to eq(edition.document)
     end
 
     it "sends a create request to the draft content store for the redirect" do


### PR DESCRIPTION
https://trello.com/c/u2ty6FdR/939-3-keep-track-of-redirects-created-automatically

Adds an optional `Document#owner` for redirects. This is an association with the `Document` of the edition which is being redirected. Because redirects are created with a new Document and content id, this will help us track where redirects originated.