### PR TITLE
[Do not merge] Downgrade Airbrake gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,8 +7,7 @@ gem "arel", "8.0"
 gem "unicorn", "~> 4.9.0"
 gem "logstasher", "0.6.2"
 gem "plek", "~> 1.10"
-gem 'airbrake', '~> 5.5'
-gem 'airbrake-ruby', '1.5'
+gem 'airbrake', github: 'alphagov/airbrake', branch: 'silence-dep-warnings-for-rails-5'
 gem "pg"
 gem 'dalli'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,13 @@
+GIT
+  remote: git://github.com/alphagov/airbrake.git
+  revision: ad9c926a56535c48f95c33824a76e10bc8f91179
+  branch: silence-dep-warnings-for-rails-5
+  specs:
+    airbrake (4.3.8)
+      builder
+      multi_json
+      rails (>= 5.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -40,9 +50,6 @@ GEM
       minitest (~> 5.1)
       tzinfo (~> 1.1)
     addressable (2.3.8)
-    airbrake (5.5.0)
-      airbrake-ruby (~> 1.5)
-    airbrake-ruby (1.5.0)
     amq-protocol (2.1.0)
     arel (8.0.0)
     ast (2.3.0)
@@ -389,8 +396,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  airbrake (~> 5.5)
-  airbrake-ruby (= 1.5)
+  airbrake!
   arel (= 8.0)
   aws-sdk (~> 2)
   bunny (~> 2.6)

--- a/config/initializers/airbrake.rb
+++ b/config/initializers/airbrake.rb
@@ -2,9 +2,9 @@ if ENV['ERRBIT_API_KEY'].present?
   errbit_uri = Plek.find_uri('errbit')
 
   Airbrake.configure do |config|
-    config.project_key = ENV['ERRBIT_API_KEY']
-    config.project_id = 1 # dummy, not used in Errbit
-    config.host = errbit_uri.to_s
-    config.environment = ENV['ERRBIT_ENVIRONMENT_NAME']
+    config.api_key = ENV["ERRBIT_API_KEY"]
+    config.host = errbit_uri.host
+    config.secure = errbit_uri.scheme == "https"
+    config.environment_name = ENV["ERRBIT_ENVIRONMENT_NAME"]
   end
 end


### PR DESCRIPTION
Trello card: https://trello.com/c/wg6F6Gk3

The inconsistent document checker task is no longer sending an error report to Errbit. 
This seems to have started happening when the app was upgraded to Rails 5. As it's known that version 5 of Airbrake is not compatible with Rails 5, the hope is that simply changing the version of Airbrake used to the alphagov fork will fix the problem.