### PR TITLE
Re-enable Edition Diffing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,7 +27,7 @@ gem 'bunny', '~> 2.6'
 gem "govuk_sidekiq", "~> 2.0"
 gem 'whenever', '0.9.4', require: false
 gem "json-schema", require: false
-gem "hashdiff"
+gem "hashdiff", "~> 0.3.6"
 gem "sidekiq-unique-jobs", "~> 5.0", require: false
 gem "govspeak", "~> 5.0.2"
 gem "diffy", "~> 3.1", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -124,7 +124,7 @@ GEM
       sidekiq (~> 4.2.8)
       sidekiq-logging-json (~> 0.0)
       sidekiq-statsd (~> 0.1)
-    hashdiff (0.3.5)
+    hashdiff (0.3.6)
     hashie (3.4.6)
     highline (1.7.8)
     htmlentities (4.3.4)
@@ -407,7 +407,7 @@ DEPENDENCIES
   govuk_document_types (~> 0.1)
   govuk_schemas (~> 2.1.1)
   govuk_sidekiq (~> 2.0)
-  hashdiff
+  hashdiff (~> 0.3.6)
   json-schema
   logstasher (= 0.6.2)
   oj (~> 2.16.1)

--- a/app/commands/v2/put_content.rb
+++ b/app/commands/v2/put_content.rb
@@ -3,6 +3,9 @@ module Commands
     class PutContent < BaseCommand
       def call
         PutContentValidator.new(payload, self).validate
+
+        edition_diff.previous_item = previous_drafted_edition
+
         prepare_content_with_base_path
         check_update_type
 
@@ -36,6 +39,10 @@ module Commands
 
     private
 
+      def edition_diff
+        @edition_diff ||= HashDiffBuilder.new(Presenters::EditionDiffPresenter)
+      end
+
       def link_diff_between(old_links, new_links)
         old_links - new_links
       end
@@ -56,7 +63,8 @@ module Commands
         update_last_edited_at(edition, payload[:last_edited_at])
         ChangeNote.create_from_edition(payload, edition)
         create_links(edition)
-        Action.create_put_content_action(edition, document.locale, event)
+        edition_diff.current_item = edition
+        Action.create_put_content_action(edition, document.locale, event, edition_diff.diff)
       end
 
       def check_update_type

--- a/app/models/action.rb
+++ b/app/models/action.rb
@@ -1,4 +1,5 @@
 class Action < ActiveRecord::Base
+  serialize :edition_diff
   belongs_to :edition, optional: true
   belongs_to :link_set, optional: true
   belongs_to :event
@@ -6,8 +7,8 @@ class Action < ActiveRecord::Base
   validate :one_of_edition_link_set
   validates :action, presence: true
 
-  def self.create_put_content_action(edition, locale, event)
-    create_publishing_action("PutContent", edition, locale, event)
+  def self.create_put_content_action(updated_draft, locale, event, edition_diff)
+    create_publishing_action("PutContent", updated_draft, locale, event, edition_diff: edition_diff)
   end
 
   def self.create_publish_action(edition, locale, event)
@@ -23,14 +24,15 @@ class Action < ActiveRecord::Base
     create_publishing_action("DiscardDraft", edition, locale, event)
   end
 
-  def self.create_publishing_action(action, edition, locale, event)
+  def self.create_publishing_action(action, edition, locale, event, edition_diff: nil)
     create!(
       content_id: edition.document.content_id,
       locale: locale,
       action: action,
       user_uid: event.user_uid,
       edition: edition,
-      event: event
+      event: event,
+      edition_diff: edition_diff
     )
   end
 

--- a/app/presenters/edition_diff_presenter.rb
+++ b/app/presenters/edition_diff_presenter.rb
@@ -1,0 +1,24 @@
+module Presenters
+  class EditionDiffPresenter
+    def self.call(edition)
+      attributes = {}
+      return attributes unless edition.present?
+
+      Edition::TOP_LEVEL_FIELDS.each do |field|
+        attributes[field.to_sym] = edition.public_send(field)
+      end
+
+      attributes[:links] = {}
+
+      edition.links.each do |link|
+        link_type = link.link_type.to_sym
+        attributes[:links][link_type] ||= []
+        attributes[:links][link_type] << link.target_content_id
+      end
+
+      attributes[:change_note] = edition.change_note&.note || {}
+
+      attributes
+    end
+  end
+end

--- a/db/migrate/20170912095536_add_edition_diff_to_action_again.rb
+++ b/db/migrate/20170912095536_add_edition_diff_to_action_again.rb
@@ -1,0 +1,5 @@
+class AddEditionDiffToActionAgain < ActiveRecord::Migration[5.1]
+  def change
+    add_column :actions, :edition_diff, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170905123649) do
+ActiveRecord::Schema.define(version: 20170912095536) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -34,6 +34,7 @@ ActiveRecord::Schema.define(version: 20170905123649) do
     t.integer "event_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.text "edition_diff"
     t.index ["edition_id"], name: "index_actions_on_edition_id"
     t.index ["event_id"], name: "index_actions_on_event_id"
     t.index ["link_set_id"], name: "index_actions_on_link_set_id"

--- a/lib/hash_diff_builder.rb
+++ b/lib/hash_diff_builder.rb
@@ -22,7 +22,9 @@ private
   attr_reader :presenter, :previous_item, :current_item
 
   def create_diff(previous_item, current_item)
-    HashDiff.diff(previous_item, current_item, array_path: true)
+    HashDiff.diff(
+      previous_item, current_item, array_path: true, use_lcs: false
+    )
   end
 
   class MissingItemError < RuntimeError; end

--- a/lib/hash_diff_builder.rb
+++ b/lib/hash_diff_builder.rb
@@ -1,0 +1,29 @@
+class HashDiffBuilder
+  def initialize(presenter)
+    @presenter = presenter
+  end
+
+  def previous_item=(previous_item)
+    @previous_item = presenter ? presenter.call(previous_item) : previous_item
+  end
+
+  def current_item=(current_item)
+    @current_item = presenter ? presenter.call(current_item) : current_item
+  end
+
+  def diff
+    raise MissingItemError, "No previous item provided" if previous_item.nil?
+    raise MissingItemError, "No current item provided" if current_item.nil?
+    create_diff(previous_item, current_item)
+  end
+
+private
+
+  attr_reader :presenter, :previous_item, :current_item
+
+  def create_diff(previous_item, current_item)
+    HashDiff.diff(previous_item, current_item, array_path: true)
+  end
+
+  class MissingItemError < RuntimeError; end
+end

--- a/spec/commands/v2/put_content_spec.rb
+++ b/spec/commands/v2/put_content_spec.rb
@@ -8,10 +8,15 @@ RSpec.describe Commands::V2::PutContent do
     end
 
     let(:content_id) { SecureRandom.uuid }
+    let(:new_content_id) { SecureRandom.uuid }
     let(:base_path) { "/vat-rates" }
     let(:locale) { "en" }
 
     let(:change_note) { { note: "Info", public_timestamp: Time.now.utc.to_s } }
+    let(:new_change_note) { { note: "Changed Info", public_timestamp: Time.now.utc.to_s } }
+
+    let(:links_1) { { organisations: [content_id] } }
+    let(:links_2) { { policy_areas: [new_content_id] } }
 
     let(:payload) do
       {
@@ -26,7 +31,28 @@ RSpec.describe Commands::V2::PutContent do
         locale: locale,
         routes: [{ path: base_path, type: "exact" }],
         redirects: [],
-        phase: "beta"
+        phase: "beta",
+        change_note: change_note,
+        links: links_1
+      }
+    end
+
+    let(:updated_payload) do
+      {
+        content_id: content_id,
+        base_path: base_path,
+        update_type: "major",
+        title: "New Title",
+        publishing_app: "publisher",
+        rendering_app: "frontend",
+        document_type: "nonexistent-schema",
+        schema_name: "nonexistent-schema",
+        locale: locale,
+        routes: [{ path: base_path, type: "exact" }],
+        redirects: [],
+        phase: "beta",
+        change_note: new_change_note,
+        links: links_2
       }
     end
 
@@ -59,10 +85,18 @@ RSpec.describe Commands::V2::PutContent do
       expect(Action.count).to be 0
       described_class.call(payload)
       expect(Action.count).to be 1
-      expect(Action.first.attributes).to match a_hash_including(
+      described_class.call(updated_payload)
+      expect(Action.last.attributes).to match a_hash_including(
         "content_id" => content_id,
         "locale" => locale,
         "action" => "PutContent",
+      )
+
+      expect(Action.last.edition_diff).to include(
+        ["~", [:title], "Some Title", "New Title"],
+        ["-", [:links, :organisations], [content_id]],
+        ["+", [:links, :policy_areas], [new_content_id]],
+        ["~", [:change_note], change_note.to_s, new_change_note.to_s],
       )
     end
 

--- a/spec/lib/hash_diff_builder_spec.rb
+++ b/spec/lib/hash_diff_builder_spec.rb
@@ -1,0 +1,94 @@
+require "rails_helper"
+
+RSpec.describe HashDiffBuilder do
+  let(:content_id) { SecureRandom.uuid }
+  let(:organisation_links) do
+    [
+      OpenStruct.new(
+        target_content_id: content_id,
+        link_type: "organisations"
+      )
+    ]
+  end
+
+  let(:policy_areas_links) do
+    [
+      OpenStruct.new(
+        target_content_id: content_id,
+        link_type: "policy_areas"
+      )
+    ]
+  end
+
+  let(:previous_edition) do
+    double(:edition,
+      description: "A description",
+      title: "A title",
+      links: organisation_links
+    )
+  end
+
+  let(:updated_edition) do
+    double(:edition,
+      description: "A description",
+      title: "A new title",
+      links: policy_areas_links
+    )
+  end
+
+  let(:presented_previous_edition) do
+    {
+      title: "A title",
+      links: { organisations: [content_id] }
+    }
+  end
+
+  let(:presented_updated_edition) do
+    {
+      title: "A new title",
+      links: { policy_areas: [content_id] },
+    }
+  end
+
+  describe "#diff" do
+    let(:presenter) { double("presenter") }
+    let(:hash_diff) { described_class.new(presenter) }
+    subject { hash_diff.diff }
+
+    context "when a previous item and current item is provided" do
+      before do
+        allow(presenter).to receive(:call).with(previous_edition).and_return(presented_previous_edition)
+        allow(presenter).to receive(:call).with(updated_edition).and_return(presented_updated_edition)
+        hash_diff.previous_item = previous_edition
+        hash_diff.current_item = updated_edition
+      end
+
+      let(:previous_and_updated_diff) do
+        [
+          ["~", [:title], "A title", "A new title"],
+          ["-", [:links, :organisations], [content_id]],
+          ["+", [:links, :policy_areas], [content_id]]
+        ]
+      end
+
+      it { is_expected.to match_array(previous_and_updated_diff) }
+    end
+
+    context "when no previous item is provided" do
+      it "raises a 'MissingItemError' error" do
+        expect { subject }.to raise_error(HashDiffBuilder::MissingItemError, "No previous item provided")
+      end
+    end
+
+    context "when no current item is provided" do
+      before do
+        allow(presenter).to receive(:call).with(previous_edition).and_return(presented_previous_edition)
+        hash_diff.previous_item = previous_edition
+      end
+
+      it "raises a 'MissingItemError' error" do
+        expect { subject }.to raise_error(HashDiffBuilder::MissingItemError, "No current item provided")
+      end
+    end
+  end
+end

--- a/spec/presenters/edition_diff_presenter_spec.rb
+++ b/spec/presenters/edition_diff_presenter_spec.rb
@@ -1,0 +1,53 @@
+require 'rails_helper'
+
+RSpec.describe Presenters::EditionDiffPresenter do
+  let(:content_id) { SecureRandom.uuid }
+  let(:edition) do
+    FactoryGirl.create(:edition,
+                        update_type: "major",
+                        links_hash: { "organisations" => [content_id] },
+                        change_note: "a note"
+                      )
+  end
+
+  let(:edition_without_links) do
+    FactoryGirl.create(:edition)
+  end
+
+  let(:edition_without_change_note) do
+    FactoryGirl.create(:edition,
+                        update_type: "minor",
+                        links_hash: { "organisations" => [content_id] }
+                      )
+  end
+
+  EXCLUDED_ATTRIBUTES = %w(updated_at created_at id publishing_request_id document_id).freeze
+
+  describe "#call" do
+    subject { described_class }
+
+    context "with links and change_note" do
+      it "returns an edition hash presented for diffing" do
+        expect(subject.call(edition)).to match a_hash_including(
+          edition.as_json.except(*EXCLUDED_ATTRIBUTES).symbolize_keys,
+          links: { organisations: [content_id] },
+          change_note: edition.change_note.note
+        )
+      end
+    end
+
+    context "without links" do
+      it "returns an edition hash presented for diffing" do
+        expect(subject.call(edition_without_links)).
+          to match a_hash_including(links: {})
+      end
+    end
+
+    context "without change_note" do
+      it "returns an edition hash presented for diffing" do
+        expect(subject.call(edition_without_change_note)).
+          to match a_hash_including(change_note: {})
+      end
+    end
+  end
+end

--- a/spec/presenters/edition_diff_presenter_spec.rb
+++ b/spec/presenters/edition_diff_presenter_spec.rb
@@ -21,7 +21,21 @@ RSpec.describe Presenters::EditionDiffPresenter do
                       )
   end
 
-  EXCLUDED_ATTRIBUTES = %w(updated_at created_at id publishing_request_id document_id).freeze
+  EXCLUDED_ATTRIBUTES = %w(
+    updated_at
+    created_at
+    id
+    publishing_request_id
+    document_id
+    temporary_first_published_at
+    published_at
+    major_published_at
+    temporary_last_edited_at
+    publisher_first_published_at
+    publisher_major_published_at
+    publisher_published_at
+    publisher_last_edited_at
+  ).freeze
 
   describe "#call" do
     subject { described_class }


### PR DESCRIPTION
We had to disable this as it was found to be too slow, but since there is a new `use_lcs` option in HashDiff, we can re-enable it.

[Trello Card](https://trello.com/c/nxfFJGNe/1048-1-reimplement-edition-diffing)