### PR TITLE
Improve content cache to save queries.

### DIFF
--- a/lib/link_expansion/content_cache.rb
+++ b/lib/link_expansion/content_cache.rb
@@ -41,6 +41,7 @@ private
       locale_fallback_order: locale_fallback_order,
       state_fallback_order: state_fallback_order,
     )
+    return [] unless edition_ids
     Edition
       .joins(
         <<-SQL.strip_heredoc

--- a/lib/link_expansion/content_cache.rb
+++ b/lib/link_expansion/content_cache.rb
@@ -25,6 +25,11 @@ private
       attrs = edition_hash.from(edition_values)
       hash[attrs[:content_id]] = attrs
     end
+
+    # fill in where the preloading didn't find a result
+    (to_preload - store.keys).each_with_object(store) do |content_id, hash|
+      hash[content_id] = nil
+    end
   end
 
   def edition(content_id)


### PR DESCRIPTION
Trello: https://trello.com/c/mOdpAGVj/961-improve-performance-of-the-expanded-link-set-endpoint-3

See commits for individual changes.

This gives us a small speed boost:

Given link expansion with a warm graph
```
> le = LinkExpansion.by_content_id("91b8ef20-74e7-4552-880c-50e6d73c2ff9")
> le.link_graph.to_h
```

Before:

```
> puts Benchmark.measure { le.instance_variable_set(:@content_cache, nil); le.links_with_content }
  0.320000   0.030000   0.350000 (  0.657331)
```

After:

```
> puts Benchmark.measure { le.instance_variable_set(:@content_cache, nil); le.links_with_content }
  0.300000   0.000000   0.300000 (  0.574295)
```