### PR TITLE
Preview of rabbit MQ message

### DIFF
--- a/lib/tasks/queue.rake
+++ b/lib/tasks/queue.rake
@@ -40,4 +40,24 @@ namespace :queue do
 
     RequeueContent.new(scope).call
   end
+
+  desc "Preview of the message published onto rabbit MQ"
+  task :preview_recent_message, [:document_type] => :environment do |_, args|
+    document_type = args[:document_type]
+    raise ValueError("expecting document_type") unless document_type.present?
+
+    edition = Edition
+              .with_document
+              .order(public_updated_at: :desc)
+              .find_by!(
+                editions: { state: 'published' },
+                document_type: document_type
+              )
+    version = Event.maximum(:id)
+
+    presenter = DownstreamPayload.new(edition, version, draft: false)
+    payload = presenter.message_queue_payload
+
+    pp payload
+  end
 end

--- a/spec/lib/tasks/queue_spec.rb
+++ b/spec/lib/tasks/queue_spec.rb
@@ -1,0 +1,17 @@
+require "rails_helper"
+
+RSpec.describe "Queue rake task" do
+  before do
+    Rake::Task['queue:preview_recent_message'].reenable
+  end
+
+  it "previews the rabbit MQ message for a document type" do
+    edition = FactoryGirl.create(:live_edition, base_path: '/ci1')
+    FactoryGirl.create(:event, id: 12)
+
+    expect_any_instance_of(Object).to receive(:pp).with(
+      hash_including(title: "VAT rates", payload_version: 12)
+    )
+    Rake::Task['queue:preview_recent_message'].invoke(edition.document_type)
+  end
+end


### PR DESCRIPTION
This is helpful when building consumers as otehrwise
it is hard to reason about the actual message that will be received
and setting the system up to capture the message is time consuming.

This functionality has been added to the documentation.

https://github.com/alphagov/govuk-developer-docs/pull/488
https://trello.com/c/KDfyOeS1/331-specialist-publisher-implementation