### PR TITLE
Update first_published_at for Dfid Research Output editions

### DIFF
--- a/db/migrate/20171005150944_fix_dfid_research_output_first_published_at.rb
+++ b/db/migrate/20171005150944_fix_dfid_research_output_first_published_at.rb
@@ -1,0 +1,31 @@
+class FixDfidResearchOutputFirstPublishedAt < ActiveRecord::Migration[5.1]
+  disable_ddl_transaction!
+
+  # There are ~63000 editions which have a first_published_at timestamp
+  # later than their public_updated_at timestamp. So use legacy data from
+  # metadata to fix this.
+  #
+  def up
+    content_ids = Edition.joins(:document)
+                         .where(publishing_app: "specialist_publisher",
+                                document_type: "dfid_research_output",
+                                state: %w(draft published unpublished))
+                         .where("first_published_at > (public_updated_at + interval '1 second')")
+                         .pluck(:"documents.content_id")
+
+    sql = <<-SQL.strip_heredoc
+      UPDATE editions
+      SET    first_published_at = (details->'metadata'->>'first_published_at')::timestamp
+      WHERE  publishing_app = 'specialist-publisher'
+      AND    document_type  = 'dfid_research_output'
+      AND    first_published_at > (public_updated_at + interval '1 second')
+      AND    (details->'metadata'->>'first_published_at')::timestamp < (public_updated_at + interval '1 second')
+    SQL
+
+    ActiveRecord::Base.connection.execute(sql)
+
+    if Rails.env.production?
+      Commands::V2::RepresentDownstream.new.call(content_ids)
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171003155609) do
+ActiveRecord::Schema.define(version: 20171005150944) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
Part of https://trello.com/c/1gZgk0HF/10-switch-specialist-documents-to-use-firstpublishedat

There are 63000 `dfid_research_output` editions which have a `first_published_at` date
after their `public_updated_at` date. The correct date is stored in the edition metadata
so update these records with the correct `first_published_at` value.

```
== 20171002152414 FixDfidResearchOutputFirstPublishedAt: migrating ============
== 20171002152414 FixDfidResearchOutputFirstPublishedAt: migrated (41.4836s) ==
```