### PR TITLE
Add missing `public_updated_at` dates for specialist-publisher docs

### DIFF
--- a/db/migrate/20170623091950_add_missing_public_updated_timestamps.rb
+++ b/db/migrate/20170623091950_add_missing_public_updated_timestamps.rb
@@ -1,0 +1,17 @@
+class AddMissingPublicUpdatedTimestamps < ActiveRecord::Migration[5.1]
+  disable_ddl_transaction!
+
+  def up
+    editions_to_update = Edition
+      .where(publishing_app: "specialist-publisher")
+      .where(public_updated_at: nil)
+      .where(state: "published")
+
+    puts "Populating `public_updated_at` for #{editions_to_update.size} editions"
+
+    editions_to_update.each do |edition|
+      edition.public_updated_at = edition.first_published_at
+      edition.save
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170612115845) do
+ActiveRecord::Schema.define(version: 20170623091950) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
There are around 1146 published specialist-publisher docs with a missing `public_updated_at` date. This prevents them from being republished as a minor update because specialist-publisher requires a `public_updated_at` date to generate a `public_timestamp` in the search index.

This migration populates that field with the best data available, which is the `first_published_at` date. This is populated for all published specialist-publisher documents.

There are long-term plans to simplifiy the document and edition timestamps, so this is just a temporary workaround to allow all specialist-publisher documents to be republished.

https://trello.com/c/ECoFt3Yq/136-dfid-research-output-finder-issues-to-investigate

cc @kevindew 