### PR TITLE
Migration to remove orphaned links

### DIFF
--- a/db/migrate/20170830145359_delete_orphaned_links.rb
+++ b/db/migrate/20170830145359_delete_orphaned_links.rb
@@ -1,0 +1,5 @@
+class DeleteOrphanedLinks < ActiveRecord::Migration[5.1]
+  def up
+    Link.where(edition_id: nil, link_set_id: nil).delete_all
+  end
+end


### PR DESCRIPTION
This should not be merged until https://github.com/alphagov/publishing-api/pull/1016 has been deployed

This removes Links which have an edition_id of nil and a link_set_id of
nil. Which were created by us not understanding the default behaviour of
`edition.links.delete_all`.

This deletes approximately 3 million rows, I did consider running it
through a find_in_batches but it only took 5 seconds to run on my
machine and as these are orphaned I don't think this will lock anything
that's used.