### PR TITLE
bundle update govuk_document_types

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,7 @@ end
 
 gem "gds-sso", "13.0.0"
 gem "govuk_schemas", "~> 2.1.1"
-gem "govuk_document_types", "~> 0.1.4"
+gem "govuk_document_types", "~> 0.1.5"
 
 gem 'bunny', '~> 2.6'
 gem 'whenever', '0.9.4', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -115,7 +115,7 @@ GEM
     govuk-lint (1.2.1)
       rubocop (~> 0.39.0)
       scss_lint
-    govuk_document_types (0.1.4)
+    govuk_document_types (0.1.5)
     govuk_schemas (2.1.1)
       json-schema (~> 2.5.0)
     govuk_sidekiq (1.0.3)
@@ -404,7 +404,7 @@ DEPENDENCIES
   gds-sso (= 13.0.0)
   govspeak (~> 5.0.2)
   govuk-lint
-  govuk_document_types (~> 0.1.4)
+  govuk_document_types (~> 0.1.5)
   govuk_schemas (~> 2.1.1)
   govuk_sidekiq (~> 1.0.3)
   hashdiff


### PR DESCRIPTION
This is to fix some subscriber list matching problems between
govuk-delivery and email-alert-api.