### PR TITLE
Expand `associated_taxons`

### DIFF
--- a/lib/link_expansion/rules.rb
+++ b/lib/link_expansion/rules.rb
@@ -12,6 +12,7 @@ module LinkExpansion::Rules
   using RecurringLinks
 
   MULTI_LEVEL_LINK_PATHS = [
+    [:associated_taxons.recurring],
     [:child_taxons.recurring],
     [:parent.recurring],
     [:parent_taxons.recurring],


### PR DESCRIPTION
We have added an `associated_taxon` link type to the `taxon`. This will be used to allow content from other taxons to be included when the content from a child taxon is rendered. We need this to be expanded with the same rules as `child_taxons`.

[Trello](https://trello.com/c/OBMDMymd/208-add-rule-to-publishing-api-to-expand-associated-taxons)