### PR TITLE
Remove `topic_content` and `mainstream_browse_content` links

### DIFF
--- a/lib/link_expansion/rules.rb
+++ b/lib/link_expansion/rules.rb
@@ -27,8 +27,6 @@ module LinkExpansion::Rules
     documents: :document_collections,
     working_groups: :policies,
     parent_taxons: :child_taxons,
-    topics: :topic_content,
-    mainstream_browse_pages: :mainstream_browse_content,
   }.freeze
 
   DEFAULT_FIELDS = [


### PR DESCRIPTION
These link types were added to allow the collections app to render the things linked to browse & topic pages from the content-store (https://github.com/alphagov/govuk-content-schemas/pull/535, https://trello.com/c/D8Heon8X). This didn't work, because there seemed to be too many differences between rummager and the content-store (https://github.com/alphagov/collections/pull/274).

Since then we've had a bit of a change in thinking about this and we now accept that navigation pages can be built from search as well as the content-store. In any case, topic and browse pages will be retired at some point, so there's little value in trying to do this now.

Related PR in schemas: https://github.com/alphagov/govuk-content-schemas/pull/635