### PR TITLE
Add an index on edition state

### DIFF
--- a/db/migrate/20170711122824_add_index_on_edition_state.rb
+++ b/db/migrate/20170711122824_add_index_on_edition_state.rb
@@ -1,0 +1,7 @@
+class AddIndexOnEditionState < ActiveRecord::Migration[5.1]
+  disable_ddl_transaction!
+
+  def change
+    add_index :editions, :state, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170703153415) do
+ActiveRecord::Schema.define(version: 20170711122824) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -95,6 +95,7 @@ ActiveRecord::Schema.define(version: 20170703153415) do
     t.index ["publishing_app"], name: "index_editions_on_publishing_app"
     t.index ["rendering_app"], name: "index_editions_on_rendering_app"
     t.index ["state", "base_path"], name: "index_editions_on_state_and_base_path"
+    t.index ["state"], name: "index_editions_on_state"
     t.index ["updated_at"], name: "index_editions_on_updated_at"
   end
 


### PR DESCRIPTION
It seems that the various indexes on state with another field can't be used in this case.

Previous:

```
 Seq Scan on editions  (cost=0.00..308447.38 rows=380037 width=541) (actual time=0.039..1555.785 rows=375091 loops=1)
   Filter: ((state)::text = 'published'::text)
   Rows Removed by Filter: 2170939
 Total runtime: 2092.298 ms
```

Now:

```
 Bitmap Heap Scan on editions  (cost=8761.72..304727.41 rows=380037 width=541) (actual time=74.664..1126.715 rows=375091 loops=1)
   Recheck Cond: ((state)::text = 'published'::text)
   Rows Removed by Index Recheck: 921250
   ->  Bitmap Index Scan on editions_state_idx  (cost=0.00..8666.71 rows=380037 width=0) (actual time=72.198..72.198 rows=375091 loops=1)
         Index Cond: ((state)::text = 'published'::text)
 Total runtime: 1493.419 ms
```