### PR TITLE
Only convert edition to hash once when expanding fields

### DIFF
--- a/lib/link_expansion/rules.rb
+++ b/lib/link_expansion/rules.rb
@@ -118,9 +118,10 @@ module LinkExpansion::Rules
   end
 
   def expand_fields(edition, link_type)
+    edition_hash = edition.to_h
     expansion_fields(edition.document_type, link_type).each_with_object({}) do |field, expanded|
       field = Array(field)
-      expanded[field.last] = edition.to_h.dig(*field)
+      expanded[field.last] = edition_hash.dig(*field)
     end
   end
 


### PR DESCRIPTION
https://trello.com/c/mOdpAGVj/961-improve-performance-of-the-expanded-link-set-endpoint-3

Once the edition hash has been created it can be reused, no need to
repeat this operation for each field expansion.

Before:
```
Benchmark.measure { LinkExpansion.by_content_id("91b8ef20-74e7-4552-880c-50e6d73c2ff9").links_with_content }
#<Benchmark::Tms:0x007f5dab4fe4e8 @cstime=0.0, @cutime=0.0, @label="", @real=11.048068525000417, @stime=0.6499999999999997, @total=8.540000000000001, @utime=7.890000000000001>
```

After:
```
Benchmark.measure { LinkExpansion.by_content_id("91b8ef20-74e7-4552-880c-50e6d73c2ff9").links_with_content }
#<Benchmark::Tms:0x007faa2b0a19f0 @cstime=0.0, @cutime=0.0, @label="", @real=8.579836010998406, @stime=0.7100000000000002, @total=5.88, @utime=5.17>
```