### PR TITLE
Set the dependent method for links to delete

### DIFF
--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -36,7 +36,7 @@ class Edition < ApplicationRecord
   belongs_to :document
   has_one :unpublishing
   has_one :change_note
-  has_many :links
+  has_many :links, dependent: :delete_all
 
   scope :renderable_content, -> { where.not(document_type: NON_RENDERABLE_FORMATS) }
   scope :with_document, -> { joins(:document) }


### PR DESCRIPTION
This defaults to nullify technique which is leaving links in our
database with null foreign keys rather than deleting them.

We currently have ~3,000,000 links with null edition_id and link_set_id
values due to this.