### PR TITLE
Hash diff 0.3.5

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -125,7 +125,7 @@ GEM
       sidekiq (~> 4.2.8)
       sidekiq-logging-json (~> 0.0)
       sidekiq-statsd (~> 0.1)
-    hashdiff (0.3.0)
+    hashdiff (0.3.5)
     hashie (3.4.6)
     highline (1.7.8)
     htmlentities (4.3.4)
@@ -436,4 +436,4 @@ DEPENDENCIES
   with_advisory_lock (~> 3.1)
 
 BUNDLED WITH
-   1.14.5
+   1.15.1

--- a/app/presenters/edition_diff_presenter.rb
+++ b/app/presenters/edition_diff_presenter.rb
@@ -5,17 +5,18 @@ module Presenters
       return attributes unless edition.present?
 
       Edition::TOP_LEVEL_FIELDS.each do |field|
-        attributes[field.to_s] = edition.public_send(field)
+        attributes[field.to_sym] = edition.public_send(field)
       end
 
-      attributes["links"] = {}
+      attributes[:links] = {}
 
       edition.links.each do |link|
-        attributes["links"][link.link_type] ||= []
-        attributes["links"][link.link_type] << link.target_content_id
+        link_type = link.link_type.to_sym
+        attributes[:links][link_type] ||= []
+        attributes[:links][link_type] << link.target_content_id
       end
 
-      attributes["change_note"] = edition.change_note&.note || {}
+      attributes[:change_note] = edition.change_note&.note || {}
 
       attributes
     end

--- a/lib/hash_diff_builder.rb
+++ b/lib/hash_diff_builder.rb
@@ -22,7 +22,7 @@ private
   attr_reader :presenter, :previous_item, :current_item
 
   def create_diff(previous_item, current_item)
-    HashDiff.diff(previous_item, current_item)
+    HashDiff.diff(previous_item, current_item, array_path: true)
   end
 
   class MissingItemError < RuntimeError; end

--- a/spec/commands/v2/put_content_spec.rb
+++ b/spec/commands/v2/put_content_spec.rb
@@ -93,10 +93,10 @@ RSpec.describe Commands::V2::PutContent do
       )
 
       expect(Action.last.edition_diff).to include(
-        ["~", "title", "Some Title", "New Title"],
-        ["-", "links.organisations", [content_id]],
-        ["+", "links.policy_areas", [new_content_id]],
-        ["~", "change_note", change_note.to_s, new_change_note.to_s],
+        ["~", [:title], "Some Title", "New Title"],
+        ["-", [:links, :organisations], [content_id]],
+        ["+", [:links, :policy_areas], [new_content_id]],
+        ["~", [:change_note], change_note.to_s, new_change_note.to_s],
       )
     end
 

--- a/spec/lib/hash_diff_builder_spec.rb
+++ b/spec/lib/hash_diff_builder_spec.rb
@@ -38,15 +38,15 @@ RSpec.describe HashDiffBuilder do
 
   let(:presented_previous_edition) do
     {
-      "title" => "A title",
-      "links" => { "organisations" => [content_id] }
+      title: "A title",
+      links: { organisations: [content_id] }
     }
   end
 
   let(:presented_updated_edition) do
     {
-      "title" => "A new title",
-      "links" => { "policy_areas" => [content_id] },
+      title: "A new title",
+      links: { policy_areas: [content_id] },
     }
   end
 
@@ -65,9 +65,9 @@ RSpec.describe HashDiffBuilder do
 
       let(:previous_and_updated_diff) do
         [
-          ["~", "title", "A title", "A new title"],
-          ["-", "links.organisations", [content_id]],
-          ["+", "links.policy_areas", [content_id]]
+          ["~", [:title], "A title", "A new title"],
+          ["-", [:links, :organisations], [content_id]],
+          ["+", [:links, :policy_areas], [content_id]]
         ]
       end
 

--- a/spec/presenters/edition_diff_presenter_spec.rb
+++ b/spec/presenters/edition_diff_presenter_spec.rb
@@ -29,9 +29,9 @@ RSpec.describe Presenters::EditionDiffPresenter do
     context "with links and change_note" do
       it "returns an edition hash presented for diffing" do
         expect(subject.call(edition)).to match a_hash_including(
-          edition.as_json.except(*EXCLUDED_ATTRIBUTES),
-          "links" => { "organisations" => [content_id] },
-          "change_note" => edition.change_note.note
+          edition.as_json.except(*EXCLUDED_ATTRIBUTES).symbolize_keys,
+          links: { organisations: [content_id] },
+          change_note: edition.change_note.note
         )
       end
     end
@@ -39,14 +39,14 @@ RSpec.describe Presenters::EditionDiffPresenter do
     context "without links" do
       it "returns an edition hash presented for diffing" do
         expect(subject.call(edition_without_links)).
-          to match a_hash_including("links" => {})
+          to match a_hash_including(links: {})
       end
     end
 
     context "without change_note" do
       it "returns an edition hash presented for diffing" do
         expect(subject.call(edition_without_change_note)).
-          to match a_hash_including("change_note" => {})
+          to match a_hash_including(change_note: {})
       end
     end
   end


### PR DESCRIPTION
This upgrades to Hash Diff 0.3.5 which has the `array_path` option (which preserves the types of keys, making patching and unpatching more reliable).

This also changes the hashes used in the edition diffs to use symbol keys rather than strings.