### PR TITLE
Set first_published_at from edition history

### DIFF
--- a/db/migrate/20170901095633_repopulate_first_published_at_from_change_history.rb
+++ b/db/migrate/20170901095633_repopulate_first_published_at_from_change_history.rb
@@ -1,0 +1,42 @@
+class RepopulateFirstPublishedAtFromChangeHistory < ActiveRecord::Migration[5.1]
+  disable_ddl_transaction!
+
+  def up
+    min_date = '2016-02-29T09:24:09'
+    max_date = '2016-02-29T09:24:11'
+    document_ids = []
+    statements_ary = []
+
+    sql = <<-SQL.strip_heredoc
+      SELECT e.id,
+             e.document_id,
+             hist->>'public_timestamp'
+      FROM   editions e,
+             json_array_elements(details->'change_history') hist
+      WHERE  e.document_type != 'placeholder'
+      AND    e.first_published_at BETWEEN '#{min_date}' AND '#{max_date}'
+      AND    hist IS NOT NULL
+      AND    hist->>'note' = 'First published.'
+      AND    hist->>'public_timestamp' NOT BETWEEN '#{min_date}' AND '#{max_date}'
+    SQL
+
+    # ~224000 records
+    results = ActiveRecord::Base.connection.execute(sql).values
+    puts "#{results.size} records found with change history and first_published_at on 2016-02-29."
+
+    results.each do |edition_id, document_id, timestamp|
+      statements_ary << "UPDATE editions SET first_published_at = '#{timestamp}' WHERE id = #{edition_id};"
+      document_ids << document_id
+    end
+
+    statements_ary.each_slice(1000).each do |statements|
+      ActiveRecord::Base.connection.execute(statements.join("\n"))
+    end
+
+    if Rails.env.production?
+      document_content_ids = Document.where(id: document_ids.uniq).pluck(:content_id)
+      puts "Representing #{document_content_ids.size} items downstream."
+      Commands::V2::RepresentDownstream.new.call(document_content_ids)
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170831141117) do
+ActiveRecord::Schema.define(version: 20170901095633) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
https://trello.com/c/BHzWqzPF/1043-3-sort-out-the-same-firstpublishedat-date-for-1-4-of-the-database

We have 800000 records with a `first_published_at` on 2016-02-29,
a quarter of these are placeholders, just over 200000 have a
'First published' change history item, so use the date from this
to set the correct `first_published_at` value.