### PR TITLE
Encode request url correctly

### DIFF
--- a/app/presenters/keyset_pagination_presenter.rb
+++ b/app/presenters/keyset_pagination_presenter.rb
@@ -36,7 +36,7 @@ module Presenters
     end
 
     def self_link
-      { href: request_url, rel: "self" }
+      { href: self_url, rel: "self" }
     end
 
     def previous_link
@@ -51,12 +51,21 @@ module Presenters
       page_href(before: pagination_query.next_before_key.join(","))
     end
 
-    def page_href(params)
+    def self_url
+      page_href
+    end
+
+    def page_href(before: nil, after: nil)
+      except = (before || after) ? %w(before after) : []
+
       uri = URI.parse(request_url)
-      uri.query = Rack::Utils.build_query(
-        Rack::Utils.parse_query(uri.query)
-          .except("before", "after").merge(params)
-      )
+
+      new_params = Rack::Utils.parse_query(uri.query)
+        .except(*except).merge({ before: before, after: after }.compact)
+
+      new_query = Rack::Utils.build_query(new_params) unless new_params.empty?
+
+      uri.query = new_query
       uri.to_s
     end
   end

--- a/spec/controllers/v2/editions_controller_spec.rb
+++ b/spec/controllers/v2/editions_controller_spec.rb
@@ -159,6 +159,10 @@ RSpec.describe V2::EditionsController do
         get :index, params: { fields: %w(content_id publishing_app) }
         expect(parsed_response["results"].first.keys)
           .to eq(%w(content_id publishing_app))
+        expect(parsed_response["links"]).to eq([
+          { "href" => "http://test.host/v2/editions?fields%5B%5D=content_id&fields%5B%5D=publishing_app&after=2017-01-01T09%3A00%3A00.200000Z%2C100", "rel" => "next" },
+          { "href" => "http://test.host/v2/editions?fields%5B%5D=content_id&fields%5B%5D=publishing_app", "rel" => "self" },
+        ])
       end
     end
   end


### PR DESCRIPTION
This means that the query parameters are correctly encoded in the output rather than relying on the input to be. This is mainly a problem in the pact tests where the self URL would be formatted as `fields[]=` and the next/previous URLs would be formatted as `fields%5B%5D=`. 

We don't encounter this discrepancy in the offset/limit pagination endpoints as they use regular expressions to modify the `page=` parameter and leave all the others exactly as they came in.