### PR TITLE
Make change notes deletable

### DIFF
--- a/app/models/update_existing_draft_edition.rb
+++ b/app/models/update_existing_draft_edition.rb
@@ -42,6 +42,10 @@ private
     # including them in the payload.
     edition.links.delete_all
 
+    if edition.update_type == "minor" && edition.change_note.present?
+      edition.change_note.delete
+    end
+
     edition.save!
     [edition, old_edition]
   end

--- a/spec/integration/put_content/content_with_a_previous_draft_spec.rb
+++ b/spec/integration/put_content/content_with_a_previous_draft_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe "PUT /v2/content when the payload is for an already drafted editi
       base_path: base_path,
       title: "Old Title",
       publishing_app: "publisher",
+      update_type: "major",
     )
   end
 
@@ -248,6 +249,28 @@ RSpec.describe "PUT /v2/content when the payload is for an already drafted editi
         expect(access_limit.users).to eq(["new-user"])
         expect(access_limit.auth_bypass_ids).to eq([auth_bypass_id])
       end
+    end
+  end
+
+  context "when the change note has been updated" do
+    let(:change_note) { "updated note" }
+
+    it "updates the change note" do
+      expect { put "/v2/content/#{content_id}", params: payload.to_json }
+        .to change { previously_drafted_item.change_note.reload.note }
+        .from("note").to("updated note")
+    end
+  end
+
+  context "when the change note has been removed" do
+    before do
+      payload.delete(:change_note)
+      payload[:update_type] = "minor"
+    end
+
+    it "removes the change note" do
+      expect { put "/v2/content/#{content_id}", params: payload.to_json }
+        .to change(ChangeNote, :count).by(-1)
     end
   end
 end

--- a/spec/integration/put_content/new_edition_spec.rb
+++ b/spec/integration/put_content/new_edition_spec.rb
@@ -45,7 +45,12 @@ RSpec.describe "PUT /v2/content when the payload is for a brand new edition" do
   context "and the change history is in the details hash" do
     before do
       payload.delete(:change_note)
-      payload[:details] = { change_history: [change_note] }
+
+      payload[:details] = {
+        change_history: [
+          { note: change_note, public_timestamp: Time.now.utc.to_s },
+        ]
+      }
     end
 
     include_examples "creates a change note"
@@ -54,7 +59,7 @@ RSpec.describe "PUT /v2/content when the payload is for a brand new edition" do
   context "and the change note is in the details hash" do
     before do
       payload.delete(:change_note)
-      payload[:details] = { change_note: change_note[:note] }
+      payload[:details] = { change_note: change_note }
     end
 
     include_examples "creates a change note"

--- a/spec/support/shared_context/put_content_calls.rb
+++ b/spec/support/shared_context/put_content_calls.rb
@@ -13,15 +13,12 @@ RSpec.shared_context "PutContent call" do
       routes: [{ path: base_path, type: "exact" }],
       redirects: [],
       phase: "beta",
-      change_note: change_note
+      change_note: change_note,
     }
   end
 
   let(:base_path) { "/vat-rates" }
   let(:locale) { "en" }
   let(:content_id) { SecureRandom.uuid }
-
-  let(:change_note) do
-    { note: "Info", public_timestamp: Time.now.utc.to_s }
-  end
+  let(:change_note) { "change note" }
 end


### PR DESCRIPTION
We have found a case where an Edition originally has an `update_type` of
"major" and a change note, and subsequently has its `update_type` changed to
"minor", the change note persists. This ensures that in these cases the change
note is deleted.

This is to fix an issue relating to this Zendesk ticket:
https://govuk.zendesk.com/agent/tickets/2393067

For [Trello](https://trello.com/c/GbvuESJT/1112-remove-change-note-when-switching-update-type-from-major-to-minor)