### PR TITLE
Ensure that content_id and locale are populated

### DIFF
--- a/lib/link_expansion/content_cache.rb
+++ b/lib/link_expansion/content_cache.rb
@@ -18,7 +18,7 @@ private
   attr_reader :store, :with_drafts, :locale
 
   def build_store(editions, content_ids)
-    store = Hash[editions.map { |edition| [edition.content_id, edition_hash.from(edition.attributes)] }]
+    store = Hash[editions.map { |edition| [edition.content_id, edition_hash.from(edition)] }]
 
     to_preload = content_ids - editions.map(&:content_id)
     editions(to_preload).each_with_object(store) do |edition_values, hash|

--- a/lib/link_expansion/edition_hash.rb
+++ b/lib/link_expansion/edition_hash.rb
@@ -2,7 +2,7 @@ class LinkExpansion::EditionHash
   class << self
     def from(values)
       return nil unless values.present?
-      hash = values.is_a?(Array) ? hash_for(values) : values
+      hash = hash_for(values)
       hash = SymbolizeJSON.symbolize(hash)
       hash = hash.slice(*edition_fields)
       hash[:api_path] = api_path(hash) unless hash[:base_path].nil?
@@ -20,7 +20,20 @@ class LinkExpansion::EditionHash
 
     def hash_for(values)
       return nil unless values.present?
-      Hash[edition_fields.zip(values)]
+      case values
+      when Array
+        Hash[edition_fields.zip(values)]
+      when Edition
+        values.attributes.merge(
+          content_id: values.content_id,
+          locale: values.locale
+        )
+      when Hash
+        values
+      else
+        raise ArgumentError.new(
+          "Values passed to EditionHash.from must be an Array, Edition or Hash.")
+      end
     end
 
     def api_path(hash)

--- a/spec/lib/link_expansion/content_cache_spec.rb
+++ b/spec/lib/link_expansion/content_cache_spec.rb
@@ -78,5 +78,28 @@ RSpec.describe LinkExpansion::ContentCache do
         instance.find(content_id)
       end
     end
+
+    context "preload_editions" do
+      let!(:published) { FactoryGirl.create(:live_edition, document: document) }
+      let(:preload_editions) { [published] }
+      let!(:instance) do
+        described_class.new(
+          locale: :en,
+          with_drafts: with_drafts,
+          preload_editions: preload_editions
+        )
+      end
+
+      it "doesn't run a query" do
+        expect(Edition).not_to receive(:find)
+        instance.find(content_id)
+      end
+
+      it "fully populates edition attributes" do
+        edition_hash = instance.find(content_id)
+        expect(edition_hash.fetch(:content_id)).to eq(content_id)
+        expect(edition_hash.fetch(:locale)).to eq("en")
+      end
+    end
   end
 end

--- a/spec/lib/link_expansion/edition_hash_spec.rb
+++ b/spec/lib/link_expansion/edition_hash_spec.rb
@@ -1,0 +1,27 @@
+require "rails_helper"
+
+RSpec.describe LinkExpansion::EditionHash do
+  describe "from" do
+    it "accepts a nil argument" do
+      expect(described_class.from(nil)).to be_nil
+    end
+    it "accepts an array argument" do
+      expect(described_class.from(["123"])).to include(
+        analytics_identifier: "123")
+    end
+    it "accepts a Hash argument" do
+      expect(described_class.from(analytics_identifier: "123")).to include(
+        analytics_identifier: "123")
+    end
+    it "accepts an Edition argument" do
+      edition = FactoryGirl.build(:live_edition)
+      edition_hash = described_class.from(edition)
+      expect(edition_hash[:content_id]).to eq(edition.content_id)
+    end
+    it "raises an ArgumentError otherwise" do
+      expect {
+        described_class.from(Time.now)
+      }.to raise_error ArgumentError
+    end
+  end
+end


### PR DESCRIPTION
https://trello.com/c/AJxouyp6/1044-2-fix-issue-with-contentid-locale-sometimes-not-being-sent-to-content-store-in-expanded-links

These were not being populated correctly when `LinkExpansion` was initialised by edition, because
they are not  included in `Edition#attributes`.
Make sure these are correctly populated so that calling `LinkExpansion.by_edition` produces the same output as `LinkExpansion.by_content_id`.

See https://github.com/alphagov/collections/pull/365/commits/9bdf07195c72b001a3c7ad3c32a9fa93d1d2b4f7 for workaround in collections.

@MatMoore - Hopefully this means you can remove the defensive code in the commit above.