### PR TITLE
Keep track of change history for links

### DIFF
--- a/app/commands/v2/patch_link_set.rb
+++ b/app/commands/v2/patch_link_set.rb
@@ -9,7 +9,7 @@ module Commands
 
         link_set.increment!(:stale_lock_version)
 
-        links_before_patch = link_set.links.map(&:target_content_id)
+        before_links = link_set.links.to_a
 
         grouped_links.each do |group, payload_content_ids|
           # For each set of links in a LinkSet scoped by link_type, this iterator
@@ -25,13 +25,13 @@ module Commands
         # we need to reload the link_set as the links association will be stale
         link_set.reload
 
-        orphaned_content_ids = link_diff_between(links_before_patch, link_set.links.map(&:target_content_id))
+        orphaned_content_ids = link_diff_between(before_links.map(&:target_content_id), link_set.links.map(&:target_content_id))
 
         after_transaction_commit do
           send_downstream(orphaned_content_ids)
         end
 
-        Action.create_patch_link_set_action(link_set, event)
+        Action.create_patch_link_set_action(link_set, before_links, event)
 
         presented = Presenters::Queries::LinkSetPresenter.present(link_set)
         Success.new(presented)

--- a/app/models/action.rb
+++ b/app/models/action.rb
@@ -34,8 +34,8 @@ class Action < ActiveRecord::Base
     )
   end
 
-  def self.create_patch_link_set_action(link_set, event)
-    create!(
+  def self.create_patch_link_set_action(link_set, before_links, event)
+    action = create!(
       content_id: link_set.content_id,
       locale: nil,
       action: "PatchLinkSet",
@@ -43,6 +43,9 @@ class Action < ActiveRecord::Base
       link_set: link_set,
       event: event,
     )
+
+    after_links = link_set.links.to_a
+    LinkChangeService.new(action, before_links, after_links).record
   end
 
 private

--- a/app/models/link_change.rb
+++ b/app/models/link_change.rb
@@ -1,0 +1,4 @@
+class LinkChange < ApplicationRecord
+  belongs_to :action
+  enum change: { add: 1, remove: -1 }
+end

--- a/app/services/link_change_service.rb
+++ b/app/services/link_change_service.rb
@@ -1,0 +1,38 @@
+class LinkChangeService
+  attr_reader :action, :before_links, :after_links
+
+  def initialize(action, before_links, after_links)
+    @action = action
+    @before_links = before_links
+    @after_links = after_links
+  end
+
+  def record
+    before_set = Set.new(before_links.map { |link| [link.target_content_id, link.link_type] })
+    after_set = Set.new(after_links.map { |link| [link.target_content_id, link.link_type] })
+
+    after_links.each do |link|
+      unless before_set.include?([link.target_content_id, link.link_type])
+        create_link_change(link: link, change: :add)
+      end
+    end
+
+    before_links.each do |link|
+      unless after_set.include?([link.target_content_id, link.link_type])
+        create_link_change(link: link, change: :remove)
+      end
+    end
+  end
+
+private
+
+  def create_link_change(link:, change:)
+    LinkChange.create!(
+      source_content_id: action.content_id,
+      target_content_id: link.target_content_id,
+      link_type: link.link_type,
+      change: change,
+      action: action
+    )
+  end
+end

--- a/db/migrate/20170905123649_create_link_changes.rb
+++ b/db/migrate/20170905123649_create_link_changes.rb
@@ -1,0 +1,13 @@
+class CreateLinkChanges < ActiveRecord::Migration[5.1]
+  def change
+    create_table :link_changes do |t|
+      t.uuid :source_content_id, null: false
+      t.uuid :target_content_id, null: false
+      t.string :link_type, null: false
+      t.integer :change, null: false
+      t.references :action, null: false, index: true, foreign_key: { on_delete: :cascade }
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170901095633) do
+ActiveRecord::Schema.define(version: 20170905123649) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -130,6 +130,17 @@ ActiveRecord::Schema.define(version: 20170901095633) do
     t.index ["content_id", "locale", "with_drafts"], name: "expanded_links_content_id_locale_with_drafts_index", unique: true
   end
 
+  create_table "link_changes", force: :cascade do |t|
+    t.uuid "source_content_id", null: false
+    t.uuid "target_content_id", null: false
+    t.string "link_type", null: false
+    t.integer "change", null: false
+    t.bigint "action_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["action_id"], name: "index_link_changes_on_action_id"
+  end
+
   create_table "link_sets", id: :serial, force: :cascade do |t|
     t.uuid "content_id"
     t.datetime "created_at"
@@ -191,6 +202,7 @@ ActiveRecord::Schema.define(version: 20170901095633) do
 
   add_foreign_key "change_notes", "editions"
   add_foreign_key "editions", "documents"
+  add_foreign_key "link_changes", "actions", on_delete: :cascade
   add_foreign_key "links", "editions", on_delete: :cascade
   add_foreign_key "links", "link_sets"
   add_foreign_key "unpublishings", "editions", on_delete: :cascade

--- a/spec/factories/link_change.rb
+++ b/spec/factories/link_change.rb
@@ -1,0 +1,9 @@
+FactoryGirl.define do
+  factory :link_change do
+    source_content_id { SecureRandom.uuid }
+    target_content_id { SecureRandom.uuid }
+    action
+    link_type "taxons"
+    change "add"
+  end
+end

--- a/spec/requests/patch_link_set_spec.rb
+++ b/spec/requests/patch_link_set_spec.rb
@@ -1,0 +1,50 @@
+require "rails_helper"
+
+RSpec.describe "Keeping track of link changes", type: :request do
+  scenario "No links are added or changed" do
+    make_patch_links_request(
+      "2ee935c3-d926-4737-aa23-e8c5edb5c3ca",
+      {}
+    )
+
+    expect(LinkChange.count).to eql(0)
+  end
+
+  scenario "A link is added" do
+    make_patch_links_request(
+      "2ee935c3-d926-4737-aa23-e8c5edb5c3ca",
+      something: ["1f0b3601-6a1d-4065-adc6-bf6040e2a806"]
+    )
+
+    expect(LinkChange.count).to eql(1)
+
+    expect(
+      LinkChange.last.as_json(only: %w[target_content_id source_content_id link_type change])
+    ).to eql(
+      "source_content_id" => "2ee935c3-d926-4737-aa23-e8c5edb5c3ca",
+      "target_content_id" => "1f0b3601-6a1d-4065-adc6-bf6040e2a806",
+      "link_type" => "something",
+      "change" => "add",
+    )
+  end
+
+  scenario "A link is changed" do
+    make_patch_links_request(
+      "2ee935c3-d926-4737-aa23-e8c5edb5c3ca",
+      something: ["1f0b3601-6a1d-4065-adc6-bf6040e2a806"]
+    )
+
+    make_patch_links_request(
+      "2ee935c3-d926-4737-aa23-e8c5edb5c3ca",
+      something: ["0bbd6b21-b6f4-4327-aa40-696bda836000"]
+    )
+
+    expect(LinkChange.count).to eql(3)
+  end
+
+  def make_patch_links_request(content_id, links)
+    patch "/v2/links/#{content_id}",
+          params: { links: links }.to_json,
+          headers: { "X-GOVUK-AUTHENTICATED-USER" => SecureRandom.uuid }
+  end
+end


### PR DESCRIPTION
This is the first PR to implement a change tracking feature for links. It's half of https://github.com/alphagov/publishing-api/pull/1024.

We'll create a separate PR to expose the change history via the API. That information will be used in content tagger by users who want to see when a page was tagged to a certain taxon and who tagged what to which taxon. This enables them to monitor tagging behaviour.

Initial code by @koetsier.

https://trello.com/c/KDFBohiV