### PR TITLE
Add experimental "bulk links" endpoint

### DIFF
--- a/app/controllers/v2/link_sets_controller.rb
+++ b/app/controllers/v2/link_sets_controller.rb
@@ -4,6 +4,18 @@ module V2
       render json: Queries::GetLinkSet.call(content_id)
     end
 
+    def bulk_links
+      if Date.today > Date.parse("2017-09-18")
+        raise "This experimental endpoint has been disabled, please ask Taxonomy team to remove it."
+      end
+
+      json = params.fetch(:content_ids).map do |content_id|
+        Queries::GetLinkSet.call(content_id)
+      end
+
+      render json: json
+    end
+
     def expanded_links
       json = Queries::GetExpandedLinks.call(
         content_id,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,6 +30,8 @@ Rails.application.routes.draw do
         get "/linked/:content_id", to: "link_sets#get_linked"
       end
 
+      get "/bulk/links", to: "link_sets#bulk_links"
+
       get "/editions", to: "editions#index"
 
       get "/linkables", to: "content_items#linkables"


### PR DESCRIPTION
This adds an experimental "bulk" links endpoint. It has this endpoint:

```
/v2/bulk/links?content_ids[]=content-id-1&content_ids[]=content-id-2
```

It returns an array of hashes, which contain the exact response as you would get from a /v2/links/:content-id call.

Therefore:

```
/v2/bulk/links?content_ids[]=content-id-1 == [/v2/links/content-id-1]
```

We're not sure about the API and/or if we end up using this. To remind ourselves to remove or productionise it, the endpoint will stop working in a month.