### PR TITLE
Add a migration to fix old specialist documents

### DIFF
--- a/db/migrate/20170816101652_fix_old_specialist_publisher_schema_names.rb
+++ b/db/migrate/20170816101652_fix_old_specialist_publisher_schema_names.rb
@@ -1,0 +1,23 @@
+class FixOldSpecialistPublisherSchemaNames < ActiveRecord::Migration[5.1]
+  disable_ddl_transaction!
+
+  def up
+    content_ids = editions.with_document.pluck(:content_id)
+
+    editions.update_all(
+      schema_name: "specialist_document"
+    )
+
+    if Rails.env.production?
+      Commands::V2::RepresentDownstream.new.call(content_ids)
+    end
+  end
+
+  def editions
+    Edition
+      .where(
+        schema_name: "placeholder_specialist_document",
+        content_store: %w(live draft),
+      )
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170816071321) do
+ActiveRecord::Schema.define(version: 20170816101652) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
These were left over from migration, they are live and should be
rendered but have a placeholder schema name which isn't supported
by government frontend.