### PR TITLE
Persist expanded links when downstreaming

### DIFF
--- a/app/controllers/v2/link_sets_controller.rb
+++ b/app/controllers/v2/link_sets_controller.rb
@@ -5,13 +5,12 @@ module V2
     end
 
     def expanded_links
-      json = Rails.cache.fetch ['expanded-links', content_id, params[:with_drafts], params[:locale]], expires_in: 1.hour do
-        Queries::GetExpandedLinks.call(
-          content_id,
-          params[:locale],
-          with_drafts: with_drafts?,
-        )
-      end
+      json = Queries::GetExpandedLinks.call(
+        content_id,
+        locale,
+        with_drafts: with_drafts?,
+        generate: generate?,
+      )
 
       render json: json
     end
@@ -37,12 +36,20 @@ module V2
       ActiveModel::Type::Boolean.new.cast(params.fetch(:with_drafts, true))
     end
 
+    def generate?
+      ActiveModel::Type::Boolean.new.cast(params.fetch(:generate, false))
+    end
+
     def links_params
       payload.merge(content_id: content_id)
     end
 
     def content_id
       params.fetch(:content_id)
+    end
+
+    def locale
+      params.fetch(:locale, Edition::DEFAULT_LOCALE)
     end
   end
 end

--- a/app/downstream_payload.rb
+++ b/app/downstream_payload.rb
@@ -38,6 +38,10 @@ class DownstreamPayload
     message_queue_presenter.for_message_queue
   end
 
+  def expanded_links
+    content_presenter.expanded_links
+  end
+
 private
 
   def unpublishing

--- a/app/downstream_payload.rb
+++ b/app/downstream_payload.rb
@@ -45,7 +45,7 @@ private
   end
 
   def content_presenter
-    Presenters::EditionPresenter.new(edition, draft: draft)
+    @content_presenter ||= Presenters::EditionPresenter.new(edition, draft: draft)
   end
 
   def redirect_presenter

--- a/app/models/expanded_links.rb
+++ b/app/models/expanded_links.rb
@@ -1,0 +1,3 @@
+class ExpandedLinks < ApplicationRecord
+  include FindOrCreateLocked
+end

--- a/app/models/expanded_links.rb
+++ b/app/models/expanded_links.rb
@@ -1,3 +1,26 @@
 class ExpandedLinks < ApplicationRecord
   include FindOrCreateLocked
+
+  def self.locked_update(
+    content_id:,
+    locale:,
+    with_drafts:,
+    payload_version:,
+    expanded_links:
+  )
+    transaction do
+      entry = find_or_create_locked(
+        content_id: content_id,
+        locale: locale,
+        with_drafts: with_drafts,
+      )
+
+      next unless entry.payload_version <= payload_version
+
+      entry.update!(
+        payload_version: payload_version,
+        expanded_links: expanded_links,
+      )
+    end
+  end
 end

--- a/app/presenters/edition_presenter.rb
+++ b/app/presenters/edition_presenter.rb
@@ -37,12 +37,16 @@ module Presenters
       edition.to_h
         .except(*NON_PRESENTED_PROPERTIES)
         .merge(rendered_details)
-        .merge(expanded_links)
+        .merge(expanded_links_attributes)
         .merge(access_limited)
         .merge(schema_name_and_document_type)
         .merge(document_supertypes)
         .merge(withdrawal_notice)
         .merge(publishing_request_id)
+    end
+
+    def expanded_links
+      expanded_link_set_presenter.links
     end
 
     def rendered_details
@@ -59,9 +63,9 @@ module Presenters
       ).links
     end
 
-    def expanded_links
+    def expanded_links_attributes
       {
-        expanded_links: expanded_link_set_presenter.links,
+        expanded_links: expanded_links
       }
     end
 

--- a/app/workers/downstream_live_worker.rb
+++ b/app/workers/downstream_live_worker.rb
@@ -35,6 +35,7 @@ class DownstreamLiveWorker
 
     payload = DownstreamPayload.new(edition, payload_version, draft: false)
 
+    update_expanded_links(payload)
     DownstreamService.update_live_content_store(payload) if edition.base_path
 
     if %w(published unpublished).include?(edition.state)
@@ -80,5 +81,15 @@ private
 
   def notify_airbrake(error, parameters)
     Airbrake.notify(error, parameters: parameters)
+  end
+
+  def update_expanded_links(downstream_payload)
+    ExpandedLinks.locked_update(
+      content_id: content_id,
+      locale: locale,
+      with_drafts: false,
+      payload_version: payload_version,
+      expanded_links: downstream_payload.expanded_links,
+    )
   end
 end

--- a/db/migrate/20170726114449_create_expanded_links.rb
+++ b/db/migrate/20170726114449_create_expanded_links.rb
@@ -1,0 +1,16 @@
+class CreateExpandedLinks < ActiveRecord::Migration[5.1]
+  def change
+    create_table :expanded_links do |t|
+      t.uuid :content_id, null: false
+      t.string :locale, null: false
+      t.boolean :with_drafts, null: false
+      t.json :expanded_links, null: false, default: {}
+      t.bigint :payload_version, null: false, default: 0
+      t.timestamps
+
+      t.index [:content_id, :locale, :with_drafts],
+        unique: true,
+        name: "expanded_links_content_id_locale_with_drafts_index"
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170719143106) do
+ActiveRecord::Schema.define(version: 20170726114449) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -110,6 +110,17 @@ ActiveRecord::Schema.define(version: 20170719143106) do
     t.string "request_id"
     t.uuid "content_id"
     t.index ["content_id"], name: "index_events_on_content_id"
+  end
+
+  create_table "expanded_links", force: :cascade do |t|
+    t.uuid "content_id", null: false
+    t.string "locale", null: false
+    t.boolean "with_drafts", null: false
+    t.json "expanded_links", default: {}, null: false
+    t.bigint "payload_version", default: 0, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["content_id", "locale", "with_drafts"], name: "expanded_links_content_id_locale_with_drafts_index", unique: true
   end
 
   create_table "link_sets", id: :serial, force: :cascade do |t|

--- a/doc/admin-tasks.md
+++ b/doc/admin-tasks.md
@@ -52,3 +52,23 @@ bundle exec represent_downstream:content_id['some-content-id']
 bundle exec represent_downstream:content_id['some-content-id some-other-content-id']
 ```
 N.B. The content ids are separated by a space.
+
+## Populating expanded links into database
+
+The [expanded-links endpoint](api.md#get-v2expanded-linkscontent_id) defaults
+to accessing denormalised data stored in the database. If there are reasons
+that this is now out of sync or data is missing you can populate it with
+a couple of rake commands.
+
+It will also be rebuilt any time a piece of content is represented downstream.
+
+* To populate every document (this will take a long time - hours)
+```
+bundle exec expanded_links:populate
+```
+
+* To populate every document of a document_type
+```
+bundle exec expanded_links:populate_by_document_type['document-type']
+```
+

--- a/doc/api.md
+++ b/doc/api.md
@@ -496,6 +496,16 @@ were created.
 Retrieves the expanded link set for the given `content_id`. Returns arrays of
 details for each linked edition in groupings of `link_type`.
 
+To ensure fast performance the result for this is pulled from a database which
+is updated whenever the content store is updated. This may mean that if you
+update links and then request this endpoint you may get a stale response.
+
+You can request a fresh response by adding a query string of `generate=true`,
+this response can be slow though for large link sets.
+
+The response includes a field of `generated` and the timestamp of when the
+expanded link set was generated.
+
 ### Path parameters
 
 - [`content_id`](model.md#content_id)
@@ -503,8 +513,13 @@ details for each linked edition in groupings of `link_type`.
 
 ### Query string parameters:
 
+- `locale` *(optional, default: "en")*
+  - Accepts: An available locale from the [Rails I18n gem][i18n-gem]
 - `with_drafts` *(optional, default: true)*
   - Whether links to draft editions should be included in the response.
+- `generate` *(optional, default: false)*
+  - Whether to generate the expanded links at request time, ensures a fresh
+    response but could make the request slow
 
 ## `GET /v2/linked/:content_id`
 

--- a/lib/tasks/expanded_links.rake
+++ b/lib/tasks/expanded_links.rake
@@ -1,0 +1,59 @@
+namespace :expanded_links do
+  desc "Populate the Expanded Links table in the database"
+  task populate: :environment do
+    document_count = Document.count
+    payload_version = Event.maximum(:id)
+    Document.find_each.with_index do |document, index|
+      content_id = document.content_id
+      locale = document.locale
+
+      update_links(content_id, locale, payload_version, with_drafts: true)
+      update_links(content_id, locale, payload_version, with_drafts: false)
+
+      progress(index, document_count)
+    end
+  end
+
+  desc "
+  Populate the Expanded Links table with content of a particular document type
+  Usage
+  rake 'expanded_links:populate_by_document_type[:document_type]'
+  "
+  task :populate_by_document_type, [:document_type] => :environment do |_t, args|
+    tuples = Edition
+      .with_document
+      .where(document_type: args[:document_type])
+      .distinct
+      .pluck("documents.content_id", "documents.locale")
+
+    payload_version = Event.maximum(:id)
+    tuples.each_with_index do |(content_id, locale), index|
+      update_links(content_id, locale, payload_version, with_drafts: true)
+      update_links(content_id, locale, payload_version, with_drafts: false)
+
+      progress(index, tuples.count, every: 100)
+    end
+  end
+
+  def update_links(content_id, locale, payload_version, with_drafts:)
+    links = Presenters::Queries::ExpandedLinkSet.by_content_id(
+      content_id,
+      locale: locale,
+      with_drafts: with_drafts,
+    ).links
+
+    ExpandedLinks.locked_update(
+      content_id: content_id,
+      locale: locale,
+      with_drafts: with_drafts,
+      expanded_links: links,
+      payload_version: payload_version,
+    )
+  end
+
+  def progress(index, count, every: 1000)
+    if ((index + 1) % every == 0) || (index + 1) == count
+      puts "processed: #{index + 1}/#{count}"
+    end
+  end
+end

--- a/spec/factories/expanded_links.rb
+++ b/spec/factories/expanded_links.rb
@@ -1,0 +1,7 @@
+FactoryGirl.define do
+  factory :expanded_links do
+    content_id { SecureRandom.uuid }
+    locale { "en" }
+    with_drafts { false }
+  end
+end

--- a/spec/models/expanded_links_spec.rb
+++ b/spec/models/expanded_links_spec.rb
@@ -1,0 +1,73 @@
+require "rails_helper"
+
+RSpec.describe ExpandedLinks do
+  describe ".locked_update" do
+    let(:content_id) { SecureRandom.uuid }
+    let(:locale) { "en" }
+    let(:with_drafts) { true }
+    let(:payload_version) { 2 }
+    let(:expanded_links) do
+      {
+        organisations: [
+          { content_id: SecureRandom.uuid }
+        ]
+      }
+    end
+
+    let(:attributes) do
+      {
+        content_id: content_id,
+        locale: locale,
+        with_drafts: with_drafts,
+        payload_version: payload_version,
+        expanded_links: expanded_links,
+      }
+    end
+
+    subject(:run_method) { described_class.locked_update(attributes) }
+
+    context "when there isn't an instance" do
+      it "creates one" do
+        expect { run_method }.to change(ExpandedLinks, :count).by(1)
+      end
+    end
+
+    context "when there is an instance and the payload version of the update is greater" do
+      let!(:expanded_links_instance) do
+        FactoryGirl.create(:expanded_links,
+          content_id: content_id,
+          locale: locale,
+          with_drafts: with_drafts,
+          payload_version: 1,
+          expanded_links: {},
+        )
+      end
+
+      it "updates the links" do
+        run_method
+        expanded_links_instance.reload
+        expect(expanded_links_instance.expanded_links).to match(expanded_links.as_json)
+        expect(expanded_links_instance.payload_version).to match(payload_version)
+      end
+    end
+
+    context "when there is an instance and the payload version of the update is lower" do
+      let!(:expanded_links_instance) do
+        FactoryGirl.create(:expanded_links,
+          content_id: content_id,
+          locale: locale,
+          with_drafts: with_drafts,
+          payload_version: 5,
+          expanded_links: {},
+        )
+      end
+
+      it "doesn't update" do
+        run_method
+        expanded_links_instance.reload
+        expect(expanded_links_instance.expanded_links).to match({})
+        expect(expanded_links_instance.payload_version).to match(5)
+      end
+    end
+  end
+end

--- a/spec/presenters/edition_presenter_spec.rb
+++ b/spec/presenters/edition_presenter_spec.rb
@@ -6,6 +6,25 @@ RSpec.describe Presenters::EditionPresenter do
   let(:details) { { body: "<p>Text</p>\n", change_history: [change_history], } }
   let(:payload_version) { 1 }
 
+  describe "#expanded_links" do
+    let(:edition) { FactoryGirl.create(:live_edition) }
+    subject(:result) do
+      described_class.new(
+        edition, draft: present_drafts
+      ).expanded_links
+    end
+
+    context "when there aren't links" do
+      it "has a link to itself as an available translation" do
+        expect(result).to match(
+          available_translations: [
+            a_hash_including(content_id: edition.content_id)
+          ]
+        )
+      end
+    end
+  end
+
   describe "#for_message_queue" do
     let(:update_type) { "moussaka" }
     let(:edition) { FactoryGirl.create(:draft_edition, update_type: update_type) }

--- a/spec/workers/downstream_discard_draft_worker_spec.rb
+++ b/spec/workers/downstream_discard_draft_worker_spec.rb
@@ -10,10 +10,12 @@ RSpec.describe DownstreamDiscardDraftWorker do
     )
   end
 
+  let(:content_id) { edition.content_id }
+
   let(:arguments) do
     {
       "base_path" => base_path,
-      "content_id" => edition.document.content_id,
+      "content_id" => content_id,
       "locale" => "en",
       "payload_version" => 1,
       "update_dependencies" => true,
@@ -172,6 +174,31 @@ RSpec.describe DownstreamDiscardDraftWorker do
       it "doesn't enqueue dependencies" do
         expect(DependencyResolutionWorker).to_not receive(:perform_async)
         subject.perform(arguments.merge("update_dependencies" => false))
+      end
+    end
+  end
+
+  describe "update expanded links" do
+    context "when there is not an edition" do
+      before do
+        FactoryGirl.create(:expanded_links, content_id: content_id, with_drafts: true)
+      end
+
+      it "deletes the expanded links" do
+        expect { subject.perform(arguments) }
+          .to change { ExpandedLinks.exists?(content_id: content_id, with_drafts: true) }
+          .from(true).to(false)
+      end
+    end
+
+    context "when there is an edition" do
+      let!(:live_edition) do
+        FactoryGirl.create(:live_edition, document: edition.document)
+      end
+      it "updates expanded links" do
+        expect { subject.perform(arguments) }
+          .to change { ExpandedLinks.exists?(content_id: content_id, with_drafts: true) }
+          .from(false).to(true)
       end
     end
   end

--- a/spec/workers/downstream_draft_worker_spec.rb
+++ b/spec/workers/downstream_draft_worker_spec.rb
@@ -4,10 +4,11 @@ RSpec.describe DownstreamDraftWorker do
   let(:edition) do
     FactoryGirl.create(:draft_edition, base_path: "/foo")
   end
+  let(:content_id) { edition.content_id }
 
   let(:base_arguments) do
     {
-      "content_id" => edition.document.content_id,
+      "content_id" => content_id,
       "locale" => "en",
       "payload_version" => 1,
       "update_dependencies" => true,
@@ -69,6 +70,17 @@ RSpec.describe DownstreamDraftWorker do
         expect(Adapters::DraftContentStore).to_not receive(:put_content_item)
         subject.perform(arguments.merge("content_id" => pathless.document.content_id))
       end
+    end
+  end
+
+  describe "updates expanded links" do
+    it "creates a ExpandedLinks with_drafts: true entry" do
+      expect { subject.perform(arguments) }
+        .to change { ExpandedLinks.exists?(content_id: content_id, with_drafts: true) }
+    end
+    it "creates a ExpandedLinks with_drafts: false entry" do
+      expect { subject.perform(arguments) }
+        .to change { ExpandedLinks.exists?(content_id: content_id, with_drafts: false) }
     end
   end
 

--- a/spec/workers/downstream_live_worker_spec.rb
+++ b/spec/workers/downstream_live_worker_spec.rb
@@ -5,9 +5,11 @@ RSpec.describe DownstreamLiveWorker do
     FactoryGirl.create(:live_edition, base_path: "/foo")
   end
 
+  let(:content_id) { edition.document.content_id }
+
   let(:base_arguments) do
     {
-      "content_id" => edition.document.content_id,
+      "content_id" => content_id,
       "locale" => "en",
       "payload_version" => 1,
       "message_queue_event_type" => "major",
@@ -92,6 +94,13 @@ RSpec.describe DownstreamLiveWorker do
       )
       expect(Adapters::ContentStore).to_not receive(:put_content_item)
       subject.perform(arguments.merge("content_id" => pathless.document.content_id))
+    end
+  end
+
+  describe "updates expanded links" do
+    it "creates a ExpandedLinks entry" do
+      expect { subject.perform(arguments) }
+        .to change { ExpandedLinks.exists?(content_id: content_id, with_drafts: false) }
     end
   end
 


### PR DESCRIPTION
Trello: https://trello.com/c/mOdpAGVj/961-improve-performance-of-the-expanded-link-set-endpoint-3

This stores expanded links to the database when content items are downstreamed. This is to allow for a much faster lookup of the expanded-links endpoint and avoid the need for a long cache to be on it.

It has the downside that the result of a /expanded-links call may return stale data as it is only updated when the content store is updated. However you can specify a generate=true query string which will generate the expanded-links with the controller, you just have to deal with it potentially taking a second or two.

## Breaking changes

This changes the output of the expanded-links endpoint.

Previously it returned data like so:
```
{
  "content_id": "some-content-id",
  "expanded_links": {},
  "version": 32
}
```
Now it returns data like so:
```
{
  "generated": "2017-07-28T08:52:44Z"
  "expanded_links": {}
}
```

`content_id` is no longer returned as it seemed superfluous (why not all the other parameters that query this request).
`version`, which was the LinkSet stale_lock_version value, is no longer returned as it didn't adequately reflect the version. There is both Document and LinkSet stale_lock_version numbers that reflect the expanded_links - and the expanded links could change without this number changing.

I've not been able to find any evidence that these values are used:
- [content_tagger](https://github.com/alphagov/content-tagger/blob/a658875f7a0ce66da048e462cf674ea9c8cef39b/app/services/legacy_taxonomy/client/publishing_api.rb#L22-L23)
- [govuk_taxonomy_helpers](https://github.com/alphagov/govuk_taxonomy_helpers/blob/947e2ec9d7a20fe31fd594926a91ce95a9a46a6d/lib/govuk_taxonomy_helpers/publishing_api_response.rb#L39-L41)
- [whitehall](https://github.com/alphagov/whitehall/blob/e9fece297555adc1576ffa27af382e830d390dd2/lib/taxonomy/publishing_api_adapter.rb#L42-L44)
- [rummager](https://github.com/alphagov/rummager/blob/cc0841de674d765cef247bae8cd861067e8e2d3d/lib/indexer/links_lookup.rb#L77)