### PR TITLE
Clarify a point about minor updates we weren't sure about

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -155,6 +155,7 @@ presented edition and [warnings](#warnings).
   - Required for a `document_type` that is not "redirect" or "gone".
 - `update_type` *(optional)*
   - Accepts: "major", "minor", "republish"
+  - It is acceptable to send a "minor" update for the first ever draft
 
 ### State changes
 


### PR DESCRIPTION
A "major" update_type triggers email notifications
so we wanted to clarify that it is acceptable to
send "minor" as an update_type, even if it's the
first ever draft. This was causing some confusion.