### PR TITLE
Notify downstream services on unpublish

### DIFF
--- a/app/commands/v2/patch_link_set.rb
+++ b/app/commands/v2/patch_link_set.rb
@@ -104,7 +104,7 @@ module Commands
           queue,
           content_id: content_id,
           locale: locale,
-          message_queue_update_type: "links",
+          message_queue_event_type: "links",
           payload_version: event.id,
           orphaned_content_ids: orphaned_content_ids,
         )

--- a/app/commands/v2/publish.rb
+++ b/app/commands/v2/publish.rb
@@ -219,7 +219,7 @@ module Commands
 
       def live_worker_params
         {
-          message_queue_update_type: update_type,
+          message_queue_event_type: update_type,
           update_dependencies: update_dependencies?,
           orphaned_content_ids: orphaned_content_ids,
         }.merge(worker_params)

--- a/app/commands/v2/publish.rb
+++ b/app/commands/v2/publish.rb
@@ -30,6 +30,7 @@ module Commands
         set_public_updated_at
         set_first_published_at
         set_publishing_request_id
+        set_update_type
         edition.publish
         remove_access_limit
         create_publish_action
@@ -175,6 +176,11 @@ module Commands
         edition.update_attributes!(
           publishing_request_id: GdsApi::GovukHeaders.headers[:govuk_request_id]
         )
+      end
+
+      def set_update_type
+        return if edition.update_type
+        edition.update_attributes!(update_type: update_type)
       end
 
       def publish_redirect(previous_base_path, locale)

--- a/app/commands/v2/represent_downstream.rb
+++ b/app/commands/v2/represent_downstream.rb
@@ -48,7 +48,7 @@ module Commands
             content_id: content_id,
             locale: locale,
             payload_version: event.id,
-            message_queue_update_type: "links",
+            message_queue_event_type: "links",
             update_dependencies: false,
           )
         end

--- a/app/commands/v2/unpublish.rb
+++ b/app/commands/v2/unpublish.rb
@@ -122,6 +122,7 @@ module Commands
           payload_version: event.id,
           update_dependencies: true,
           orphaned_content_ids: orphaned_content_ids,
+          message_queue_event_type: "unpublish",
         )
       end
 

--- a/app/downstream_payload.rb
+++ b/app/downstream_payload.rb
@@ -40,10 +40,10 @@ class DownstreamPayload
     end
   end
 
-  def message_queue_payload(update_type)
+  def message_queue_payload
     Presenters::EditionPresenter.new(
       edition, draft: draft
-    ).for_message_queue(update_type || edition.update_type)
+    ).for_message_queue
   end
 
 private

--- a/app/downstream_payload.rb
+++ b/app/downstream_payload.rb
@@ -46,6 +46,7 @@ class DownstreamPayload
     case unpublishing.type
     when "redirect" then redirect_payload_for_message_queue
     when "gone" then gone_payload_for_message_queue
+    when "vanish" then vanish_payload_for_message_queue
     else content_payload_for_message_queue
     end
   end
@@ -90,5 +91,13 @@ private
 
   def gone_payload_for_message_queue
     gone_presenter.for_message_queue
+  end
+
+  def vanish_presenter
+    VanishPresenter.from_edition(edition)
+  end
+
+  def vanish_payload_for_message_queue
+    vanish_presenter.for_message_queue
   end
 end

--- a/app/downstream_payload.rb
+++ b/app/downstream_payload.rb
@@ -31,24 +31,11 @@ class DownstreamPayload
   end
 
   def content_store_payload
-    return content_payload_for_content_store unless unpublished?
-
-    case unpublishing.type
-    when "redirect" then redirect_payload_for_content_store
-    when "gone" then gone_payload_for_content_store
-    else content_payload_for_content_store
-    end
+    content_store_presenter.for_content_store(payload_version)
   end
 
   def message_queue_payload
-    return content_payload_for_message_queue unless unpublished?
-
-    case unpublishing.type
-    when "redirect" then redirect_payload_for_message_queue
-    when "gone" then gone_payload_for_message_queue
-    when "vanish" then vanish_payload_for_message_queue
-    else content_payload_for_message_queue
-    end
+    message_queue_presenter.for_message_queue
   end
 
 private
@@ -61,43 +48,36 @@ private
     Presenters::EditionPresenter.new(edition, draft: draft)
   end
 
-  def content_payload_for_content_store
-    content_presenter.for_content_store(payload_version)
-  end
-
-  def content_payload_for_message_queue
-    content_presenter.for_message_queue
-  end
-
   def redirect_presenter
     RedirectPresenter.from_edition(edition)
-  end
-
-  def redirect_payload_for_content_store
-    redirect_presenter.for_content_store(payload_version)
-  end
-
-  def redirect_payload_for_message_queue
-    redirect_presenter.for_message_queue
   end
 
   def gone_presenter
     GonePresenter.from_edition(edition)
   end
 
-  def gone_payload_for_content_store
-    gone_presenter.for_content_store(payload_version)
-  end
-
-  def gone_payload_for_message_queue
-    gone_presenter.for_message_queue
-  end
-
   def vanish_presenter
     VanishPresenter.from_edition(edition)
   end
 
-  def vanish_payload_for_message_queue
-    vanish_presenter.for_message_queue
+  def content_store_presenter
+    return content_presenter unless unpublished?
+
+    case unpublishing.type
+    when "redirect" then redirect_presenter
+    when "gone" then gone_presenter
+    else content_presenter
+    end
+  end
+
+  def message_queue_presenter
+    return content_presenter unless unpublished?
+
+    case unpublishing.type
+    when "redirect" then redirect_presenter
+    when "gone" then gone_presenter
+    when "vanish" then vanish_presenter
+    else content_presenter
+    end
   end
 end

--- a/app/downstream_payload.rb
+++ b/app/downstream_payload.rb
@@ -35,7 +35,7 @@ class DownstreamPayload
 
     case unpublishing.type
     when "redirect" then redirect_payload_for_content_store
-    when "gone" then gone_payload
+    when "gone" then gone_payload_for_content_store
     else content_payload_for_content_store
     end
   end
@@ -45,8 +45,8 @@ class DownstreamPayload
 
     case unpublishing.type
     when "redirect" then redirect_payload_for_message_queue
-    #when "gone" then gone_payload
-  else content_payload_for_message_queue
+    when "gone" then gone_payload_for_message_queue
+    else content_payload_for_message_queue
     end
   end
 
@@ -80,12 +80,15 @@ private
     redirect_presenter.for_message_queue
   end
 
-  def gone_payload
-    GonePresenter.present(
-      base_path: base_path,
-      publishing_app: edition.publishing_app,
-      alternative_path: unpublishing.alternative_path,
-      explanation: unpublishing.explanation,
-    ).merge(payload_version: payload_version)
+  def gone_presenter
+    GonePresenter.from_edition(edition)
+  end
+
+  def gone_payload_for_content_store
+    gone_presenter.for_content_store(payload_version)
+  end
+
+  def gone_payload_for_message_queue
+    gone_presenter.for_message_queue
   end
 end

--- a/app/helpers/redirect_helper.rb
+++ b/app/helpers/redirect_helper.rb
@@ -12,12 +12,12 @@ module RedirectHelper
     def create
       return unless path_has_changed?
 
-      redirect_payload = RedirectPresenter.present(
+      redirect_payload = RedirectPresenter.new(
         base_path: previous_base_path,
         public_updated_at: Time.zone.now,
         redirects: redirects_for(previous_routes, previous_base_path, payload[:base_path]),
-        publishing_app: payload[:publishing_app]
-      ).merge(content_id: SecureRandom.uuid)
+        publishing_app: payload[:publishing_app],
+      ).for_redirect_helper(SecureRandom.uuid)
 
       Commands::V2::PutContent.call(redirect_payload,
                                     callbacks: callbacks,

--- a/app/presenters/edition_presenter.rb
+++ b/app/presenters/edition_presenter.rb
@@ -26,9 +26,8 @@ module Presenters
       present.except(:update_type).merge(payload_version: payload_version)
     end
 
-    def for_message_queue(update_type)
+    def for_message_queue
       present.merge(
-        update_type: update_type,
         govuk_request_id: GdsApi::GovukHeaders.headers[:govuk_request_id],
         links: unexpanded_links
       )

--- a/app/presenters/gone_presenter.rb
+++ b/app/presenters/gone_presenter.rb
@@ -1,5 +1,35 @@
-module GonePresenter
-  def self.present(base_path:, publishing_app:, alternative_path:, explanation:)
+class GonePresenter
+  def initialize(base_path:, publishing_app:, alternative_path:, explanation:)
+    @base_path = base_path
+    @publishing_app = publishing_app
+    @alternative_path = alternative_path
+    @explanation = explanation
+  end
+
+  def self.from_edition(edition)
+    new(
+      base_path: edition.base_path,
+      publishing_app: edition.publishing_app,
+      alternative_path: edition.unpublishing.alternative_path,
+      explanation: edition.unpublishing.explanation,
+    )
+  end
+
+  def for_content_store(payload_version)
+    present.merge(payload_version: payload_version)
+  end
+
+  def for_message_queue
+    present.merge(
+      govuk_request_id: GdsApi::GovukHeaders.headers[:govuk_request_id],
+    )
+  end
+
+private
+
+  attr_reader :base_path, :publishing_app, :alternative_path, :explanation
+
+  def present
     {
       document_type: "gone",
       schema_name: "gone",

--- a/app/presenters/redirect_presenter.rb
+++ b/app/presenters/redirect_presenter.rb
@@ -1,5 +1,40 @@
-module RedirectPresenter
-  def self.present(base_path:, publishing_app:, public_updated_at:, redirects:)
+class RedirectPresenter
+  def initialize(base_path:, publishing_app:, public_updated_at:, redirects:)
+    @base_path = base_path
+    @publishing_app = publishing_app
+    @public_updated_at = public_updated_at
+    @redirects = redirects
+  end
+
+  def self.from_edition(edition)
+    new(
+      base_path: edition.base_path,
+      publishing_app: edition.publishing_app,
+      public_updated_at: edition.unpublishing.created_at,
+      redirects: edition.unpublishing.redirects,
+    )
+  end
+
+  def for_content_store(payload_version)
+    present.merge(payload_version: payload_version)
+  end
+
+  def for_message_queue
+    present.merge(
+      govuk_request_id: GdsApi::GovukHeaders.headers[:govuk_request_id]
+    )
+  end
+
+  def for_redirect_helper(content_id)
+    present.merge(content_id: content_id)
+  end
+
+private
+
+  attr_reader :base_path, :publishing_app, :public_updated_at, :redirects,
+    :content_id, :locale
+
+  def present
     {
       document_type: "redirect",
       schema_name: "redirect",

--- a/app/presenters/vanish_presenter.rb
+++ b/app/presenters/vanish_presenter.rb
@@ -1,0 +1,38 @@
+class VanishPresenter
+  def initialize(base_path:, publishing_app:)
+    @base_path = base_path
+    @publishing_app = publishing_app
+    @content_id = content_id
+    @locale = locale
+  end
+
+  def self.from_edition(edition)
+    new(
+      base_path: edition.base_path,
+      publishing_app: edition.publishing_app,
+    )
+  end
+
+  def for_content_store(payload_version)
+    present.merge(payload_version: payload_version)
+  end
+
+  def for_message_queue
+    present.merge(
+      govuk_request_id: GdsApi::GovukHeaders.headers[:govuk_request_id],
+    )
+  end
+
+private
+
+  attr_reader :base_path, :publishing_app, :content_id, :locale
+
+  def present
+    {
+      document_type: "vanish",
+      schema_name: "vanish",
+      base_path: base_path,
+      publishing_app: publishing_app,
+    }
+  end
+end

--- a/app/services/downstream_service.rb
+++ b/app/services/downstream_service.rb
@@ -33,9 +33,10 @@ module DownstreamService
   end
 
   def self.broadcast_to_message_queue(downstream_payload, event_type)
-    if downstream_payload.state != "published"
-      message = "Can only send published items to the message queue"
-      raise DownstreamInvalidStateError.new(message)
+    unless %w(unpublished published).include?(downstream_payload.state)
+      raise DownstreamInvalidStateError.new(
+        "Can only send published or unpublished items to the message queue"
+      )
     end
 
     payload = downstream_payload.message_queue_payload

--- a/app/services/downstream_service.rb
+++ b/app/services/downstream_service.rb
@@ -32,14 +32,14 @@ module DownstreamService
     end
   end
 
-  def self.broadcast_to_message_queue(downstream_payload, update_type)
+  def self.broadcast_to_message_queue(downstream_payload, event_type)
     if downstream_payload.state != "published"
       message = "Can only send published items to the message queue"
       raise DownstreamInvalidStateError.new(message)
     end
 
-    payload = downstream_payload.message_queue_payload(update_type)
-    PublishingAPI.service(:queue_publisher).send_message(payload)
+    payload = downstream_payload.message_queue_payload
+    PublishingAPI.service(:queue_publisher).send_message(payload, event_type: event_type)
   end
 
   def self.discard_from_draft_content_store(base_path)

--- a/app/workers/dependency_resolution_worker.rb
+++ b/app/workers/dependency_resolution_worker.rb
@@ -63,7 +63,7 @@ private
       DownstreamLiveWorker::LOW_QUEUE,
       content_id: dependent_content_id,
       locale: locale,
-      message_queue_update_type: "links",
+      message_queue_event_type: "links",
       payload_version: payload_version,
       update_dependencies: false,
       dependency_resolution_source_content_id: content_id,

--- a/app/workers/downstream_live_worker.rb
+++ b/app/workers/downstream_live_worker.rb
@@ -13,7 +13,7 @@ class DownstreamLiveWorker
     [
       args.first["content_id"],
       args.first["locale"],
-      args.first["message_queue_update_type"],
+      args.first["message_queue_event_type"],
       args.first.fetch("update_dependencies", true),
       args.first.fetch("orphaned_content_ids", []),
       name,
@@ -38,7 +38,7 @@ class DownstreamLiveWorker
     DownstreamService.update_live_content_store(payload) if edition.base_path
 
     if edition.state == "published"
-      update_type = message_queue_update_type || edition.update_type
+      update_type = message_queue_event_type || edition.update_type
       DownstreamService.broadcast_to_message_queue(payload, update_type)
     end
 
@@ -50,7 +50,7 @@ class DownstreamLiveWorker
 private
 
   attr_reader :content_id, :locale, :edition, :payload_version,
-    :message_queue_update_type, :update_dependencies,
+    :message_queue_event_type, :update_dependencies,
     :dependency_resolution_source_content_id, :orphaned_content_ids
 
   def assign_attributes(attributes)
@@ -59,7 +59,7 @@ private
     @edition = Queries::GetEditionForContentStore.(content_id, locale, false)
     @payload_version = attributes.fetch(:payload_version)
     @orphaned_content_ids = attributes.fetch(:orphaned_content_ids, [])
-    @message_queue_update_type = attributes.fetch(:message_queue_update_type, nil)
+    @message_queue_event_type = attributes.fetch(:message_queue_event_type, nil)
     @update_dependencies = attributes.fetch(:update_dependencies, true)
     @dependency_resolution_source_content_id = attributes.fetch(
       :dependency_resolution_source_content_id,

--- a/app/workers/downstream_live_worker.rb
+++ b/app/workers/downstream_live_worker.rb
@@ -38,8 +38,8 @@ class DownstreamLiveWorker
     DownstreamService.update_live_content_store(payload) if edition.base_path
 
     if edition.state == "published"
-      update_type = message_queue_event_type || edition.update_type
-      DownstreamService.broadcast_to_message_queue(payload, update_type)
+      event_type = message_queue_event_type || edition.update_type
+      DownstreamService.broadcast_to_message_queue(payload, event_type)
     end
 
     enqueue_dependencies if update_dependencies

--- a/app/workers/downstream_live_worker.rb
+++ b/app/workers/downstream_live_worker.rb
@@ -37,7 +37,7 @@ class DownstreamLiveWorker
 
     DownstreamService.update_live_content_store(payload) if edition.base_path
 
-    if edition.state == "published"
+    if %w(published unpublished).include?(edition.state)
       event_type = message_queue_event_type || edition.update_type
       DownstreamService.broadcast_to_message_queue(payload, event_type)
     end

--- a/doc/rabbitmq.md
+++ b/doc/rabbitmq.md
@@ -18,13 +18,20 @@ Publishing to the message queue can be disabled by setting the
 
 ## Post-publishing notifications
 
-After an edition is added or updated, a message is published to RabbitMQ.
-It will be published to the `published_documents` topic exchange with the
-routing_key `"#{edition.schema_name}.#{edition.update_type}"`.
-Interested parties can subscribe to this exchange to perform post-publishing
-actions. For example, a search indexing service would be able to add/update the
-search index based on these messages. Or an email notification service would be
-able to send email updates (see
-https://github.com/alphagov/email-alert-service).
+After an edition is changed, a message is published to RabbitMQ. It will be
+published to the `published_documents` topic exchange with the routing_key
+`"#{edition.schema_name}.#{event_type}"`. Interested parties can subscribe to
+this exchange to perform post-publishing actions. For example, a search
+indexing service would be able to add/update the search index based on these
+messages. Or an email notification service would be able to send email updates
+(see https://github.com/alphagov/email-alert-service).
+
+### `event_type`
+
+- `major`: Used when an edition is published with an `update_type` of major.
+- `minor`: Used when an edition is published with an `update_type` of minor.
+- `republish`: Used when an edition is published with an `update_type` of republish.
+- `links`: Used whenever links related to an edition have changed.
+- `unpublish`: Used when an edition is unpublished.
 
 [puppet_manifest]: https://github.com/alphagov/govuk-puppet/blob/master/modules/govuk/manifests/apps/publishing_api/rabbitmq.pp

--- a/lib/queue_publisher.rb
+++ b/lib/queue_publisher.rb
@@ -18,15 +18,16 @@ class QueuePublisher
   class PublishFailedError < StandardError
   end
 
-  def send_message(edition, routing_key: nil)
+  def send_message(edition, event_type: nil, routing_key: nil)
     return if @noop
-    routing_key ||= routing_key(edition)
+    routing_key ||= routing_key(edition, event_type)
     publish_message(routing_key, edition, content_type: 'application/json', persistent: true)
   end
 
-  def routing_key(edition)
+  def routing_key(edition, event_type)
     normalised = edition.symbolize_keys
-    "#{normalised[:schema_name]}.#{normalised[:update_type]}"
+    event_type ||= normalised[:update_type]
+    "#{normalised[:schema_name]}.#{event_type}"
   end
 
   def send_heartbeat

--- a/lib/requeue_content.rb
+++ b/lib/requeue_content.rb
@@ -22,16 +22,16 @@ private
   def publish_to_queue(edition)
     queue_payload = Presenters::EditionPresenter.new(
       edition, draft: false,
-    ).for_message_queue("links")
+    ).for_message_queue
 
     # FIXME: Rummager currently only listens to the message queue for the
-    # update type 'links'. This behaviour will eventually be updated so that
+    # event type 'links'. This behaviour will eventually be updated so that
     # it listens to other update types as well. This will happen as part of
     # ongoing architectural work to make the message queue the sole source of
-    # search index updates. When that happens, the update_type below should
+    # search index updates. When that happens, the event_type below should
     # be changed - perhaps to a newly introduced, more-appropriately named
     # one. Maybe something like 'reindex'.
 
-    PublishingAPI.service(:queue_publisher).send_message(queue_payload)
+    PublishingAPI.service(:queue_publisher).send_message(queue_payload, event_type: "links")
   end
 end

--- a/spec/commands/v2/patch_link_set_spec.rb
+++ b/spec/commands/v2/patch_link_set_spec.rb
@@ -288,7 +288,7 @@ RSpec.describe Commands::V2::PatchLinkSet do
             :content_id,
             :locale,
             :payload_version,
-            message_queue_update_type: "links",
+            message_queue_event_type: "links",
           ),
         )
 
@@ -303,7 +303,7 @@ RSpec.describe Commands::V2::PatchLinkSet do
             :content_id,
             :locale,
             :payload_version,
-            message_queue_update_type: "links",
+            message_queue_event_type: "links",
           ),
         )
 
@@ -326,7 +326,7 @@ RSpec.describe Commands::V2::PatchLinkSet do
               "downstream_high",
               content_id: content_id,
               locale: locale,
-              message_queue_update_type: "links",
+              message_queue_event_type: "links",
               payload_version: an_instance_of(Fixnum),
               orphaned_content_ids: [],
             )
@@ -380,7 +380,7 @@ RSpec.describe Commands::V2::PatchLinkSet do
             :content_id,
             :locale,
             :payload_version,
-            message_queue_update_type: "links",
+            message_queue_event_type: "links",
           ),
         )
 

--- a/spec/commands/v2/publish_spec.rb
+++ b/spec/commands/v2/publish_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe Commands::V2::Publish do
 
         it "uses the update_type from the draft edition" do
           expect(DownstreamLiveWorker).to receive(:perform_async_in_queue)
-            .with("downstream_high", hash_including(message_queue_update_type: "major"))
+            .with("downstream_high", hash_including(message_queue_event_type: "major"))
 
           described_class.call(payload)
         end

--- a/spec/commands/v2/represent_downstream_spec.rb
+++ b/spec/commands/v2/represent_downstream_spec.rb
@@ -40,9 +40,9 @@ RSpec.describe Commands::V2::RepresentDownstream do
         subject.call(Document.pluck(:content_id), with_drafts: false)
       end
 
-      it "has a message_queue_update_type of 'links'" do
+      it "has a message_queue_event_type of 'links'" do
         expect(DownstreamLiveWorker).to receive(:perform_async_in_queue)
-          .with(anything, a_hash_including(message_queue_update_type: "links"))
+          .with(anything, a_hash_including(message_queue_event_type: "links"))
           .at_least(1).times
         subject.call(Document.pluck(:content_id), with_drafts: false)
       end

--- a/spec/downstream_payload_spec.rb
+++ b/spec/downstream_payload_spec.rb
@@ -160,13 +160,15 @@ RSpec.describe DownstreamPayload do
   end
 
   describe "#message_queue_payload" do
-    let(:edition) { create_edition(:live_edition) }
+    let(:edition) do
+      create_edition(:live_edition, update_type: "major")
+    end
 
     it "returns a message queue payload" do
-      expect(downstream_payload.message_queue_payload("major")).to include(
+      expect(downstream_payload.message_queue_payload).to include(
         base_path: edition.base_path,
         title: edition.title,
-        update_type: "major",
+        update_type: edition.update_type,
         govuk_request_id: anything,
       )
     end

--- a/spec/lib/requeue_content_spec.rb
+++ b/spec/lib/requeue_content_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe RequeueContent do
       expect(PublishingAPI.service(:queue_publisher)).to receive(:send_message)
         .exactly(1)
         .times
-        .with(a_hash_including(:content_id))
+        .with(a_hash_including(:content_id), event_type: "links")
       RequeueContent.new(number_of_items: 1).call
     end
   end

--- a/spec/presenters/edition_presenter_spec.rb
+++ b/spec/presenters/edition_presenter_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Presenters::EditionPresenter do
 
   describe "#for_message_queue" do
     let(:update_type) { "moussaka" }
-    let(:edition) { FactoryGirl.create(:draft_edition) }
+    let(:edition) { FactoryGirl.create(:draft_edition, update_type: update_type) }
     let(:target_content_id) { "d16216ce-7487-4bde-b817-ef68317fe3ab" }
 
     before do
@@ -26,7 +26,7 @@ RSpec.describe Presenters::EditionPresenter do
     subject(:result) do
       described_class.new(
         edition, draft: present_drafts
-      ).for_message_queue(update_type)
+      ).for_message_queue
     end
 
     it "presents the unexpanded links" do

--- a/spec/requests/content_item_requests/downstream_requests_spec.rb
+++ b/spec/requests/content_item_requests/downstream_requests_spec.rb
@@ -191,9 +191,9 @@ RSpec.describe "Downstream requests", type: :request do
       allow(PublishingAPI.service(:draft_content_store)).to receive(:put_content_item)
       allow(PublishingAPI.service(:live_content_store)).to receive(:put_content_item)
       expect(PublishingAPI.service(:queue_publisher)).to receive(:send_message)
-        .with(a_hash_including(base_path: '/a'))
+        .with(a_hash_including(base_path: '/a'), event_type: "major")
       expect(PublishingAPI.service(:queue_publisher)).to_not receive(:send_message)
-        .with(a_hash_including(base_path: '/b'))
+        .with(a_hash_including(base_path: '/b'), event_type: anything)
       post "/v2/content/#{a}/publish", params: { update_type: "major" }.to_json
       expect(response.code).to eq("200")
     end

--- a/spec/requests/logging_requests_spec.rb
+++ b/spec/requests/logging_requests_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe "Logging requests", type: :request do
     draft_edition = FactoryGirl.create(:draft_edition, base_path: base_path)
 
     expect(PublishingAPI.service(:queue_publisher)).to receive(:send_message)
-      .with(hash_including(govuk_request_id: govuk_request_id))
+      .with(hash_including(govuk_request_id: govuk_request_id), event_type: "minor")
 
     post("/v2/content/#{draft_edition.document.content_id}/publish", params: { update_type: "minor" }.to_json,
       headers: { "HTTP_GOVUK_REQUEST_ID" => "12345-67890" }

--- a/spec/requests/unpublishing_spec.rb
+++ b/spec/requests/unpublishing_spec.rb
@@ -68,10 +68,11 @@ RSpec.describe "POST /v2/content/:content_id/unpublish", type: :request do
       end
     end
 
-    it "does not send to the message queue" do
+    it "does send to the message queue" do
       allow(PublishingAPI.service(:live_content_store)).to receive(:put_content_item)
       allow(PublishingAPI.service(:draft_content_store)).to receive(:put_content_item)
-      expect(PublishingAPI.service(:queue_publisher)).not_to receive(:send_message)
+      expect(PublishingAPI.service(:queue_publisher)).to receive(:send_message)
+        .with(a_hash_including(document_type: "nonexistent-schema"), event_type: "unpublish")
 
       post "/v2/content/#{content_id}/unpublish", params: withdrawal_params
 
@@ -154,10 +155,11 @@ RSpec.describe "POST /v2/content/:content_id/unpublish", type: :request do
         end
       end
 
-      it "does not send to the message queue" do
+      it "does send to the message queue" do
         allow(PublishingAPI.service(:live_content_store)).to receive(:put_content_item)
         allow(PublishingAPI.service(:draft_content_store)).to receive(:put_content_item)
-        expect(PublishingAPI.service(:queue_publisher)).not_to receive(:send_message)
+        expect(PublishingAPI.service(:queue_publisher)).to receive(:send_message)
+          .with(a_hash_including(document_type: "nonexistent-schema"), event_type: "unpublish")
 
         post "/v2/content/#{content_id}/unpublish", params: redirect_params
 
@@ -240,10 +242,11 @@ RSpec.describe "POST /v2/content/:content_id/unpublish", type: :request do
       end
     end
 
-    it "does not send to the message queue" do
+    it "does send to the message queue" do
       allow(PublishingAPI.service(:live_content_store)).to receive(:put_content_item)
       allow(PublishingAPI.service(:draft_content_store)).to receive(:put_content_item)
-      expect(PublishingAPI.service(:queue_publisher)).not_to receive(:send_message)
+      expect(PublishingAPI.service(:queue_publisher)).to receive(:send_message)
+        .with(a_hash_including(document_type: "nonexistent-schema"), event_type: "unpublish")
 
       post "/v2/content/#{content_id}/unpublish", params: gone_params
 
@@ -289,10 +292,11 @@ RSpec.describe "POST /v2/content/:content_id/unpublish", type: :request do
       end
     end
 
-    it "does not send to the message queue" do
+    it "does send to the message queue" do
       allow(PublishingAPI.service(:live_content_store)).to receive(:delete_content_item)
       allow(PublishingAPI.service(:draft_content_store)).to receive(:delete_content_item)
-      expect(PublishingAPI.service(:queue_publisher)).not_to receive(:send_message)
+      expect(PublishingAPI.service(:queue_publisher)).to receive(:send_message)
+        .with(a_hash_including(document_type: "nonexistent-schema"), event_type: "unpublish")
 
       post "/v2/content/#{content_id}/unpublish", params: vanish_params
 

--- a/spec/requests/unpublishing_spec.rb
+++ b/spec/requests/unpublishing_spec.rb
@@ -308,7 +308,10 @@ RSpec.describe "POST /v2/content/:content_id/unpublish", type: :request do
       allow(PublishingAPI.service(:live_content_store)).to receive(:delete_content_item)
       allow(PublishingAPI.service(:draft_content_store)).to receive(:delete_content_item)
       expect(PublishingAPI.service(:queue_publisher)).to receive(:send_message)
-        .with(a_hash_including(document_type: "nonexistent-schema"), event_type: "unpublish")
+        .with(
+          a_hash_including(document_type: "vanish"),
+          event_type: "unpublish"
+        )
 
       post "/v2/content/#{content_id}/unpublish", params: vanish_params
 

--- a/spec/requests/unpublishing_spec.rb
+++ b/spec/requests/unpublishing_spec.rb
@@ -252,7 +252,13 @@ RSpec.describe "POST /v2/content/:content_id/unpublish", type: :request do
       allow(PublishingAPI.service(:live_content_store)).to receive(:put_content_item)
       allow(PublishingAPI.service(:draft_content_store)).to receive(:put_content_item)
       expect(PublishingAPI.service(:queue_publisher)).to receive(:send_message)
-        .with(a_hash_including(document_type: "nonexistent-schema"), event_type: "unpublish")
+        .with(
+          a_hash_including(
+            document_type: "gone",
+            details: a_hash_including(alternative_path: "/new-path"),
+          ),
+          event_type: "unpublish"
+        )
 
       post "/v2/content/#{content_id}/unpublish", params: gone_params
 

--- a/spec/requests/unpublishing_spec.rb
+++ b/spec/requests/unpublishing_spec.rb
@@ -159,7 +159,13 @@ RSpec.describe "POST /v2/content/:content_id/unpublish", type: :request do
         allow(PublishingAPI.service(:live_content_store)).to receive(:put_content_item)
         allow(PublishingAPI.service(:draft_content_store)).to receive(:put_content_item)
         expect(PublishingAPI.service(:queue_publisher)).to receive(:send_message)
-          .with(a_hash_including(document_type: "nonexistent-schema"), event_type: "unpublish")
+          .with(
+            a_hash_including(
+              document_type: "redirect",
+              redirects: [a_hash_including(destination: "/new-path")]
+            ),
+            event_type: "unpublish"
+          )
 
         post "/v2/content/#{content_id}/unpublish", params: redirect_params
 

--- a/spec/services/downstream_service_spec.rb
+++ b/spec/services/downstream_service_spec.rb
@@ -184,7 +184,7 @@ RSpec.describe DownstreamService do
     {
       "draft" => true,
       "published" => false,
-      "unpublished" => true,
+      "unpublished" => false,
       "superseded" => true,
     }.each do |state, should_error|
       context "#{state} item" do

--- a/spec/workers/dependency_resolution_worker_spec.rb
+++ b/spec/workers/dependency_resolution_worker_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe DependencyResolutionWorker, :perform do
         :content_id,
         :locale,
         :payload_version,
-        message_queue_update_type: "links",
+        message_queue_event_type: "links",
         update_dependencies: false,
       ),
     )

--- a/spec/workers/downstream_live_worker_spec.rb
+++ b/spec/workers/downstream_live_worker_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe DownstreamLiveWorker do
       "content_id" => edition.document.content_id,
       "locale" => "en",
       "payload_version" => 1,
-      "message_queue_update_type" => "major",
+      "message_queue_event_type" => "major",
       "update_dependencies" => true,
     }
   end
@@ -37,9 +37,9 @@ RSpec.describe DownstreamLiveWorker do
       }.to raise_error(KeyError)
     end
 
-    it "doesn't require message_queue_update_type" do
+    it "doesn't require message_queue_event_type" do
       expect {
-        subject.perform(arguments.except("message_queue_update_type"))
+        subject.perform(arguments.except("message_queue_event_type"))
       }.not_to raise_error
     end
 
@@ -102,11 +102,11 @@ RSpec.describe DownstreamLiveWorker do
       subject.perform(arguments)
     end
 
-    it "uses the `message_queue_update_type`" do
+    it "uses the `message_queue_event_type`" do
       expect(PublishingAPI.service(:queue_publisher)).to receive(:send_message)
         .with(hash_including(update_type: "minor"))
 
-      subject.perform(arguments.merge("message_queue_update_type" => "minor"))
+      subject.perform(arguments.merge("message_queue_event_type" => "minor"))
     end
   end
 

--- a/spec/workers/downstream_live_worker_spec.rb
+++ b/spec/workers/downstream_live_worker_spec.rb
@@ -104,7 +104,7 @@ RSpec.describe DownstreamLiveWorker do
 
     it "uses the `message_queue_event_type`" do
       expect(PublishingAPI.service(:queue_publisher)).to receive(:send_message)
-        .with(hash_including(update_type: "minor"))
+        .with(hash_including(update_type: "minor"), event_type: "minor")
 
       subject.perform(arguments.merge("message_queue_event_type" => "minor"))
     end


### PR DESCRIPTION
[Trello Card](https://trello.com/c/5a7bQyHI/963-notify-downstream-services-search-indexing-when-documents-are-unpublished-3)