### PR TITLE
Update the json gem from 1.8.3 to 1.8.6

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -135,7 +135,7 @@ GEM
       multi_xml (>= 0.5.2)
     i18n (0.8.1)
     jmespath (1.3.1)
-    json (1.8.3)
+    json (1.8.6)
     json-schema (2.5.2)
       addressable (~> 2.3.8)
     jwt (1.5.6)


### PR DESCRIPTION
This avoids issues with ruby 2.4, as it doesn't work with version
1.8.3.