### PR TITLE
Add task to fix invalid documents

### DIFF
--- a/lib/tasks/fix_invalid_document.rake
+++ b/lib/tasks/fix_invalid_document.rake
@@ -1,0 +1,18 @@
+require_relative "../../db/migrate/helpers/delete_content"
+
+namespace :tmp do
+  task fix_invalid_document: :environment do
+    document_created_by_whitehall_bug_content_id = "a8364f44-3f21-43e5-8351-d150fb177649"
+    Helpers::DeleteContent.destroy_documents_with_links([document_created_by_whitehall_bug_content_id])
+
+    #this edition has an en base_path but a cy locale
+    edition_with_incorrect_base_path = Edition.find(267679)
+    edition_with_incorrect_base_path.base_path = "/government/organisations/land-registry/about/recruitment.cy"
+
+    route = edition_with_incorrect_base_path.routes.first
+    route[:path] = edition_with_incorrect_base_path.base_path
+    edition_with_incorrect_base_path.routes = [route]
+
+    edition_with_incorrect_base_path.save!
+  end
+end


### PR DESCRIPTION
This commit adds a temporary rake task that fixes an invalid document introduced by a Whitehall bug.

There are documents with `content_id: "5fe3cc51-7631-11e4-a3cb-005056011aef"`. There is an `:en` version and a `:cy` version. Due to the Whitehall issue the last edition on the `:cy`
version has an incorrect `base_path` (no `.cy`).

The issue has caused another document to be created `content_id: "a8364f44-3f21-43e5-8351-d150fb177649"`. The presence of this document is preventing Whitehall from updating the correct one.

The task deletes the erroneously created document then updates the `base_path` of the most recent edition of the otherwise valid document to correctly reflect its locale.

Once this has been run the document will be republished from Whitehall.

[Trello](https://trello.com/c/gImtx9x6/101-land-registry-corporate-information-page-only-displaying-in-welsh)

NB I've already fixed this manually in integration. Staging/Production are still in the incorrect state.