### PR TITLE
Store edition diff on action

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,7 +28,7 @@ gem 'bunny', '~> 2.6'
 gem 'whenever', '0.9.4', require: false
 gem "govuk_sidekiq", "~> 1.0.3"
 gem "json-schema", require: false
-gem "hashdiff", require: false
+gem "hashdiff"
 gem "sidekiq-unique-jobs", "~> 5.0", require: false
 gem "govspeak", "~> 5.0.2"
 gem "diffy", "~> 3.1", require: false

--- a/app/commands/v2/put_content.rb
+++ b/app/commands/v2/put_content.rb
@@ -3,6 +3,9 @@ module Commands
     class PutContent < BaseCommand
       def call
         PutContentValidator.new(payload, self).validate
+
+        edition_diff.previous_item = previous_drafted_edition
+
         prepare_content_with_base_path
 
         edition = create_or_update_edition
@@ -35,6 +38,10 @@ module Commands
 
     private
 
+      def edition_diff
+        @edition_diff ||= HashDiffBuilder.new(Presenters::EditionDiffPresenter)
+      end
+
       def link_diff_between(old_links, new_links)
         old_links - new_links
       end
@@ -54,8 +61,10 @@ module Commands
         access_limit(edition)
         update_last_edited_at(edition, payload[:last_edited_at])
         ChangeNote.create_from_edition(payload, edition)
-        Action.create_put_content_action(edition, document.locale, event)
+        edition.reload
         create_links(edition)
+        edition_diff.current_item = edition
+        Action.create_put_content_action(edition, document.locale, event, edition_diff.diff)
       end
 
       def create_links(edition)

--- a/app/models/action.rb
+++ b/app/models/action.rb
@@ -1,4 +1,5 @@
 class Action < ActiveRecord::Base
+  serialize :edition_diff
   belongs_to :edition, optional: true
   belongs_to :link_set, optional: true
   belongs_to :event
@@ -6,8 +7,8 @@ class Action < ActiveRecord::Base
   validate :one_of_edition_link_set
   validates :action, presence: true
 
-  def self.create_put_content_action(edition, locale, event)
-    create_publishing_action("PutContent", edition, locale, event)
+  def self.create_put_content_action(updated_draft, locale, event, edition_diff)
+    create_publishing_action("PutContent", updated_draft, locale, event, edition_diff: edition_diff)
   end
 
   def self.create_publish_action(edition, locale, event)
@@ -23,7 +24,7 @@ class Action < ActiveRecord::Base
     create_publishing_action("DiscardDraft", edition, locale, event)
   end
 
-  def self.create_publishing_action(action, edition, locale, event)
+  def self.create_publishing_action(action, edition, locale, event, edition_diff: nil)
     create!(
       content_id: edition.document.content_id,
       locale: locale,
@@ -31,6 +32,7 @@ class Action < ActiveRecord::Base
       user_uid: event.user_uid,
       edition: edition,
       event: event,
+      edition_diff: edition_diff
     )
   end
 

--- a/app/presenters/edition_diff_presenter.rb
+++ b/app/presenters/edition_diff_presenter.rb
@@ -1,0 +1,23 @@
+module Presenters
+  class EditionDiffPresenter
+    def self.call(edition)
+      attributes = {}
+      return attributes unless edition.present?
+
+      Edition::TOP_LEVEL_FIELDS.each do |field|
+        attributes[field.to_s] = edition.public_send(field)
+      end
+
+      attributes["links"] = {}
+
+      edition.links.each do |link|
+        attributes["links"][link.link_type] ||= []
+        attributes["links"][link.link_type] << link.target_content_id
+      end
+
+      attributes["change_note"] = edition.change_note&.note || {}
+
+      attributes
+    end
+  end
+end

--- a/db/migrate/20170728101003_add_edition_diff_to_action.rb
+++ b/db/migrate/20170728101003_add_edition_diff_to_action.rb
@@ -1,0 +1,5 @@
+class AddEditionDiffToAction < ActiveRecord::Migration[5.1]
+  def change
+    add_column :actions, :edition_diff, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170726114449) do
+ActiveRecord::Schema.define(version: 20170728101003) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -34,6 +34,7 @@ ActiveRecord::Schema.define(version: 20170726114449) do
     t.integer "event_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.text "edition_diff"
     t.index ["edition_id"], name: "index_actions_on_edition_id"
     t.index ["event_id"], name: "index_actions_on_event_id"
     t.index ["link_set_id"], name: "index_actions_on_link_set_id"

--- a/lib/hash_diff_builder.rb
+++ b/lib/hash_diff_builder.rb
@@ -1,0 +1,29 @@
+class HashDiffBuilder
+  def initialize(presenter)
+    @presenter = presenter
+  end
+
+  def previous_item=(previous_item)
+    @previous_item = presenter ? presenter.call(previous_item) : previous_item
+  end
+
+  def current_item=(current_item)
+    @current_item = presenter ? presenter.call(current_item) : current_item
+  end
+
+  def diff
+    raise MissingItemError, "No previous item provided" if previous_item.nil?
+    raise MissingItemError, "No current item provided" if current_item.nil?
+    create_diff(previous_item, current_item)
+  end
+
+private
+
+  attr_reader :presenter, :previous_item, :current_item
+
+  def create_diff(previous_item, current_item)
+    HashDiff.diff(previous_item, current_item)
+  end
+
+  class MissingItemError < RuntimeError; end
+end

--- a/spec/lib/hash_diff_builder_spec.rb
+++ b/spec/lib/hash_diff_builder_spec.rb
@@ -1,0 +1,94 @@
+require "rails_helper"
+
+RSpec.describe HashDiffBuilder do
+  let(:content_id) { SecureRandom.uuid }
+  let(:organisation_links) do
+    [
+      OpenStruct.new(
+        target_content_id: content_id,
+        link_type: "organisations"
+      )
+    ]
+  end
+
+  let(:policy_areas_links) do
+    [
+      OpenStruct.new(
+        target_content_id: content_id,
+        link_type: "policy_areas"
+      )
+    ]
+  end
+
+  let(:previous_edition) do
+    double(:edition,
+      description: "A description",
+      title: "A title",
+      links: organisation_links
+    )
+  end
+
+  let(:updated_edition) do
+    double(:edition,
+      description: "A description",
+      title: "A new title",
+      links: policy_areas_links
+    )
+  end
+
+  let(:presented_previous_edition) do
+    {
+      "title" => "A title",
+      "links" => { "organisations" => [content_id] }
+    }
+  end
+
+  let(:presented_updated_edition) do
+    {
+      "title" => "A new title",
+      "links" => { "policy_areas" => [content_id] },
+    }
+  end
+
+  describe "#diff" do
+    let(:presenter) { double("presenter") }
+    let(:hash_diff) { described_class.new(presenter) }
+    subject { hash_diff.diff }
+
+    context "when a previous item and current item is provided" do
+      before do
+        allow(presenter).to receive(:call).with(previous_edition).and_return(presented_previous_edition)
+        allow(presenter).to receive(:call).with(updated_edition).and_return(presented_updated_edition)
+        hash_diff.previous_item = previous_edition
+        hash_diff.current_item = updated_edition
+      end
+
+      let(:previous_and_updated_diff) do
+        [
+          ["~", "title", "A title", "A new title"],
+          ["-", "links.organisations", [content_id]],
+          ["+", "links.policy_areas", [content_id]]
+        ]
+      end
+
+      it { is_expected.to match_array(previous_and_updated_diff) }
+    end
+
+    context "when no previous item is provided" do
+      it "raises a 'MissingItemError' error" do
+        expect { subject }.to raise_error(HashDiffBuilder::MissingItemError, "No previous item provided")
+      end
+    end
+
+    context "when no current item is provided" do
+      before do
+        allow(presenter).to receive(:call).with(previous_edition).and_return(presented_previous_edition)
+        hash_diff.previous_item = previous_edition
+      end
+
+      it "raises a 'MissingItemError' error" do
+        expect { subject }.to raise_error(HashDiffBuilder::MissingItemError, "No current item provided")
+      end
+    end
+  end
+end

--- a/spec/presenters/edition_diff_presenter_spec.rb
+++ b/spec/presenters/edition_diff_presenter_spec.rb
@@ -1,0 +1,53 @@
+require 'rails_helper'
+
+RSpec.describe Presenters::EditionDiffPresenter do
+  let(:content_id) { SecureRandom.uuid }
+  let(:edition) do
+    FactoryGirl.create(:edition,
+                        update_type: "major",
+                        links_hash: { "organisations" => [content_id] },
+                        change_note: "a note"
+                      )
+  end
+
+  let(:edition_without_links) do
+    FactoryGirl.create(:edition)
+  end
+
+  let(:edition_without_change_note) do
+    FactoryGirl.create(:edition,
+                        update_type: "minor",
+                        links_hash: { "organisations" => [content_id] }
+                      )
+  end
+
+  EXCLUDED_ATTRIBUTES = %w(updated_at created_at id publishing_request_id document_id).freeze
+
+  describe "#call" do
+    subject { described_class }
+
+    context "with links and change_note" do
+      it "returns an edition hash presented for diffing" do
+        expect(subject.call(edition)).to match a_hash_including(
+          edition.as_json.except(*EXCLUDED_ATTRIBUTES),
+          "links" => { "organisations" => [content_id] },
+          "change_note" => edition.change_note.note
+        )
+      end
+    end
+
+    context "without links" do
+      it "returns an edition hash presented for diffing" do
+        expect(subject.call(edition_without_links)).
+          to match a_hash_including("links" => {})
+      end
+    end
+
+    context "without change_note" do
+      it "returns an edition hash presented for diffing" do
+        expect(subject.call(edition_without_change_note)).
+          to match a_hash_including("change_note" => {})
+      end
+    end
+  end
+end


### PR DESCRIPTION
Before creating a PutContent Action we now create a diff between the previous
draft edition and the newly updated draft edition and store this on the new
Action.

https://trello.com/c/8gah2r5G/988-5-store-a-diff-of-an-edition-in-the-action-when-it-changes

I noticed that, when updating a change note for an updated draft edition, the updated draft still showed an old change note.  For now we used `edition.reload` in the PutContent command to overcome this, but we need to look at how change notes are created in the [ChangeNote model](https://github.com/alphagov/publishing-api/blob/master/app/models/change_note.rb) to find a better solution.