### PR TITLE
Add update_type to redirect payload

### DIFF
--- a/app/commands/v2/publish.rb
+++ b/app/commands/v2/publish.rb
@@ -183,7 +183,6 @@ module Commands
           {
             content_id: draft_redirect.document.content_id,
             locale: draft_redirect.document.locale,
-            update_type: "major",
           },
           downstream: downstream,
           callbacks: callbacks,

--- a/app/presenters/redirect_presenter.rb
+++ b/app/presenters/redirect_presenter.rb
@@ -27,7 +27,7 @@ class RedirectPresenter
   end
 
   def for_redirect_helper(content_id)
-    present.merge(content_id: content_id)
+    present.merge(content_id: content_id, update_type: "major")
   end
 
 private


### PR DESCRIPTION
We found a bug where redirect payloads don't include `update_type` when sent
with PUT content, and `update_type` is soon to be a required field for PUT
content requests. This ensures that `update_type` is now sent in this
situation.

For [Trello](https://trello.com/c/UaxgGUDI/1115-require-updatetype-in-put-content)