### PR TITLE
Fix state of latest edition for /business-finance-support-finder

### DIFF
--- a/db/migrate/20171030153415_fix_business_finance_support_finder_state.rb
+++ b/db/migrate/20171030153415_fix_business_finance_support_finder_state.rb
@@ -1,0 +1,27 @@
+require 'gds_api/content_store'
+
+class FixBusinessFinanceSupportFinderState < ActiveRecord::Migration[5.1]
+  def up
+    unpublished_edition = nil
+    say_with_time "Checking the world is as we expect for /business-finance-support-finder before we update it" do
+      content_store = GdsApi::ContentStore.new(Plek.find('content-store'))
+      business_finance_support_finder = content_store.content_item('/business-finance-support-finder').to_hash
+      raise "Expected /business-finance-support-finder to be a 'business_support_finder' in content_store but it's a '#{business_finance_support_finder['document_type']}'" if business_finance_support_finder['document_type'] != 'business_support_finder'
+
+      unpublished_editions = Edition.where(base_path: '/business-finance-support-finder').where.not(state: 'superseded')
+      raise "Expected 1 edition for /business-finance-support-finder but there were #{unpublished_editions.count}" if unpublished_editions.size != 1
+
+      unpublished_edition = unpublished_editions.first
+      raise "Expected /business-finance-support-finder edition to be unpublished but it was '#{unpublished_edition.state}'" if unpublished_edition.state != 'unpublished'
+
+      raise "Expected unpublishing for /business-finance-support-finder to be a substitute, but it was '#{unpublished_edition.unpublishing.type}" if unpublished_edition.unpublishing.nil? || unpublished_edition.unpublishing.type != 'substitute'
+    end
+
+    say_with_time "Destroying substitute unpublishing for '/business-finance-support-finder'" do
+      unpublished_edition.unpublishing.destroy
+    end
+    say_with_time "Setting state and content_store to that of a published edition for '/business-finance-support-finder'" do
+      unpublished_edition.publish
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171017153703) do
+ActiveRecord::Schema.define(version: 20171030153415) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
For: https://trello.com/c/ufw2S0ZX/265-create-publishing-api-redirect-for-business-finance-support-finder

This path represents the old custom finder for business_support documents
that were managed by publisher.  This was replaced by a standard finder
published by specialist-publisher, and the documents are now also managed
by specialist-publisher.  The routes are different for the old and new
finders and this was handled by a redirect defined in router-data.  We
want to unpublish the current route with a new redirect content item so
we can remove the router-data entry.  One blocker to this is that the old
finder is tagged to a bunch of stuff (browse pages, taxons, etc...) that
mean it shows up in search, but the new one isn't.  When we tried to load
the old finder in content-tagger to see what it was tagged to it would
not load. We can see some of the tags via its content-store representation,
but this only shows us live tags, content-tagger will also show us draft
tags which is why we want to use it.  The reason it won't load is that
even though there is a live version of /business-finance-support-finder
in content-store, the latest edition in publishing-api (which is what
content-tagger users to map from a path to a content-id to load the item)
is marked as unpublished, and content-tagger won't load unpublished items.

We did some investigation and it's not clear at all why the latest edition
is unpublished, but there's still a live representation in content-store.
The easiest thing for us to do is to reset the state and remove the
unpublishing object for this latest edition.  We could do this through the
api but that would ultimately cause the routes to be republished from
publishing-api and that would clobber the redirect put in place by
router-data.  Ultimately getting rid of that router-data route is our goal
but we're not ready to do it before we've tagged the new finder and
unpublished the old finder as a redirect.

This PR therefore runs a migration that fixes the state of the latest
edition, and will break if the world is not as we expect.