### PR TITLE
Record changes in links through patch_links

### DIFF
--- a/app/controllers/v2/link_changes_controller.rb
+++ b/app/controllers/v2/link_changes_controller.rb
@@ -1,0 +1,7 @@
+module V2
+  class LinkChangesController < ApplicationController
+    def index
+      render json: Queries::GetLinkChanges.new(params).as_json
+    end
+  end
+end

--- a/app/controllers/v2/link_changes_controller.rb
+++ b/app/controllers/v2/link_changes_controller.rb
@@ -1,7 +1,7 @@
 module V2
   class LinkChangesController < ApplicationController
     def index
-      render json: Queries::GetLinkChanges.new(params).as_json
+      render json: Queries::GetLinkChanges.new(params, request.original_url).as_json
     end
   end
 end

--- a/app/models/link_change.rb
+++ b/app/models/link_change.rb
@@ -1,0 +1,3 @@
+class LinkChange < ApplicationRecord
+  belongs_to :action
+end

--- a/app/queries/get_link_changes.rb
+++ b/app/queries/get_link_changes.rb
@@ -1,0 +1,43 @@
+module Queries
+  class GetLinkChanges
+    PAGE_LENGTH = 1000
+    attr_reader :params
+
+    def initialize(params)
+      @params = params
+    end
+
+    def as_json
+      results = link_changes.map do |link_change|
+        {
+          id: link_change.id,
+          source_content_id: link_change.source_content_id,
+          target_content_id: link_change.target_content_id,
+          link_type: link_change.link_type,
+          change: link_change.change,
+          user_uid: link_change.action.user_uid,
+          created_at: link_change.created_at
+        }
+      end
+
+      {
+        link_changes: results,
+        next_page_path: next_page_path
+      }
+    end
+
+    def link_changes
+      @link_changes ||= begin
+        change_query = LinkChange.order(:id).limit(PAGE_LENGTH).includes(:action)
+        change_query = change_query.where("ID >= ?", params[:start]) unless params[:start].nil?
+        change_query
+      end
+    end
+
+    def next_page_path
+      if link_changes.count == PAGE_LENGTH
+        "/v2/links/changes?start=#{link_changes.last.id + 1}"
+      end
+    end
+  end
+end

--- a/app/services/link_change_service.rb
+++ b/app/services/link_change_service.rb
@@ -1,0 +1,38 @@
+class LinkChangeService
+  attr_reader :action, :before_links, :after_links
+
+  def initialize(action, before_links, after_links)
+    @action = action
+    @before_links = before_links
+    @after_links = after_links
+  end
+
+  def record
+    before_set = Set.new(before_links.map { |link| [link.target_content_id, link.link_type] })
+    after_set = Set.new(after_links.map { |link| [link.target_content_id, link.link_type] })
+
+    after_links.each do |link|
+      unless before_set.include?([link.target_content_id, link.link_type])
+        create_link_change(link: link, change: 1)
+      end
+    end
+
+    before_links.each do |link|
+      unless after_set.include?([link.target_content_id, link.link_type])
+        create_link_change(link: link, change: -1)
+      end
+    end
+  end
+
+private
+
+  def create_link_change(link:, change:)
+    LinkChange.create!(
+      source_content_id: action.content_id,
+      target_content_id: link.target_content_id,
+      link_type: link.link_type,
+      change: change,
+      action: action
+    )
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -38,6 +38,8 @@ Rails.application.routes.draw do
       get "/new-linkables", to: "content_items#new_linkables"
 
       post "/actions/:content_id", to: "actions#create"
+
+      get "/links/changes", to: "link_changes#index"
     end
 
     if ENV.include?("CONTENT_API_PROTOTYPE")

--- a/db/migrate/20170905123649_create_link_changes.rb
+++ b/db/migrate/20170905123649_create_link_changes.rb
@@ -1,0 +1,13 @@
+class CreateLinkChanges < ActiveRecord::Migration[5.1]
+  def change
+    create_table :link_changes do |t|
+      t.uuid :source_content_id, null: false
+      t.uuid :target_content_id, null: false
+      t.string :link_type, null: false
+      t.integer :change, null: false
+      t.references :action, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170901095633) do
+ActiveRecord::Schema.define(version: 20170905123649) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -128,6 +128,17 @@ ActiveRecord::Schema.define(version: 20170901095633) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["content_id", "locale", "with_drafts"], name: "expanded_links_content_id_locale_with_drafts_index", unique: true
+  end
+
+  create_table "link_changes", force: :cascade do |t|
+    t.uuid "source_content_id", null: false
+    t.uuid "target_content_id", null: false
+    t.string "link_type", null: false
+    t.integer "change", null: false
+    t.bigint "action_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["action_id"], name: "index_link_changes_on_action_id"
   end
 
   create_table "link_sets", id: :serial, force: :cascade do |t|

--- a/spec/factories/link_change.rb
+++ b/spec/factories/link_change.rb
@@ -1,0 +1,9 @@
+FactoryGirl.define do
+  factory :link_change do
+    source_content_id { SecureRandom.uuid }
+    target_content_id { SecureRandom.uuid }
+    action
+    link_type "taxons"
+    change 1
+  end
+end

--- a/spec/queries/get_link_changes_spec.rb
+++ b/spec/queries/get_link_changes_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Queries::GetLinkChanges do
     it 'returns the link changes with the correct data' do
       FactoryGirl.create(:link_change)
 
-      result = Queries::GetLinkChanges.new({}).as_json
+      result = Queries::GetLinkChanges.new({}, double).as_json
 
       change = result[:link_changes].first
 

--- a/spec/queries/get_link_changes_spec.rb
+++ b/spec/queries/get_link_changes_spec.rb
@@ -1,0 +1,17 @@
+require "rails_helper"
+
+RSpec.describe Queries::GetLinkChanges do
+  describe '#as_json' do
+    it 'returns the link changes with the correct data' do
+      FactoryGirl.create(:link_change)
+
+      result = Queries::GetLinkChanges.new({}).as_json
+
+      change = result[:link_changes].first
+
+      expect(change.keys).to eql(
+        [:id, :source_content_id, :target_content_id, :link_type, :change, :user_uid, :created_at]
+      )
+    end
+  end
+end

--- a/spec/requests/patch_link_set_spec.rb
+++ b/spec/requests/patch_link_set_spec.rb
@@ -69,15 +69,15 @@ RSpec.describe "Keeping track of link changes", type: :request do
       expect(parsed_response["link_changes"].length).to eq(2)
       expect(parsed_response["link_changes"].first["id"]).to eq(LinkChange.first.id)
 
-      get parsed_response["next_page_path"]
+      get parsed_response["links"].first["href"]
 
       expect(parsed_response["link_changes"].length).to eq(2)
 
-      get parsed_response["next_page_path"]
+      get parsed_response["links"].first["href"]
 
       expect(parsed_response["link_changes"].length).to eq(1)
       expect(parsed_response["link_changes"].last["id"]).to eq(LinkChange.last.id)
-      expect(parsed_response["next_page_path"]).to be_nil
+      expect(parsed_response["links"]).to be_empty
     end
   end
 

--- a/spec/requests/patch_link_set_spec.rb
+++ b/spec/requests/patch_link_set_spec.rb
@@ -1,0 +1,93 @@
+require "rails_helper"
+
+RSpec.describe "Keeping track of link changes", type: :request do
+  scenario "No links are added" do
+    make_patch_links_request(
+      "2ee935c3-d926-4737-aa23-e8c5edb5c3ca",
+      {}
+    )
+
+    when_i_request_link_changes
+
+    expect(parsed_response["link_changes"]).to eql([])
+  end
+
+  scenario "A link is added" do
+    make_patch_links_request(
+      "2ee935c3-d926-4737-aa23-e8c5edb5c3ca",
+      something: ["1f0b3601-6a1d-4065-adc6-bf6040e2a806"]
+    )
+
+    when_i_request_link_changes
+
+    expect(parsed_response["link_changes"].size).to eql(1)
+  end
+
+  scenario "A link is changed" do
+    make_patch_links_request(
+      "2ee935c3-d926-4737-aa23-e8c5edb5c3ca",
+      something: ["1f0b3601-6a1d-4065-adc6-bf6040e2a806"]
+    )
+
+    make_patch_links_request(
+      "2ee935c3-d926-4737-aa23-e8c5edb5c3ca",
+      something: ["0bbd6b21-b6f4-4327-aa40-696bda836000"]
+    )
+
+    when_i_request_link_changes
+
+    expect(parsed_response["link_changes"].size).to eql(3)
+  end
+
+  scenario "Fetching the link actions" do
+    4.times {
+      make_patch_links_request(
+        "2ee935c3-d926-4737-aa23-e8c5edb5c3ca",
+        something: [SecureRandom.uuid]
+      )
+    }
+
+    get "/v2/links/changes?start=#{LinkChange.last.id}"
+
+    expect(parsed_response["link_changes"].size).to eql(1)
+  end
+
+  describe "Paging through the actions" do
+    it "supplies the next page" do
+      3.times {
+        make_patch_links_request(
+          "31f8cfad-6804-40f9-8124-8725c45a8371",
+          something: [SecureRandom.uuid]
+        )
+      }
+
+      # Dirty trick to limit pagination
+      stub_const("Queries::GetLinkChanges::PAGE_LENGTH", 2)
+
+      when_i_request_link_changes
+
+      expect(parsed_response["link_changes"].length).to eq(2)
+      expect(parsed_response["link_changes"].first["id"]).to eq(LinkChange.first.id)
+
+      get parsed_response["next_page_path"]
+
+      expect(parsed_response["link_changes"].length).to eq(2)
+
+      get parsed_response["next_page_path"]
+
+      expect(parsed_response["link_changes"].length).to eq(1)
+      expect(parsed_response["link_changes"].last["id"]).to eq(LinkChange.last.id)
+      expect(parsed_response["next_page_path"]).to be_nil
+    end
+  end
+
+  def when_i_request_link_changes
+    get "/v2/links/changes"
+  end
+
+  def make_patch_links_request(content_id, links)
+    patch "/v2/links/#{content_id}",
+          params: { links: links }.to_json,
+          headers: { "X-GOVUK-AUTHENTICATED-USER" => SecureRandom.uuid }
+  end
+end


### PR DESCRIPTION
After each call to Patch Links, the Links added and Removed are recorded in a new LinkChange model. The source- and target_content_id are recorded, the link type and if the change was an addition (change=1) or a removal (change=-1), the index of the record and the related Action

The LinkChanges are exposed through a new API call (/v2/link-changes?start=<id>) which outputs the LinkChanges in JSON. The number of records can be limited through the start parameter which takes the ID of the first LinkChange to fetch

Trello: https://trello.com/c/162iqEul/185-update-change-history-every-minute-from-publishing-api