### PR TITLE
Remove documents from change_notes

### DIFF
--- a/app/models/change_note.rb
+++ b/app/models/change_note.rb
@@ -1,5 +1,4 @@
 class ChangeNote < ActiveRecord::Base
-  belongs_to :document
   belongs_to :edition, optional: true
 
   def self.create_from_edition(payload, edition)
@@ -54,7 +53,7 @@ private
   end
 
   def change_note_instance
-    edition.change_note || edition.create_change_note!(document: document)
+    edition.change_note || edition.create_change_note!
   end
 
   def change_note
@@ -67,9 +66,5 @@ private
 
   def change_history
     edition.details[:change_history]
-  end
-
-  def document
-    edition.document
   end
 end

--- a/app/presenters/change_history_presenter.rb
+++ b/app/presenters/change_history_presenter.rb
@@ -27,16 +27,10 @@ module Presenters
 
     def change_notes
       ChangeNote
-        .where(document: document)
-        .where("edition_id IS NULL OR edition_id IN (?)", edition_ids)
-        .order(:public_timestamp)
-    end
-
-    def edition_ids
-      Edition
-        .where(document: document)
+        .joins(:edition)
+        .where(editions: { document: document })
         .where("user_facing_version <= ?", version_number)
-        .pluck(:id)
+        .order(:public_timestamp)
     end
 
     def version_number

--- a/db/migrate/20170810084422_remove_document_id_from_change_notes.rb
+++ b/db/migrate/20170810084422_remove_document_id_from_change_notes.rb
@@ -1,0 +1,6 @@
+class RemoveDocumentIdFromChangeNotes < ActiveRecord::Migration[5.1]
+  def up
+    remove_foreign_key :change_notes, :documents
+    remove_column :change_notes, :document_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -45,7 +45,6 @@ ActiveRecord::Schema.define(version: 20170810090002) do
     t.integer "edition_id"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.integer "document_id", null: false
     t.index ["edition_id"], name: "index_change_notes_on_edition_id"
   end
 
@@ -182,7 +181,6 @@ ActiveRecord::Schema.define(version: 20170810090002) do
     t.datetime "updated_at"
   end
 
-  add_foreign_key "change_notes", "documents", on_delete: :cascade
   add_foreign_key "change_notes", "editions"
   add_foreign_key "editions", "documents"
   add_foreign_key "links", "editions", on_delete: :cascade

--- a/spec/commands/v2/publish_spec.rb
+++ b/spec/commands/v2/publish_spec.rb
@@ -341,7 +341,7 @@ RSpec.describe Commands::V2::Publish do
         before do
           draft_item.update(update_type: "major")
           payload[:update_type] = "minor"
-          ChangeNote.create!(document: draft_item.document, edition: draft_item)
+          ChangeNote.create!(edition: draft_item)
         end
         it "deletes associated ChangeNote records" do
           expect { described_class.call(payload) }

--- a/spec/factories/edition.rb
+++ b/spec/factories/edition.rb
@@ -41,7 +41,6 @@ FactoryGirl.define do
           :change_note,
           note: evaluator.change_note,
           edition: item,
-          document: item.document,
         )
       end
 

--- a/spec/presenters/change_history_presenter_spec.rb
+++ b/spec/presenters/change_history_presenter_spec.rb
@@ -29,7 +29,6 @@ RSpec.describe Presenters::ChangeHistoryPresenter do
         2.times do |i|
           ChangeNote.create(
             edition: edition,
-            document: document,
             note: i.to_s,
             public_timestamp: Time.now.utc
           )
@@ -44,7 +43,6 @@ RSpec.describe Presenters::ChangeHistoryPresenter do
       [1, 3, 2].to_a.each do |i|
         ChangeNote.create(
           edition: edition,
-          document: document,
           note: i.to_s,
           public_timestamp: i.days.ago
         )
@@ -68,20 +66,19 @@ RSpec.describe Presenters::ChangeHistoryPresenter do
         )
       end
       before do
-        ChangeNote.create(edition: item1, document: document)
-        ChangeNote.create(edition: item2, document: document)
-        ChangeNote.create(document: document)
+        ChangeNote.create(edition: item1)
+        ChangeNote.create(edition: item2)
       end
 
       context "reviewing latest version of a edition" do
         it "constructs content history from all change notes for content id" do
-          expect(described_class.new(item2).change_history.count).to eq 3
+          expect(described_class.new(item2).change_history.count).to eq 2
         end
       end
 
       context "reviewing older version of a edition" do
         it "doesn't include change notes corresponding to newer versions" do
-          expect(described_class.new(item1).change_history.count).to eq 2
+          expect(described_class.new(item1).change_history.count).to eq 1
         end
       end
     end

--- a/spec/presenters/edition_presenter_spec.rb
+++ b/spec/presenters/edition_presenter_spec.rb
@@ -223,7 +223,7 @@ RSpec.describe Presenters::EditionPresenter do
           details: details.slice(:body))
       end
       before do
-        ChangeNote.create(change_history.merge(edition: edition, document: edition.document))
+        ChangeNote.create(change_history.merge(edition: edition))
       end
 
       it "constructs the change history" do


### PR DESCRIPTION
https://trello.com/c/Ui6ln1cw/975-5-remove-association-between-change-notes-and-documents

Removes `document_id` column and fk from `change_notes`

Depends on https://github.com/alphagov/publishing-api/pull/994