### PR TITLE
Content history prototype

### DIFF
--- a/app/controllers/content_api_prototype/content_items/content_controller.rb
+++ b/app/controllers/content_api_prototype/content_items/content_controller.rb
@@ -31,13 +31,43 @@ module ContentApiPrototype
           .new(edition, draft: edition.draft?)
           .for_content_store(0)
 
-        resolve_text_html(presented_edition)
+        presented_edition = resolve_text_html(presented_edition)
+
+        inject_links(presented_edition, edition)
       end
 
       def resolve_text_html(presented_edition)
         resolver = ContentTypeResolver.new("text/html")
         presented_edition[:details] = resolver.resolve(presented_edition[:details])
         presented_edition[:description] = resolver.resolve(presented_edition[:description])
+        presented_edition
+      end
+
+      def user_facing_version_for(edition, position)
+        return edition.user_facing_version + 1 if position == :next
+        return edition.user_facing_version - 1 if position == :prev
+        raise "Invalid position, must be :next or :prev"
+      end
+
+      def sibling_edition(edition, position)
+        version = user_facing_version_for(edition, position)
+        edition.document.editions
+          .where(user_facing_version: version, content_store: [nil, "live"])
+          .first
+      end
+
+      def link_to_sibling(edition, position)
+        other_edition = sibling_edition(edition, position)
+        return unless other_edition
+        "/content/#{other_edition.document.content_id}/#{other_edition.document.locale}/#{other_edition.user_facing_version}"
+      end
+
+      def inject_links(presented_edition, edition)
+        presented_edition[:historical_links] = {
+          next: link_to_sibling(edition, :next),
+          prev: link_to_sibling(edition, :prev),
+        }
+
         presented_edition
       end
     end

--- a/app/controllers/content_api_prototype/content_items/content_controller.rb
+++ b/app/controllers/content_api_prototype/content_items/content_controller.rb
@@ -27,9 +27,18 @@ module ContentApiPrototype
     private
 
       def present(edition)
-        Presenters::EditionPresenter
+        presented_edition = Presenters::EditionPresenter
           .new(edition, draft: edition.draft?)
           .for_content_store(0)
+
+        resolve_text_html(presented_edition)
+      end
+
+      def resolve_text_html(presented_edition)
+        resolver = ContentTypeResolver.new("text/html")
+        presented_edition[:details] = resolver.resolve(presented_edition[:details])
+        presented_edition[:description] = resolver.resolve(presented_edition[:description])
+        presented_edition
       end
     end
   end

--- a/app/controllers/content_api_prototype/content_items/content_controller.rb
+++ b/app/controllers/content_api_prototype/content_items/content_controller.rb
@@ -1,0 +1,36 @@
+module ContentApiPrototype
+  module ContentItems
+    class ContentController < ApplicationController
+      def by_base_path
+        edition = Edition
+          .where(base_path: base_path, content_store: "live")
+          .order(user_facing_version: "DESC")
+          .first!
+
+        render json: present(edition)
+      end
+
+      def by_content_id
+        edition = Edition
+          .with_document
+          .find_by!(
+            documents: {
+              content_id: path_params[:content_id],
+              locale: path_params[:locale]
+            },
+            user_facing_version: path_params[:user_facing_version]
+          )
+
+        render json: present(edition)
+      end
+
+    private
+
+      def present(edition)
+        Presenters::EditionPresenter
+          .new(edition, draft: edition.draft?)
+          .for_content_store(0)
+      end
+    end
+  end
+end

--- a/app/controllers/content_api_prototype/content_items/content_type_resolver.rb
+++ b/app/controllers/content_api_prototype/content_items/content_type_resolver.rb
@@ -1,0 +1,47 @@
+# taken from https://github.com/alphagov/content-store/blob/master/app/presenters/content_type_resolver.rb
+module ContentApiPrototype
+  module ContentItems
+    class ContentTypeResolver
+      def initialize(content_type)
+        self.content_type = content_type
+      end
+
+      def resolve(object)
+        if object.is_a?(Hash)
+          resolve_hash(object)
+        elsif object.is_a?(Array)
+          resolve_array(object)
+        else
+          object
+        end
+      end
+
+    private
+
+      def resolve_hash(hash)
+        hash.inject({}) do |memo, (key, value)|
+          memo.merge(key => resolve(value))
+        end
+      end
+
+      def resolve_array(array)
+        if array.all? { |v| v.is_a?(Hash) }
+          array = array.map(&:symbolize_keys)
+          content_for_type = extract_content(array)
+        end
+
+        if content_for_type
+          content_for_type[:content]
+        else
+          array.map { |e| resolve(e) }
+        end
+      end
+
+      def extract_content(array)
+        array.detect { |h| h[:content_type] == content_type && h[:content] }
+      end
+
+      attr_accessor :content_type
+    end
+  end
+end

--- a/app/presenters/change_history_presenter.rb
+++ b/app/presenters/change_history_presenter.rb
@@ -7,7 +7,7 @@ module Presenters
     end
 
     def change_history
-      details[:change_history] || change_notes_for_content_item
+      details[:change_history] || presented_change_notes
     end
 
   private
@@ -16,14 +16,20 @@ module Presenters
       SymbolizeJSON.symbolize(edition.details)
     end
 
-    def change_notes_for_content_item
-      change_notes = ChangeNote
+    def presented_change_notes
+      SymbolizeJSON.symbolize(
+        change_notes
+          .pluck(:note, :public_timestamp)
+          .map { |note, timestamp| { note: note, public_timestamp: timestamp } }
+          .as_json
+      )
+    end
+
+    def change_notes
+      ChangeNote
         .where(document: document)
         .where("edition_id IS NULL OR edition_id IN (?)", edition_ids)
         .order(:public_timestamp)
-        .pluck(:note, :public_timestamp)
-        .map { |note, timestamp| { note: note, public_timestamp: timestamp } }
-      SymbolizeJSON.symbolize(change_notes.as_json)
     end
 
     def edition_ids

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,15 +12,6 @@ Rails.application.routes.draw do
 
     post '/lookup-by-base-path', to: 'lookups#by_base_path'
 
-    namespace :content_api_prototype do
-      namespace :content_items do
-        scope "/content" do
-          get "/:content_id/:locale/:user_facing_version", to: "content#by_content_id"
-          get "(/*base_path)", to: "content#by_base_path"
-        end
-      end
-    end
-
     namespace :v2 do
       get "/content", to: "content_items#index"
       scope constraints: method(:content_id_constraint) do
@@ -43,6 +34,15 @@ Rails.application.routes.draw do
       get "/new-linkables", to: "content_items#new_linkables"
 
       post "/actions/:content_id", to: "actions#create"
+    end
+
+    namespace :content_api_prototype do
+      namespace :content_items do
+        scope constraints: method(:content_id_constraint) do
+          get "/content/:content_id/:locale/:user_facing_version", to: "content#by_content_id"
+        end
+        get "/content(/*base_path)", to: "content#by_base_path"
+      end
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,12 +36,14 @@ Rails.application.routes.draw do
       post "/actions/:content_id", to: "actions#create"
     end
 
-    namespace :content_api_prototype do
-      namespace :content_items do
-        scope constraints: method(:content_id_constraint) do
-          get "/content/:content_id/:locale/:user_facing_version", to: "content#by_content_id"
+    if ENV.include?("CONTENT_API_PROTOTYPE")
+      namespace :content_api_prototype do
+        namespace :content_items do
+          scope constraints: method(:content_id_constraint) do
+            get "/content/:content_id/:locale/:user_facing_version", to: "content#by_content_id"
+          end
+          get "/content(/*base_path)", to: "content#by_base_path"
         end
-        get "/content(/*base_path)", to: "content#by_base_path"
       end
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,15 @@ Rails.application.routes.draw do
 
     post '/lookup-by-base-path', to: 'lookups#by_base_path'
 
+    namespace :content_api_prototype do
+      namespace :content_items do
+        scope "/content" do
+          get "/:content_id/:locale/:user_facing_version", to: "content#by_content_id"
+          get "(/*base_path)", to: "content#by_base_path"
+        end
+      end
+    end
+
     namespace :v2 do
       get "/content", to: "content_items#index"
       scope constraints: method(:content_id_constraint) do


### PR DESCRIPTION
Implementation of a basic content history prototype based on what the new content API might look like.

You must have the environment variable `CONTENT_API_PROTOTYPE` set to something to test it out.

[Trello Card](https://trello.com/c/01I7Xn05/88-historic-content-store-simple-publishing-api-prototype)