### PR TITLE
Remove edition_diff from Action

### DIFF
--- a/db/migrate/20170810090002_remove_edition_diff_from_action.rb
+++ b/db/migrate/20170810090002_remove_edition_diff_from_action.rb
@@ -1,0 +1,5 @@
+class RemoveEditionDiffFromAction < ActiveRecord::Migration[5.1]
+  def change
+    remove_column :actions, :edition_diff, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170728101003) do
+ActiveRecord::Schema.define(version: 20170810090002) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -34,7 +34,6 @@ ActiveRecord::Schema.define(version: 20170728101003) do
     t.integer "event_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.text "edition_diff"
     t.index ["edition_id"], name: "index_actions_on_edition_id"
     t.index ["event_id"], name: "index_actions_on_event_id"
     t.index ["link_set_id"], name: "index_actions_on_link_set_id"


### PR DESCRIPTION
We need to temporarily remove `edition_diff` from Action.

https://trello.com/c/MnNWuuIj/1016-revert-the-diff-work-temporarily