### PR TITLE
Fix expanded links

### DIFF
--- a/app/workers/downstream_draft_worker.rb
+++ b/app/workers/downstream_draft_worker.rb
@@ -98,7 +98,7 @@ private
       locale: locale,
       with_drafts: false,
       payload_version: payload_version,
-      expanded_links: live_links,
+      expanded_links: live_links.links,
     )
   end
 end

--- a/doc/admin-tasks.md
+++ b/doc/admin-tasks.md
@@ -72,3 +72,7 @@ bundle exec expanded_links:populate
 bundle exec expanded_links:populate_by_document_type['document-type']
 ```
 
+* To purge the expanded links cache
+```
+bundle exec expanded_links:truncate
+```

--- a/lib/tasks/expanded_links.rake
+++ b/lib/tasks/expanded_links.rake
@@ -35,6 +35,16 @@ namespace :expanded_links do
     end
   end
 
+  desc "
+  Truncate the Expanded Links table to reset the store
+  Usage
+  rake 'expanded_links:truncate
+  "
+  task truncate: :environment do
+    ExpandedLinks.connection.execute("TRUNCATE expanded_links RESTART IDENTITY")
+    puts "expanded_links table truncated"
+  end
+
   def update_links(content_id, locale, payload_version, with_drafts:)
     links = Presenters::Queries::ExpandedLinkSet.by_content_id(
       content_id,

--- a/spec/workers/downstream_draft_worker_spec.rb
+++ b/spec/workers/downstream_draft_worker_spec.rb
@@ -82,6 +82,22 @@ RSpec.describe DownstreamDraftWorker do
       expect { subject.perform(arguments) }
         .to change { ExpandedLinks.exists?(content_id: content_id, with_drafts: false) }
     end
+
+    context "when there aren't any links" do
+      it "has only available_translations in the draft" do
+        subject.perform(arguments)
+        links = ExpandedLinks.find_by(content_id: content_id, with_drafts: true)
+          .expanded_links
+        expect(links).to match a_hash_including("available_translations")
+      end
+
+      it "has no links without drafts" do
+        subject.perform(arguments)
+        links = ExpandedLinks.find_by(content_id: content_id, with_drafts: false)
+          .expanded_links
+        expect(links).to match({})
+      end
+    end
   end
 
   describe "update dependencies" do

--- a/spec/workers/downstream_live_worker_spec.rb
+++ b/spec/workers/downstream_live_worker_spec.rb
@@ -102,6 +102,14 @@ RSpec.describe DownstreamLiveWorker do
       expect { subject.perform(arguments) }
         .to change { ExpandedLinks.exists?(content_id: content_id, with_drafts: false) }
     end
+
+    context "when there aren't any links" do
+      it "has only available_translations in the cache" do
+        subject.perform(arguments)
+        links = ExpandedLinks.find_by(content_id: content_id).expanded_links
+        expect(links).to match a_hash_including("available_translations")
+      end
+    end
   end
 
   describe "broadcast to message queue" do


### PR DESCRIPTION
Trello: https://trello.com/c/VBILK9Bn/1033-fix-the-expanded-links-cache

This fixes an issue we have where we forget to call the `links` method on a presenter and are accidentally serializing the presenter in our Expanded Links store rather than the links contents.

It also adds a truncate command so the expanded links can be easily removed in situations like this.