### PR TITLE
De dupe more specialist publisher change notes

### DIFF
--- a/db/migrate/20170703153415_dedupe_more_specialist_publisher_change_notes.rb
+++ b/db/migrate/20170703153415_dedupe_more_specialist_publisher_change_notes.rb
@@ -1,0 +1,31 @@
+class DedupeMoreSpecialistPublisherChangeNotes < ActiveRecord::Migration[5.1]
+  disable_ddl_transaction!
+
+  def up
+    dupe_change_note_ids = ChangeNote.group(:public_timestamp, :note)
+                                     .having("COUNT(*) > 1")
+                                     .pluck("array_agg(id)")
+
+    document_ids = ChangeNote.where(id: dupe_change_note_ids.flatten,
+                                    edition_id: nil)
+                             .pluck(:document_id).flatten.uniq
+
+    # ~ 572 specialist-publisher change notes.
+    ChangeNote.where(id: dupe_change_note_ids.flatten,
+                     edition_id: nil).delete_all
+
+    # Remove Edition#details[:change_history] and represent the Edition
+    # downstream, the history will be reconstructed from ChangeNotes.
+    Edition.where(document_id: document_ids).each do |edition|
+      edition_details = edition.details
+      edition_details.delete(:change_history)
+      edition.update!(details: edition_details)
+    end
+
+    content_ids = Document.where(id: document_ids).pluck(&:content_id)
+
+    if Rails.env.production?
+      Commands::V2::RepresentDownstream.new.call(content_ids)
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170623091950) do
+ActiveRecord::Schema.define(version: 20170703153415) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
This fell out of this story: https://trello.com/c/NbATcan2/956-de-duplicate-specialist-publisher-embedded-change-history-2

There are approx. 570 change notes which are duplicates but
do not have a corresponding edition id, their duplicates do have
this id so delete them and represent the affected editions downstream.