### PR TITLE
Fix (some) whitehall first published at values

### DIFF
--- a/db/migrate/20170927104523_fix_whitehall_editions_first_published_at.rb
+++ b/db/migrate/20170927104523_fix_whitehall_editions_first_published_at.rb
@@ -1,0 +1,17 @@
+class FixWhitehallEditionsFirstPublishedAt < ActiveRecord::Migration[5.1]
+  def up
+    start_datetime = "2016-02-29 09:24:09"
+    end_datetime = "2016-02-29 09:24:11"
+
+    # 5184 records
+    Edition
+      .where("first_published_at BETWEEN '#{start_datetime}' AND '#{end_datetime}'")
+      .where(publishing_app: "whitehall")
+      .where.not(document_type: "placeholder")
+      .where("(details->'first_public_at') IS NOT NULL")
+      .where.not("(details->>'first_public_at')::date BETWEEN '#{start_datetime}' AND '#{end_datetime}'")
+      .find_each do |edition|
+        edition.update(first_published_at: edition.details[:first_public_at])
+      end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170912095536) do
+ActiveRecord::Schema.define(version: 20170927104523) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
https://trello.com/c/SSbguUQA/558-fix-whitehall-firstpublishedat-dates-in-publishing-api

Around 5000 of the 272000 Whitehall records with a
`first_published_at` of `2016-02-29 09:24:10` have a `details->'first_public_at'`
value, so use this date to update `first_published_at`.