### PR TITLE
Add rake task to find redirected DFID reports

### DIFF
--- a/lib/tasks/dfid_redirects.rake
+++ b/lib/tasks/dfid_redirects.rake
@@ -1,0 +1,14 @@
+require "csv"
+
+desc "Find DFID research report redirects"
+task dfid_redirects: :environment do
+  dfid_redirects = Edition
+    .where(document_type: "redirect")
+    .where("base_path LIKE :prefix", prefix: "/dfid-research-outputs/%")
+
+  csv_out = CSV.new($stdout)
+
+  dfid_redirects.each do |i|
+    csv_out << [i.base_path]
+  end
+end


### PR DESCRIPTION
Add a temporary rake task which finds all published redirects with the DFID base path (`/dfid-research-outputs/`). These were not removed from the search API when the redirects were configured. This commit will allow us to build a list of them in order to remove them from the search API in bulk.

This rake task will be removed once it has been run in production.

https://trello.com/c/ECoFt3Yq/136-dfid-research-output-finder-issues-to-investigate