### PR TITLE
Add expanded links caching

### DIFF
--- a/app/controllers/v2/link_sets_controller.rb
+++ b/app/controllers/v2/link_sets_controller.rb
@@ -5,11 +5,15 @@ module V2
     end
 
     def expanded_links
-      render json: Queries::GetExpandedLinks.call(
-        content_id,
-        params[:locale],
-        with_drafts: with_drafts?,
-      )
+      json = Rails.cache.fetch ['expanded-links', content_id, params[:with_drafts], params[:locale]], expires_in: 1.hour do
+        Queries::GetExpandedLinks.call(
+          content_id,
+          params[:locale],
+          with_drafts: with_drafts?,
+        )
+      end
+
+      render json: json
     end
 
     def patch_links

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -32,7 +32,8 @@ Rails.application.configure do
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr
 
-  config.cache_store = :memory_store
+  # Don't cache anything in test
+  config.cache_store = :null_store
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true


### PR DESCRIPTION
This adds caching for the expanded links endpoint. It is unfortunately needed since the `/world` taxon is huge and takes about 20s to build. A more permanent solution is hopefully forthcoming via https://trello.com/c/mOdpAGVj.