### PR TITLE
Add migration to fix taxons visible_to_department_editors

### DIFF
--- a/db/migrate/20171114152513_fix_visible_to_departmental_editors_field_for_taxons.rb
+++ b/db/migrate/20171114152513_fix_visible_to_departmental_editors_field_for_taxons.rb
@@ -1,0 +1,19 @@
+class FixVisibleToDepartmentalEditorsFieldForTaxons < ActiveRecord::Migration[5.1]
+  disable_ddl_transaction!
+
+  def up
+    published_taxons = Edition.where(document_type: "taxon").where(state: "published")
+    content_ids = published_taxons.joins(:document).pluck(:content_id)
+
+    published_taxons.each do |t|
+      updated_details = t.details.merge(visible_to_departmental_editors: true)
+      t.update(details: updated_details)
+    end
+
+    if Rails.env.production?
+      Commands::V2::RepresentDownstream.new.call(content_ids)
+    end
+
+    puts "Updated #{published_taxons.count} taxon editions."
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171030153415) do
+ActiveRecord::Schema.define(version: 20171114152513) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
For https://trello.com/c/b3TTdin2/157-prevent-publishers-seeing-draft-taxons-in-government-frontend

This value should be `true` for all published editions, since this
will now control whether taxons are visible in the taxonomy sidebar.

We are doing work in ContentTagger to set this value to true once
a taxon is published so that the state is maintained properly going
forward.

See https://github.com/alphagov/content-tagger/pull/516