### PR TITLE
Create exporter for a tagging event log

### DIFF
--- a/lib/tasks/taxonomy_event_log.rake
+++ b/lib/tasks/taxonomy_event_log.rake
@@ -1,0 +1,13 @@
+task taxonomy_event_log: [:environment] do
+  events = TaxonomyEventLog.new.export
+
+  file = CSV.generate(headers: true) do |csv|
+    csv << events.first.keys
+
+    events.each do |event|
+      csv << event.values
+    end
+  end
+
+  puts file
+end

--- a/lib/tasks/taxonomy_event_log.rb
+++ b/lib/tasks/taxonomy_event_log.rb
@@ -1,0 +1,69 @@
+class TaxonomyEventLog
+  def export
+    exported = []
+    previous_events = {}
+
+    raw_events.each do |event|
+      previous_taxons = previous_events[event.content_id].to_a
+      current_taxons = event.payload[:links][:taxons]
+
+      # Nil means that this `PatchLinkSet` doesn't change the `taxons` (which is
+      # different from sending an empty array)
+      next if current_taxons.nil?
+      edition = fetch_edition(event.content_id)
+
+      # It is possible for documents to not have an edition. This happens
+      # when they are created as drafts, never published and then discarded.
+      next unless edition
+
+      (current_taxons - previous_taxons).each do |taxon_id|
+        exported << build_line(event, edition, taxon_id, 1)
+      end
+
+      (previous_taxons - current_taxons).each do |taxon_id|
+        exported << build_line(event, edition, taxon_id, -1)
+      end
+
+      previous_events[event.content_id] = current_taxons
+    end
+
+    exported.compact
+  end
+
+  def build_line(event, edition, taxon_id, change)
+    supertype = GovukDocumentTypes.supertypes(document_type: edition.document_type)["navigation_document_supertype"]
+    taxon = fetch_edition(taxon_id)
+    return unless taxon
+
+    {
+      taggable_content_id: event.content_id,
+      taggable_title: edition.title,
+      taggable_navigation_document_supertype: supertype,
+      taggable_base_path: edition.base_path,
+      tagged_at: event.created_at,
+      tagged_on: event.created_at.to_date,
+      user_uid: event.user_uid,
+      taxon_content_id: taxon_id,
+      taxon_title: taxon.title,
+      change: change,
+    }
+  end
+
+private
+
+  def fetch_edition(content_id)
+    @edition_cache ||= {}
+
+    @edition_cache[content_id] ||= begin
+      document = Document.find_by(content_id: content_id) || return
+      document.editions.last
+    end
+  end
+
+  def raw_events
+    Event
+      .where("payload IS NOT NULL")
+      .where(action: "PatchLinkSet")
+      .order("id ASC")
+  end
+end

--- a/spec/lib/tasks/taxonomy_event_log_spec.rb
+++ b/spec/lib/tasks/taxonomy_event_log_spec.rb
@@ -1,0 +1,58 @@
+require "rails_helper"
+
+RSpec.describe TaxonomyEventLog do
+  before do
+    Timecop.freeze("2017-01-02 12:23")
+  end
+
+  after do
+    Timecop.return
+  end
+
+  it "exports all the events" do
+    # Create 2 relationships
+    FactoryGirl.create(:event, user_uid: 'bf61e464-aae9-4ec6-b6ae-6acfde796bdb', action: 'PatchLinkSet', content_id: '1dd96f5d-c260-438b-ba58-57ba910e9291', payload: { links: { taxons: ['7f2a716a-e527-4485-9381-fd47cb49d30c', '396253a1-fb87-48d0-91e9-570c63166068'] } })
+
+    # Create another relationship (which doesn't include `taxons`)
+    FactoryGirl.create(:event, user_uid: 'bf61e464-aae9-4ec6-b6ae-6acfde796bdb', action: 'PatchLinkSet', content_id: '1dd96f5d-c260-438b-ba58-57ba910e9291', payload: { links: { something_else: [] } })
+
+    # Keep one the same and replace another
+    FactoryGirl.create(:event, user_uid: 'bf61e464-aae9-4ec6-b6ae-6acfde796bdb', action: 'PatchLinkSet', content_id: '1dd96f5d-c260-438b-ba58-57ba910e9291', payload: { links: { taxons: ['7f2a716a-e527-4485-9381-fd47cb49d30c', 'c231acfd-4cb1-427d-9b00-b67b5146ea52'] } })
+
+    # Remove all taxons
+    FactoryGirl.create(:event, user_uid: 'bf61e464-aae9-4ec6-b6ae-6acfde796bdb', action: 'PatchLinkSet', content_id: '1dd96f5d-c260-438b-ba58-57ba910e9291', payload: { links: { taxons: [] } })
+
+    document = FactoryGirl.create(:document, content_id: '1dd96f5d-c260-438b-ba58-57ba910e9291')
+    taggable = FactoryGirl.create(:edition, document: document, title: 'Content Foo')
+
+    document = FactoryGirl.create(:document, content_id: '7f2a716a-e527-4485-9381-fd47cb49d30c')
+    FactoryGirl.create(:edition, document: document, title: 'Taxon Foo')
+
+    document = FactoryGirl.create(:document, content_id: 'c231acfd-4cb1-427d-9b00-b67b5146ea52')
+    FactoryGirl.create(:edition, document: document, title: 'Taxon Bar')
+
+    document = FactoryGirl.create(:document, content_id: '396253a1-fb87-48d0-91e9-570c63166068')
+    FactoryGirl.create(:edition, document: document, title: 'Taxon Baz')
+
+    diffo = TaxonomyEventLog.new.export
+
+    base = {
+      taggable_content_id: '1dd96f5d-c260-438b-ba58-57ba910e9291',
+      taggable_title: 'Content Foo',
+      taggable_navigation_document_supertype: 'other',
+      taggable_base_path: taggable.base_path,
+      tagged_at: Time.now,
+      tagged_on: Date.today,
+      user_uid: 'bf61e464-aae9-4ec6-b6ae-6acfde796bdb',
+    }
+
+    expect(diffo).to eql([
+      base.merge(taxon_content_id: '7f2a716a-e527-4485-9381-fd47cb49d30c', taxon_title: 'Taxon Foo', change: 1),
+      base.merge(taxon_content_id: '396253a1-fb87-48d0-91e9-570c63166068', taxon_title: 'Taxon Baz', change: 1),
+      base.merge(taxon_content_id: 'c231acfd-4cb1-427d-9b00-b67b5146ea52', taxon_title: 'Taxon Bar', change: 1),
+      base.merge(taxon_content_id: '396253a1-fb87-48d0-91e9-570c63166068', taxon_title: 'Taxon Baz', change: -1),
+      base.merge(taxon_content_id: '7f2a716a-e527-4485-9381-fd47cb49d30c', taxon_title: 'Taxon Foo', change: -1),
+      base.merge(taxon_content_id: 'c231acfd-4cb1-427d-9b00-b67b5146ea52', taxon_title: 'Taxon Bar', change: -1),
+    ])
+  end
+end


### PR DESCRIPTION
This creates a rake task that exports a CSV with a "tagging history". It contains all the taxonomy-related tagging events. We use the CSV in content tagger to show the history of how much was tagged to a taxon when, and by whom. We use a CSV rather than an actual API to postpone a decision on what the API should look like.

The tests for the exporter really need some de-duping, but I'm not sure yet which way is best.

https://trello.com/c/GRPCKmbU