### PR TITLE
Add Pact test for gds-api-adapter pagination

### DIFF
--- a/spec/service_consumers/pact_helper.rb
+++ b/spec/service_consumers/pact_helper.rb
@@ -450,4 +450,18 @@ Pact.provider_states_for "GDS API Adapters" do
       FactoryGirl.create(:live_edition, base_path: '/bar', document: document_2)
     end
   end
+
+  provider_state "there are 4 live content items with fixed updated timestamps" do
+    set_up do
+      document_1 = FactoryGirl.create(:document, content_id: 'bd50a6d9-f03d-4ccf-94aa-ad79579990a9')
+      document_2 = FactoryGirl.create(:document, content_id: '989033fe-252a-4e69-976d-5c0059bca949')
+      document_3 = FactoryGirl.create(:document, content_id: '271d4270-9186-4d60-b2ca-1d7dae7e0f73')
+      document_4 = FactoryGirl.create(:document, content_id: '638af19c-27fc-4cc9-a914-4cca49028688')
+
+      FactoryGirl.create(:live_edition, base_path: '/1', document: document_1, updated_at: '2017-01-01T00:00:00Z')
+      FactoryGirl.create(:live_edition, base_path: '/2', document: document_2, updated_at: '2017-02-01T00:00:00Z')
+      FactoryGirl.create(:live_edition, base_path: '/3', document: document_3, updated_at: '2017-03-01T00:00:00Z')
+      FactoryGirl.create(:live_edition, base_path: '/4', document: document_4, updated_at: '2017-04-01T00:00:00Z')
+    end
+  end
 end


### PR DESCRIPTION
This change adds a `provider_state` for the Pact tests for
`gds-api-adapters` to page through. For this to work, we need multiple
live editions with fixed `updated_at` times, so we have a predictable
`updated_at` time to set as the last viewed.

Corresponding `gds-api-adapters` Pull Request: https://github.com/alphagov/gds-api-adapters/pull/728