### PR TITLE
Populate new date fields on Edition

### DIFF
--- a/app/commands/v2/publish.rb
+++ b/app/commands/v2/publish.rb
@@ -28,7 +28,6 @@ module Commands
         end
 
         set_public_updated_at
-        set_first_published_at
         set_publishing_request_id
         set_update_type
         set_timestamps
@@ -166,11 +165,6 @@ module Commands
 
       def set_timestamps
         Edition::Timestamps.live_transition(edition, previous_item)
-      end
-
-      def set_first_published_at
-        return if edition.first_published_at.present?
-        edition.update_attributes!(first_published_at: default_datetime)
       end
 
       def default_datetime

--- a/app/commands/v2/publish.rb
+++ b/app/commands/v2/publish.rb
@@ -31,6 +31,7 @@ module Commands
         set_first_published_at
         set_publishing_request_id
         set_update_type
+        set_timestamps
         edition.publish
         remove_access_limit
         create_publish_action
@@ -161,6 +162,10 @@ module Commands
         else
           edition.update_attributes!(public_updated_at: previous_item.public_updated_at)
         end
+      end
+
+      def set_timestamps
+        Edition::Timestamps.live_transition(edition, previous_item)
       end
 
       def set_first_published_at

--- a/app/commands/v2/publish.rb
+++ b/app/commands/v2/publish.rb
@@ -153,7 +153,7 @@ module Commands
       end
 
       def set_timestamps
-        Edition::Timestamps.live_transition(edition, previous_item)
+        Edition::Timestamps.live_transition(edition, update_type, previous_item)
       end
 
       def default_datetime

--- a/app/commands/v2/publish.rb
+++ b/app/commands/v2/publish.rb
@@ -27,7 +27,6 @@ module Commands
           clear_published_items_of_same_locale_and_base_path
         end
 
-        set_public_updated_at
         set_publishing_request_id
         set_update_type
         set_timestamps
@@ -151,16 +150,6 @@ module Commands
           callbacks: callbacks,
           nested: true,
         )
-      end
-
-      def set_public_updated_at
-        return if edition.public_updated_at.present?
-
-        if update_type == "major" || previous_item.blank?
-          edition.update_attributes!(public_updated_at: default_datetime)
-        else
-          edition.update_attributes!(public_updated_at: previous_item.public_updated_at)
-        end
       end
 
       def set_timestamps

--- a/app/commands/v2/put_content.rb
+++ b/app/commands/v2/put_content.rb
@@ -7,6 +7,7 @@ module Commands
         check_update_type
 
         edition = create_or_update_edition
+        set_timestamps(edition)
 
         update_content_dependencies(edition)
 
@@ -57,6 +58,10 @@ module Commands
         ChangeNote.create_from_edition(payload, edition)
         create_links(edition)
         Action.create_put_content_action(edition, document.locale, event)
+      end
+
+      def set_timestamps(edition)
+        Edition::Timestamps.edited(edition, payload, previously_published_edition)
       end
 
       def check_update_type

--- a/app/commands/v2/put_content.rb
+++ b/app/commands/v2/put_content.rb
@@ -54,7 +54,6 @@ module Commands
       def update_content_dependencies(edition)
         create_redirect
         access_limit(edition)
-        update_last_edited_at(edition, payload[:last_edited_at])
         ChangeNote.create_from_edition(payload, edition)
         create_links(edition)
         Action.create_put_content_action(edition, document.locale, event)
@@ -148,14 +147,6 @@ module Commands
           callbacks: callbacks,
           nested: true,
         )
-      end
-
-      def update_last_edited_at(edition, last_edited_at = nil)
-        if last_edited_at.nil? && %w(major minor).include?(payload[:update_type])
-          last_edited_at = Time.zone.now
-        end
-
-        edition.update_attributes(last_edited_at: last_edited_at) if last_edited_at
       end
 
       def bulk_publishing?

--- a/app/commands/v2/unpublish.rb
+++ b/app/commands/v2/unpublish.rb
@@ -83,7 +83,10 @@ module Commands
       end
 
       def unpublish
-        Edition::Timestamps.live_transition(edition, previous) if edition.draft?
+        if edition.draft?
+          Edition::Timestamps.live_transition(edition, edition.update_type, previous)
+        end
+
         edition.unpublish(
           payload
             .slice(:type, :explanation, :alternative_path, :unpublished_at)

--- a/app/commands/v2/unpublish.rb
+++ b/app/commands/v2/unpublish.rb
@@ -83,6 +83,7 @@ module Commands
       end
 
       def unpublish
+        Edition::Timestamps.live_transition(edition, previous) if edition.draft?
         edition.unpublish(
           payload
             .slice(:type, :explanation, :alternative_path, :unpublished_at)

--- a/app/helpers/redirect_helper.rb
+++ b/app/helpers/redirect_helper.rb
@@ -14,7 +14,6 @@ module RedirectHelper
 
       redirect_payload = RedirectPresenter.new(
         base_path: previous_base_path,
-        public_updated_at: Time.zone.now,
         redirects: redirects_for(previous_routes, previous_base_path, payload[:base_path]),
         publishing_app: payload[:publishing_app],
       ).for_redirect_helper(SecureRandom.uuid)

--- a/app/models/create_draft_edition.rb
+++ b/app/models/create_draft_edition.rb
@@ -39,7 +39,6 @@ private
   def fill_out_new_edition
     document.increment!(:stale_lock_version)
     set_first_published_at
-    set_last_edited_at
     set_document_owner
   end
 
@@ -48,14 +47,6 @@ private
     return if edition.first_published_at
     edition.update_attributes(
       first_published_at: previously_published_item.first_published_at,
-    )
-  end
-
-  def set_last_edited_at
-    return unless previously_published_item.has_last_edited_at?
-    return if edition.last_edited_at
-    edition.update_attributes(
-      last_edited_at: previously_published_item.last_edited_at,
     )
   end
 

--- a/app/models/create_draft_edition.rb
+++ b/app/models/create_draft_edition.rb
@@ -38,16 +38,7 @@ private
 
   def fill_out_new_edition
     document.increment!(:stale_lock_version)
-    set_first_published_at
     set_document_owner
-  end
-
-  def set_first_published_at
-    return unless previously_published_item.has_first_published_at?
-    return if edition.first_published_at
-    edition.update_attributes(
-      first_published_at: previously_published_item.first_published_at,
-    )
   end
 
   def set_document_owner

--- a/app/models/edition/timestamps.rb
+++ b/app/models/edition/timestamps.rb
@@ -20,6 +20,11 @@ class Edition::Timestamps
       edition.major_published_at = previous_live_version&.major_published_at
     end
 
+    # In time we'd like to rename public_updated_at to major_published_at as
+    # part of the payload, but in the meantime we are populating the field
+    # with the optionally provided public_updated_at field.
+    edition.publisher_major_published_at = payload[:public_updated_at]
+
     edition.save!
   end
 

--- a/app/models/edition/timestamps.rb
+++ b/app/models/edition/timestamps.rb
@@ -7,6 +7,7 @@ class Edition::Timestamps
   )
     edition.temporary_last_edited_at = now
     edition.publisher_last_edited_at = payload[:last_edited_at]
+    edition.last_edited_at = payload[:last_edited_at] || now
 
     # first_published_at should eventually be associated with a document model,
     # therefore avoiding the need to copy between editions as this is fragile

--- a/app/models/edition/timestamps.rb
+++ b/app/models/edition/timestamps.rb
@@ -13,6 +13,8 @@ class Edition::Timestamps
     # therefore avoiding the need to copy between editions as this is fragile
     edition.temporary_first_published_at = previous_live_version&.temporary_first_published_at
     edition.publisher_first_published_at = payload[:first_published_at]
+    edition.first_published_at = payload[:first_published_at] ||
+      previous_live_version&.first_published_at
 
     # We set this on non-major updates so that editions can maintain their value
     # from previous items. In future we'd like to avoid this date being copied
@@ -43,6 +45,10 @@ class Edition::Timestamps
       edition.temporary_first_published_at = now
     end
 
+    unless edition.first_published_at.present?
+      edition.first_published_at = now
+    end
+
     edition.published_at = now
 
     if edition.update_type == "major"
@@ -54,7 +60,6 @@ class Edition::Timestamps
       # sent in put content.
       edition.major_published_at = previous_live_version&.major_published_at
     end
-
 
     edition.save!
   end

--- a/app/models/edition/timestamps.rb
+++ b/app/models/edition/timestamps.rb
@@ -39,6 +39,7 @@ class Edition::Timestamps
 
   def self.live_transition(
     edition,
+    update_type,
     previous_live_version = nil,
     now = Time.zone.now
   )
@@ -54,7 +55,7 @@ class Edition::Timestamps
 
     edition.published_at = now
 
-    if edition.update_type == "major"
+    if update_type == "major"
       edition.major_published_at = now
       edition.public_updated_at = now unless edition.public_updated_at.present?
     else

--- a/app/models/edition/timestamps.rb
+++ b/app/models/edition/timestamps.rb
@@ -5,6 +5,8 @@ class Edition::Timestamps
     previous_live_version = nil,
     now = Time.zone.now
   )
+    edition.temporary_last_edited_at = now
+    
     # first_published_at should eventually be associated with a document model,
     # therefore avoiding the need to copy between editions as this is fragile
     edition.temporary_first_published_at = previous_live_version&.temporary_first_published_at
@@ -24,7 +26,7 @@ class Edition::Timestamps
     # part of the payload, but in the meantime we are populating the field
     # with the optionally provided public_updated_at field.
     edition.publisher_major_published_at = payload[:public_updated_at]
-    
+
     edition.save!
   end
 

--- a/app/models/edition/timestamps.rb
+++ b/app/models/edition/timestamps.rb
@@ -1,0 +1,28 @@
+class Edition::Timestamps
+  def self.edited(
+    edition,
+    payload,
+    previous_live_version = nil,
+    now = Time.zone.now
+  )
+    # first_published_at should eventually be associated with a document model,
+    # therefore avoiding the need to copy between editions as this is fragile
+    edition.temporary_first_published_at = previous_live_version&.temporary_first_published_at
+
+    edition.save!
+  end
+
+  def self.live_transition(
+    edition,
+    previous_live_version = nil,
+    now = Time.zone.now
+  )
+    # We set this because a lack of temporary_first_published_at indicates the
+    # edition has not been published
+    unless edition.temporary_first_published_at.present?
+      edition.temporary_first_published_at = now
+    end
+
+    edition.save!
+  end
+end

--- a/app/models/edition/timestamps.rb
+++ b/app/models/edition/timestamps.rb
@@ -8,6 +8,7 @@ class Edition::Timestamps
     # first_published_at should eventually be associated with a document model,
     # therefore avoiding the need to copy between editions as this is fragile
     edition.temporary_first_published_at = previous_live_version&.temporary_first_published_at
+    edition.publisher_first_published_at = payload[:first_published_at]
 
     edition.save!
   end

--- a/app/models/edition/timestamps.rb
+++ b/app/models/edition/timestamps.rb
@@ -6,7 +6,8 @@ class Edition::Timestamps
     now = Time.zone.now
   )
     edition.temporary_last_edited_at = now
-    
+    edition.publisher_last_edited_at = payload[:last_edited_at]
+
     # first_published_at should eventually be associated with a document model,
     # therefore avoiding the need to copy between editions as this is fragile
     edition.temporary_first_published_at = previous_live_version&.temporary_first_published_at

--- a/app/models/edition/timestamps.rb
+++ b/app/models/edition/timestamps.rb
@@ -39,6 +39,8 @@ class Edition::Timestamps
       edition.temporary_first_published_at = now
     end
 
+    edition.published_at = now
+
     if edition.update_type == "major"
       edition.major_published_at = now
     else
@@ -48,6 +50,7 @@ class Edition::Timestamps
       # sent in put content.
       edition.major_published_at = previous_live_version&.major_published_at
     end
+
 
     edition.save!
   end

--- a/app/models/edition/timestamps.rb
+++ b/app/models/edition/timestamps.rb
@@ -24,7 +24,7 @@ class Edition::Timestamps
     # part of the payload, but in the meantime we are populating the field
     # with the optionally provided public_updated_at field.
     edition.publisher_major_published_at = payload[:public_updated_at]
-
+    
     edition.save!
   end
 

--- a/app/models/previously_published_item.rb
+++ b/app/models/previously_published_item.rb
@@ -27,6 +27,10 @@ class PreviouslyPublishedItem
     previously_published_item.first_published_at
   end
 
+  def temporary_first_published_at
+    previously_published_item.temporary_first_published_at
+  end
+
   def has_last_edited_at?
     true
   end
@@ -77,5 +81,9 @@ class PreviouslyPublishedItem
 
     def routes
     end
+
+    def first_published_at; end
+
+    def temporary_first_published_at; end
   end
 end

--- a/app/models/previously_published_item.rb
+++ b/app/models/previously_published_item.rb
@@ -39,6 +39,10 @@ class PreviouslyPublishedItem
     previously_published_item.last_edited_at
   end
 
+  def major_published_at
+    previously_published_item.major_published_at
+  end
+
   def previous_base_path
     previously_published_item.base_path
   end
@@ -85,5 +89,7 @@ class PreviouslyPublishedItem
     def first_published_at; end
 
     def temporary_first_published_at; end
+
+    def major_published_at; end
   end
 end

--- a/app/models/previously_published_item.rb
+++ b/app/models/previously_published_item.rb
@@ -35,6 +35,10 @@ class PreviouslyPublishedItem
     previously_published_item.major_published_at
   end
 
+  def public_updated_at
+    previously_published_item.public_updated_at
+  end
+
   def previous_base_path
     previously_published_item.base_path
   end
@@ -75,5 +79,7 @@ class PreviouslyPublishedItem
     def temporary_first_published_at; end
 
     def major_published_at; end
+
+    def public_updated_at; end
   end
 end

--- a/app/models/previously_published_item.rb
+++ b/app/models/previously_published_item.rb
@@ -31,10 +31,6 @@ class PreviouslyPublishedItem
     previously_published_item.temporary_first_published_at
   end
 
-  def has_last_edited_at?
-    true
-  end
-
   def last_edited_at
     previously_published_item.last_edited_at
   end
@@ -69,10 +65,6 @@ class PreviouslyPublishedItem
     end
 
     def has_first_published_at?
-      false
-    end
-
-    def has_last_edited_at?
       false
     end
 

--- a/app/models/previously_published_item.rb
+++ b/app/models/previously_published_item.rb
@@ -19,10 +19,6 @@ class PreviouslyPublishedItem
     previously_published_item.user_facing_version + 1
   end
 
-  def has_first_published_at?
-    true
-  end
-
   def first_published_at
     previously_published_item.first_published_at
   end
@@ -62,10 +58,6 @@ class PreviouslyPublishedItem
 
     def links
       []
-    end
-
-    def has_first_published_at?
-      false
     end
 
     def path_has_changed?

--- a/app/models/update_existing_draft_edition.rb
+++ b/app/models/update_existing_draft_edition.rb
@@ -63,9 +63,7 @@ private
   end
 
   def attributes_from_payload
-    remove_first_published_at_if_not_explicitly_set(
-      without_protected_attributes
-    )
+    remove_first_published_at_if_not_explicitly_set(without_protected_attributes)
   end
 
   def attributes

--- a/app/presenters/redirect_presenter.rb
+++ b/app/presenters/redirect_presenter.rb
@@ -1,5 +1,5 @@
 class RedirectPresenter
-  def initialize(base_path:, publishing_app:, public_updated_at:, redirects:)
+  def initialize(base_path:, publishing_app:, public_updated_at: nil, redirects:)
     @base_path = base_path
     @publishing_app = publishing_app
     @public_updated_at = public_updated_at
@@ -36,13 +36,16 @@ private
     :content_id, :locale
 
   def present
-    {
-      document_type: "redirect",
-      schema_name: "redirect",
-      base_path: base_path,
-      publishing_app: publishing_app,
-      public_updated_at: public_updated_at.iso8601,
-      redirects: redirects,
-    }
+    attributes = {
+                    document_type: "redirect",
+                    schema_name: "redirect",
+                    base_path: base_path,
+                    publishing_app: publishing_app,
+                    redirects: redirects,
+                 }
+    if public_updated_at.present?
+      attributes[:public_updated_at] = public_updated_at.iso8601
+    end
+    attributes
   end
 end

--- a/doc/api.md
+++ b/doc/api.md
@@ -108,6 +108,8 @@ presented edition and [warnings](#warnings).
 - `document_type` *(required)*
   - A particular type of document, used to differentiate between documents that
     are of different types but share the same schema.
+- `first_published_at` *(optional)*
+  - Specifies the first_published_at date from the publishing app.
 - `last_edited_at` *(optional)*
   - An [RFC 3339][rfc-3339] formatted timestamp should be provided, although
     [other formats][to-time-docs] may be accepted.

--- a/spec/commands/v2/publish_spec.rb
+++ b/spec/commands/v2/publish_spec.rb
@@ -115,6 +115,12 @@ RSpec.describe Commands::V2::Publish do
         described_class.call(payload)
       end
 
+      it "updates the published_at time to current time" do
+        described_class.call(payload)
+
+        expect(draft_item.reload.published_at).to eq(Time.zone.now)
+      end
+
       context "and update_type is major" do
         before do
           draft_item.update_attributes!(update_type: "major")

--- a/spec/commands/v2/publish_spec.rb
+++ b/spec/commands/v2/publish_spec.rb
@@ -2,6 +2,14 @@ require "rails_helper"
 
 RSpec.describe Commands::V2::Publish do
   describe "call" do
+    before do
+      Timecop.freeze(Time.local(2017, 9, 1, 12, 0, 0))
+    end
+
+    after do
+      Timecop.return
+    end
+
     let(:base_path) { "/vat-rates" }
     let(:locale) { "en" }
     let(:user_facing_version) { 5 }
@@ -376,9 +384,18 @@ RSpec.describe Commands::V2::Publish do
       end
     end
 
+    context "with no temporary_first_published_at set on the edition" do
+      it "updates the temporary_first_published_at time to current time" do
+        described_class.call(payload)
+        expect(draft_item.reload.temporary_first_published_at)
+          .to eq(Time.zone.now)
+      end
+    end
+
     context "with no first_published_at and no public_updated_at set on the draft edition" do
       before do
-        draft_item.update_attributes!(first_published_at: nil, public_updated_at: nil)
+        draft_item.update_attributes!(
+          first_published_at: nil, public_updated_at: nil)
       end
 
       it "updates both fields with the same value" do

--- a/spec/commands/v2/put_content_spec.rb
+++ b/spec/commands/v2/put_content_spec.rb
@@ -165,18 +165,6 @@ RSpec.describe Commands::V2::PutContent do
           expect(edition.last_edited_at.iso8601).to eq(Time.zone.now.iso8601)
         end
       end
-
-      context "when other update type" do
-        it "dosen't change last_edited_at" do
-          old_last_edited_at = edition.last_edited_at
-
-          described_class.call(payload.merge(update_type: "republish"))
-
-          edition.reload
-
-          expect(edition.last_edited_at).to eq(old_last_edited_at)
-        end
-      end
     end
 
     context "field doesn't change between drafts" do
@@ -187,38 +175,6 @@ RSpec.describe Commands::V2::PutContent do
           .with(anything, a_hash_including(update_dependencies: false))
         described_class.call(payload)
         described_class.call(payload)
-      end
-    end
-
-    context "when the update_type is 'republish'" do
-      before { payload[:update_type] = "republish" }
-
-      context "and there is a previous edition" do
-        let(:document) do
-          FactoryGirl.create(:document, content_id: content_id)
-        end
-
-        let!(:previous_edition) do
-          FactoryGirl.create(:live_edition,
-            document: document,
-            base_path: base_path,
-            last_edited_at: Time.zone.now
-          )
-        end
-
-        it "uses the last_edited_at value from the previous edition" do
-          described_class.call(payload)
-          edition = Edition.last
-          expect(edition.last_edited_at.iso8601).to eq previous_edition.last_edited_at.iso8601
-        end
-      end
-
-      context "but there is not a previous edition" do
-        it "has a last_edited_at of nil" do
-          described_class.call(payload)
-          edition = Edition.last
-          expect(edition.last_edited_at).to be_nil
-        end
       end
     end
 

--- a/spec/commands/v2/unpublish_spec.rb
+++ b/spec/commands/v2/unpublish_spec.rb
@@ -1,6 +1,14 @@
 require "rails_helper"
 
 RSpec.describe Commands::V2::Unpublish do
+  before do
+    Timecop.freeze(Time.local(2017, 9, 1, 12, 0, 0))
+  end
+
+  after do
+    Timecop.return
+  end
+
   let(:content_id) { SecureRandom.uuid }
   let(:base_path) { "/vat-rates" }
   let(:locale) { "en" }
@@ -270,6 +278,13 @@ RSpec.describe Commands::V2::Unpublish do
           expect(unpublishing.type).to eq("gone")
           expect(unpublishing.explanation).to eq("Removed for testing porpoises")
           expect(unpublishing.alternative_path).to eq("/new-path")
+        end
+
+        it "sets temporary_first_published_at to current time" do
+          described_class.call(payload_with_allow_draft)
+
+          expect(draft_edition.reload.temporary_first_published_at)
+            .to eq(Time.zone.now)
         end
 
         context "where there is an access limit" do

--- a/spec/integration/put_content/content_with_a_previous_draft_spec.rb
+++ b/spec/integration/put_content/content_with_a_previous_draft_spec.rb
@@ -79,21 +79,6 @@ RSpec.describe "PUT /v2/content when the payload is for an already drafted editi
     end
   end
 
-  context "when first_published_at is not set in payload" do
-    let(:first_published_at) { 1.year.ago }
-    before do
-      previously_drafted_item.update_attributes(first_published_at: first_published_at)
-      put "/v2/content/#{content_id}", params: payload.to_json
-      previously_drafted_item.reload
-    end
-
-    it "keeps the existing timestamp for first_published_at" do
-      expect(previously_drafted_item.first_published_at).to be_present
-      expect(previously_drafted_item.first_published_at.iso8601)
-        .to eq(first_published_at.iso8601)
-    end
-  end
-
   it "has a temporary_first_published_at of nil" do
     put "/v2/content/#{content_id}", params: payload.to_json
     expect(previously_drafted_item.reload.temporary_first_published_at)

--- a/spec/integration/put_content/content_with_a_previous_draft_spec.rb
+++ b/spec/integration/put_content/content_with_a_previous_draft_spec.rb
@@ -53,15 +53,25 @@ RSpec.describe "PUT /v2/content when the payload is for an already drafted editi
   end
 
   context "when public_updated_at is in the payload" do
-    it "allows the setting of publisher_major_published_at" do
-      public_updated_at = 1.year.ago
+    let(:public_updated_at) { Time.now }
+    before do
       payload[:public_updated_at] = public_updated_at
+    end
 
+    it "allows the setting of publisher_major_published_at" do
       put "/v2/content/#{content_id}", params: payload.to_json
       previously_drafted_item.reload
 
-      expect(previously_drafted_item.publisher_major_published_at.iso8601)
-        .to eq(public_updated_at.iso8601)
+      expect(previously_drafted_item.publisher_major_published_at)
+        .to eq(public_updated_at)
+    end
+
+    it "allows the setting of public_updated_at" do
+      put "/v2/content/#{content_id}", params: payload.to_json
+      previously_drafted_item.reload
+
+      expect(previously_drafted_item.public_updated_at)
+        .to eq(public_updated_at)
     end
   end
 

--- a/spec/integration/put_content/content_with_a_previous_draft_spec.rb
+++ b/spec/integration/put_content/content_with_a_previous_draft_spec.rb
@@ -45,6 +45,13 @@ RSpec.describe "PUT /v2/content when the payload is for an already drafted editi
     expect(previously_drafted_item.temporary_last_edited_at).to eq(Time.now)
   end
 
+  it "sets last_edited_at to current time" do
+    put "/v2/content/#{content_id}", params: payload.to_json
+    previously_drafted_item.reload
+
+    expect(previously_drafted_item.last_edited_at).to eq(Time.now)
+  end
+
   context "when public_updated_at is in the payload" do
     it "allows the setting of publisher_major_published_at" do
       public_updated_at = 1.year.ago

--- a/spec/integration/put_content/content_with_a_previous_draft_spec.rb
+++ b/spec/integration/put_content/content_with_a_previous_draft_spec.rb
@@ -5,6 +5,11 @@ RSpec.describe "PUT /v2/content when the payload is for an already drafted editi
 
   before do
     stub_request(:put, %r{.*content-store.*/content/.*})
+    Timecop.freeze(Time.local(2017, 9, 1, 12, 0, 0))
+  end
+
+  after do
+    Timecop.return
   end
 
   let(:document) do
@@ -31,6 +36,13 @@ RSpec.describe "PUT /v2/content when the payload is for an already drafted editi
     previously_drafted_item.reload
 
     expect(previously_drafted_item.content_store).to eq("draft")
+  end
+
+  it "sets temporary_last_edited_at to current time" do
+    put "/v2/content/#{content_id}", params: payload.to_json
+    previously_drafted_item.reload
+
+    expect(previously_drafted_item.temporary_last_edited_at).to eq(Time.now)
   end
 
   context "when public_updated_at is in the payload" do

--- a/spec/integration/put_content/content_with_a_previous_draft_spec.rb
+++ b/spec/integration/put_content/content_with_a_previous_draft_spec.rb
@@ -33,6 +33,19 @@ RSpec.describe "PUT /v2/content when the payload is for an already drafted editi
     expect(previously_drafted_item.content_store).to eq("draft")
   end
 
+  context "when public_updated_at is in the payload" do
+    it "allows the setting of publisher_major_published_at" do
+      public_updated_at = 1.year.ago
+      payload[:public_updated_at] = public_updated_at
+
+      put "/v2/content/#{content_id}", params: payload.to_json
+      previously_drafted_item.reload
+
+      expect(previously_drafted_item.publisher_major_published_at.iso8601)
+        .to eq(public_updated_at.iso8601)
+    end
+  end
+
   context "when first_published_at is in the payload" do
     it "allows the setting of first_published_at and publisher_first_published_at" do
       explicit_first_published = DateTime.new(2016, 05, 23, 1, 1, 1).rfc3339

--- a/spec/integration/put_content/content_with_a_previous_draft_spec.rb
+++ b/spec/integration/put_content/content_with_a_previous_draft_spec.rb
@@ -54,6 +54,12 @@ RSpec.describe "PUT /v2/content when the payload is for an already drafted editi
     expect(previously_drafted_item.first_published_at.iso8601).to eq(first_published_at.iso8601)
   end
 
+  it "has a temporary_first_published_at of nil" do
+    put "/v2/content/#{content_id}", params: payload.to_json
+    expect(previously_drafted_item.reload.temporary_first_published_at)
+      .to be_nil
+  end
+
   it "does not increment the user-facing version for the edition" do
     put "/v2/content/#{content_id}", params: payload.to_json
     previously_drafted_item.reload

--- a/spec/integration/put_content/content_with_a_previously_published_edition_spec.rb
+++ b/spec/integration/put_content/content_with_a_previously_published_edition_spec.rb
@@ -98,6 +98,23 @@ RSpec.describe "PUT /v2/content when creating a draft for a previously published
     end
   end
 
+  context "and public_updated_at has changed in the payload" do
+    let(:public_updated_at) { Time.now.utc }
+    before do
+      payload.merge!(
+        public_updated_at: public_updated_at,
+        update_type: "major"
+      )
+    end
+
+    it "updates publisher_major_published_at" do
+      put "/v2/content/#{content_id}", params: payload.to_json
+
+      edition = Edition.last
+      expect(edition.publisher_major_published_at).to eq(public_updated_at)
+    end
+  end
+
   context "and the base path has changed" do
     before do
       payload.merge!(

--- a/spec/integration/put_content/content_with_a_previously_published_edition_spec.rb
+++ b/spec/integration/put_content/content_with_a_previously_published_edition_spec.rb
@@ -96,22 +96,12 @@ RSpec.describe "PUT /v2/content when creating a draft for a previously published
       expect(edition.publisher_first_published_at.iso8601)
         .to eq(new_first_published_at)
     end
-  end
 
-  context "and public_updated_at has changed in the payload" do
-    let(:public_updated_at) { Time.now.utc }
-    before do
-      payload.merge!(
-        public_updated_at: public_updated_at,
-        update_type: "major"
-      )
-    end
-
-    it "updates publisher_major_published_at" do
+    it "updates first_published_at" do
       put "/v2/content/#{content_id}", params: payload.to_json
 
       edition = Edition.last
-      expect(edition.publisher_major_published_at).to eq(public_updated_at)
+      expect(edition.first_published_at.iso8601).to eq(new_first_published_at)
     end
   end
 

--- a/spec/integration/put_content/content_with_a_previously_published_edition_spec.rb
+++ b/spec/integration/put_content/content_with_a_previously_published_edition_spec.rb
@@ -51,14 +51,14 @@ RSpec.describe "PUT /v2/content when creating a draft for a previously published
     expect(edition.user_facing_version).to eq(6)
   end
 
-  it "copies over the first_published_at timestamp" do
+  it "sets first_published_at to the previously published version's value" do
     put "/v2/content/#{content_id}", params: payload.to_json
 
     edition = Edition.last
     expect(edition).to be_present
     expect(edition.document.content_id).to eq(content_id)
 
-    expect(edition.first_published_at.iso8601).to eq(first_published_at.iso8601)
+    expect(edition.first_published_at).to eq(first_published_at)
   end
 
   it "sets temporary_first_published_at to the previously published version's value" do

--- a/spec/integration/put_content/content_with_a_previously_published_edition_spec.rb
+++ b/spec/integration/put_content/content_with_a_previously_published_edition_spec.rb
@@ -62,6 +62,21 @@ RSpec.describe "PUT /v2/content when creating a draft for a previously published
       .to eq(temporary_first_published_at)
   end
 
+  context "when first_published_at has changed in the payload" do
+    let(:new_first_published_at) { Time.now.utc.iso8601 }
+    before do
+      payload.merge!(first_published_at: new_first_published_at)
+    end
+
+    it "updates publisher_first_published_at" do
+      put "/v2/content/#{content_id}", params: payload.to_json
+
+      edition = Edition.last
+      expect(edition.publisher_first_published_at.iso8601)
+        .to eq(new_first_published_at)
+    end
+  end
+
   context "and the base path has changed" do
     before do
       payload.merge!(

--- a/spec/integration/put_content/content_with_a_previously_published_edition_spec.rb
+++ b/spec/integration/put_content/content_with_a_previously_published_edition_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe "PUT /v2/content when creating a draft for a previously published
   end
 
   let(:first_published_at) { 1.year.ago }
+  let(:temporary_first_published_at) { 2.years.ago }
 
   let(:document) do
     FactoryGirl.create(
@@ -22,6 +23,7 @@ RSpec.describe "PUT /v2/content when creating a draft for a previously published
       document: document,
       user_facing_version: 5,
       first_published_at: first_published_at,
+      temporary_first_published_at: temporary_first_published_at,
       base_path: base_path,
     )
   end
@@ -50,6 +52,14 @@ RSpec.describe "PUT /v2/content when creating a draft for a previously published
     expect(edition.document.content_id).to eq(content_id)
 
     expect(edition.first_published_at.iso8601).to eq(first_published_at.iso8601)
+  end
+
+  it "sets temporary_first_published_at to the previously published version's value" do
+    put "/v2/content/#{content_id}", params: payload.to_json
+
+    edition = Edition.last
+    expect(edition.temporary_first_published_at)
+      .to eq(temporary_first_published_at)
   end
 
   context "and the base path has changed" do

--- a/spec/integration/put_content/content_with_a_previously_unpublished_edition_spec.rb
+++ b/spec/integration/put_content/content_with_a_previously_unpublished_edition_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe "PUT /v2/content when creating a draft for a previously unpublish
   let(:temporary_first_published_at) { "2016-01-02 12:23" }
 
   before do
+    Timecop.freeze(Time.local(2017, 9, 1, 12, 0, 0))
     FactoryGirl.create(:unpublished_edition,
       document: FactoryGirl.create(:document, content_id: content_id, stale_lock_version: 2),
       user_facing_version: 5,

--- a/spec/integration/put_content/content_with_a_previously_unpublished_edition_spec.rb
+++ b/spec/integration/put_content/content_with_a_previously_unpublished_edition_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe "PUT /v2/content when creating a draft for a previously unpublish
     expect(edition.user_facing_version).to eq(6)
   end
 
-  it "allows the setting of first_published_at" do
+  it "allows the setting of first_published_at and publisher_first_published_at" do
     explicit_first_published = DateTime.new(2016, 05, 23, 1, 1, 1).rfc3339
     payload[:first_published_at] = explicit_first_published
 
@@ -49,6 +49,7 @@ RSpec.describe "PUT /v2/content when creating a draft for a previously unpublish
     expect(edition).to be_present
     expect(edition.document.content_id).to eq(content_id)
     expect(edition.first_published_at).to eq(explicit_first_published)
+    expect(edition.publisher_first_published_at).to eq(explicit_first_published)
   end
 
   it "sets temporary_first_published_at to the previously unpublished verson's value" do

--- a/spec/integration/put_content/content_with_a_previously_unpublished_edition_spec.rb
+++ b/spec/integration/put_content/content_with_a_previously_unpublished_edition_spec.rb
@@ -3,11 +3,16 @@ require "rails_helper"
 RSpec.describe "PUT /v2/content when creating a draft for a previously unpublished edition" do
   include_context "PutContent call"
 
+  let(:first_published_at) { "2017-01-02 12:23" }
+  let(:temporary_first_published_at) { "2016-01-02 12:23" }
+
   before do
     FactoryGirl.create(:unpublished_edition,
       document: FactoryGirl.create(:document, content_id: content_id, stale_lock_version: 2),
       user_facing_version: 5,
       base_path: base_path,
+      first_published_at: first_published_at,
+      temporary_first_published_at: temporary_first_published_at,
     )
   end
 
@@ -44,5 +49,14 @@ RSpec.describe "PUT /v2/content when creating a draft for a previously unpublish
     expect(edition).to be_present
     expect(edition.document.content_id).to eq(content_id)
     expect(edition.first_published_at).to eq(explicit_first_published)
+  end
+
+  it "sets temporary_first_published_at to the previously unpublished verson's value" do
+    put "/v2/content/#{content_id}", params: payload.to_json
+
+    edition = Edition.last
+
+    expect(edition.temporary_first_published_at)
+      .to eq(temporary_first_published_at)
   end
 end

--- a/spec/integration/put_content/content_with_a_previously_unpublished_edition_spec.rb
+++ b/spec/integration/put_content/content_with_a_previously_unpublished_edition_spec.rb
@@ -2,6 +2,13 @@ require "rails_helper"
 
 RSpec.describe "PUT /v2/content when creating a draft for a previously unpublished edition" do
   include_context "PutContent call"
+  before do
+    Timecop.freeze("2017-01-02 12:23")
+  end
+
+  after do
+    Timecop.return
+  end
 
   let(:first_published_at) { "2017-01-02 12:23" }
   let(:temporary_first_published_at) { "2016-01-02 12:23" }

--- a/spec/integration/put_content/content_with_a_previously_unpublished_edition_spec.rb
+++ b/spec/integration/put_content/content_with_a_previously_unpublished_edition_spec.rb
@@ -10,7 +10,6 @@ RSpec.describe "PUT /v2/content when creating a draft for a previously unpublish
     Timecop.return
   end
 
-  let(:first_published_at) { "2017-01-02 12:23" }
   let(:temporary_first_published_at) { "2016-01-02 12:23" }
 
   before do
@@ -19,7 +18,6 @@ RSpec.describe "PUT /v2/content when creating a draft for a previously unpublish
       document: FactoryGirl.create(:document, content_id: content_id, stale_lock_version: 2),
       user_facing_version: 5,
       base_path: base_path,
-      first_published_at: first_published_at,
       temporary_first_published_at: temporary_first_published_at,
     )
   end
@@ -44,20 +42,6 @@ RSpec.describe "PUT /v2/content when creating a draft for a previously unpublish
     expect(edition.document.content_id).to eq(content_id)
     expect(edition.state).to eq("draft")
     expect(edition.user_facing_version).to eq(6)
-  end
-
-  it "allows the setting of first_published_at and publisher_first_published_at" do
-    explicit_first_published = DateTime.new(2016, 05, 23, 1, 1, 1).rfc3339
-    payload[:first_published_at] = explicit_first_published
-
-    put "/v2/content/#{content_id}", params: payload.to_json
-
-    edition = Edition.last
-
-    expect(edition).to be_present
-    expect(edition.document.content_id).to eq(content_id)
-    expect(edition.first_published_at).to eq(explicit_first_published)
-    expect(edition.publisher_first_published_at).to eq(explicit_first_published)
   end
 
   it "sets temporary_first_published_at to the previously unpublished verson's value" do

--- a/spec/integration/put_content/new_edition_spec.rb
+++ b/spec/integration/put_content/new_edition_spec.rb
@@ -57,6 +57,11 @@ RSpec.describe "PUT /v2/content when the payload is for a brand new edition" do
     expect(subject.publisher_published_at).to be_nil
   end
 
+  it "sets temporary_last_edited_at to current time" do
+    put "/v2/content/#{content_id}", params: payload.to_json
+    expect(subject.temporary_last_edited_at).to eq(Time.now)
+  end
+
   shared_examples "creates a change note" do
     it "creates a change note" do
       expect {

--- a/spec/integration/put_content/new_edition_spec.rb
+++ b/spec/integration/put_content/new_edition_spec.rb
@@ -3,6 +3,14 @@ require "rails_helper"
 RSpec.describe "PUT /v2/content when the payload is for a brand new edition" do
   include_context "PutContent call"
 
+  before do
+    Timecop.freeze(Time.local(2017, 9, 1, 12, 0, 0))
+  end
+
+  after do
+    Timecop.return
+  end
+
   subject { Edition.last }
 
   it "creates an edition" do
@@ -42,6 +50,19 @@ RSpec.describe "PUT /v2/content when the payload is for a brand new edition" do
       expect {
         put "/v2/content/#{content_id}", params: payload.to_json
       }.to change { ChangeNote.count }.by(1)
+    end
+  end
+
+  context "first_published_at is present in the payload" do
+    let(:first_published_at) { Time.now }
+    before do
+      payload[:first_published_at] = first_published_at
+    end
+
+    it "sets publisher_first_published_at to first_published_at" do
+      put "/v2/content/#{content_id}", params: payload.to_json
+
+      expect(subject.publisher_first_published_at).to eq(first_published_at)
     end
   end
 

--- a/spec/integration/put_content/new_edition_spec.rb
+++ b/spec/integration/put_content/new_edition_spec.rb
@@ -11,8 +11,6 @@ RSpec.describe "PUT /v2/content when the payload is for a brand new edition" do
     Timecop.return
   end
 
-  let(:public_updated_at) { Time.now }
-
   subject { Edition.last }
 
   it "creates an edition" do

--- a/spec/integration/put_content/new_edition_spec.rb
+++ b/spec/integration/put_content/new_edition_spec.rb
@@ -62,6 +62,11 @@ RSpec.describe "PUT /v2/content when the payload is for a brand new edition" do
     expect(subject.temporary_last_edited_at).to eq(Time.now)
   end
 
+  it "sets last_edited_at to current time" do
+    put "/v2/content/#{content_id}", params: payload.to_json
+    expect(subject.last_edited_at).to eq(Time.zone.now)
+  end
+
   shared_examples "creates a change note" do
     it "creates a change note" do
       expect {

--- a/spec/integration/put_content/new_edition_spec.rb
+++ b/spec/integration/put_content/new_edition_spec.rb
@@ -52,6 +52,11 @@ RSpec.describe "PUT /v2/content when the payload is for a brand new edition" do
     expect(subject.major_published_at).to be_nil
   end
 
+  it "has a publisher_published_at of nil" do
+    put "/v2/content/#{content_id}", params: payload.to_json
+    expect(subject.publisher_published_at).to be_nil
+  end
+
   shared_examples "creates a change note" do
     it "creates a change note" do
       expect {

--- a/spec/integration/put_content/new_edition_spec.rb
+++ b/spec/integration/put_content/new_edition_spec.rb
@@ -11,6 +11,8 @@ RSpec.describe "PUT /v2/content when the payload is for a brand new edition" do
     Timecop.return
   end
 
+  let(:public_updated_at) { Time.now }
+
   subject { Edition.last }
 
   it "creates an edition" do

--- a/spec/integration/put_content/new_edition_spec.rb
+++ b/spec/integration/put_content/new_edition_spec.rb
@@ -45,6 +45,11 @@ RSpec.describe "PUT /v2/content when the payload is for a brand new edition" do
     expect(subject.temporary_first_published_at).to be_nil
   end
 
+  it "has a major_published_at of nil" do
+    put "/v2/content/#{content_id}", params: payload.to_json
+    expect(subject.major_published_at).to be_nil
+  end
+
   shared_examples "creates a change note" do
     it "creates a change note" do
       expect {

--- a/spec/integration/put_content/new_edition_spec.rb
+++ b/spec/integration/put_content/new_edition_spec.rb
@@ -86,6 +86,12 @@ RSpec.describe "PUT /v2/content when the payload is for a brand new edition" do
 
       expect(subject.publisher_first_published_at).to eq(first_published_at)
     end
+
+    it "sets first_published_at to first_published_at" do
+      put "/v2/content/#{content_id}", params: payload.to_json
+
+      expect(subject.first_published_at).to eq(first_published_at)
+    end
   end
 
   context "and the change node is in the payload" do

--- a/spec/integration/put_content/new_edition_spec.rb
+++ b/spec/integration/put_content/new_edition_spec.rb
@@ -1,3 +1,4 @@
+require "rails_helper"
 
 RSpec.describe "PUT /v2/content when the payload is for a brand new edition" do
   include_context "PutContent call"
@@ -28,6 +29,12 @@ RSpec.describe "PUT /v2/content when the payload is for a brand new edition" do
     put "/v2/content/#{content_id}", params: payload.to_json
 
     expect(subject.document.stale_lock_version).to eq(1)
+  end
+
+  it "has a temporary_first_published_at of nil" do
+    put "/v2/content/#{content_id}", params: payload.to_json
+
+    expect(subject.temporary_first_published_at).to be_nil
   end
 
   shared_examples "creates a change note" do

--- a/spec/models/edition/timestamps_spec.rb
+++ b/spec/models/edition/timestamps_spec.rb
@@ -1,0 +1,239 @@
+require "rails_helper"
+
+RSpec.describe Edition::Timestamps do
+  before { Timecop.freeze(Time.local(2017, 9, 1, 12, 0, 0)) }
+  after { Timecop.return }
+  let(:current_time) { Time.zone.now }
+
+  describe "#edited" do
+    let(:edition) { FactoryGirl.build(:edition, update_type: update_type) }
+    let(:previous_live_version) do
+      FactoryGirl.build(:edition,
+        temporary_first_published_at: "2017-01-01",
+        first_published_at: "2017-04-01",
+        major_published_at: "2017-11-11",
+      )
+    end
+
+    let(:update_type) { "major" }
+    let(:payload) do
+      {
+        first_published_at: first_published_at,
+        last_edited_at: last_edited_at,
+        public_updated_at: public_updated_at,
+      }
+    end
+    let(:first_published_at) { nil }
+    let(:last_edited_at) { nil }
+    let(:public_updated_at) { nil }
+
+    before { described_class.edited(edition, payload, previous_live_version) }
+
+    it "saves the edition" do
+      expect(edition.id).not_to be_nil
+    end
+
+    it "sets temporary_last_edited_at to current time" do
+      expect(edition.temporary_last_edited_at).to eq current_time
+    end
+
+    it "sets temporary_first_published_at to same value as previous_live_version" do
+      expect(edition.temporary_first_published_at).to eq previous_live_version.temporary_first_published_at
+    end
+
+    context "when previous_live_version is nil" do
+      let(:previous_live_version) { nil }
+
+      it "sets temporary_first_published_at to nil" do
+        expect(edition.temporary_first_published_at).to be_nil
+      end
+    end
+
+    context "when edition has an update_type that is not major" do
+      let(:update_type) { "minor" }
+
+      it "sets major_published_at to same value as previous_live_version" do
+        expect(edition.major_published_at).to eq previous_live_version.major_published_at
+      end
+    end
+
+    context "when first_published_at is provided in payload" do
+      let(:first_published_at) { "2017-12-25" }
+
+      it "sets first_published_at to provided value" do
+        expect(edition.first_published_at).to eq Time.zone.parse(first_published_at)
+      end
+    end
+
+    context "when first_published_at is not provided in payload" do
+      let(:first_published_at) { nil }
+
+      it "sets first_published_at to previous_live_version" do
+        expect(edition.first_published_at).to eq previous_live_version.first_published_at
+      end
+    end
+
+    context "when last_edited_at is provided in payload" do
+      let(:last_edited_at) { "2017-10-30" }
+
+      it "sets last_edited_at to provided value" do
+        expect(edition.last_edited_at).to eq Time.zone.parse(last_edited_at)
+      end
+
+      it "sets publisher_last_edited_at to provided value" do
+        expect(edition.publisher_last_edited_at).to eq Time.zone.parse(last_edited_at)
+      end
+    end
+
+    context "when last_edited_at is not provided in payload" do
+      let(:last_edited_at) { nil }
+
+      it "sets last_edited_at to current time" do
+        expect(edition.last_edited_at).to eq current_time
+      end
+
+      it "sets publisher_last_edited_at to nil" do
+        expect(edition.publisher_last_edited_at).to be_nil
+      end
+    end
+
+    context "when public_updated_at is provided in payload" do
+      let(:public_updated_at) { "2017-10-30" }
+
+      it "sets publisher_major_published_at to provided public_updated_at_value" do
+        expect(edition.publisher_major_published_at).to eq Time.zone.parse(public_updated_at)
+      end
+
+      it "sets public_updated_at to provided value" do
+        expect(edition.public_updated_at).to eq Time.zone.parse(public_updated_at)
+      end
+    end
+
+    context "when public_updated_at is not provided in payload" do
+      let(:public_updated_at) { nil }
+
+      it "sets publisher_major_published_at to nil" do
+        expect(edition.publisher_major_published_at).to be_nil
+      end
+
+      it "sets public_updated_at to nil" do
+        expect(edition.public_updated_at).to be_nil
+      end
+    end
+  end
+
+  describe "#live_transition" do
+    let(:edition) do
+      FactoryGirl.build(:edition,
+        temporary_first_published_at: temporary_first_published_at,
+        first_published_at: first_published_at,
+        public_updated_at: public_updated_at,
+      )
+    end
+    let(:temporary_first_published_at) { nil }
+    let(:first_published_at) { nil }
+    let(:public_updated_at) { nil }
+
+    let(:previous_live_version) do
+      FactoryGirl.build(:edition,
+        major_published_at: "2017-11-05",
+        public_updated_at: previous_public_updated_at,
+      )
+    end
+    let(:previous_public_updated_at) { "2017-10-30" }
+
+    let(:update_type) { "major" }
+
+    before { described_class.live_transition(edition, update_type, previous_live_version) }
+
+    it "saves the edition" do
+      expect(edition.id).not_to be_nil
+    end
+
+    it "sets the published_at value to current time" do
+      expect(edition.published_at).to eq current_time
+    end
+
+    context "when the edition is being published for the first time" do
+      let(:temporary_first_published_at) { nil }
+      let(:first_published_at) { nil }
+
+      it "sets temporary_first_published_at to current time" do
+        expect(edition.temporary_first_published_at).to eq current_time
+      end
+
+      it "sets first_published_at to current time" do
+        expect(edition.first_published_at).to eq current_time
+      end
+    end
+
+    context "when an edition has already been published" do
+      let(:temporary_first_published_at) { "2010-05-01" }
+      let(:first_published_at) { "2011-05-01" }
+
+      it "doesn't change temporary first published at" do
+        expect(edition.temporary_first_published_at).to eq Time.zone.parse(temporary_first_published_at)
+      end
+
+      it "doesn't change first published at" do
+        expect(edition.first_published_at).to eq Time.zone.parse(first_published_at)
+      end
+    end
+
+    context "when update type is major" do
+      it "sets major_published_at to current time" do
+        expect(edition.major_published_at).to eq current_time
+      end
+
+      context "and public_updated_at hasn't been set on edition" do
+        let(:public_updated_at) { nil }
+
+        it "sets public_updated_at to current time" do
+          expect(edition.public_updated_at).to eq current_time
+        end
+      end
+
+      context "and public_updated_at has been set on the edition" do
+        let(:public_updated_at) { "2017-04-01" }
+
+        it "doesn't change public_updated_at" do
+          expect(edition.public_updated_at).to eq Time.zone.parse(public_updated_at)
+        end
+      end
+    end
+
+    context "when update type is not major" do
+      let(:update_type) { "minor" }
+
+      it "sets major_published_at to the value from the previous live edition" do
+        expect(edition.major_published_at).to eq previous_live_version.major_published_at
+      end
+
+      context "and public_updated_at isn't set, also previous live edition has a public_updated_at value" do
+        let(:public_updated_at) { nil }
+        let(:previous_public_updated_at) { "2017-07-03" }
+
+        it "sets public_updated_at to the value of the previous edition" do
+          expect(edition.public_updated_at).to eq previous_live_version.public_updated_at
+        end
+      end
+
+      context "and neither edition or previous live edition have a public_updated_at value" do
+        let(:public_updated_at) { nil }
+        let(:previous_public_updated_at) { nil }
+
+        it "sets public_updated_at to current time" do
+          expect(edition.public_updated_at).to eq current_time
+        end
+      end
+
+      context "and public_updated_at has been set on the edition" do
+        let(:public_updated_at) { "2017-04-01" }
+
+        it "doesn't change public_updated_at" do
+          expect(edition.public_updated_at).to eq Time.zone.parse(public_updated_at)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
We added some new date fields to Edition (see #1005).  This PR populates those fields.

https://trello.com/c/lGZFJaDB/1020-2-additional-publishing-api-date-fields