### PR TITLE
Fix specialist-publisher editions with that first_published_at date

### DIFF
--- a/db/migrate/20171009122700_fix_specialist_publisher_editions_first_published_at_dupes.rb
+++ b/db/migrate/20171009122700_fix_specialist_publisher_editions_first_published_at_dupes.rb
@@ -1,0 +1,24 @@
+class FixSpecialistPublisherEditionsFirstPublishedAtDupes < ActiveRecord::Migration[5.1]
+  disable_ddl_transaction!
+
+  # Update all the specialist-publisher editions with a
+  # first_published_at date of 2016-02-29 09:24:10 where
+  # this date is after the public_updated_at value
+  def up
+    scope = Edition.where(publishing_app: "specialist-publisher")
+                   .where("first_published_at BETWEEN '2016-02-29 09:24:10' AND '2016-02-29 09:24:11'")
+                   .where("first_published_at > (public_updated_at + interval '1 second')")
+
+    document_ids = scope.where(state: %w(draft published unpublished)).distinct(:document_id).pluck(:document_id)
+    content_ids = Document.where(id: document_ids).pluck(:content_id)
+
+    count = scope.update_all("first_published_at = public_updated_at")
+
+    puts "Updated #{count} specialist-publisher editions."
+
+    # Represent the relevant editions downstream
+    if Rails.env.production?
+      Commands::V2::RepresentDownstream.new.call(content_ids)
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171005150944) do
+ActiveRecord::Schema.define(version: 20171009122700) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
There are around 17000 specialist publisher editions which have
a `first_published_at` date of `2016-02-29 09:24:10` and a `public_updated_at`
timestamp earlier than this. So update these records to the `public_updated_at`
timestamp.