### PR TITLE
[DO NOT MERGE] Send first_published_at to GA when publishing

### DIFF
--- a/spec/commands/v2/import_spec.rb
+++ b/spec/commands/v2/import_spec.rb
@@ -1,6 +1,8 @@
 require "rails_helper"
 
 RSpec.describe Commands::V2::Import, type: :request do
+  include GoogleAnalyticsTestHelper
+
   describe "#call" do
     let(:content_id) { SecureRandom.uuid }
     let(:base_path) { "/bar" }
@@ -34,6 +36,10 @@ RSpec.describe Commands::V2::Import, type: :request do
           ),
         ]
       }
+    end
+
+    before do
+      stub_generic_ga_request
     end
 
     subject { described_class.call(payload) }

--- a/spec/commands/v2/patch_link_set_spec.rb
+++ b/spec/commands/v2/patch_link_set_spec.rb
@@ -1,6 +1,8 @@
 require "rails_helper"
 
 RSpec.describe Commands::V2::PatchLinkSet do
+  include GoogleAnalyticsTestHelper
+
   let(:expected_content_store_payload) { { base_path: "/vat-rates" } }
   let(:content_id) { SecureRandom.uuid }
   let(:topics) { 3.times.map { SecureRandom.uuid } }
@@ -356,6 +358,8 @@ RSpec.describe Commands::V2::PatchLinkSet do
         base_path: "/some-path",
         title: "Some Title",
       )
+
+      stub_generic_ga_request
     end
 
     it "sends to downstream draft worker" do

--- a/spec/commands/v2/publish_spec.rb
+++ b/spec/commands/v2/publish_spec.rb
@@ -1,6 +1,8 @@
 require "rails_helper"
 
 RSpec.describe Commands::V2::Publish do
+  include GoogleAnalyticsTestHelper
+
   describe "call" do
     let(:base_path) { "/vat-rates" }
     let(:locale) { "en" }
@@ -24,6 +26,8 @@ RSpec.describe Commands::V2::Publish do
 
     before do
       stub_request(:put, %r{.*content-store.*/content/.*})
+
+      stub_generic_ga_request
 
       allow(DependencyResolutionWorker).to receive(:perform_async)
     end

--- a/spec/commands/v2/represent_downstream_spec.rb
+++ b/spec/commands/v2/represent_downstream_spec.rb
@@ -1,6 +1,8 @@
 require "rails_helper"
 
 RSpec.describe Commands::V2::RepresentDownstream do
+  include GoogleAnalyticsTestHelper
+
   before do
     stub_request(:put, %r{.*content-store.*/content/.*})
   end
@@ -71,6 +73,10 @@ RSpec.describe Commands::V2::RepresentDownstream do
     end
 
     context "drafts optional" do
+      before do
+        stub_generic_ga_request
+      end
+
       it "can send to downstream draft worker" do
         expect(DownstreamDraftWorker).to receive(:perform_async_in_queue)
           .with(

--- a/spec/commands/v2/unpublish_spec.rb
+++ b/spec/commands/v2/unpublish_spec.rb
@@ -1,6 +1,8 @@
 require "rails_helper"
 
 RSpec.describe Commands::V2::Unpublish do
+  include GoogleAnalyticsTestHelper
+
   let(:content_id) { SecureRandom.uuid }
   let(:base_path) { "/vat-rates" }
   let(:locale) { "en" }
@@ -9,6 +11,10 @@ RSpec.describe Commands::V2::Unpublish do
       content_id: content_id,
       locale: locale,
     )
+  end
+
+  before do
+    stub_generic_ga_request
   end
 
   describe "call" do

--- a/spec/controllers/v2/content_items_controller_spec.rb
+++ b/spec/controllers/v2/content_items_controller_spec.rb
@@ -1,6 +1,8 @@
 require "rails_helper"
 
 RSpec.describe V2::ContentItemsController do
+  include GoogleAnalyticsTestHelper
+
   let(:content_id) { SecureRandom.uuid }
   let(:validator) do
     instance_double(SchemaValidator, valid?: true, errors: [])
@@ -466,6 +468,7 @@ RSpec.describe V2::ContentItemsController do
       let(:body) { { update_type: "major" } }
       let(:govuk_request_id) { "test" }
       before do
+        stub_generic_ga_request
         request.set_header("HTTP_GOVUK_REQUEST_ID", govuk_request_id)
         GdsApi::GovukHeaders.set_header(:govuk_request_id, govuk_request_id)
         put :publish, params: { content_id: content_id }, body: body.to_json

--- a/spec/integration/message_queue_publishing_spec.rb
+++ b/spec/integration/message_queue_publishing_spec.rb
@@ -2,6 +2,11 @@ require "rails_helper"
 
 RSpec.describe "Message queue publishing" do
   include RandomContentHelpers
+  include GoogleAnalyticsTestHelper
+
+  before do
+    stub_generic_ga_request
+  end
 
   it "puts the correct message on the queue" do
     base_path = "/#{SecureRandom.hex}"

--- a/spec/integration/pathless_content_spec.rb
+++ b/spec/integration/pathless_content_spec.rb
@@ -1,6 +1,8 @@
 require "rails_helper"
 
 RSpec.describe "pathless content" do
+  include GoogleAnalyticsTestHelper
+
   describe Commands::V2::PutContent do
     describe "call" do
       let(:content_id) { FactoryGirl.build(:document).content_id }
@@ -158,6 +160,10 @@ RSpec.describe "pathless content" do
     end
 
     context "with no Location" do
+      before do
+        stub_generic_ga_request
+      end
+
       it "publishes the item" do
         described_class.call(payload)
 

--- a/spec/integration/put_content/race_conditions_spec.rb
+++ b/spec/integration/put_content/race_conditions_spec.rb
@@ -2,6 +2,7 @@ require "rails_helper"
 
 RSpec.describe Commands::V2::PutContent do
   include_context "PutContent call"
+  include GoogleAnalyticsTestHelper
 
   describe "race conditions", skip_cleaning: true do
     let(:document) do
@@ -19,6 +20,10 @@ RSpec.describe Commands::V2::PutContent do
         first_published_at: 1.year.ago,
         base_path: base_path,
       )
+    end
+
+    before do
+      stub_generic_ga_request
     end
 
     after do

--- a/spec/integration/random_content_spec.rb
+++ b/spec/integration/random_content_spec.rb
@@ -1,7 +1,12 @@
 require "rails_helper"
 
 RSpec.describe "Randomised content" do
+  include GoogleAnalyticsTestHelper
   include RandomContentHelpers
+
+  before do
+    stub_generic_ga_request
+  end
 
   50.times do |i|
     it "it can publish randomly generated content #{i + 1}/50" do

--- a/spec/integration/redirecting_spec.rb
+++ b/spec/integration/redirecting_spec.rb
@@ -1,6 +1,8 @@
 require "rails_helper"
 
 RSpec.describe "Redirecting editions that are redrafted" do
+  include GoogleAnalyticsTestHelper
+
   let(:put_content) { Commands::V2::PutContent }
   let(:publish) { Commands::V2::Publish }
 
@@ -33,6 +35,7 @@ RSpec.describe "Redirecting editions that are redrafted" do
 
   before do
     stub_request(:put, %r{.*content-store.*/content/.*})
+    stub_generic_ga_request
   end
 
   context "when a published item's base path is updated" do

--- a/spec/integration/reinstating_spec.rb
+++ b/spec/integration/reinstating_spec.rb
@@ -1,6 +1,8 @@
 require "rails_helper"
 
 RSpec.describe "Reinstating editions that were previously unpublished" do
+  include GoogleAnalyticsTestHelper
+
   let(:put_content_command) { Commands::V2::PutContent }
   let(:publish_command) { Commands::V2::Publish }
 
@@ -57,6 +59,7 @@ RSpec.describe "Reinstating editions that were previously unpublished" do
 
   before do
     allow(SchemaValidator).to receive(:new).and_return(validator)
+    stub_generic_ga_request
   end
 
   describe "after the edition is unpublished" do

--- a/spec/integration/superseding_spec.rb
+++ b/spec/integration/superseding_spec.rb
@@ -1,6 +1,8 @@
 require "rails_helper"
 
 RSpec.describe "Superseding editions" do
+  include GoogleAnalyticsTestHelper
+
   let(:put_content_command) { Commands::V2::PutContent }
   let(:publish_command) { Commands::V2::Publish }
 
@@ -30,6 +32,7 @@ RSpec.describe "Superseding editions" do
   end
 
   def call_commands
+    stub_generic_ga_request
     put_content_command.call(put_content_payload)
     publish_command.call(publish_payload)
   end

--- a/spec/integration/unpublish/document_is_already_unpublished_spec.rb
+++ b/spec/integration/unpublish/document_is_already_unpublished_spec.rb
@@ -1,6 +1,8 @@
 require "rails_helper"
 
 RSpec.describe "/v2/content/:content_id/unpublish when the document is already unpublished" do
+  include GoogleAnalyticsTestHelper
+
   let(:content_id) { SecureRandom.uuid }
   let(:document) do
     FactoryGirl.create(:document,
@@ -24,6 +26,10 @@ RSpec.describe "/v2/content/:content_id/unpublish when the document is already u
       type: "gone",
       explanation: "This explanation is correct",
     }
+  end
+
+  before do
+    stub_generic_ga_request
   end
 
   context "creates an action" do

--- a/spec/integration/unpublishing_spec.rb
+++ b/spec/integration/unpublishing_spec.rb
@@ -1,6 +1,8 @@
 require "rails_helper"
 
 RSpec.describe "Unpublishing editions" do
+  include GoogleAnalyticsTestHelper
+
   let(:put_content_command) { Commands::V2::PutContent }
   let(:publish_command) { Commands::V2::Publish }
   let(:unpublish_command) { Commands::V2::Unpublish }
@@ -39,6 +41,7 @@ RSpec.describe "Unpublishing editions" do
 
   describe "after the first unpublishing" do
     before do
+      stub_generic_ga_request
       put_content_command.call(put_content_payload)
       publish_command.call(publish_payload)
       unpublish_command.call(unpublish_payload)

--- a/spec/requests/content_item_requests/downstream_requests_spec.rb
+++ b/spec/requests/content_item_requests/downstream_requests_spec.rb
@@ -1,6 +1,8 @@
 require "rails_helper"
 
 RSpec.describe "Downstream requests", type: :request do
+  include GoogleAnalyticsTestHelper
+
   describe "PUT /v2/content" do
     let(:content_item_for_draft_content_store) {
       v2_content_item
@@ -93,6 +95,8 @@ RSpec.describe "Downstream requests", type: :request do
           document: FactoryGirl.create(:document, content_id: content_id),
           base_path: base_path,
         )
+
+        stub_generic_ga_request
       end
 
       it "sends the live item to both content stores" do
@@ -127,6 +131,8 @@ RSpec.describe "Downstream requests", type: :request do
           document: document,
           base_path: base_path,
         )
+
+        stub_generic_ga_request
       end
 
       it "sends to both content stores" do
@@ -166,6 +172,8 @@ RSpec.describe "Downstream requests", type: :request do
       create_edition(a, "/a", factory: :draft_edition, version: 2)
       create_edition(b, "/b", factory: :draft_edition)
       create_link(a, b, "parent")
+
+      stub_generic_ga_request
     end
 
     it "sends the dependencies to the draft content store" do
@@ -235,6 +243,10 @@ RSpec.describe "Downstream requests", type: :request do
           :content_store,
         )
     }
+
+    before do
+      stub_generic_ga_request
+    end
 
     it "sends to the live content store" do
       allow(PublishingAPI.service(:live_content_store)).to receive(:put_content_item).with(anything)

--- a/spec/requests/content_item_requests/message_bus_spec.rb
+++ b/spec/requests/content_item_requests/message_bus_spec.rb
@@ -1,6 +1,8 @@
 require "rails_helper"
 
 RSpec.describe "Message bus", type: :request do
+  include GoogleAnalyticsTestHelper
+
   context "/v2/content" do
     it "doesn't send any messages" do
       expect(DownstreamService).to_not receive(:broadcast_to_message_queue)
@@ -22,6 +24,8 @@ RSpec.describe "Message bus", type: :request do
           document: FactoryGirl.create(:document, content_id: content_id),
           base_path: base_path,
         )
+
+        stub_generic_ga_request
       end
 
       it "sends a message with a 'links' routing key" do
@@ -59,6 +63,8 @@ RSpec.describe "Message bus", type: :request do
         schema_name: "nonexistent-schema",
         base_path: base_path,
       )
+
+      stub_generic_ga_request
     end
 
     it "sends a message with the 'document_type.update_type' routing key" do

--- a/spec/requests/logging_requests_spec.rb
+++ b/spec/requests/logging_requests_spec.rb
@@ -2,6 +2,8 @@ require "rails_helper"
 require "sidekiq/testing"
 
 RSpec.describe "Logging requests", type: :request do
+  include GoogleAnalyticsTestHelper
+
   let(:govuk_request_id) { "12345-67890" }
 
   it "adds a request uuid to the content store worker job" do
@@ -21,6 +23,7 @@ RSpec.describe "Logging requests", type: :request do
   end
 
   it "adds a request uuid to the message bus" do
+    stub_generic_ga_request
     draft_edition = FactoryGirl.create(:draft_edition, base_path: base_path)
 
     expect(PublishingAPI.service(:queue_publisher)).to receive(:send_message)

--- a/spec/requests/unpublishing_spec.rb
+++ b/spec/requests/unpublishing_spec.rb
@@ -7,6 +7,8 @@ require "rails_helper"
 # and failure modes.
 #
 RSpec.describe "POST /v2/content/:content_id/unpublish", type: :request do
+  include GoogleAnalyticsTestHelper
+
   let(:content_id) { SecureRandom.uuid }
   let(:base_path) { "/vat-rates" }
   let!(:document) { FactoryGirl.create(:document, content_id: content_id) }
@@ -35,6 +37,10 @@ RSpec.describe "POST /v2/content/:content_id/unpublish", type: :request do
         ),
       }
     }
+
+    before do
+      stub_generic_ga_request
+    end
 
     it "creates an Unpublishing" do
       post "/v2/content/#{content_id}/unpublish", params: withdrawal_params
@@ -118,6 +124,10 @@ RSpec.describe "POST /v2/content/:content_id/unpublish", type: :request do
         },
       }
     }
+
+    before do
+      stub_generic_ga_request
+    end
 
     shared_examples "unpublishing with redirects" do
       it "creates an Unpublishing" do
@@ -207,6 +217,10 @@ RSpec.describe "POST /v2/content/:content_id/unpublish", type: :request do
       }
     }
 
+    before do
+      stub_generic_ga_request
+    end
+
     it "creates an Unpublishing" do
       post "/v2/content/#{content_id}/unpublish", params: gone_params
 
@@ -257,6 +271,10 @@ RSpec.describe "POST /v2/content/:content_id/unpublish", type: :request do
         type: "vanish",
       }.to_json
     }
+
+    before do
+      stub_generic_ga_request
+    end
 
     it "creates an Unpublishing" do
       post "/v2/content/#{content_id}/unpublish", params: vanish_params

--- a/spec/support/google_analytics_test_helper.rb
+++ b/spec/support/google_analytics_test_helper.rb
@@ -1,0 +1,13 @@
+module GoogleAnalyticsTestHelper
+  def stub_generic_ga_request
+    stub_request(:post, 'http://www.google-analytics.com/collect')
+        .to_return(status: 200, body: '', headers: {})
+  end
+
+  def stub_first_published_at_ga_request(edition)
+    stub_request(:post, 'http://www.google-analytics.com/collect').
+        with(body: { 'v': '1', 'tid': 'UA-26179049-1', 'cid': '660ad712-9753-4cb9-97a7-c9e9f13c318e', 't': 'event', 'cd90': edition.first_published_at },
+             headers: { 'Accept': '*/*', 'Accept-Encoding': 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Content-Type': 'application/x-www-form-urlencoded', 'Host': 'www.google-analytics.com', 'User-Agent': 'Ruby' }).
+        to_return(status: 200, body: '', headers: {})
+  end
+end

--- a/spec/workers/downstream_live_worker_spec.rb
+++ b/spec/workers/downstream_live_worker_spec.rb
@@ -1,6 +1,8 @@
 require "rails_helper"
 
 RSpec.describe DownstreamLiveWorker do
+  include GoogleAnalyticsTestHelper
+
   let(:edition) do
     FactoryGirl.create(:live_edition, base_path: "/foo")
   end
@@ -22,6 +24,10 @@ RSpec.describe DownstreamLiveWorker do
   end
 
   describe "arguments" do
+    before do
+      stub_generic_ga_request
+    end
+
     it "requires content_item_id or content_id" do
       expect {
         subject.perform(arguments.except("content_id"))
@@ -53,8 +59,20 @@ RSpec.describe DownstreamLiveWorker do
   describe "send to live content store" do
     context "published edition" do
       it "sends content to live content store" do
+        stub_generic_ga_request
         expect(Adapters::ContentStore).to receive(:put_content_item)
         subject.perform(arguments)
+      end
+
+      it "sends GA event with first_published_at" do
+        stub_first_published_at_ga_request(edition)
+
+        subject.perform(arguments)
+
+        expect(a_request(:post, /google-analytics.com\/collect/).
+            with(body: { 'v': '1', 'tid': 'UA-26179049-1', 'cid': '660ad712-9753-4cb9-97a7-c9e9f13c318e', 't': 'event', 'cd90': edition.first_published_at },
+                 headers: { 'Accept': '*/*', 'Accept-Encoding': 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Content-Type': 'application/x-www-form-urlencoded', 'Host': 'www.google-analytics.com', 'User-Agent': 'Ruby' })).
+            to have_been_made
       end
     end
 
@@ -63,7 +81,16 @@ RSpec.describe DownstreamLiveWorker do
       let(:unpublished_arguments) { arguments.merge(content_id: unpublished_edition.document.content_id) }
 
       it "sends content to live content store" do
+        stub_generic_ga_request
         expect(Adapters::ContentStore).to receive(:put_content_item)
+        subject.perform(unpublished_arguments)
+      end
+
+      it "does not send a GA event with the first_published_at date" do
+        stub_first_published_at_ga_request(edition)
+
+        expect(a_request(:post, /google-analytics.com\/collect/)).to_not have_been_made
+
         subject.perform(unpublished_arguments)
       end
     end
@@ -77,6 +104,14 @@ RSpec.describe DownstreamLiveWorker do
         subject.perform(superseded_arguments)
       end
 
+      it "does not send a GA event with the first_published_at date" do
+        stub_first_published_at_ga_request(edition)
+
+        expect(a_request(:post, /google-analytics.com\/collect/)).to_not have_been_made
+
+        subject.perform(superseded_arguments)
+      end
+
       it "absorbs an error" do
         expect(Airbrake).to receive(:notify)
           .with(an_instance_of(AbortWorkerError), a_hash_including(:parameters))
@@ -85,6 +120,7 @@ RSpec.describe DownstreamLiveWorker do
     end
 
     it "wont send to content store without a base_path" do
+      stub_generic_ga_request
       pathless = FactoryGirl.create(:live_edition,
         base_path: nil,
         document_type: "contact",
@@ -96,6 +132,10 @@ RSpec.describe DownstreamLiveWorker do
   end
 
   describe "broadcast to message queue" do
+    before do
+      stub_generic_ga_request
+    end
+
     it "sends a message" do
       expect(PublishingAPI.service(:queue_publisher)).to receive(:send_message)
 
@@ -111,6 +151,9 @@ RSpec.describe DownstreamLiveWorker do
   end
 
   describe "update dependencies" do
+    before do
+      stub_generic_ga_request
+    end
     context "can update dependencies" do
       it "enqueues dependencies" do
         expect(DependencyResolutionWorker).to receive(:perform_async)
@@ -127,6 +170,10 @@ RSpec.describe DownstreamLiveWorker do
   end
 
   describe "draft-to-live protection" do
+    before do
+      stub_generic_ga_request
+    end
+
     it "rejects draft editions" do
       draft = FactoryGirl.create(:draft_edition)
 


### PR DESCRIPTION
For: [Trello card](https://trello.com/c/7HwMeMfX/177-custom-dimension-first-published-date)

This will send a GA hit whenever an edition is published for the first time.
The information will be sent along as an `event`, using the `trackerId` currently in
use in govuk_admin_template (`tid: UA-26179049-6`).

The client id we're sending (`cid: 660ad712-9753-4cb9-97a7-c9e9f13c318e`) is
randomly generated and can be used to identify that the hits are coming from the
publishing-api rather than govuk_admin_template or govuk_frontend_toolkit (both
apps are normally used to send analytics information).