### PR TITLE
Pre-cache expanded links

### DIFF
--- a/app/commands/v2/patch_link_set.rb
+++ b/app/commands/v2/patch_link_set.rb
@@ -29,7 +29,9 @@ module Commands
 
         after_transaction_commit do
           send_downstream(orphaned_content_ids)
+          ExpandedLinkSetCacheWorker.perform_async(content_id)
         end
+
 
         Action.create_patch_link_set_action(link_set, event)
 

--- a/app/commands/v2/patch_link_set.rb
+++ b/app/commands/v2/patch_link_set.rb
@@ -32,7 +32,6 @@ module Commands
           ExpandedLinkSetCacheWorker.perform_async(content_id)
         end
 
-
         Action.create_patch_link_set_action(link_set, event)
 
         presented = Presenters::Queries::LinkSetPresenter.present(link_set)

--- a/app/commands/v2/publish.rb
+++ b/app/commands/v2/publish.rb
@@ -10,6 +10,10 @@ module Commands
           after_transaction_commit do
             send_downstream_live
             send_downstream_draft if access_limit
+
+            if orphaned_content_ids.any?
+              ExpandedLinkSetCacheWorker.perform_async(document.content_id)
+            end
           end
         end
 

--- a/app/commands/v2/put_content.rb
+++ b/app/commands/v2/put_content.rb
@@ -21,6 +21,10 @@ module Commands
             update_dependencies?(edition),
             orphaned_links
           )
+
+          unless payload[:links].nil?
+            ExpandedLinkSetCacheWorker.perform_async(document.content_id)
+          end
         end
 
         Success.new(present_response(edition))

--- a/app/commands/v2/unpublish.rb
+++ b/app/commands/v2/unpublish.rb
@@ -10,6 +10,10 @@ module Commands
 
         after_transaction_commit do
           send_downstream
+
+          if orphaned_content_ids.any?
+            ExpandedLinkSetCacheWorker.perform_async(document.content_id)
+          end
         end
 
         Action.create_unpublish_action(edition, unpublishing_type,

--- a/app/controllers/v2/link_sets_controller.rb
+++ b/app/controllers/v2/link_sets_controller.rb
@@ -5,15 +5,11 @@ module V2
     end
 
     def expanded_links
-      json = Rails.cache.fetch ['expanded-links', content_id, params[:with_drafts], params[:locale]], expires_in: 1.hour do
-        Queries::GetExpandedLinks.call(
-          content_id,
-          params[:locale],
-          with_drafts: with_drafts?,
-        )
-      end
-
-      render json: json
+      render json: Queries::GetExpandedLinks.call(
+        content_id,
+        params[:locale],
+        with_drafts: with_drafts?,
+      )
     end
 
     def patch_links

--- a/app/presenters/queries/expanded_link_set.rb
+++ b/app/presenters/queries/expanded_link_set.rb
@@ -17,12 +17,18 @@ module Presenters
       end
 
       def links
-        @links ||= expanded_links.merge(translations)
+        @links ||= Rails.cache.fetch(cache_key, expires_in: 1.hour) do
+          expanded_links.merge(translations)
+        end
       end
 
     private
 
       attr_reader :options, :with_drafts
+
+      def cache_key
+        ["expanded-link-set", content_id, locale, with_drafts]
+      end
 
       def edition
         @edition ||= options[:edition]

--- a/app/presenters/queries/expanded_link_set.rb
+++ b/app/presenters/queries/expanded_link_set.rb
@@ -17,9 +17,7 @@ module Presenters
       end
 
       def links
-        @links ||= Rails.cache.fetch(cache_key, expires_in: 1.hour) do
-          expanded_links.merge(translations)
-        end
+        @links ||= expanded_links.merge(translations)
       end
 
     private

--- a/app/presenters/queries/expanded_link_set.rb
+++ b/app/presenters/queries/expanded_link_set.rb
@@ -24,10 +24,6 @@ module Presenters
 
       attr_reader :options, :with_drafts
 
-      def cache_key
-        ["expanded-link-set", content_id, locale, with_drafts]
-      end
-
       def edition
         @edition ||= options[:edition]
       end

--- a/app/queries/get_expanded_links.rb
+++ b/app/queries/get_expanded_links.rb
@@ -24,9 +24,14 @@ module Queries
         with_drafts: with_drafts,
       )
 
+      cache_key = ["expanded-link-set", link_set.content_id, locale, with_drafts]
+      expanded_links = Rails.cache.fetch(cache_key) do
+        expanded_link_set.links
+      end
+
       {
         content_id: link_set.content_id,
-        expanded_links: expanded_link_set.links,
+        expanded_links: expanded_links,
         version: link_set.stale_lock_version,
       }
     end

--- a/app/workers/expanded_link_set_cache_worker.rb
+++ b/app/workers/expanded_link_set_cache_worker.rb
@@ -1,0 +1,20 @@
+class ExpandedLinkSetCacheWorker
+  include Sidekiq::Worker
+  include PerformAsyncInQueue
+
+  def perform(content_id, with_drafts: false)
+    locales_for(content_id).each do |locale|
+      cache_key = ["expanded-link-set", content_id, locale, with_drafts]
+      presenter = Presenters::Queries::ExpandedLinkSet.by_content_id(content_id,
+                                                                     locale: locale,
+                                                                     with_drafts: with_drafts)
+      Rails.cache.write(cache_key, presenter.links)
+    end
+  end
+
+private
+
+  def locales_for(content_id)
+    Document.where(content_id: content_id).pluck(:locale)
+  end
+end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -32,8 +32,7 @@ Rails.application.configure do
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr
 
-  # Don't cache anything in test
-  config.cache_store = :null_store
+  config.cache_store = :memory_store
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true

--- a/spec/commands/v2/publish_spec.rb
+++ b/spec/commands/v2/publish_spec.rb
@@ -448,6 +448,13 @@ RSpec.describe Commands::V2::Publish do
 
         described_class.call(payload)
       end
+
+      it "enqueues a job for the expanded links cache worker" do
+        expect(ExpandedLinkSetCacheWorker).to receive(:perform_async)
+          .with(document.content_id)
+
+        described_class.call(payload)
+      end
     end
 
     context "when an access limit is set on the draft edition" do

--- a/spec/commands/v2/unpublish_spec.rb
+++ b/spec/commands/v2/unpublish_spec.rb
@@ -409,6 +409,11 @@ RSpec.describe Commands::V2::Unpublish do
         expect(DownstreamDraftWorker).to receive(:perform_async_in_queue)
           .with("downstream_high", hash_excluding(:orphaned_content_ids))
       end
+
+      it "enqueues a job for the expanded links cache worker" do
+        expect(ExpandedLinkSetCacheWorker).to receive(:perform_async)
+          .with(document.content_id)
+      end
     end
 
     context "when the document is redrafted" do

--- a/spec/integration/put_content/content_with_links_spec.rb
+++ b/spec/integration/put_content/content_with_links_spec.rb
@@ -29,6 +29,13 @@ RSpec.describe "PUT /v2/content when the 'links' parameter is provided" do
 
       expect(Link.find_by(target_content_id: document.content_id)).to be
     end
+
+    it "enqueues an expanded links cache worker job" do
+      expect(ExpandedLinkSetCacheWorker).to receive(:perform_async)
+        .with(document.content_id)
+
+      put "/v2/content/#{document.content_id}", params: payload.to_json
+    end
   end
 
   context "existing links" do
@@ -61,6 +68,13 @@ RSpec.describe "PUT /v2/content when the 'links' parameter is provided" do
           a_hash_including(orphaned_content_ids: [content_id])
         )
         put "/v2/content/#{content_id}", params: payload.to_json
+      end
+
+      it "enqueues an expanded links cache worker job" do
+        expect(ExpandedLinkSetCacheWorker).to receive(:perform_async)
+          .with(document.content_id)
+
+        put "/v2/content/#{document.content_id}", params: payload.to_json
       end
     end
   end

--- a/spec/queries/get_expanded_links_spec.rb
+++ b/spec/queries/get_expanded_links_spec.rb
@@ -81,5 +81,11 @@ RSpec.describe Queries::GetExpandedLinks do
         ]
       )
     end
+
+    it "fetches links from the cache" do
+      expect(Rails.cache).to receive(:fetch).with(["expanded-link-set", content_id, "en", false])
+
+      described_class.call(content_id, "en", with_drafts: false)
+    end
   end
 end

--- a/spec/requests/expanded_links_endpoint_spec.rb
+++ b/spec/requests/expanded_links_endpoint_spec.rb
@@ -83,6 +83,8 @@ RSpec.describe "GET /v2/expanded-links/:id", type: :request do
       content_id: edition.document.content_id,
     )
 
+    Rails.cache.clear
+
     get "/v2/expanded-links/#{link_set.content_id}"
 
     expect(parsed_response).to eql(
@@ -99,6 +101,8 @@ RSpec.describe "GET /v2/expanded-links/:id", type: :request do
       content_id: edition.document.content_id,
       stale_lock_version: 11,
     )
+
+    Rails.cache.clear
 
     get "/v2/expanded-links/#{link_set.content_id}"
 

--- a/spec/workers/expanded_link_set_cache_worker_spec.rb
+++ b/spec/workers/expanded_link_set_cache_worker_spec.rb
@@ -1,0 +1,33 @@
+require "rails_helper"
+
+RSpec.describe ExpandedLinkSetCacheWorker do
+  describe "perform" do
+    let(:content_id) { edition.document.content_id }
+    let(:edition) { FactoryGirl.create(:live_edition) }
+    let!(:fr_document) { FactoryGirl.create(:document, content_id: content_id, locale: "fr") }
+    let(:link) { SecureRandom.uuid }
+    let!(:link_set) do
+      FactoryGirl.create(:link_set,
+        content_id: content_id,
+        links: [
+          FactoryGirl.create(:link,
+            link_type: "topics",
+            target_content_id: edition.content_id,
+          )
+        ]
+      )
+    end
+
+    it "caches expanded links keyed by content id and locale" do
+      expect(Rails.cache).to receive(:write)
+        .with(["expanded-link-set", content_id, "en", false],
+              a_hash_including(topics: [a_hash_including(content_id: content_id)]))
+
+      expect(Rails.cache).to receive(:write)
+        .with(["expanded-link-set", content_id, "fr", false],
+              a_hash_including(topics: [a_hash_including(content_id: content_id)]))
+
+      subject.perform(content_id)
+    end
+  end
+end


### PR DESCRIPTION
Part of https://trello.com/c/mOdpAGVj/961-improve-performance-of-the-expanded-link-set-endpoint-3

Paired with @emmabeynon on this work.

Pre-cache expanded links when writing links from the various Publishing API commands.
Uses Rails.cache to store expanded links, no decisions have yet been made about underlying cache implementation though it would be preferable to use a shared memcached for best performance.