### PR TITLE
Add a migration which makes edition_id not nullable

### DIFF
--- a/db/migrate/20170816071321_make_changes_notes_edition_id_not_nullable.rb
+++ b/db/migrate/20170816071321_make_changes_notes_edition_id_not_nullable.rb
@@ -1,0 +1,5 @@
+class MakeChangesNotesEditionIdNotNullable < ActiveRecord::Migration[5.1]
+  def change
+    change_column_null :change_notes, :edition_id, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170810090002) do
+ActiveRecord::Schema.define(version: 20170816071321) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -42,7 +42,7 @@ ActiveRecord::Schema.define(version: 20170810090002) do
   create_table "change_notes", id: :serial, force: :cascade do |t|
     t.string "note", default: ""
     t.datetime "public_timestamp"
-    t.integer "edition_id"
+    t.integer "edition_id", null: false
     t.datetime "created_at"
     t.datetime "updated_at"
     t.index ["edition_id"], name: "index_change_notes_on_edition_id"


### PR DESCRIPTION
This should mean that we never get a change note that's not associated with an edition.