### PR TITLE
Allow world_location to be base_path-less

### DIFF
--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -32,8 +32,7 @@ class Edition < ApplicationRecord
   ].freeze
 
   NON_RENDERABLE_FORMATS = %w(redirect gone).freeze
-  EMPTY_BASE_PATH_FORMATS = %w(contact government).freeze
-
+  EMPTY_BASE_PATH_FORMATS = %w(contact government world_location).freeze
   belongs_to :document
   has_one :unpublishing
   has_one :change_note

--- a/spec/models/edition_spec.rb
+++ b/spec/models/edition_spec.rb
@@ -256,7 +256,9 @@ RSpec.describe Edition do
 
   context "EMPTY_BASE_PATH_FORMATS" do
     it "defines formats not requiring a base_path attibute" do
-      expect(Edition::EMPTY_BASE_PATH_FORMATS).to eq(%w(contact government))
+      expect(Edition::EMPTY_BASE_PATH_FORMATS).to eq(
+        %w(contact government world_location)
+      )
     end
   end
 
@@ -268,6 +270,11 @@ RSpec.describe Edition do
 
     it "doesn't require a base path for 'government' document_type" do
       subject.document_type = "government"
+      expect(subject.requires_base_path?).to be false
+    end
+
+    it "doesn't require a base path for 'world_location' document_type" do
+      subject.document_type = "world_location"
       expect(subject.requires_base_path?).to be false
     end
 


### PR DESCRIPTION
WorldLocation pages are going to become taxon based but we still need them in the publishing API as content is linked to them in Whitehall and we need this to continue for now.

So, as they will no longer be renderable we are making them base_path less.

This PR allows `world_location` to be `base_path`-less.

[Trello](https://trello.com/c/6tio72jl/221-split-world-locations-from-international-delegations-in-whitehall)

[Accompanying schema change PR](https://github.com/alphagov/govuk-content-schemas/pull/628)