### PR TITLE
Add deprecated version field for generated expanded links

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -506,6 +506,11 @@ this response can be slow though for large link sets.
 The response includes a field of `generated` and the timestamp of when the
 expanded link set was generated.
 
+If the links are generated at runtime (which happens if use `generate=true`)
+a version field will be returned which will be the `stale_lock_version` for
+the LinkSet of that content_id. This is a deprecated field and should not be
+used as it is not a reliable indicate of the version of the links.
+
 ### Path parameters
 
 - [`content_id`](model.md#content_id)

--- a/spec/requests/expanded_links_endpoint_spec.rb
+++ b/spec/requests/expanded_links_endpoint_spec.rb
@@ -143,6 +143,7 @@ RSpec.describe "GET /v2/expanded-links/:id", type: :request do
         expect(parsed_response).to match(
           "generated" => Time.now.utc.iso8601,
           "expanded_links" => expanded_links,
+          "version" => 0,
         )
       end
     end


### PR DESCRIPTION
My bad... I didn't find that content tagger uses version with expanded
links, so this has broken since this field was removed.

The field has brought back, but deprecated, as it does not represent a
distinct version of extended links.