### PR TITLE
Update contact fields in specs

### DIFF
--- a/spec/integration/pathless_content_spec.rb
+++ b/spec/integration/pathless_content_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "pathless content" do
           publishing_app: "publisher",
           rendering_app: "frontend",
           document_type: "contact",
-          details: { title: "Contact Title" },
+          details: { title: "Contact Title", contact_groups: [] },
           schema_name: "contact",
           locale: "en",
           phase: "beta",


### PR DESCRIPTION
Add a `contact_groups` field to the contact payload used to test pathless content.

This field is going to be made a required field, so this change is necessary to make the payload consistent with the content schemas.

Paired with @Rosa-Fox 

https://trello.com/c/KX2WILnc/332-add-contactgroups-to-publishing-api