### PR TITLE
Link expansion bug

### DIFF
--- a/lib/dependency_resolution/link_reference.rb
+++ b/lib/dependency_resolution/link_reference.rb
@@ -53,7 +53,7 @@ private
     next_allowed_link_types_from = rules.dependency_resolution
       .next_allowed_reverse_link_types(allowed_link_types, link_types_path, reverse_to_direct: true)
     next_allowed_link_types_to = rules.dependency_resolution
-      .next_allowed_direct_link_types(allowed_link_types, link_types_path)
+      .next_allowed_direct_link_types(allowed_link_types, link_types_path, reverse_to_direct: true)
 
     links = Queries::Links.from(content_id,
       allowed_link_types: rules.reverse_to_direct_link_types(allowed_link_types),
@@ -78,7 +78,7 @@ private
     next_allowed_link_types_from = rules.dependency_resolution
       .next_allowed_reverse_link_types(allowed_link_types, link_types_path, reverse_to_direct: true)
     next_allowed_link_types_to = rules.dependency_resolution
-      .next_allowed_direct_link_types(allowed_link_types, link_types_path)
+      .next_allowed_direct_link_types(allowed_link_types, link_types_path, reverse_to_direct: true)
 
     Queries::Links.to(content_id,
       allowed_link_types: allowed_link_types,

--- a/lib/expansion_rules.rb
+++ b/lib/expansion_rules.rb
@@ -124,9 +124,11 @@ module ExpansionRules
     end
   end
 
-  def next_allowed_direct_link_types(next_allowed_link_types)
+  def next_allowed_direct_link_types(next_allowed_link_types, reverse_to_direct: false)
     next_allowed_link_types.each_with_object({}) do |(link_type, allowed_links), memo|
       next if allowed_links.empty?
+
+      link_type = (reverse_to_direct_link_type(link_type) || link_type) if reverse_to_direct
 
       links = allowed_links.select { |link| !is_reverse_link_type?(link) }
 

--- a/lib/expansion_rules/dependency_resolution.rb
+++ b/lib/expansion_rules/dependency_resolution.rb
@@ -32,9 +32,9 @@ class ExpansionRules::DependencyResolution
     multi_level_links.next_allowed_link_types(link_types, link_types_path)
   end
 
-  def next_allowed_direct_link_types(link_types, link_types_path = [])
+  def next_allowed_direct_link_types(link_types, link_types_path = [], reverse_to_direct: false)
     next_allowed = next_allowed_link_types(link_types, link_types_path)
-    rules.next_allowed_direct_link_types(next_allowed)
+    rules.next_allowed_direct_link_types(next_allowed, reverse_to_direct: reverse_to_direct)
   end
 
   def next_allowed_reverse_link_types(link_types, link_types_path = [], reverse_to_direct: false)

--- a/lib/expansion_rules/link_expansion.rb
+++ b/lib/expansion_rules/link_expansion.rb
@@ -31,9 +31,9 @@ class ExpansionRules::LinkExpansion
     multi_level_links.next_allowed_link_types(link_types, link_types_path)
   end
 
-  def next_allowed_direct_link_types(link_types, link_types_path = [])
+  def next_allowed_direct_link_types(link_types, link_types_path = [], reverse_to_direct: false)
     next_allowed = next_allowed_link_types(link_types, link_types_path)
-    rules.next_allowed_direct_link_types(next_allowed)
+    rules.next_allowed_direct_link_types(next_allowed, reverse_to_direct: reverse_to_direct)
   end
 
   def next_allowed_reverse_link_types(link_types, link_types_path = [], reverse_to_direct: false)

--- a/lib/link_expansion/link_reference.rb
+++ b/lib/link_expansion/link_reference.rb
@@ -48,7 +48,7 @@ private
 
   def own_links(content_id, allowed_link_types = nil, link_types_path = [], parent_content_ids = [])
     next_allowed_link_types_from = rules.link_expansion
-      .next_allowed_direct_link_types(allowed_link_types, link_types_path)
+      .next_allowed_direct_link_types(allowed_link_types, link_types_path, reverse_to_direct: true)
     next_allowed_link_types_to = rules.link_expansion
       .next_allowed_reverse_link_types(allowed_link_types, link_types_path, reverse_to_direct: true)
 
@@ -71,7 +71,7 @@ private
 
   def linked_to(content_id, allowed_link_types = nil, link_types_path = [], parent_content_ids = [])
     next_allowed_link_types_from = rules.link_expansion
-      .next_allowed_direct_link_types(allowed_link_types, link_types_path)
+      .next_allowed_direct_link_types(allowed_link_types, link_types_path, reverse_to_direct: true)
     next_allowed_link_types_to = rules.link_expansion
       .next_allowed_reverse_link_types(allowed_link_types, link_types_path, reverse_to_direct: true)
 

--- a/spec/integration/dependency_resolution_spec.rb
+++ b/spec/integration/dependency_resolution_spec.rb
@@ -142,6 +142,24 @@ RSpec.describe "Dependency Resolution" do
     end
   end
 
+  context "where there are reverse links: child_taxons and direct links: associated_taxons" do
+    let(:a) { SecureRandom.uuid }
+    let(:b) { SecureRandom.uuid }
+
+    before do
+      # creates links from
+      # a -(child_taxons)-> b -(associated_taxons)-> content_id
+      create_link_set(b, links_hash: {
+        parent_taxons: [a],
+        associated_taxons: [content_id],
+      })
+    end
+
+    it "has a dependency to all items" do
+      expect(dependency_resolution).to match_array([a, b])
+    end
+  end
+
   context "when there is an edition that has an edition link to content_id" do
     let(:edition_content_id) { SecureRandom.uuid }
     let(:edition_locale) { :en }

--- a/spec/integration/link_expansion_spec.rb
+++ b/spec/integration/link_expansion_spec.rb
@@ -170,6 +170,20 @@ RSpec.describe "Link Expansion" do
       end
     end
 
+    context "graph with reverse links linking to direct links" do
+      it "has the direct link (associated_taxons) from the reverse link (child_taxons)" do
+        create_link(b, a, "parent_taxons")
+        create_link(b, c, "associated_taxons")
+
+        expect(expanded_links[:child_taxons]).to match([
+          a_hash_including(
+            base_path: "/b",
+            links: a_hash_including(:associated_taxons),
+          )
+        ])
+      end
+    end
+
     context "cyclic dependencies" do
       it "expands the links for node a correctly" do
         create_link(a, b, "parent")

--- a/spec/lib/expansion_rules_spec.rb
+++ b/spec/lib/expansion_rules_spec.rb
@@ -50,8 +50,11 @@ RSpec.describe ExpansionRules do
   end
 
   describe ".next_allowed_direct_link_types" do
+    let(:reverse_to_direct) { false }
     subject do
-      described_class.next_allowed_direct_link_types(next_allowed_link_types)
+      described_class.next_allowed_direct_link_types(
+        next_allowed_link_types, reverse_to_direct: reverse_to_direct
+      )
     end
 
     context "when passed direct links only" do
@@ -86,6 +89,31 @@ RSpec.describe ExpansionRules do
       end
 
       it "returns the direct links" do
+        is_expected.to match(parent: [:parent])
+      end
+    end
+
+    context "when passed a reverse link with direct links" do
+      let(:next_allowed_link_types) do
+        {
+          children: [:parent],
+        }
+      end
+
+      it "returns the direct links" do
+        is_expected.to match(children: [:parent])
+      end
+    end
+
+    context "when reverse_to_direct is true and passed a reverse link with direct links" do
+      let(:reverse_to_direct) { true }
+      let(:next_allowed_link_types) do
+        {
+          children: [:parent],
+        }
+      end
+
+      it "reverses the link type" do
         is_expected.to match(parent: [:parent])
       end
     end


### PR DESCRIPTION
This fixes something that was overlooked when the link caching was
introduced. When a reverse has direct links, the resultant SQL query was
using the reverse link name and not finding results.

eg `WHERE link_type = 'child_taxons' AND other_link_type IN
('associated_taxons')`

Which would yield no results as child_taxons isn't in the database

This corrects this to be

`WHERE link_type = 'parent_taxons' AND other_link_type IN
('associated_taxons')`

