### PR TITLE
Fix migrations to run against an empty DB in CI

### DIFF
--- a/db/migrate/20150908145609_create_events.rb
+++ b/db/migrate/20150908145609_create_events.rb
@@ -1,4 +1,4 @@
-class CreateEvents < ActiveRecord::Migration
+class CreateEvents < ActiveRecord::Migration[4.2]
   def change
     create_table :events do |t|
       t.string   "action", null: false

--- a/db/migrate/20150922125847_add_derived_representations.rb
+++ b/db/migrate/20150922125847_add_derived_representations.rb
@@ -1,4 +1,4 @@
-class AddDerivedRepresentations < ActiveRecord::Migration
+class AddDerivedRepresentations < ActiveRecord::Migration[4.2]
   def change
     create_table :draft_content_items do |t|
       t.string :content_id

--- a/db/migrate/20151012094145_set_empty_default_for_json_fields.rb
+++ b/db/migrate/20151012094145_set_empty_default_for_json_fields.rb
@@ -1,4 +1,4 @@
-class SetEmptyDefaultForJsonFields < ActiveRecord::Migration
+class SetEmptyDefaultForJsonFields < ActiveRecord::Migration[4.2]
   def change
     change_column_default(:events, :payload, {})
 

--- a/db/migrate/20151012095129_set_default_version_to_zero.rb
+++ b/db/migrate/20151012095129_set_default_version_to_zero.rb
@@ -1,4 +1,4 @@
-class SetDefaultVersionToZero < ActiveRecord::Migration
+class SetDefaultVersionToZero < ActiveRecord::Migration[4.2]
   def change
     change_column_default(:draft_content_items, :version, 0)
     change_column_default(:live_content_items, :version, 0)

--- a/db/migrate/20151014133602_add_draft_content_item_id_to_live_content_item.rb
+++ b/db/migrate/20151014133602_add_draft_content_item_id_to_live_content_item.rb
@@ -1,4 +1,4 @@
-class AddDraftContentItemIdToLiveContentItem < ActiveRecord::Migration
+class AddDraftContentItemIdToLiveContentItem < ActiveRecord::Migration[4.2]
   class DraftContentItem < ActiveRecord::Base
   end
 

--- a/db/migrate/20151015102423_create_path_reservations.rb
+++ b/db/migrate/20151015102423_create_path_reservations.rb
@@ -1,4 +1,4 @@
-class CreatePathReservations < ActiveRecord::Migration
+class CreatePathReservations < ActiveRecord::Migration[4.2]
   def change
     create_table :path_reservations do |t|
       t.string :base_path, :null => false

--- a/db/migrate/20151016145941_add_foreign_key_to_link_content_items.rb
+++ b/db/migrate/20151016145941_add_foreign_key_to_link_content_items.rb
@@ -1,4 +1,4 @@
-class AddForeignKeyToLinkContentItems < ActiveRecord::Migration
+class AddForeignKeyToLinkContentItems < ActiveRecord::Migration[4.2]
   def change
     add_foreign_key :live_content_items, :draft_content_items
   end

--- a/db/migrate/20151021091248_create_versions.rb
+++ b/db/migrate/20151021091248_create_versions.rb
@@ -1,4 +1,4 @@
-class CreateVersions < ActiveRecord::Migration
+class CreateVersions < ActiveRecord::Migration[4.2]
   def change
     create_table :versions do |t|
       t.integer :target_id, null: false

--- a/db/migrate/20151026112807_make_base_path_unique.rb
+++ b/db/migrate/20151026112807_make_base_path_unique.rb
@@ -1,4 +1,4 @@
-class MakeBasePathUnique < ActiveRecord::Migration
+class MakeBasePathUnique < ActiveRecord::Migration[4.2]
   def change
     add_index :draft_content_items, :base_path, unique: true
     add_index :live_content_items, :base_path, unique: true

--- a/db/migrate/20151029102155_set_default_locale_to_en.rb
+++ b/db/migrate/20151029102155_set_default_locale_to_en.rb
@@ -1,4 +1,4 @@
-class SetDefaultLocaleToEn < ActiveRecord::Migration
+class SetDefaultLocaleToEn < ActiveRecord::Migration[4.2]
   def change
     change_column_default :draft_content_items, :locale, "en"
     change_column_default :live_content_items, :locale, "en"

--- a/db/migrate/20151029110606_move_metadata_fields_to_top_level.rb
+++ b/db/migrate/20151029110606_move_metadata_fields_to_top_level.rb
@@ -1,4 +1,4 @@
-class MoveMetadataFieldsToTopLevel < ActiveRecord::Migration
+class MoveMetadataFieldsToTopLevel < ActiveRecord::Migration[4.2]
   class DraftContentItem < ActiveRecord::Base
   end
 

--- a/db/migrate/20151029144554_fix_null_links_hashes.rb
+++ b/db/migrate/20151029144554_fix_null_links_hashes.rb
@@ -1,4 +1,4 @@
-class FixNullLinksHashes < ActiveRecord::Migration
+class FixNullLinksHashes < ActiveRecord::Migration[4.2]
   def change
     change_column_null :link_sets, :links, false, {}
   end

--- a/db/migrate/20151105154432_remove_metadata_field.rb
+++ b/db/migrate/20151105154432_remove_metadata_field.rb
@@ -1,4 +1,4 @@
-class RemoveMetadataField < ActiveRecord::Migration
+class RemoveMetadataField < ActiveRecord::Migration[4.2]
   def change
     remove_column :live_content_items, :metadata
     remove_column :draft_content_items, :metadata

--- a/db/migrate/20151105154759_remove_version_fields.rb
+++ b/db/migrate/20151105154759_remove_version_fields.rb
@@ -1,4 +1,4 @@
-class RemoveVersionFields < ActiveRecord::Migration
+class RemoveVersionFields < ActiveRecord::Migration[4.2]
   def change
     remove_column :draft_content_items, :version
     remove_column :live_content_items, :version

--- a/db/migrate/20151119100750_change_description_column_types.rb
+++ b/db/migrate/20151119100750_change_description_column_types.rb
@@ -1,4 +1,4 @@
-class ChangeDescriptionColumnTypes < ActiveRecord::Migration
+class ChangeDescriptionColumnTypes < ActiveRecord::Migration[4.2]
   class DraftContentItem < ActiveRecord::Base
   end
 

--- a/db/migrate/20151124113325_allow_null_draft_content_id.rb
+++ b/db/migrate/20151124113325_allow_null_draft_content_id.rb
@@ -1,4 +1,4 @@
-class AllowNullDraftContentId < ActiveRecord::Migration
+class AllowNullDraftContentId < ActiveRecord::Migration[4.2]
   def change
     remove_foreign_key :live_content_items, :draft_content_items
     change_column_null :live_content_items, :draft_content_item_id, true

--- a/db/migrate/20151126102119_add_links_table.rb
+++ b/db/migrate/20151126102119_add_links_table.rb
@@ -1,4 +1,4 @@
-class AddLinksTable < ActiveRecord::Migration
+class AddLinksTable < ActiveRecord::Migration[4.2]
   def change
     create_table :links do |t|
       t.references :link_set, index: true, foreign_key: true

--- a/db/migrate/20151126135748_retire_links_column.rb
+++ b/db/migrate/20151126135748_retire_links_column.rb
@@ -1,4 +1,4 @@
-class RetireLinksColumn < ActiveRecord::Migration
+class RetireLinksColumn < ActiveRecord::Migration[4.2]
   def change
     rename_column :link_sets, :links, :legacy_links
   end

--- a/db/migrate/20151215102213_create_users.rb
+++ b/db/migrate/20151215102213_create_users.rb
@@ -1,4 +1,4 @@
-class CreateUsers < ActiveRecord::Migration
+class CreateUsers < ActiveRecord::Migration[4.2]
   def change
     create_table :users do |t|
       t.string   :name

--- a/db/migrate/20151231125222_extract_access_limiting.rb
+++ b/db/migrate/20151231125222_extract_access_limiting.rb
@@ -1,4 +1,4 @@
-class ExtractAccessLimiting < ActiveRecord::Migration
+class ExtractAccessLimiting < ActiveRecord::Migration[4.2]
   class DraftContentItem < ActiveRecord::Base
   end
 

--- a/db/migrate/20160101090938_add_timestamps_to_link_set.rb
+++ b/db/migrate/20160101090938_add_timestamps_to_link_set.rb
@@ -1,4 +1,4 @@
-class AddTimestampsToLinkSet < ActiveRecord::Migration
+class AddTimestampsToLinkSet < ActiveRecord::Migration[4.2]
   def up
     add_timestamps :link_sets
   end

--- a/db/migrate/20160101090939_new_object_model.rb
+++ b/db/migrate/20160101090939_new_object_model.rb
@@ -1,4 +1,4 @@
-class NewObjectModel < ActiveRecord::Migration
+class NewObjectModel < ActiveRecord::Migration[4.2]
   class DraftContentItem < ActiveRecord::Base; end
   class LiveContentItem < ActiveRecord::Base; end
   class ContentItem < ActiveRecord::Base; end

--- a/db/migrate/20160111093455_fix_nil_descriptions.rb
+++ b/db/migrate/20160111093455_fix_nil_descriptions.rb
@@ -1,5 +1,5 @@
 # https://trello.com/c/DHVC2pH1/488-bug-investigate-why-description-encapsulation-has-been-bypassed
-class FixNilDescriptions < ActiveRecord::Migration
+class FixNilDescriptions < ActiveRecord::Migration[4.2]
   class DraftContentItem < ActiveRecord::Base; end
   class LiveContentItem < ActiveRecord::Base; end
 

--- a/db/migrate/20160111103706_remove_access_limited_column.rb
+++ b/db/migrate/20160111103706_remove_access_limited_column.rb
@@ -1,4 +1,4 @@
-class RemoveAccessLimitedColumn < ActiveRecord::Migration
+class RemoveAccessLimitedColumn < ActiveRecord::Migration[4.2]
   def change
     remove_column :draft_content_items, :access_limited, :json, default: {}
   end

--- a/db/migrate/20160115162121_add_indexes_for_content_collection_access.rb
+++ b/db/migrate/20160115162121_add_indexes_for_content_collection_access.rb
@@ -1,4 +1,4 @@
-class AddIndexesForContentCollectionAccess < ActiveRecord::Migration
+class AddIndexesForContentCollectionAccess < ActiveRecord::Migration[4.2]
   def change
     add_index :draft_content_items, :format
     add_index :live_content_items, :format

--- a/db/migrate/20160125143518_add_passthrough_field_to_link.rb
+++ b/db/migrate/20160125143518_add_passthrough_field_to_link.rb
@@ -1,4 +1,4 @@
-class AddPassthroughFieldToLink < ActiveRecord::Migration
+class AddPassthroughFieldToLink < ActiveRecord::Migration[4.2]
   def change
     add_column :links, :passthrough_hash, :json
     change_column_null :links, :target_content_id, true

--- a/db/migrate/20160203142246_rename_put_links_to_patch_links.rb
+++ b/db/migrate/20160203142246_rename_put_links_to_patch_links.rb
@@ -1,4 +1,4 @@
-class RenamePutLinksToPatchLinks < ActiveRecord::Migration
+class RenamePutLinksToPatchLinks < ActiveRecord::Migration[4.2]
   class Event < ActiveRecord::Base
   end
 

--- a/db/migrate/20160209143547_add_document_type_and_schema_name_to_content_items.rb
+++ b/db/migrate/20160209143547_add_document_type_and_schema_name_to_content_items.rb
@@ -1,4 +1,4 @@
-class AddDocumentTypeAndSchemaNameToContentItems < ActiveRecord::Migration
+class AddDocumentTypeAndSchemaNameToContentItems < ActiveRecord::Migration[4.2]
   def change
     add_column :content_items, :document_type, :string
     add_column :content_items, :schema_name, :string

--- a/db/migrate/20160224104428_add_indexes_to_improve_performance.rb
+++ b/db/migrate/20160224104428_add_indexes_to_improve_performance.rb
@@ -1,4 +1,4 @@
-class AddIndexesToImprovePerformance < ActiveRecord::Migration
+class AddIndexesToImprovePerformance < ActiveRecord::Migration[4.2]
   def change
     add_index :content_items, :content_id
     add_index :content_items, :format

--- a/db/migrate/20160225113309_create_content_store_payload_versions.rb
+++ b/db/migrate/20160225113309_create_content_store_payload_versions.rb
@@ -1,4 +1,4 @@
-class CreateContentStorePayloadVersions < ActiveRecord::Migration
+class CreateContentStorePayloadVersions < ActiveRecord::Migration[4.2]
   def change
     create_table :content_store_payload_versions do |t|
       t.integer :content_item_id

--- a/db/migrate/20160303101053_drop_content_store_payload_versions.rb
+++ b/db/migrate/20160303101053_drop_content_store_payload_versions.rb
@@ -1,4 +1,4 @@
-class DropContentStorePayloadVersions < ActiveRecord::Migration
+class DropContentStorePayloadVersions < ActiveRecord::Migration[4.2]
   def change
     drop_table :content_store_payload_versions
   end

--- a/db/migrate/20160307112043_index_content_items_public_updated_at.rb
+++ b/db/migrate/20160307112043_index_content_items_public_updated_at.rb
@@ -1,4 +1,4 @@
-class IndexContentItemsPublicUpdatedAt < ActiveRecord::Migration
+class IndexContentItemsPublicUpdatedAt < ActiveRecord::Migration[4.2]
   def change
     add_index :content_items, :public_updated_at
   end

--- a/db/migrate/20160309155913_drop_old_tables.rb
+++ b/db/migrate/20160309155913_drop_old_tables.rb
@@ -1,4 +1,4 @@
-class DropOldTables < ActiveRecord::Migration
+class DropOldTables < ActiveRecord::Migration[4.2]
   def change
     drop_table :draft_content_items
     drop_table :live_content_items

--- a/db/migrate/20160315070023_add_content_items_index_on_document_type.rb
+++ b/db/migrate/20160315070023_add_content_items_index_on_document_type.rb
@@ -1,4 +1,4 @@
-class AddContentItemsIndexOnDocumentType < ActiveRecord::Migration
+class AddContentItemsIndexOnDocumentType < ActiveRecord::Migration[4.2]
   def change
     add_index :content_items, :document_type
   end

--- a/db/migrate/20160315123002_add_index_to_links_target.rb
+++ b/db/migrate/20160315123002_add_index_to_links_target.rb
@@ -1,4 +1,4 @@
-class AddIndexToLinksTarget < ActiveRecord::Migration
+class AddIndexToLinksTarget < ActiveRecord::Migration[4.2]
   def change
     add_index :links, :target_content_id
     add_index :links, [:target_content_id, :link_type]

--- a/db/migrate/20160418144039_add_request_id_to_events.rb
+++ b/db/migrate/20160418144039_add_request_id_to_events.rb
@@ -1,4 +1,4 @@
-class AddRequestIdToEvents < ActiveRecord::Migration
+class AddRequestIdToEvents < ActiveRecord::Migration[4.2]
   def change
     add_column :events, :request_id, :string
   end

--- a/db/migrate/20160420093816_add_content_id_to_event.rb
+++ b/db/migrate/20160420093816_add_content_id_to_event.rb
@@ -1,4 +1,4 @@
-class AddContentIdToEvent < ActiveRecord::Migration
+class AddContentIdToEvent < ActiveRecord::Migration[4.2]
   def up
     add_column :events, :content_id, :string
 

--- a/db/migrate/20160429095656_change_withdrawn_to_unpublished.rb
+++ b/db/migrate/20160429095656_change_withdrawn_to_unpublished.rb
@@ -1,4 +1,4 @@
-class ChangeWithdrawnToUnpublished < ActiveRecord::Migration
+class ChangeWithdrawnToUnpublished < ActiveRecord::Migration[4.2]
   def up
     create_table :unpublishings do |t|
       t.references :content_item, null: false

--- a/db/migrate/20160429123756_add_first_published_at.rb
+++ b/db/migrate/20160429123756_add_first_published_at.rb
@@ -1,4 +1,4 @@
-class AddFirstPublishedAt < ActiveRecord::Migration
+class AddFirstPublishedAt < ActiveRecord::Migration[4.2]
   def change
     add_column :content_items, :first_published_at, :datetime
   end

--- a/db/migrate/20160505133601_rename_alternative_url.rb
+++ b/db/migrate/20160505133601_rename_alternative_url.rb
@@ -1,4 +1,4 @@
-class RenameAlternativeUrl < ActiveRecord::Migration
+class RenameAlternativeUrl < ActiveRecord::Migration[4.2]
   def change
     rename_column :unpublishings, :alternative_url, :alternative_path
   end

--- a/db/migrate/20160512122441_index_content_items_on_updated_at.rb
+++ b/db/migrate/20160512122441_index_content_items_on_updated_at.rb
@@ -1,4 +1,4 @@
-class IndexContentItemsOnUpdatedAt < ActiveRecord::Migration
+class IndexContentItemsOnUpdatedAt < ActiveRecord::Migration[4.2]
   def change
     add_index :content_items, :updated_at
   end

--- a/db/migrate/20160513163056_deduplicate_links.rb
+++ b/db/migrate/20160513163056_deduplicate_links.rb
@@ -1,4 +1,4 @@
-class DeduplicateLinks < ActiveRecord::Migration
+class DeduplicateLinks < ActiveRecord::Migration[4.2]
   def up
     res = Link.connection.execute(<<-SQL
       SELECT SUM(cnt), COUNT(cnt)

--- a/db/migrate/20160516135536_remove_column_legacy_links_from_link_set.rb
+++ b/db/migrate/20160516135536_remove_column_legacy_links_from_link_set.rb
@@ -1,4 +1,4 @@
-class RemoveColumnLegacyLinksFromLinkSet < ActiveRecord::Migration
+class RemoveColumnLegacyLinksFromLinkSet < ActiveRecord::Migration[4.2]
   def change
     remove_column :link_sets, :legacy_links, :json
   end

--- a/db/migrate/20160517134907_create_linkables.rb
+++ b/db/migrate/20160517134907_create_linkables.rb
@@ -1,4 +1,4 @@
-class CreateLinkables < ActiveRecord::Migration
+class CreateLinkables < ActiveRecord::Migration[4.2]
   def change
     create_table :linkables do |t|
       t.references :content_item, null: false

--- a/db/migrate/20160524210649_create_index_on_linkables_base_path.rb
+++ b/db/migrate/20160524210649_create_index_on_linkables_base_path.rb
@@ -1,4 +1,4 @@
-class CreateIndexOnLinkablesBasePath < ActiveRecord::Migration
+class CreateIndexOnLinkablesBasePath < ActiveRecord::Migration[4.2]
   def change
     add_index :linkables, :base_path
   end

--- a/db/migrate/20160607153243_remove_format_from_content_item.rb
+++ b/db/migrate/20160607153243_remove_format_from_content_item.rb
@@ -1,4 +1,4 @@
-class RemoveFormatFromContentItem < ActiveRecord::Migration
+class RemoveFormatFromContentItem < ActiveRecord::Migration[4.2]
   def change
     remove_column :content_items, :format, :string
   end

--- a/db/migrate/20160614144815_add_last_edited_at_to_content_item.rb
+++ b/db/migrate/20160614144815_add_last_edited_at_to_content_item.rb
@@ -1,4 +1,4 @@
-class AddLastEditedAtToContentItem < ActiveRecord::Migration
+class AddLastEditedAtToContentItem < ActiveRecord::Migration[4.2]
   def change
     add_column :content_items, :last_edited_at, :datetime
     add_index :content_items, :last_edited_at

--- a/db/migrate/20160715153009_add_content_item_indexes.rb
+++ b/db/migrate/20160715153009_add_content_item_indexes.rb
@@ -1,4 +1,4 @@
-class AddContentItemIndexes < ActiveRecord::Migration
+class AddContentItemIndexes < ActiveRecord::Migration[4.2]
   def change
     add_index :access_limits, :content_item_id
     add_index :linkables, :content_item_id

--- a/db/migrate/20160729091936_rename_alpha_taxon_link_type.rb
+++ b/db/migrate/20160729091936_rename_alpha_taxon_link_type.rb
@@ -1,4 +1,4 @@
-class RenameAlphaTaxonLinkType < ActiveRecord::Migration
+class RenameAlphaTaxonLinkType < ActiveRecord::Migration[4.2]
   def up
     alpha_taxon_links = Link.where(link_type: "alpha_taxons")
     link_sets = LinkSet.where(id: alpha_taxon_links.pluck(:link_set_id).uniq)

--- a/db/migrate/20160816141116_remove_path_reservation_for_find_local_council.rb
+++ b/db/migrate/20160816141116_remove_path_reservation_for_find_local_council.rb
@@ -1,4 +1,4 @@
-class RemovePathReservationForFindLocalCouncil < ActiveRecord::Migration
+class RemovePathReservationForFindLocalCouncil < ActiveRecord::Migration[4.2]
   def change
     # Actually fully delete this path reservation.
     # It was created to reserve a path for an artefact that was created in

--- a/db/migrate/20160912141753_drop_passthrough_hash_from_links.rb
+++ b/db/migrate/20160912141753_drop_passthrough_hash_from_links.rb
@@ -1,4 +1,4 @@
-class DropPassthroughHashFromLinks < ActiveRecord::Migration
+class DropPassthroughHashFromLinks < ActiveRecord::Migration[4.2]
   def change
     Link.where("passthrough_hash IS NOT NULL").each do |link|
       link.update_attributes!(target_content_id: link.passthrough_hash[:content_id])

--- a/db/migrate/20161003145646_add_position_to_links.rb
+++ b/db/migrate/20161003145646_add_position_to_links.rb
@@ -1,4 +1,4 @@
-class AddPositionToLinks < ActiveRecord::Migration
+class AddPositionToLinks < ActiveRecord::Migration[4.2]
   def change
     add_column :links, :position, :integer
   end

--- a/db/migrate/20161006115515_add_position_to_existing_links.rb
+++ b/db/migrate/20161006115515_add_position_to_existing_links.rb
@@ -1,4 +1,4 @@
-class AddPositionToExistingLinks < ActiveRecord::Migration
+class AddPositionToExistingLinks < ActiveRecord::Migration[4.2]
   def change
     Link.where(position: nil).update_all(position: 0)
   end

--- a/db/migrate/20161006115850_make_position_required.rb
+++ b/db/migrate/20161006115850_make_position_required.rb
@@ -1,4 +1,4 @@
-class MakePositionRequired < ActiveRecord::Migration
+class MakePositionRequired < ActiveRecord::Migration[4.2]
   def change
     change_column :links, :position, :integer, null: false, default: 0
   end

--- a/db/migrate/20161007080213_create_change_notes.rb
+++ b/db/migrate/20161007080213_create_change_notes.rb
@@ -1,4 +1,4 @@
-class CreateChangeNotes < ActiveRecord::Migration
+class CreateChangeNotes < ActiveRecord::Migration[4.2]
   def change
     create_table :change_notes do |t|
       t.string :note, default: ""

--- a/db/migrate/20170111161439_delete_document_collection_links.rb
+++ b/db/migrate/20170111161439_delete_document_collection_links.rb
@@ -1,5 +1,5 @@
 class DeleteDocumentCollectionLinks < ActiveRecord::Migration[5.0]
   def change
-    Link.delete_all(link_type: "document_collections")
+    Link.where(link_type: "document_collections").delete_all
   end
 end

--- a/db/migrate/20170217120853_remove_invalid_unpublishings.rb
+++ b/db/migrate/20170217120853_remove_invalid_unpublishings.rb
@@ -92,6 +92,6 @@ class RemoveInvalidUnpublishings < ActiveRecord::Migration[5.0]
       719125,
     ]
 
-    Unpublishing.delete_all(edition_id: ids)
+    Unpublishing.where(edition_id: ids).delete_all
   end
 end

--- a/db/migrate/20170504075801_fix_highway_code_public_updated_at.rb
+++ b/db/migrate/20170504075801_fix_highway_code_public_updated_at.rb
@@ -1,6 +1,7 @@
 class FixHighwayCodePublicUpdatedAt < ActiveRecord::Migration[5.0]
   def up
     document = Document.find_by(content_id: content_id)
+    return unless document
     edition = document.editions.last
     edition.update!(public_updated_at: "2017-03-01T00:00:00.000+00:00")
 

--- a/db/migrate/20170509133559_repair_missing_attachment_content_type.rb
+++ b/db/migrate/20170509133559_repair_missing_attachment_content_type.rb
@@ -2,6 +2,7 @@ class RepairMissingAttachmentContentType < ActiveRecord::Migration[5.0]
   def change
     BASE_PATHS.each do |base_path|
       edition = Edition.where(base_path: base_path).last
+      next unless edition
       edition_details = edition.details
 
       updated_attachments = edition_details[:attachments].map do |attachment|

--- a/db/migrate/20170602111120_add_timestamps_to_documents.rb
+++ b/db/migrate/20170602111120_add_timestamps_to_documents.rb
@@ -95,6 +95,7 @@ private
   def update_multiple_locale_documents_without_editions
     MULTIPLE_LOCALE_DOCUMENTS_WITHOUT_EDITIONS.each do |data|
       document = Document.find_by(content_id: data[:content_id], locale: data[:locale])
+      next unless document
       update_timestamps(document, data[:created_at], data[:updated_at])
     end
   end


### PR DESCRIPTION
- Adds Rails version numbers to migration classes
- Fixes `delete_all` syntax
- Deals with empty data cases