### PR TITLE
Easier to understand get content 404 message

### DIFF
--- a/app/queries/get_content.rb
+++ b/app/queries/get_content.rb
@@ -17,25 +17,18 @@ module Queries
       if response.present?
         response
       else
-        message = not_found_message(content_id, locale, version)
+        message = not_found_message(content_id, locale_to_use, version)
         raise_not_found(message)
       end
     end
 
     def self.raise_not_found(message)
-      error_details = {
-        error: {
-          code: 404,
-          message: message
-        }
-      }
-
-      raise CommandError.new(code: 404, error_details: error_details)
+      raise CommandError.new(code: 404, message: message)
     end
 
     def self.not_found_message(content_id, locale, version)
-      if (locale || version) && Document.exists?(content_id: content_id)
-        locale_message = locale ? "locale: #{locale}" : nil
+      if Document.exists?(content_id: content_id)
+        locale_message = "locale: #{locale}"
         version_message = version ? "version: #{version}" : nil
         reason = [locale_message, version_message].compact.join(" and ")
 


### PR DESCRIPTION
This provides a clearer 404 message when you try to access content by
just content_id but a different locale exists for it.

Only in cases where there is no document will you receive a message of
no document known for this content_id.