### PR TITLE
Bump govuk_document_types gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -115,7 +115,7 @@ GEM
     govuk_app_config (0.2.0)
       sentry-raven (~> 2.6.3)
       statsd-ruby (~> 1.4.0)
-    govuk_document_types (0.1.8)
+    govuk_document_types (0.1.10)
     govuk_schemas (2.1.1)
       json-schema (~> 2.5.0)
     govuk_sidekiq (2.0.0)


### PR DESCRIPTION
This now uses the version which includes the `search_user_need_document_supertype`.

Merge after: 
- [x] https://github.com/alphagov/govuk_document_types/pull/28
- [x] Subsequent PR bumping the govuk_document_types to 0.1.10
- [x] https://github.com/alphagov/content-store/pull/326

https://trello.com/c/z9wtoGTV