### PR TITLE
Add payload_version to message queue messages

### DIFF
--- a/app/downstream_payload.rb
+++ b/app/downstream_payload.rb
@@ -35,7 +35,7 @@ class DownstreamPayload
   end
 
   def message_queue_payload
-    message_queue_presenter.for_message_queue
+    message_queue_presenter.for_message_queue(payload_version)
   end
 
   def expanded_links

--- a/app/presenters/edition_presenter.rb
+++ b/app/presenters/edition_presenter.rb
@@ -26,10 +26,11 @@ module Presenters
       present.except(:update_type).merge(payload_version: payload_version)
     end
 
-    def for_message_queue
+    def for_message_queue(payload_version)
       present.merge(
         govuk_request_id: GdsApi::GovukHeaders.headers[:govuk_request_id],
-        links: unexpanded_links
+        links: unexpanded_links,
+        payload_version: payload_version
       )
     end
 

--- a/app/presenters/gone_presenter.rb
+++ b/app/presenters/gone_presenter.rb
@@ -19,9 +19,10 @@ class GonePresenter
     present.merge(payload_version: payload_version)
   end
 
-  def for_message_queue
+  def for_message_queue(payload_version)
     present.merge(
       govuk_request_id: GdsApi::GovukHeaders.headers[:govuk_request_id],
+      payload_version: payload_version
     )
   end
 

--- a/app/presenters/redirect_presenter.rb
+++ b/app/presenters/redirect_presenter.rb
@@ -19,9 +19,10 @@ class RedirectPresenter
     present.merge(payload_version: payload_version)
   end
 
-  def for_message_queue
+  def for_message_queue(payload_version)
     present.merge(
-      govuk_request_id: GdsApi::GovukHeaders.headers[:govuk_request_id]
+      govuk_request_id: GdsApi::GovukHeaders.headers[:govuk_request_id],
+      payload_version: payload_version
     )
   end
 

--- a/app/presenters/vanish_presenter.rb
+++ b/app/presenters/vanish_presenter.rb
@@ -17,9 +17,10 @@ class VanishPresenter
     present.merge(payload_version: payload_version)
   end
 
-  def for_message_queue
+  def for_message_queue(payload_version)
     present.merge(
       govuk_request_id: GdsApi::GovukHeaders.headers[:govuk_request_id],
+      payload_version: payload_version
     )
   end
 

--- a/lib/requeue_content.rb
+++ b/lib/requeue_content.rb
@@ -20,9 +20,11 @@ class RequeueContent
 private
 
   def publish_to_queue(edition)
+    version = Event.maximum(:id)
+
     queue_payload = Presenters::EditionPresenter.new(
       edition, draft: false,
-    ).for_message_queue
+    ).for_message_queue(version)
 
     # FIXME: Rummager currently only listens to the message queue for the
     # event type 'links'. This behaviour will eventually be updated so that

--- a/spec/presenters/edition_presenter_spec.rb
+++ b/spec/presenters/edition_presenter_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe Presenters::EditionPresenter do
     subject(:result) do
       described_class.new(
         edition, draft: present_drafts
-      ).for_message_queue
+      ).for_message_queue(payload_version)
     end
 
     it "presents the unexpanded links" do
@@ -58,6 +58,10 @@ RSpec.describe Presenters::EditionPresenter do
 
     it "adds the supertypes" do
       expect(subject["user_journey_document_supertype"]).to eq "thing"
+    end
+
+    it "includes the version" do
+      expect(subject[:payload_version]).to eq 1
     end
   end
 


### PR DESCRIPTION
This is the same field passed to content store.

This allows the search indexing consumer to end up in the right state when
publish/unpublish messages are processed out of order, because we can ignore
version numbers that older than our existing copy for a given content id.

This means for the requeue task, we'll have to query the events from the
database and pick the most recent one for each document. This could probably be
written more efficiently but I'm expecting the bottleneck to be on the consumer
side.

Trello: https://trello.com/c/kkRWlPKy/207-spike-ignore-messages-from-old-versions