### PR TITLE
Improve get content performance

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,8 @@ gem 'airbrake-ruby', '1.5'
 gem "pg"
 gem 'dalli'
 
+gem "pg-eyeballs"
+
 gem "colorize", "~> 0.8"
 
 if ENV["API_DEV"]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -223,6 +223,9 @@ GEM
     parser (2.3.1.4)
       ast (~> 2.2)
     pg (0.19.0)
+    pg-eyeballs (1.1.0)
+      activerecord (>= 4.0, < 6.0)
+      pg
     plek (1.12.0)
     powerpack (0.1.1)
     pry (0.10.4)
@@ -415,6 +418,7 @@ DEPENDENCIES
   pact
   pact_broker-client
   pg
+  pg-eyeballs
   plek (~> 1.10)
   pry
   pry-byebug

--- a/app/presenters/queries/content_item_presenter.rb
+++ b/app/presenters/queries/content_item_presenter.rb
@@ -76,8 +76,14 @@ module Presenters
         end]
       end
 
+      def estimate_total(query)
+        results = query.eyeballs.to_hash_array
+        results[0][0]["Plan"]["Actual Rows"]
+      end
+
       def query
-        ordering_query = Edition.select("*, COUNT(*) OVER () as total").from(fetch_items_query)
+        total = estimate_total(fetch_items_query)
+        ordering_query = Edition.select("*, #{total} as total").from(fetch_items_query)
         ordering_query = ordering_query.order(mapped_order.to_a.join(" ")) if order
         ordering_query = ordering_query.limit(limit) if limit
         ordering_query = ordering_query.offset(offset) if offset

--- a/bench/predictable_get_content_collection.rb
+++ b/bench/predictable_get_content_collection.rb
@@ -1,0 +1,22 @@
+# /usr/bin/env ruby
+
+require ::File.expand_path("../../config/environment", __FILE__)
+
+require "benchmark"
+require "stackprof"
+
+abort "Refusing to run outside of development" unless Rails.env.development?
+
+StackProf.run(mode: :wall, out: "tmp/predictable_get_content_collection.dump") do
+  puts Benchmark.measure {
+    results = Queries::GetContentCollection.new(
+      fields: ["content_id"],
+      filters: {
+        states: "published"
+      },
+      pagination: Pagination.new,
+    )
+
+    Presenters::ResultsPresenter.new(results, Pagination.new, 'http://dev.gov.uk').present
+  }
+end


### PR DESCRIPTION
Before:

```
SELECT  *, COUNT(*) OVER () as total FROM (SELECT DISTINCT ON(editions.document_id) editions.document_id, documents.content_id as content_id, to_char(public_updated_at, 'YYYY-MM-DD"T"HH24:MI:SS"Z"') as public_updated_at FROM "editions" INNER JOIN "documents" ON "documents"."id" = "editions"."document_id" WHERE "documents"."locale" = 'en' AND "editions"."state" = 'published' ORDER BY editions.document_id, user_facing_version DESC) subquery ORDER BY public_updated_at desc LIMIT 50 OFFSET 0

Took: 2.418973426 seconds
```

After:

```
SELECT  *, 363332 as total FROM (SELECT documents.content_id as content_id, to_char(public_updated_at, 'YYYY-MM-DD"T"HH24:MI:SS"Z"') as public_updated_at, public_updated_at as order_public_updated_at FROM "editions" INNER JOIN "documents" ON "documents"."id" = "editions"."document_id" WHERE "documents"."locale" = 'en' AND "editions"."state" = 'published') subquery ORDER BY order_public_updated_at desc LIMIT 50 OFFSET 0

Took: 0.002072432 seconds
```

Individually the following changes do very little to help on their own, so I provide a justification for each change and how they work together to introduce this speed increase:

## Using raw fields

We already have an index on `public_updated_at` but instead we are ordering on the `to_char` result of converting that field to an ISO8601 date, this meant that the index wasn't getting used. On its own this makes very little difference as the bottleneck came from calculating the total.

## Skip finding the latest version of an edition if possible

Avoids a `DISTINCT ON` query and some ordering. On its own this sped up the query by about 0.9 seconds, with the bottleneck still being calculating the total.

## Estimate the total

We can estimate the total number of rows using the query planner rather than performing a count over the entire set of results which can sometimes be quite large. Here is where the big speed increases come in, but on its own this wouldn't speed up the query as we would be ordering on a `to_char`'d field and still have a `DISTINCT` in the query which would become the new bottlenecks.