### PR TITLE
Update first_published_at for remaining specialist publisher editions

### DIFF
--- a/db/migrate/20171011154900_fix_remaining_specialist_publisher_first_published_at_dates.rb
+++ b/db/migrate/20171011154900_fix_remaining_specialist_publisher_first_published_at_dates.rb
@@ -1,0 +1,19 @@
+class FixRemainingSpecialistPublisherFirstPublishedAtDates < ActiveRecord::Migration[5.1]
+  disable_ddl_transaction!
+
+  def up
+    scope = Edition.where(publishing_app: "specialist-publisher")
+                   .where.not(document_type: %w(finder finder_email_signup gone redirect))
+                   .where("first_published_at > (public_updated_at + interval '1 second')")
+
+    content_ids = scope.joins(:document).pluck(:content_id)
+
+    count = scope.update_all("first_published_at = public_updated_at")
+
+    if Rails.env.production?
+      Commands::V2::RepresentDownstream.new.call(content_ids)
+    end
+
+    puts "Updated #{count} specialist-publisher editions."
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171010151218) do
+ActiveRecord::Schema.define(version: 20171011154900) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
https://trello.com/c/L7IfKMRs/13-sanitise-specialist-content-firstpublishedat-dates

There are ~165 remaining specialist publisher editions with a first published at
after the public updated at value. There's no accurate data available as
to when these were first published, so make the first published at date
the same as the current public updated at so the dates appear logical.

Publishing API date whack-a-mole level complete.