### PR TITLE
Expand associated taxons of child taxons

### DIFF
--- a/lib/link_expansion/rules.rb
+++ b/lib/link_expansion/rules.rb
@@ -13,6 +13,7 @@ module LinkExpansion::Rules
 
   MULTI_LEVEL_LINK_PATHS = [
     [:associated_taxons.recurring],
+    [:child_taxons, :associated_taxons.recurring],
     [:child_taxons.recurring],
     [:parent.recurring],
     [:parent_taxons.recurring],

--- a/spec/lib/link_expansion/rules_spec.rb
+++ b/spec/lib/link_expansion/rules_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe LinkExpansion::Rules do
 
   describe ".next_link_expansion_link_types" do
     # test error
-    specify { expect(subject.next_link_expansion_link_types([:child_taxons])).to match_array([:child_taxons]) }
+    specify { expect(subject.next_link_expansion_link_types([:child_taxons])).to match_array([:child_taxons, :associated_taxons]) }
     specify { expect(subject.next_link_expansion_link_types([:parent, :parent])).to match_array([:parent]) }
     specify { expect(subject.next_link_expansion_link_types([:children])).to be_empty }
   end


### PR DESCRIPTION
This commit adds a rule to recursively expand `associated_taxons` inside `child_taxons` rather then just for top-level taxons. This will allow taxon navigation pages to display content correctly from associated taxons.