### PR TITLE
Add an alert for when put_content is called without an update_type

### DIFF
--- a/app/commands/v2/put_content.rb
+++ b/app/commands/v2/put_content.rb
@@ -4,6 +4,7 @@ module Commands
       def call
         PutContentValidator.new(payload, self).validate
         prepare_content_with_base_path
+        check_update_type
 
         edition = create_or_update_edition
 
@@ -56,6 +57,15 @@ module Commands
         ChangeNote.create_from_edition(payload, edition)
         create_links(edition)
         Action.create_put_content_action(edition, document.locale, event)
+      end
+
+      def check_update_type
+        return unless payload[:update_type].blank?
+
+        Airbrake.notify(
+          "#{payload[:publishing_app]} sent put content without providing an update_type",
+          parameters: payload.slice(:publishing_app, :content_id, :locale),
+        )
       end
 
       def create_links(edition)

--- a/spec/commands/v2/put_content_spec.rb
+++ b/spec/commands/v2/put_content_spec.rb
@@ -221,5 +221,35 @@ RSpec.describe Commands::V2::PutContent do
         end
       end
     end
+
+    context "when no update_type is provided" do
+      before do
+        payload.delete(:update_type)
+      end
+
+      it "should send an alert to Airbrake" do
+        # swallow error about missing schema
+        expect(Airbrake).to receive(:notify)
+          .with(anything, parameters: a_hash_including(schema_path: anything))
+
+        expect(Airbrake).to receive(:notify)
+          .with(anything, parameters: a_hash_including(content_id: content_id))
+
+        described_class.call(payload)
+      end
+    end
+
+    context "when an update type is provided" do
+      it "should not send an alert to Airbrake" do
+        # swallow error about missing schema
+        expect(Airbrake).to receive(:notify)
+          .with(anything, parameters: a_hash_including(schema_path: anything))
+
+        expect(Airbrake).to_not receive(:notify)
+          .with(anything, parameters: a_hash_including(content_id: content_id))
+
+        described_class.call(payload)
+      end
+    end
   end
 end


### PR DESCRIPTION
This will help us to know when it's safe to make this field mandatory.

[Trello Card](https://trello.com/c/2wWArZR3/1019-05-add-an-alert-for-when-put-content-happens-without-an-updatetype)