### PR TITLE
Rake task to set new Publishing API dates

### DIFF
--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -231,6 +231,38 @@ class Edition < ApplicationRecord
     Plek.current.website_root + base_path
   end
 
+  # @FIXME this is only supposed to be in for temporarily changing of date fields
+  def new_dates_valid?
+    within_1_sec = ->(date_a, date_b) do
+      diff = (date_b.to_f * 1000).to_i - (date_a.to_f * 1000).to_i
+      diff.abs < 1000
+    end
+    valid = ->(old, publisher_new, api_new) do
+      if old
+        within_1_sec.(old, (publisher_new || api_new))
+      else
+        old == publisher_new
+      end
+    end
+
+    first_published_at_valid = valid.(
+      first_published_at,
+      publisher_first_published_at,
+      temporary_first_published_at
+    )
+    public_updated_at_valid = valid.(
+      public_updated_at,
+      publisher_major_published_at,
+      major_published_at
+    )
+    last_edited_at_valid = valid.(
+      last_edited_at,
+      publisher_last_edited_at,
+      temporary_last_edited_at
+    )
+    first_published_at_valid && public_updated_at_valid && last_edited_at_valid
+  end
+
 private
 
   def renderable_content?

--- a/lib/tasks/split_dates.rake
+++ b/lib/tasks/split_dates.rake
@@ -1,0 +1,13 @@
+  # @TODO Remove this file once the split dates task has run
+namespace :split_dates do
+  desc "Populate the split dates introduced September 2017"
+  task :populate, [:threads] => :environment do |_, args|
+    threads = Integer(args.fetch(:threads, 5))
+    Tasks::SplitDates.populate_threaded(threads)
+  end
+
+  desc "Validate that the dates on editions are correct"
+  task validate: :environment do
+    Tasks::SplitDates.validate
+  end
+end

--- a/lib/tasks/split_dates.rb
+++ b/lib/tasks/split_dates.rb
@@ -1,0 +1,127 @@
+module Tasks
+  class SplitDates
+    def self.populate_threaded(number_of_threads = 5)
+      response = threaded_documents_iterate(number_of_threads) do |from_id, until_id, thread_number|
+        populate(
+          from_id: from_id,
+          until_id: until_id,
+          thread: thread_number,
+        )
+      end
+
+      puts "Completed populating dates in #{response[:time_elapsed]}"
+    end
+
+    def self.populate(from_id: nil, until_id: nil, thread: nil)
+      iterate_documents_with_progress(
+        from_id: from_id, until_id: until_id, thread: thread
+      ) do |document|
+        PopulateDocument.new(document).call
+      end
+
+      prefix = thread ? "Thread #{thread}. " : ""
+
+      puts "#{prefix}Completed populating dates"
+    end
+
+    def self.validate
+      total = Edition.count
+      start = Time.now
+      invalid = 0
+      Edition.select(
+        :id,
+        :document_id,
+        :first_published_at,
+        :publisher_first_published_at,
+        :temporary_first_published_at,
+        :public_updated_at,
+        :publisher_major_published_at,
+        :major_published_at,
+        :last_edited_at,
+        :publisher_last_edited_at,
+        :temporary_last_edited_at
+      ).find_each.with_index do |e, index|
+        invalid += e.new_dates_valid? ? 0 : 1
+        completed = index + 1
+
+        if (completed % 10000).zero?
+          time = time_remaining(start, completed, total)
+
+          puts "Progress: #{completed}/#{total} editions (#{invalid} invalid), approximately #{time} remaining."
+        end
+      end
+
+      puts "Completed validing edition dates #{invalid}/#{total} are invalid."
+    end
+
+    def self.threaded_documents_iterate(number_of_threads)
+      ids = Document.order(id: :asc).pluck(:id)
+      start_time = Time.now
+
+      raise "No documents to iterate through" if ids.count.zero?
+
+      per_thread = (ids.count.to_f / number_of_threads).ceil
+      groups = ids.each_slice(per_thread)
+      responses = []
+      threads = groups.map.with_index(1) do |thread_ids, number|
+        Thread.new do
+          from_id = thread_ids.first unless number == 1
+          until_id = thread_ids.last unless number == groups.count
+
+          responses[number] = yield(from_id, until_id, number)
+        end
+      end
+
+      threads.each(&:join)
+      seconds_elapsed = Time.now.to_i - start_time.to_i
+      time_elapsed = Time.at(seconds_elapsed).utc.strftime("%H:%M:%S")
+
+      { time_elapsed: time_elapsed, thread_responses: responses }
+    end
+
+    def self.iterate_documents_with_progress(
+      from_id: nil, until_id: nil, thread: nil
+    )
+      scope = Document
+      scope = scope.where("id >= ?", from_id) if from_id
+      scope = scope.where("id <= ?", until_id) if until_id
+
+      count = scope.count
+      start = Time.now
+      prefix = thread ? "Thread #{thread}. " : ""
+
+      scope.find_each.with_index do |document, index|
+        yield(document)
+        completed = index + 1
+        if (completed % 100).zero?
+          time = time_remaining(start, completed, count)
+
+          puts "#{prefix}Progress: #{completed}/#{count} documents, approximately #{time} remaining."
+        end
+      end
+    end
+
+    def self.time_remaining(start_time, completed, total)
+      seconds_elapsed = Time.now.to_i - start_time.to_i
+      per_second = seconds_elapsed.to_f / completed
+      remaining_time = per_second * (total - completed)
+      # This won't work if it's over 24 hours, but that's probably a bigger problem
+      Time.at(remaining_time).utc.strftime("%H:%M:%S")
+    end
+
+    def self.reset_document(document)
+      Edition.where(document: document).update_all(
+        temporary_first_published_at: nil,
+        publisher_first_published_at: nil,
+        major_published_at: nil,
+        publisher_major_published_at: nil,
+        published_at: nil,
+        publisher_published_at: nil,
+        temporary_last_edited_at: nil,
+        publisher_last_edited_at: nil
+      )
+    end
+  end
+end
+
+require_dependency "tasks/split_dates/populate_document"

--- a/lib/tasks/split_dates/populate_document.rb
+++ b/lib/tasks/split_dates/populate_document.rb
@@ -1,0 +1,305 @@
+require_dependency "document"
+require_dependency "edition"
+require_dependency "action"
+require_dependency "event"
+
+class Tasks::SplitDates::PopulateDocument
+  def initialize(document)
+    @document = document
+    @editions_data = document
+      .editions
+      .order(user_facing_version: :asc)
+      .select(
+        :id,
+        :user_facing_version,
+        :state,
+        :created_at,
+        :update_type,
+        :first_published_at,
+        :temporary_first_published_at,
+        :publisher_first_published_at,
+        :public_updated_at,
+        :major_published_at,
+        :publisher_major_published_at,
+        :published_at,
+        :publisher_published_at,
+        :last_edited_at,
+        :temporary_last_edited_at,
+        :publisher_last_edited_at
+      )
+      .as_json
+  end
+
+  def call
+    to_update = Hash[editions_data.map { |e| [e["id"], {}] }]
+
+    populate_first_published_at(to_update)
+    populate_published_at(to_update)
+    populate_major_published_at(to_update)
+    populate_last_edited_at(to_update)
+
+    to_update.each do |id, data|
+      compacted = data.compact
+      next if compacted.empty?
+      Edition.where(id: id).update_all(compacted)
+    end
+  end
+
+private
+
+  attr_reader :document, :editions_data
+
+  def populate_first_published_at(to_update)
+    editions_data.each do |e|
+      row = to_update[e["id"]]
+
+      if e["temporary_first_published_at"] != first_published_at
+        row["temporary_first_published_at"] = first_published_at
+      end
+
+      if !within_1_sec(e["first_published_at"], first_published_at) &&
+          e["publisher_first_published_at"] != e["first_published_at"]
+        row["publisher_first_published_at"] = e["first_published_at"]
+      end
+    end
+  end
+
+  def populate_published_at(to_update)
+    editions_data.each_with_index do |e, i|
+      next if e["published_at"].present? || e["publisher_published_at"].present? || e["state"] == "draft"
+
+      next_edition_created_at = editions_data[i + 1]&.[]("created_at")
+
+      to_update[e["id"]]["published_at"] = PublishedAtResolver.new(
+        document, e, can_use_events?, next_edition_created_at
+      ).call
+    end
+  end
+
+  def populate_major_published_at(to_update)
+    editions_data.each do |e|
+      row = to_update[e["id"]]
+
+      previous_major = editions_data
+        .select { |p| p["update_type"] == "major" && p["user_facing_version"] < e["user_facing_version"] }
+        .last
+
+      major_published_at = MajorPublishedAtResolver.new(
+        e, previous_major, to_update
+      ).call
+
+      if e["major_published_at"] != major_published_at
+        row["major_published_at"] = major_published_at
+      end
+
+      if !within_1_sec(e["public_updated_at"], major_published_at) &&
+          e["publisher_major_published_at"] != e["public_updated_at"]
+        row["publisher_major_published_at"] = e["public_updated_at"]
+      end
+    end
+  end
+
+  def populate_last_edited_at(to_update)
+    editions_data.each_with_index do |e, i|
+      next if e["temporary_last_edited_at"].present? || e["publisher_last_edited_at"].present?
+      row = to_update[e["id"]]
+
+      next_edition_created_at = editions_data[i + 1]&.[]("created_at")
+      row["temporary_last_edited_at"] = LastEditedAtResolver.new(
+        document, e, next_edition_created_at, can_use_events?
+      ).call
+
+      if !within_1_sec(e["last_edited_at"], row["temporary_last_edited_at"])
+        row["publisher_last_edited_at"] = e["last_edited_at"]
+      end
+    end
+  end
+
+  def can_use_events?
+    return @can_use_events unless @can_use_events.nil?
+    @can_use_events = Document.where(content_id: document.content_id).count == 1
+  end
+
+  def within_1_sec(date_a, date_b)
+    diff = (date_b.to_f * 1000).to_i - (date_a.to_f * 1000).to_i
+    diff.abs < 1000
+  end
+
+  def first_published_at
+    @first_published_at_resolver ||= FirstPublishedAtResolver.new(
+      document, editions_data, can_use_events?
+    )
+    @first_published_at_resolver.first_published_at
+  end
+
+  class FirstPublishedAtResolver
+    def initialize(document, editions_data, can_use_events)
+      @document = document
+      @editions_data = editions_data
+      @can_use_events = can_use_events
+    end
+
+    def first_published_at
+      return @first_published_at if defined?(@first_published_at)
+      @first_published_at = resolve
+    end
+
+  private
+
+    attr_reader :document, :editions_data, :can_use_events
+
+    def resolve
+      resolve_from_action ||
+        resolve_from_events ||
+        resolve_from_first_edition
+    end
+
+    def resolve_from_previous_edition
+      first = editions_data.find { |e| e["temporary_first_published_at"] }
+      first&.[]("temporary_first_published_at")
+    end
+
+    def resolve_from_action
+      Action
+        .where(edition_id: editions_data.first["id"], action: "Publish")
+        .pluck(:created_at)
+        .first
+    end
+
+    def resolve_from_events
+      return unless can_use_events
+      Event.where(
+        content_id: document.content_id,
+        action: "Publish"
+      ).order(id: :asc).limit(1).pluck(:created_at).first
+    end
+
+    def resolve_from_first_edition
+      first_published_at = editions_data.first["first_published_at"]
+      return unless first_published_at
+      # If nano seconds on time aren't 0 we assume we set this date
+      first_published_at.nsec != 0 ? first_published_at : nil
+    end
+  end
+
+  class PublishedAtResolver
+    def initialize(
+      document, edition_data, can_use_events, next_edition_created_at
+    )
+      @document = document
+      @edition_data = edition_data
+      @can_use_events = can_use_events
+      @next_edition_created_at = next_edition_created_at
+    end
+
+    def call
+      resolve_from_action || resolve_from_events
+    end
+
+  private
+
+    attr_reader :document, :edition_data, :can_use_events, :next_edition_created_at
+
+    def resolve_from_action
+      Action
+        .where(edition_id: edition_data["id"], action: "Publish")
+        .pluck(:created_at)
+        .first
+    end
+
+    def resolve_from_events
+      return unless can_use_events
+      scope = Event.where(
+        content_id: document.content_id,
+        action: %w(Publish Unpublish),
+      ).where("created_at > ?", edition_data["created_at"])
+
+      if next_edition_created_at
+        scope = scope.where("created_at < ?", next_edition_created_at)
+      end
+
+      scope.order(created_at: :asc).pluck(:created_at).first
+    end
+  end
+
+  class MajorPublishedAtResolver
+    def initialize(edition_data, previous_major_edition_data, to_update)
+      @edition_data = edition_data
+      @previous_major_edition_data = previous_major_edition_data
+      @to_update = to_update
+    end
+
+    def call
+      published_at || resolve_from_edition
+    end
+
+  private
+
+    attr_reader :edition_data, :previous_major_edition_data, :to_update
+
+    def published_at
+      # We're making an assumption here that an update_type of major means it
+      # was actually published as that, this seems pretty safe since it'd be
+      # very unlikely and confusing were update_type on model and the one used
+      # in publish differed
+      if edition_data["update_type"] == "major"
+        id = edition_data["id"]
+        to_update[id]&.[]("published_at") || edition_data["published_at"]
+      else
+        id = previous_major_edition_data&.[]("id")
+        to_update[id]&.[]("published_at") || previous_major_edition_data&.[]("published_at")
+      end
+    end
+
+    def resolve_from_edition
+      public_updated_at = edition_data["public_updated_at"]
+      return unless public_updated_at
+      # If nano seconds on time aren't 0 we assume we set this date
+      public_updated_at.nsec != 0 ? public_updated_at : nil
+    end
+  end
+
+  class LastEditedAtResolver
+    def initialize(document, edition_data, next_edition_created_at, can_use_events)
+      @document = document
+      @edition_data = edition_data
+      @next_edition_created_at = next_edition_created_at
+      @can_use_events = can_use_events
+    end
+
+    def call
+      resolve_from_action || resolve_from_events || resolve_from_edition
+    end
+
+  private
+
+    attr_reader :document, :edition_data, :next_edition_created_at, :can_use_events
+
+    def resolve_from_action
+      Action.where(edition_id: edition_data["id"], action: "PutContent")
+        .pluck(:created_at)
+        .last
+    end
+
+    def resolve_from_events
+      return unless can_use_events
+      scope = Event.where(
+        content_id: document.content_id,
+        action: %w(PutContent PutContentWithLinks PutDraftContentWithLinks),
+      ).where("created_at > ?", edition_data["created_at"])
+
+      if next_edition_created_at
+        scope = scope.where("created_at < ?", next_edition_created_at)
+      end
+
+      scope.order(created_at: :asc).pluck(:created_at).first
+    end
+
+    def resolve_from_edition
+      last_edited_at = edition_data["last_edited_at"]
+      return unless last_edited_at
+      # If nano seconds on time aren't 0 we assume we set this date
+      last_edited_at.nsec != 0 ? last_edited_at : nil
+    end
+  end
+end


### PR DESCRIPTION
I've put this PR up before I go away as it'd be great to get some feedback and sanity checks as to whether this seems accurate, and whether I've missed anything (or got bad logic). If all looks good I'll plan to run once I'm back from holidays.

This is used to populate the date fields of:

- temporary_first_published_at
- publisher_first_published_at
- major_published_at
- publisher_major_published_at
- published_at
- publisher_published_at
- temporary_last_edited_at
- publisher_last_edited_at

To be consistent with the new date fields introduced by:
https://github.com/alphagov/publishing-api/pull/1007

This is a slow process, I think the script probably takes ~6 hours to
run full. It also has a few limitations:

- Only able to use events when there is a single locale
- Unable to work out major_publishing when the update_type was set in
publish (lost in events at that point)
- Makes some approximations based on nano-second value

My feeling is that although this isn't completely accurate, it's
probably accurate enough to lay some decent foundation. It introduces
a Edition#new_dates_valid? method which can be used to check that the
dates haven't deviated from what will be presented to Content Store and
other services.