### PR TITLE
Add endpoint for tagging history

### DIFF
--- a/app/controllers/v2/link_changes_controller.rb
+++ b/app/controllers/v2/link_changes_controller.rb
@@ -1,0 +1,7 @@
+module V2
+  class LinkChangesController < ApplicationController
+    def index
+      render json: Queries::GetLinkChanges.new(params).as_hash
+    end
+  end
+end

--- a/app/queries/get_link_changes.rb
+++ b/app/queries/get_link_changes.rb
@@ -1,0 +1,82 @@
+module Queries
+  class GetLinkChanges
+    # Current maximum number of results. This is an arbitrary number to prevent
+    # too much data being returned, and to hold off from implementing pagination.
+    MAXIMUM_NUMBER_OF_RESULTS = 250
+
+    attr_reader :params
+
+    def initialize(params)
+      @params = params
+    end
+
+    def as_hash
+      results = link_changes.map do |link_change|
+        {
+          source: expand_edition(link_change.source_content_id),
+          target: expand_edition(link_change.target_content_id),
+          link_type: link_change.link_type,
+          change: link_change.change,
+          user_uid: link_change.action.user_uid,
+          created_at: link_change.created_at
+        }
+      end
+
+      {
+        link_changes: results,
+      }
+    end
+
+  private
+
+    def expand_edition(content_id)
+      editions = all_related_editions[content_id]
+      editions && editions.first.slice(%w[title base_path content_id])
+    end
+
+    def link_changes
+      @link_changes ||= LinkChange
+                          .order(created_at: :desc)
+                          .where(where_query_from_params)
+                          .limit(MAXIMUM_NUMBER_OF_RESULTS)
+                          .includes(:action)
+    end
+
+    def where_query_from_params
+      # Link type is required. Calling `fetch` on a Rails parameters object
+      # will bubble up to the controller to return a 4XX response.
+      query = { link_type: params.fetch(:link_types) }
+
+      if params[:source_content_ids]
+        query[:source_content_id] = params[:source_content_ids]
+      end
+
+      if params[:target_content_ids]
+        query[:target_content_id] = params[:target_content_ids]
+      end
+
+      if params[:users]
+        query['actions.user_uid'] = params[:users]
+      end
+
+      query
+    end
+
+    # Returns all editions (with their document) that are either the source or
+    # the target of the link change.
+    def all_related_editions
+      @all_related_editions ||= begin
+        content_ids_relevant = (
+          link_changes.map(&:source_content_id) +
+          link_changes.map(&:target_content_id)
+        ).uniq
+
+        Queries::GetLatest.call(
+          Edition
+            .eager_load(:document)
+            .where('documents.content_id IN (?)', content_ids_relevant)
+        ).group_by(&:content_id)
+      end
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -38,6 +38,8 @@ Rails.application.routes.draw do
       get "/new-linkables", to: "content_items#new_linkables"
 
       post "/actions/:content_id", to: "actions#create"
+
+      get "/links/changes", to: "link_changes#index"
     end
 
     if ENV.include?("CONTENT_API_PROTOTYPE")

--- a/doc/api.md
+++ b/doc/api.md
@@ -23,6 +23,7 @@ message queue for other apps (e.g. `email-alert-service`) to consume.
 - [`GET /v2/expanded-links/:content_id`](#get-v2expanded-linkscontent_id)
 - [`GET /v2/linked/:content_id`](#get-v2linkedcontent_id)
 - [`GET /v2/linkables`](#get-v2linkables)
+- [`GET /v2/links/changes`](#get-v2linkschanges)
 - [`GET /v2/editions`](#get-v2editions)
 - [`POST /v2/links/by-content-id`](#post-v2linksby-content-id)
 - [`POST /lookup-by-base-path`](#post-lookup-by-base-path)
@@ -566,6 +567,27 @@ which is `details.internal_name` and falls back to `title`.
 
 - `document_type` *(required)*
   - The `document_type` value that returned editions has.
+
+## `GET /v2/links/changes`
+
+Returns an array of changes to links, giving the information on what
+changed (source and target content ids, and the link type), when the
+change happened, what user was associated with the action, and if the
+link was created or deleted.
+
+The results will be in descending order by date, so newer changes come before
+older changes. A maximum of 250 changes will be returned.
+
+### Query string parameters
+
+- `link_types[]` *(required)*
+  - Filter the changes by link type.
+- `source_content_ids[]`
+  - Filter the changes by source content id.
+- `target_content_ids[]`
+  - Filter the changes by source content id.
+- `users[]`
+  - Filter the changes by user UIDs.
 
 ## `GET /v2/editions`
 

--- a/spec/queries/get_link_changes_spec.rb
+++ b/spec/queries/get_link_changes_spec.rb
@@ -1,0 +1,28 @@
+require "rails_helper"
+
+RSpec.describe Queries::GetLinkChanges do
+  describe '#as_hash' do
+    it 'returns the link changes with the correct data' do
+      FactoryGirl.create(:link_change, link_type: 'topics')
+
+      result = Queries::GetLinkChanges.new(link_types: 'topics').as_hash
+
+      change = result[:link_changes].first.deep_symbolize_keys
+
+      expect(change.keys).to match_array(
+        [:source, :target, :link_type, :change, :user_uid, :created_at]
+      )
+    end
+
+    it 'expands the source and target' do
+      document = FactoryGirl.create(:document, content_id: '1dd96f5d-c260-438b-ba58-57ba910e9291')
+      FactoryGirl.create(:edition, document: document, title: 'Content Foo')
+      FactoryGirl.create(:link_change, link_type: 'topics', source_content_id: document.content_id)
+
+      result = Queries::GetLinkChanges.new(link_types: 'topics').as_hash
+
+      change = result[:link_changes].first.deep_symbolize_keys
+      expect(change[:source].keys).to match_array([:title, :base_path, :content_id])
+    end
+  end
+end

--- a/spec/requests/link_changes_spec.rb
+++ b/spec/requests/link_changes_spec.rb
@@ -1,0 +1,129 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'GET /v2/links/changes', type: :request do
+  before :each do
+    stub_request(:put, /^#{Plek.find('draft-content-store')}.*$/)
+  end
+
+  scenario 'Get a link change' do
+    editions = FactoryGirl.create_list(:edition, 2)
+    user_uid = SecureRandom.uuid
+
+    make_patch_links_request(
+      editions.first.content_id,
+      { taxons: [editions.second.content_id] },
+      user_uid: user_uid
+    )
+
+    get '/v2/links/changes', params: { link_types: ['taxons'] }
+
+    expect(parsed_response.deep_symbolize_keys)
+      .to match(link_changes: [{
+                                 source: { title: editions.first.title,
+                                           base_path: editions.first.base_path,
+                                           content_id: editions.first.content_id },
+                                 target: { title: editions.second.title,
+                                           base_path: editions.second.base_path,
+                                           content_id: editions.second.content_id },
+                                 link_type: 'taxons',
+                                 change: 'add',
+                                 user_uid: user_uid,
+                                 created_at: be_a(String)
+                               }])
+  end
+
+  scenario 'User filters by link_type' do
+    make_patch_links_request(
+      SecureRandom.uuid,
+      taxons: [SecureRandom.uuid]
+    )
+
+    make_patch_links_request(
+      SecureRandom.uuid,
+      organisations: [SecureRandom.uuid]
+    )
+
+    make_patch_links_request(
+      SecureRandom.uuid,
+      something_else: [SecureRandom.uuid]
+    )
+
+    get '/v2/links/changes', params: { link_types: %w[taxons organisations] }
+
+    expect(number_of_results).to eql(2)
+  end
+
+  scenario 'User filters by source' do
+    source_uuids = Array.new(2) { SecureRandom.uuid }
+    source_uuids.each do |uuid|
+      make_patch_links_request(
+        uuid,
+        taxons: [SecureRandom.uuid]
+      )
+    end
+
+    make_patch_links_request(
+      SecureRandom.uuid,
+      taxons: [SecureRandom.uuid]
+    )
+
+    get '/v2/links/changes', params: { link_types: ['taxons'], source_content_ids: source_uuids }
+
+    expect(number_of_results).to eql(2)
+  end
+
+  scenario 'User filters by target' do
+    target_uuids = Array.new(2) { SecureRandom.uuid }
+    target_uuids.each do |uuid|
+      make_patch_links_request(
+        SecureRandom.uuid,
+        taxons: [uuid]
+      )
+    end
+
+    make_patch_links_request(
+      SecureRandom.uuid,
+      taxons: [SecureRandom.uuid]
+    )
+
+    get '/v2/links/changes', params: { link_types: 'taxons', target_content_ids: target_uuids }
+
+    expect(number_of_results).to eql(2)
+  end
+
+  scenario 'User filters by users' do
+    user_uuids = Array.new(2) { SecureRandom.uuid }
+    user_uuids.each do |uuid|
+      make_patch_links_request(
+        SecureRandom.uuid,
+        { taxons: [SecureRandom.uuid] },
+        user_uid: uuid
+      )
+    end
+
+    make_patch_links_request(
+      SecureRandom.uuid,
+      { taxons: [SecureRandom.uuid] },
+      user_uid: SecureRandom.uuid
+    )
+
+    get '/v2/links/changes', params: {
+      link_types: ['taxons'],
+      users: user_uuids
+    }
+
+    expect(number_of_results).to eql(2)
+  end
+
+  def make_patch_links_request(content_id, links, params = {})
+    patch "/v2/links/#{content_id}",
+          params: { links: links }.to_json,
+          headers: { 'X-GOVUK-AUTHENTICATED-USER' => params[:user_uid] }
+  end
+
+  def number_of_results
+    parsed_response['link_changes'].size
+  end
+end


### PR DESCRIPTION
This is the follow up to https://github.com/alphagov/publishing-api/pull/1026, which implemented tracking changes to the links. This PR exposes the data via the API. It shouldn't be merged until we have [used it in content-tagger][ct], because that will be the primary user of the endpoint.

Things that we need to do before merging:

- [x] Use it in content tagger
- [x] Add documentation

https://trello.com/c/Ays5PBSH

[ct]: https://trello.com/c/woqZQI8n