### PR TITLE
Fix specialist publisher first_published_at dates

### DIFF
--- a/db/migrate/20171003155609_fix_specialist_first_published_at_dates_from_change_history.rb
+++ b/db/migrate/20171003155609_fix_specialist_first_published_at_dates_from_change_history.rb
@@ -1,0 +1,37 @@
+class FixSpecialistFirstPublishedAtDatesFromChangeHistory < ActiveRecord::Migration[5.1]
+  disable_ddl_transaction!
+
+  def up
+    document_ids = []
+    statements_ary = []
+
+    sql = <<-SQL.strip_heredoc
+      SELECT e.id,
+             e.document_id,
+             hist->>'public_timestamp'
+      FROM   editions e,
+             json_array_elements(details->'change_history') hist
+      WHERE  e.publishing_app = 'specialist-publisher'
+      AND    e.first_published_at > (e.public_updated_at + interval '1 second')
+      AND    hist IS NOT NULL
+      AND    hist->>'note' = 'First published.'
+      AND    (hist->>'public_timestamp')::timestamp < (e.first_published_at + interval '1 second')
+    SQL
+
+    results = ActiveRecord::Base.connection.execute(sql).values
+
+    results.each do |edition_id, document_id, timestamp|
+      statements_ary << "UPDATE editions SET first_published_at = '#{timestamp}' WHERE id = #{edition_id};"
+      document_ids << document_id
+    end
+
+    statements_ary.each_slice(1000).each do |statements|
+      ActiveRecord::Base.connection.execute(statements.join("\n"))
+    end
+
+    if Rails.env.production?
+      content_ids = Document.where(id: document_ids.uniq).pluck(:content_id)
+      Commands::V2::RepresentDownstream.new.call(content_ids)
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171002124120) do
+ActiveRecord::Schema.define(version: 20171003155609) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
https://trello.com/c/1gZgk0HF/10-switch-specialist-documents-to-use-firstpublishedat

77000 specialist publisher editions have a first_published_at
after their `public_updated_at` timestamp giving the impression
they were updated before they were created.
So attempt to use the change history to fix `first_published_at`.

This migration updates around 50000 records.

```
== 20171003155609 FixSpecialistFirstPublishedAtDatesFromChangeHistory: migrating 
== 20171003155609 FixSpecialistFirstPublishedAtDatesFromChangeHistory: migrated (75.6290s) 
```