### PR TITLE
Improve get content performance

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,8 @@ gem 'airbrake-ruby', '1.5'
 gem "pg"
 gem 'dalli'
 
+gem "pg-eyeballs"
+
 gem "colorize", "~> 0.8"
 
 if ENV["API_DEV"]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -223,6 +223,9 @@ GEM
     parser (2.3.1.4)
       ast (~> 2.2)
     pg (0.19.0)
+    pg-eyeballs (1.1.0)
+      activerecord (>= 4.0, < 6.0)
+      pg
     plek (1.12.0)
     powerpack (0.1.1)
     pry (0.10.4)
@@ -415,6 +418,7 @@ DEPENDENCIES
   pact
   pact_broker-client
   pg
+  pg-eyeballs
   plek (~> 1.10)
   pry
   pry-byebug

--- a/app/presenters/queries/content_item_presenter.rb
+++ b/app/presenters/queries/content_item_presenter.rb
@@ -63,8 +63,14 @@ module Presenters
         @results ||= execute_query(query)
       end
 
+      def estimate_total(query)
+        results = query.eyeballs.to_hash_array
+        results[0][0]["Plan"]["Plan Rows"]
+      end
+
       def query
-        ordering_query = Edition.select("*, COUNT(*) OVER () as total").from(fetch_items_query)
+        total = estimate_total(fetch_items_query)
+        ordering_query = Edition.select("*, #{total} as total").from(fetch_items_query)
         ordering_query = ordering_query.order(order.to_a.join(" ")) if order
         ordering_query = ordering_query.limit(limit) if limit
         ordering_query = ordering_query.offset(offset) if offset

--- a/app/presenters/queries/content_item_presenter.rb
+++ b/app/presenters/queries/content_item_presenter.rb
@@ -55,6 +55,10 @@ module Presenters
 
     private
 
+      def can_skip_finding_latest_edition?
+        states == [:published]
+      end
+
       def results
         @results ||= execute_query(query)
       end
@@ -89,6 +93,7 @@ module Presenters
       end
 
       def reorder(scope)
+        return scope if can_skip_finding_latest_edition?
         # used for distinct document_id by state and latest version
         scope.reorder(["editions.document_id", state_order_clause, "user_facing_version DESC"].compact)
       end
@@ -99,6 +104,11 @@ module Presenters
         priorities = { draft: 0, published: 1, unpublished: 1, superseded: 2 }.slice(*states)
         return unless priorities.values.uniq.count > 1
         "CASE state #{priorities.map { |k, v| "WHEN '#{k}' THEN #{v} " }.join} END"
+      end
+
+      def distinct_document_id_field
+        return if can_skip_finding_latest_edition?
+        "DISTINCT ON(editions.document_id) editions.document_id"
       end
 
       def select_fields(scope)
@@ -137,13 +147,10 @@ module Presenters
           end
         end
 
-        fields = [
-          "DISTINCT ON(editions.document_id) editions.document_id"
-        ] + fields_to_select.compact
+        fields = ([distinct_document_id_field] + fields_to_select).compact
 
         scope.select(*fields)
       end
-
 
       STATE_HISTORY_SQL = <<-SQL.freeze
         (
@@ -207,7 +214,6 @@ module Presenters
             result.slice!(*fields.map(&:to_s))
 
             result["warnings"] = get_warnings(result) if include_warnings
-
 
             yielder.yield(result.except("total").compact)
           end


### PR DESCRIPTION
When the state is filtered to only published, we know that we can only get the latest edition so there is no need to do the sorting and distinct.

Before:

```
SELECT  *, COUNT(*) OVER () as total FROM (SELECT DISTINCT ON(editions.document_id) editions.document_id, documents.content_id as content_id, to_char(public_updated_at, 'YYYY-MM-DD"T"HH24:MI:SS"Z"') as public_updated_at FROM "editions" INNER JOIN "documents" ON "documents"."id" = "editions"."document_id" WHERE "documents"."locale" = 'en' AND "editions"."state" = 'published' ORDER BY editions.document_id, user_facing_version DESC) subquery ORDER BY public_updated_at desc LIMIT 50 OFFSET 0
  0.290000   0.180000   0.470000 (  2.903794)
```

After:

```
SELECT  *, 369599 as total FROM (SELECT documents.content_id as content_id, to_char(public_updated_at, 'YYYY-MM-DD"T"HH24:MI:SS"Z"') as public_updated_at FROM "editions" INNER JOIN "documents" ON "documents"."id" = "editions"."document_id" WHERE "documents"."locale" = 'en' AND "editions"."state" = 'published') subquery ORDER BY public_updated_at desc LIMIT 50 OFFSET 0
  0.320000   0.180000   0.500000 (  1.835002)
```

[Trello Card](https://trello.com/c/iAdftXss/962-help-content-tools-get-content-out-of-publishing-api-faster-more-get-content-woes-3)