### PR TITLE
Bump govuk_document_types to 0.1.7

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -115,7 +115,7 @@ GEM
     govuk-lint (1.2.1)
       rubocop (~> 0.39.0)
       scss_lint
-    govuk_document_types (0.1.6)
+    govuk_document_types (0.1.7)
     govuk_schemas (2.1.1)
       json-schema (~> 2.5.0)
     govuk_sidekiq (1.0.3)


### PR DESCRIPTION
Bump gem to include https://github.com/alphagov/govuk_document_types/pull/20