### PR TITLE
Allow lookup by base path filter criteria to be specified

### DIFF
--- a/app/controllers/lookups_controller.rb
+++ b/app/controllers/lookups_controller.rb
@@ -5,13 +5,18 @@ class LookupsController < ApplicationController
     states = %w(published unpublished)
     base_paths = params.fetch(:base_paths)
 
-    base_paths_and_content_ids = Edition.with_document
-      .left_outer_joins(:unpublishing)
+    scope = Edition.left_outer_joins(:unpublishing)
+
+    # where not in (..) does not return records that where the field is null
+    scope = scope.where(unpublishings: { type: nil }).or(
+      scope.where.not(unpublishings: { type: params.fetch(:exclude_unpublishing_types, %w{vanish redirect gone}) })
+    )
+
+    scope = scope.with_document
       .where(state: states, base_path: base_paths)
-      .where("state = 'published' OR unpublishings.type = 'withdrawal'")
-      .where("document_type NOT IN ('gone', 'redirect')")
-      .pluck(:base_path, 'documents.content_id')
-      .uniq
+      .where.not(document_type: params.fetch('exclude_document_types', %w{gone redirect}))
+
+    base_paths_and_content_ids = scope.distinct.pluck(:base_path, 'documents.content_id')
 
     response = Hash[base_paths_and_content_ids]
     render json: response

--- a/doc/api.md
+++ b/doc/api.md
@@ -548,6 +548,10 @@ a mapping of `base_path` to `content_id`.
 
 - `base_paths[]` *(required)*
   - An array of `base_path`s to query by.
+- 'exclude_unpublishing_types[]' *(optional, default: ['vanish', 'redirect', 'gone'])*
+  - Content with these unpublishing types will be excluded from the lookup
+- 'exclude_document_types[]' *(optional, default: ['gone', 'redirect'])*
+  - Content with these documents types will be excluded from the lookup
 
 ## `PUT /paths/:base_path`
 

--- a/spec/requests/lookups_spec.rb
+++ b/spec/requests/lookups_spec.rb
@@ -39,6 +39,40 @@ RSpec.describe "POST /lookup-by-base-path", type: :request do
 
       expect(parsed_response).to eql({})
     end
+
+    context 'when document type filtering is set to include all content' do
+      it "returns content ids for redirected content" do
+        redirected_content_item = FactoryGirl.create(:redirect_edition, state: "published", base_path: "/redirect-page", user_facing_version: 1)
+
+        post "/lookup-by-base-path", params: { base_paths: %w(/redirect-page), exclude_document_types: ['none'] }
+
+        expect(parsed_response).to eql(
+          "/redirect-page" => redirected_content_item.document.content_id
+        )
+      end
+
+      it "returns content ids for gone content" do
+        gone_content_item = FactoryGirl.create(:gone_edition, state: "published", base_path: "/gone-page", user_facing_version: 1)
+
+        post "/lookup-by-base-path", params: { base_paths: %w(/gone-page), exclude_document_types: ['none'] }
+
+        expect(parsed_response).to eql(
+          "/gone-page" => gone_content_item.document.content_id
+        )
+      end
+    end
+
+    context 'when unpublishing type filtering is set to include all content' do
+      it "returns content ids for gone content" do
+        gone_content_item = FactoryGirl.create(:unpublished_edition, state: "unpublished", base_path: "/unpublished-gone-page", user_facing_version: 1)
+
+        post "/lookup-by-base-path", params: { base_paths: %w(/unpublished-gone-page), exclude_unpublishing_types: ['none'] }
+
+        expect(parsed_response).to eql(
+          "/unpublished-gone-page" => gone_content_item.document.content_id
+        )
+      end
+    end
   end
 
   def create_test_content


### PR DESCRIPTION
In order to migrate content out of router-data we need 
to be able to find the content ID for unpublished
redirects. 

This change allow us to remove the filtering  required 
by mainstream applications for unpublished.type and 
document_type fields.

We have inverted the existing logic around unpublishing_type
filters based on the fact that content must be `published`
or `unpublished` and only `unpublished` content will
have an unpublishing record.