### PR TITLE
Remove ChangeNotes association with Documents

### DIFF
--- a/db/migrate/20170810084422_remove_document_id_from_change_notes.rb
+++ b/db/migrate/20170810084422_remove_document_id_from_change_notes.rb
@@ -1,0 +1,6 @@
+class RemoveDocumentIdFromChangeNotes < ActiveRecord::Migration[5.1]
+  def up
+    remove_foreign_key :change_notes, :documents
+    remove_column :change_notes, :document_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170728101003) do
+ActiveRecord::Schema.define(version: 20170810084422) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -46,7 +46,6 @@ ActiveRecord::Schema.define(version: 20170728101003) do
     t.integer "edition_id"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.integer "document_id", null: false
     t.index ["edition_id"], name: "index_change_notes_on_edition_id"
   end
 
@@ -183,7 +182,6 @@ ActiveRecord::Schema.define(version: 20170728101003) do
     t.datetime "updated_at"
   end
 
-  add_foreign_key "change_notes", "documents", on_delete: :cascade
   add_foreign_key "change_notes", "editions"
   add_foreign_key "editions", "documents"
   add_foreign_key "links", "editions", on_delete: :cascade


### PR DESCRIPTION
https://trello.com/c/Ui6ln1cw/975-5-remove-association-between-change-notes-and-documents

Precursor to removing document association from change notes.

- If a ChangeNote has no edition associated with it
but there's a duplicate note on the document edition
sequence then delete this note.
- If a ChangeNote#note is "First published." and the
associated Document#editions have no "First published."
ChangeNote then assign this note to the first Edition in
the sequence.
- Failing to match any of the above, check the change_history
for the relevant document editions, cross reference the note
text and public_updated_at with the note text and public_timestamp
and associate the appropriate ChangeNote with the relevant Edition.
- Make another pass over ChangeNotes with edition:nil, if the number
of ChangeNotes for the given document matches the number of editions
for the same document then delete this note, it can't be reassigned.
- Lookup all ChangeNotes with a timestamp older than the earliest
edition for the same document, we only care about editions with no
change notes. Delete the older notes as they can't be associated
with an Edition.
- There's one ChangeNote left after this, so associated manually.

There are currently 1274 ChangeNotes with no edition associated
with them.