### PR TITLE
Amend service standard reports with nil last_edited_at

### DIFF
--- a/db/migrate/20171017153703_amend_service_standard_report_nil_last_edited_at.rb
+++ b/db/migrate/20171017153703_amend_service_standard_report_nil_last_edited_at.rb
@@ -1,0 +1,12 @@
+class AmendServiceStandardReportNilLastEditedAt < ActiveRecord::Migration[5.1]
+  def up
+    # ~22 editions
+    count = Edition.where(last_edited_at: nil,
+                          publishing_app: "specialist-publisher",
+                          document_type: "service_standard_report",
+                          state: %w(draft published unpublished))
+                   .update_all("last_edited_at = public_updated_at")
+
+    puts "#{count} editions updated."
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171011154900) do
+ActiveRecord::Schema.define(version: 20171017153703) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
These ~22 reports stick at the top of the specialist publisher
documents list for service standard reports because the default
ordering is by `last_edited_at` descending, so use the `public_updated_at`
date to populate their edit date.

As this date is only used by publishing apps there's no need to represent to the content store. 