### PR TITLE
Include the unpublishing redirects in the ContentItemPresenter

### DIFF
--- a/app/presenters/queries/content_item_presenter.rb
+++ b/app/presenters/queries/content_item_presenter.rb
@@ -168,6 +168,7 @@ module Presenters
               unpublishings.type,
               unpublishings.explanation,
               unpublishings.alternative_path,
+              unpublishings.redirects,
               unpublishings.unpublished_at
             )
           )
@@ -176,6 +177,7 @@ module Presenters
             type,
             explanation,
             alternative_path,
+            redirects,
             unpublished_at
           )
         )


### PR DESCRIPTION
This will allow requesting the content, and inspecting the redirects
to see if the details match what is in router-data.