### PR TITLE
Update requeue task to requeue by document type

### DIFF
--- a/lib/queue_publisher.rb
+++ b/lib/queue_publisher.rb
@@ -18,10 +18,10 @@ class QueuePublisher
   class PublishFailedError < StandardError
   end
 
-  def send_message(edition, event_type: nil, routing_key: nil)
+  def send_message(edition, event_type: nil, routing_key: nil, persistent: true)
     return if @noop
     routing_key ||= routing_key(edition, event_type)
-    publish_message(routing_key, edition, content_type: 'application/json', persistent: true)
+    publish_message(routing_key, edition, content_type: 'application/json', persistent: persistent)
   end
 
   def routing_key(edition, event_type)

--- a/lib/tasks/queue.rake
+++ b/lib/tasks/queue.rake
@@ -28,8 +28,16 @@ namespace :queue do
     end
   end
 
-  desc "Add published editions to the message queue, optionally specifying a limit on the number of items"
-  task :requeue_content, [:number_of_items] => :environment do |_, args|
-    RequeueContent.new(number_of_items: args[:number_of_items]).call
+  desc "Add published editions to the message queue by document type"
+  task :requeue_document_type, [:document_type] => :environment do |_, args|
+    document_type = args[:document_type]
+    raise ValueError("expecting document_type") unless document_type.present?
+
+    scope = Edition
+      .with_document
+      .with_unpublishing
+      .where(document_type: document_type)
+
+    RequeueContent.new(scope).call
   end
 end

--- a/spec/lib/requeue_content_spec.rb
+++ b/spec/lib/requeue_content_spec.rb
@@ -5,20 +5,20 @@ RSpec.describe RequeueContent do
     FactoryGirl.create(:live_edition, base_path: '/ci1')
     FactoryGirl.create(:live_edition, base_path: '/ci2')
     FactoryGirl.create(:live_edition, base_path: '/ci3')
+    FactoryGirl.create(:gone_live_edition, base_path: '/ci4')
+    FactoryGirl.create(:redirect_live_edition, base_path: '/ci5')
+    FactoryGirl.create(:draft_edition, base_path: '/ci5')
   end
 
   describe "#call" do
-    it "by default, it republishes all editions" do
-      expect(PublishingAPI.service(:queue_publisher)).to receive(:send_message).exactly(3).times
-      RequeueContent.new.call
-    end
+    it "it republishes all live editions" do
+      scope = Edition
+        .with_document
+        .with_unpublishing
 
-    it "limits the number of items published, if a limit is provided" do
-      expect(PublishingAPI.service(:queue_publisher)).to receive(:send_message)
-        .exactly(1)
-        .times
-        .with(a_hash_including(:content_id), event_type: "links")
-      RequeueContent.new(number_of_items: 1).call
+      expect(PublishingAPI.service(:queue_publisher)).to receive(:send_message).exactly(5).times
+
+      RequeueContent.new(scope).call
     end
   end
 end


### PR DESCRIPTION
This task was added when Finding Things team migrated all the links to the
publishing api, to sync everything back to Rummager.

We now need something similar to synchronise all existing content (not just links), so that
Rummager can be a direct downstream consumer of publishing api.

This PR includes a few implementation changes:

1. Use non persistent messages, because we want requeues to be as fast and low
   overhead as possible. Requeued messages are less important than normal
   publishing messages and should be abandoned if RabbitMQ goes down.

2. Use a separate routing key - `*.bulk.reindex` - to indicate the intent (see
   removed comment). This allows us to define a separate non-durable queue
   for these messages in Rummager; currently the `rummager_govuk_index`
   receives everything and is set up as `durable` to survive server restarts.

3. Filter on `content_store` instead of `state`, because we care about
   unpublished (especially withdrawn) editions as well as published.

4. Filter by document type for now, as we don't need the whole lot yet. We may
   add a 'requeue everything' task back in later.

Part of https://trello.com/c/5d4Qkt31/244-bulk-requeue-content-by-format / https://trello.com/c/VQsLP52d/246-create-rake-task-to-bulk-republish-by-format