### PR TITLE
Remove rake task to import events for a `content_id`

### DIFF
--- a/lib/tasks/events.rake
+++ b/lib/tasks/events.rake
@@ -14,23 +14,4 @@ namespace :events do
     imported = Events::S3Importer.new(args[:s3_key]).import
     puts "Imported #{imported} event#{imported == 1 ? '' : 's'} successfully 🍾"
   end
-
-  # $ EVENT_LOG_AWS_ACCESS_ID=AKIAIOSFODNN7EXAMPLE EVENT_LOG_AWS_SECRET_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY EVENT_LOG_AWS_BUCKETNAME=govuk-publishing-api-event-log-integration S3_EXPORT_REGION=eu-west-1 rake 'events:import_content_id_events[content_id]'
-  desc "import all events matching a content_id"
-  task :import_content_id_events, [:content_id] => :environment do |_, args|
-    event_dates = Event.where(content_id: args[:content_id]).where("payload IS NULL").pluck(:created_at)
-    importer = Events::S3Importer.new
-    s3_keys = event_dates.map do |event_date|
-      start_event = event_date - event_date.wday
-      "events/#{Time.zone.parse(start_event.to_s).strftime('%FT%T%:z')}.csv.gz"
-    end
-    s3_keys.uniq.each do |key|
-      begin
-        imported = importer.import(key)
-        puts "Imported #{imported} successfully"
-      rescue Events::S3Importer::BucketNotConfiguredError => e
-        puts "skipped #{key} #{e}"
-      end
-    end
-  end
 end


### PR DESCRIPTION
This rake task was created to import all events relating to a particular content_id. It does so by calculating the filename on S3 where the payload for a certain event was archived to.

This worked because we do archiving every week, so if a event happened on Tuesday, we know that it will be archived into the CSV with a name like `events/date-of-the-sunday-before.csv.gz`.

Because the job has been failing for a couple of weeks now, we can no longer determine the correct file for each event.