### PR TITLE
Fixes for random content tests

### DIFF
--- a/spec/integration/random_content_spec.rb
+++ b/spec/integration/random_content_spec.rb
@@ -13,7 +13,8 @@ RSpec.describe "Randomised content" do
 
       expect(response).to be_ok, random_content_failure_message(response, edition)
 
-      post "/v2/content/#{content_id}/publish", params: { locale: edition["locale"], update_type: "major" }.to_json
+      params = { locale: edition["locale"] || "en" }
+      post "/v2/content/#{content_id}/publish", params: params.to_json
 
       expect(response).to be_ok, random_content_failure_message(response, edition)
     end

--- a/spec/integration/random_content_spec.rb
+++ b/spec/integration/random_content_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "Randomised content" do
 
       expect(response).to be_ok, random_content_failure_message(response, edition)
 
-      params = { locale: edition["locale"] || "en" }
+      params = edition["locale"] ? { locale: edition["locale"] } : {}
       post "/v2/content/#{content_id}/publish", params: params.to_json
 
       expect(response).to be_ok, random_content_failure_message(response, edition)

--- a/spec/support/random_content_helpers.rb
+++ b/spec/support/random_content_helpers.rb
@@ -6,6 +6,7 @@ module RandomContentHelpers
 
     random.merge_and_validate(
       base_path: base_path,
+      update_type: "major",
 
       # TODOs:
       title: "Something not empty", # TODO: make schemas validate title length


### PR DESCRIPTION
This updates the random content tests to not set the update_type in publish and can handle an optional locale.