### PR TITLE
Make the Bulk Links endpoint ready for production

### DIFF
--- a/app/controllers/v2/link_sets_controller.rb
+++ b/app/controllers/v2/link_sets_controller.rb
@@ -9,10 +9,7 @@ module V2
         raise "This experimental endpoint has been disabled, please ask Taxonomy team to remove it."
       end
 
-      json = params.fetch(:content_ids).map do |content_id|
-        Queries::GetLinkSet.call(content_id)
-      end
-
+      json = Queries::GetBulkLinks.call(content_ids)
       render json: json
     end
 
@@ -50,6 +47,10 @@ module V2
 
     def generate?
       ActiveModel::Type::Boolean.new.cast(params.fetch(:generate, false))
+    end
+
+    def content_ids
+      params.fetch(:content_ids)
     end
 
     def links_params

--- a/app/controllers/v2/link_sets_controller.rb
+++ b/app/controllers/v2/link_sets_controller.rb
@@ -5,6 +5,7 @@ module V2
     end
 
     def bulk_links
+      throw_payload_error if max_payload_size_exceeded?
       json = Queries::GetBulkLinks.call(content_ids)
       render json: json
     end
@@ -43,6 +44,17 @@ module V2
 
     def generate?
       ActiveModel::Type::Boolean.new.cast(params.fetch(:generate, false))
+    end
+
+    def throw_payload_error
+      raise CommandError.new(
+        code: 413,
+        message: "Payload size exceeded 1000 ids"
+      )
+    end
+
+    def max_payload_size_exceeded?
+      content_ids.size > 1000
     end
 
     def content_ids

--- a/app/controllers/v2/link_sets_controller.rb
+++ b/app/controllers/v2/link_sets_controller.rb
@@ -5,10 +5,6 @@ module V2
     end
 
     def bulk_links
-      if Date.today > Date.parse("2017-09-18")
-        raise "This experimental endpoint has been disabled, please ask Taxonomy team to remove it."
-      end
-
       json = Queries::GetBulkLinks.call(content_ids)
       render json: json
     end

--- a/app/errors/command_error.rb
+++ b/app/errors/command_error.rb
@@ -56,7 +56,7 @@ class CommandError < StandardError
   end
 
   def valid_code?(code)
-    [400, 404, 409, 422, 500].include?(code)
+    [400, 404, 409, 413, 422, 500].include?(code)
   end
 
   def as_json(_options = nil)

--- a/app/queries/get_bulk_links.rb
+++ b/app/queries/get_bulk_links.rb
@@ -1,0 +1,18 @@
+module Queries
+  module GetBulkLinks
+    def self.call(content_ids = [])
+      content_ids.each_with_object({}) do |content_id, hsh|
+        hsh[content_id] = link_set(content_id)
+      end
+    end
+
+    def self.link_set(content_id)
+      link_set = LinkSet.find_by(content_id: content_id)
+      return { links: {}, version: 0 } unless link_set
+
+      Presenters::Queries::LinkSetPresenter
+        .present(link_set)
+        .slice(:links, :version)
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,7 +30,7 @@ Rails.application.routes.draw do
         get "/linked/:content_id", to: "link_sets#get_linked"
       end
 
-      get "/bulk/links", to: "link_sets#bulk_links"
+      post "/bulk/links", to: "link_sets#bulk_links"
 
       get "/editions", to: "editions#index"
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,7 +30,7 @@ Rails.application.routes.draw do
         get "/linked/:content_id", to: "link_sets#get_linked"
       end
 
-      post "/bulk/links", to: "link_sets#bulk_links"
+      post "/bulk-links", to: "link_sets#bulk_links"
 
       get "/editions", to: "editions#index"
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,10 +27,9 @@ Rails.application.routes.draw do
         patch "/links/:content_id", to: "link_sets#patch_links"
         # put is provided for backwards compatibility.
         put "/links/:content_id", to: "link_sets#patch_links"
+        post "/links/by-content-id", to: "link_sets#bulk_links"
         get "/linked/:content_id", to: "link_sets#get_linked"
       end
-
-      post "/bulk-links", to: "link_sets#bulk_links"
 
       get "/editions", to: "editions#index"
 

--- a/doc/api.md
+++ b/doc/api.md
@@ -24,6 +24,7 @@ message queue for other apps (e.g. `email-alert-service`) to consume.
 - [`GET /v2/linked/:content_id`](#get-v2linkedcontent_id)
 - [`GET /v2/linkables`](#get-v2linkables)
 - [`GET /v2/editions`](#get-v2editions)
+- [`POST /v2/bulk-links`](#post-v2bulk-links)
 - [`POST /lookup-by-base-path`](#post-lookup-by-base-path)
 - [`PUT /paths/:base_path`](#put-pathsbase_path)
 - [`GET /debug/:content_id`](#get-debugcontent_id)
@@ -600,6 +601,16 @@ parameters.
   - Used to restrict editions to those for a given publishing app.
 - `states[]` *(optional)*
   - Used to restrict editions to those in the specified states.
+
+## `POST /v2/bulk-links`
+
+Retrieves the set of links for a given collection of content_ids. Returns a
+mapping of `content_id` to `links` hash.
+
+### POST parameters:
+
+- `content_ids[]` *(required)*
+  - An array of `content_id`s to query by.
 
 ## `POST /lookup-by-base-path`
 

--- a/doc/api.md
+++ b/doc/api.md
@@ -24,7 +24,7 @@ message queue for other apps (e.g. `email-alert-service`) to consume.
 - [`GET /v2/linked/:content_id`](#get-v2linkedcontent_id)
 - [`GET /v2/linkables`](#get-v2linkables)
 - [`GET /v2/editions`](#get-v2editions)
-- [`POST /v2/bulk-links`](#post-v2bulk-links)
+- [`POST /v2/links/by-content-id`](#post-v2linksby-content-id)
 - [`POST /lookup-by-base-path`](#post-lookup-by-base-path)
 - [`PUT /paths/:base_path`](#put-pathsbase_path)
 - [`GET /debug/:content_id`](#get-debugcontent_id)
@@ -602,7 +602,7 @@ parameters.
 - `states[]` *(optional)*
   - Used to restrict editions to those in the specified states.
 
-## `POST /v2/bulk-links`
+## `POST /v2/links/by-content-id`
 
 Retrieves the set of links for a given collection of content_ids. Returns a
 mapping of `content_id` to `links` hash.

--- a/doc/api.md
+++ b/doc/api.md
@@ -610,7 +610,7 @@ mapping of `content_id` to `links` hash.
 ### POST parameters:
 
 - `content_ids[]` *(required)*
-  - An array of `content_id`s to query by.
+  - An array of `content_id`s to query by. This can be no longer than 1000 ids, or the API will return a 413 error.
 
 ## `POST /lookup-by-base-path`
 

--- a/spec/controllers/v2/link_sets_controller_spec.rb
+++ b/spec/controllers/v2/link_sets_controller_spec.rb
@@ -30,6 +30,15 @@ RSpec.describe V2::LinkSetsController do
         expect(response.status).to eql 200
       end
     end
+
+    context "with over 1000 content_ids" do
+      it "is unsuccessful" do
+        content_id = SecureRandom.uuid
+        content_ids = Array.new(1001) { content_id }
+        post :bulk_links, params: { content_ids: content_ids }
+        expect(response.status).to eql 413
+      end
+    end
   end
 
   describe "get_linked" do

--- a/spec/controllers/v2/link_sets_controller_spec.rb
+++ b/spec/controllers/v2/link_sets_controller_spec.rb
@@ -9,6 +9,29 @@ RSpec.describe V2::LinkSetsController do
     stub_request(:any, /content-store/)
   end
 
+  describe "bulk_links" do
+    context "called without providing content_ids parameter" do
+      it "is unsuccessful" do
+        post :bulk_links, params: {}
+        expect(response.status).to eql 422
+      end
+    end
+
+    context "called with empty content_ids parameter" do
+      it "is unsuccessful" do
+        post :bulk_links, params: { content_ids: [] }
+        expect(response.status).to eql 422
+      end
+    end
+
+    context "with content_ids" do
+      it "is successful" do
+        post :bulk_links, params: { content_ids: [SecureRandom.uuid] }
+        expect(response.status).to eql 200
+      end
+    end
+  end
+
   describe "get_linked" do
     context "called without providing fields parameter" do
       it "is unsuccessful" do

--- a/spec/queries/get_bulk_links_spec.rb
+++ b/spec/queries/get_bulk_links_spec.rb
@@ -1,6 +1,7 @@
 require "rails_helper"
 
 RSpec.describe Queries::GetBulkLinks do
+  subject { described_class }
   let(:content_id_with_links) { SecureRandom.uuid }
   let(:content_id_no_links) { SecureRandom.uuid }
 

--- a/spec/queries/get_bulk_links_spec.rb
+++ b/spec/queries/get_bulk_links_spec.rb
@@ -1,0 +1,57 @@
+require "rails_helper"
+
+RSpec.describe Queries::GetBulkLinks do
+  let(:content_id_with_links) { SecureRandom.uuid }
+  let(:content_id_no_links) { SecureRandom.uuid }
+
+  let(:parent) { [SecureRandom.uuid] }
+  let(:related) { [SecureRandom.uuid, SecureRandom.uuid] }
+
+  let(:link_set) do
+    {
+      links: {
+        parent: parent,
+        related: related
+      },
+      version: 5
+    }
+  end
+
+  let(:empty_link_set) { { links: {}, version: 0 } }
+
+  before do
+    link_set = FactoryGirl.create(:link_set,
+      content_id: content_id_with_links,
+      stale_lock_version: 5
+    )
+
+    FactoryGirl.create(:link,
+      link_set: link_set,
+      link_type: "parent",
+      target_content_id: parent.first
+    )
+
+    FactoryGirl.create(:link,
+      link_set: link_set,
+      link_type: "related",
+      target_content_id: related.first
+    )
+
+    FactoryGirl.create(:link,
+      link_set: link_set,
+      link_type: "related",
+      target_content_id: related.last
+    )
+  end
+
+  describe ".call" do
+    it "returns a hash of content_ids => links" do
+      content_ids = [content_id_with_links, content_id_no_links]
+      result = subject.call(content_ids)
+
+      expect(result.keys).to eql content_ids
+      expect(result[content_id_with_links]).to eql link_set
+      expect(result[content_id_no_links]).to eql empty_link_set
+    end
+  end
+end

--- a/spec/service_consumers/pact_helper.rb
+++ b/spec/service_consumers/pact_helper.rb
@@ -167,6 +167,19 @@ Pact.provider_states_for "GDS API Adapters" do
     end
   end
 
+  provider_state "taxon links exist for content_id bed722e6-db68-43e5-9079-063f623335a7" do
+    set_up do
+      link_set = FactoryGirl.create(:link_set,
+        content_id: "bed722e6-db68-43e5-9079-063f623335a7",
+        stale_lock_version: 2
+      )
+
+      taxon = FactoryGirl.create(:document, content_id: "20583132-1619-4c68-af24-77583172c070")
+      FactoryGirl.create(:edition, document: taxon)
+      FactoryGirl.create(:link, link_set: link_set, link_type: "taxons", target_content_id: taxon.content_id)
+    end
+  end
+
   provider_state "no links exist for content_id bed722e6-db68-43e5-9079-063f623335a7" do
     set_up do
       # no-op


### PR DESCRIPTION
This is to productionise the [bulk links endpoint](https://github.com/alphagov/publishing-api/pull/1008).

This endpoint has changed to respond to POST requests, to accommodate larger payloads.  For example:

```
curl -d "content_ids[]=e1067450-7d13-45ff-ada4-5e3dd4025fb7&content_ids[]=72ed754c-4c82-415f-914a-ab6760454cb4" localhost:3093/v2/bulk-links
```

In order to aid the efficient parsing of responses, the output has changed to a hash of content_ids => links. For example:

```
{:"e1067450-7d13-45ff-ada4-5e3dd4025fb7"=>
  {:links=>
    {:mainstream_browse_pages=>["749762c5-0e80-4d04-b766-9850192764d4"],
     :meets_user_needs=>
      ["8042330b-d973-41c1-991c-dffada2950a3",
       "436205fc-1848-41c3-b0df-359ecfbb78b2"],
     :ordered_related_items=>
      ["124edf01-5637-43d1-9c05-fe22530d54b4",
       "b589f602-7427-4ac0-b220-ee35f711548b",
       "f9d0c33a-5b1f-4ec3-8226-5eb665f33b54"],
     :organisations=>["04148522-b0c1-4137-b687-5f3c3bdd561a"],
     :parent=>["749762c5-0e80-4d04-b766-9850192764d4"],
     :taxons=>["13bba81c-b2b1-4b13-a3de-b24748977198"]},
   :version=>10},
 :"72ed754c-4c82-415f-914a-ab6760454cb4"=>
  {:links=>
    {:mainstream_browse_pages=>["26c60c2f-52f7-4da6-98fc-0183776f7fdc"],
     :ordered_related_items=>
      ["1e333395-5dd5-4452-96a3-fbe939928761",
       "e2044da3-5e2f-4fdf-bfb0-4aa5b4357c02"],
     :organisations=>["04148522-b0c1-4137-b687-5f3c3bdd561a"],
     :parent=>["26c60c2f-52f7-4da6-98fc-0183776f7fdc"],
     :taxons=>["13bba81c-b2b1-4b13-a3de-b24748977198"]},
   :version=>15}}
```

[Trello](https://trello.com/c/H3BqIPWc/190-current-tags-are-visible-in-the-bulk-tagging-tool)
