### PR TITLE
Fix bulk link ordering

### DIFF
--- a/app/queries/get_bulk_links.rb
+++ b/app/queries/get_bulk_links.rb
@@ -31,7 +31,6 @@ module Queries
       @_link_sets ||= begin
         LinkSet
           .includes(:links) # avoid an N+1 in the presenter class
-          .joins(:links) # combines with the `include` to make a single SQL statement
           .where("content_id IN (?)", content_ids)
           .index_by(&:content_id) # reform the Relation into a hash, keyed by content_id
       end


### PR DESCRIPTION
By using the join in bulk links we lost the ordering of links. This was
making the results returned unpredictable and vulnerable to failing
tests.

I chose to remove the join rather than adding ordering here as it
appears that the 2 queries run faster than a single one and it means we
don't need to re-state the default link ordering here.