### PR TITLE
Restrict by_base_path to 'live' content

### DIFF
--- a/app/controllers/lookups_controller.rb
+++ b/app/controllers/lookups_controller.rb
@@ -13,7 +13,7 @@ class LookupsController < ApplicationController
     )
 
     scope = scope.with_document
-      .where(state: states, base_path: base_paths)
+      .where(state: states, content_store: 'live', base_path: base_paths)
       .where.not(document_type: params.fetch('exclude_document_types', %w{gone redirect}))
 
     base_paths_and_content_ids = scope.distinct.pluck(:base_path, 'documents.content_id')

--- a/spec/requests/lookups_spec.rb
+++ b/spec/requests/lookups_spec.rb
@@ -42,7 +42,13 @@ RSpec.describe "POST /lookup-by-base-path", type: :request do
 
     context 'when document type filtering is set to include all content' do
       it "returns content ids for redirected content" do
-        redirected_content_item = FactoryGirl.create(:redirect_edition, state: "published", base_path: "/redirect-page", user_facing_version: 1)
+        redirected_content_item = FactoryGirl.create(
+          :redirect_edition,
+          state: "published",
+          content_store: "live",
+          base_path: "/redirect-page",
+          user_facing_version: 1
+        )
 
         post "/lookup-by-base-path", params: { base_paths: %w(/redirect-page), exclude_document_types: ['none'] }
 
@@ -52,7 +58,13 @@ RSpec.describe "POST /lookup-by-base-path", type: :request do
       end
 
       it "returns content ids for gone content" do
-        gone_content_item = FactoryGirl.create(:gone_edition, state: "published", base_path: "/gone-page", user_facing_version: 1)
+        gone_content_item = FactoryGirl.create(
+          :gone_edition,
+          state: "published",
+          content_store: "live",
+          base_path: "/gone-page",
+          user_facing_version: 1
+        )
 
         post "/lookup-by-base-path", params: { base_paths: %w(/gone-page), exclude_document_types: ['none'] }
 


### PR DESCRIPTION
Restricting by only editions in the 'published' or 'unpublished'
states is not sufficient at the moment, as there are sometimes
multiple editions with published/unpublished states for a single base
path.

Currently, it's possible to get in to this problomatic situation when
an edition is published, where the previous edition is unpublished,
and the edition being published has a different content id to the
unpublished edition. The content store for the unpublished edition
will be NULL, but it will still be in the unpublished state.