### PR TITLE
Return a 409 Conflict error upon failing to publish an edition with no draft.

### DIFF
--- a/app/commands/v2/publish.rb
+++ b/app/commands/v2/publish.rb
@@ -90,7 +90,7 @@ module Commands
       def no_draft_item_exists
         if already_published?
           message = "Cannot publish an already published edition"
-          raise_command_error(400, message, fields: {})
+          raise_command_error(409, message, fields: {})
         else
           message = "Item with content_id #{content_id} and locale #{locale} does not exist"
           raise_command_error(404, message, fields: {})


### PR DESCRIPTION
The [400 Bad Request error](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/400) that this currently returns is a poor semantic representation of the
nature of the problem encountered. 

```
The HTTP 400 Bad Request response status code indicates that the server
could not understand the request due to invalid syntax. The client should
not repeat this request without modification.
```

A better fit seems to be the [409 Conflict error](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/409)

```
The HTTP 409 Conflict response status code indicates a request conflict
with current state of the server.
```

This change is motivated by trying to catch this error in a publishing app without resorting to parsing the error message. 400 is too broad to have a specific error class, but the `GdsApi::HTTPConflict` is a perfectly reasonable thing to `rescue` from in a call to `publish`