### PR TITLE
Add custom expansion for world_location

### DIFF
--- a/lib/link_expansion/rules.rb
+++ b/lib/link_expansion/rules.rb
@@ -57,6 +57,7 @@ module LinkExpansion::Rules
     { document_type: :need,                       fields: DEFAULT_FIELDS_WITH_DETAILS },
     { document_type: :finder, link_type: :finder, fields: DEFAULT_FIELDS_WITH_DETAILS },
     { document_type: :travel_advice,              fields: DEFAULT_FIELDS + [[:details, :country], [:details, :change_description]] },
+    { document_type: :world_location,             fields: [:content_id, :title, :schema_name, :locale, :analytics_identifier] },
   ].freeze
 
   def root_reverse_links


### PR DESCRIPTION
WorldLocation links are now base_path less. This commit updates the expanded fields to remove fields that are now invalid when validated against the frontend schema for formats that contain this link type.

This change results in the following link json:

```
"world_locations": [
  {
    "content_id": "5e9edfc1-7706-11e4-a3cb-005056011aef",
    "title": "Brazil",
    "schema_name": "world_location",
    "locale": "en",
    "analytics_identifer": "W1",
    "links": {},
    "api_path": null,
    "api_url": null,
    "web_url": null
  }
]
```

~~For some reason, `api_path`, `api_url` and `web_url` persist 🤔~~

UPDATE: turns out that ^ was added by content store. Fixed in https://github.com/alphagov/content-store/pull/299 Thanks @thomasleese 

```
"world_locations": [
  {
    "content_id": "5e9edfc1-7706-11e4-a3cb-005056011aef",
    "title": "Brazil",
    "schema_name": "world_location",
    "locale": "en",
    "analytics_identifer": "W1",
    "links": {},
  }
]
```

This PR requires corresponding changes in government-frontend and govuk-content-schemas which are on the way.