### PR TITLE
Use less generic name for postgres

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ruby:2.3.1
 RUN apt-get update -qq && apt-get upgrade -y && apt-get install -y build-essential libpq-dev libxml2-dev libxslt1-dev && apt-get clean
 
-ENV DATABASE_URL postgresql://postgres@db/publishing-api
+ENV DATABASE_URL postgresql://postgres@postgres/publishing-api
 ENV GOVUK_APP_NAME publishing-api
 ENV GOVUK_CONTENT_SCHEMAS_PATH /govuk-content-schemas
 ENV PORT 3093
@@ -9,7 +9,7 @@ ENV RABBITMQ_URL amqp://guest:guest@rabbitmq:5672
 ENV RABBITMQ_EXCHANGE published_documents
 ENV RAILS_ENV development
 ENV REDIS_HOST redis
-ENV TEST_DATABASE_URL postgresql://postgres@db/publishing-api-test
+ENV TEST_DATABASE_URL postgresql://postgres@postgres/publishing-api-test
 
 ENV APP_HOME /app
 RUN mkdir $APP_HOME


### PR DESCRIPTION
Given the other database instances in the [E2E Project](https://github.com/alphagov/publishing-e2e-tests) are specific about the service they provide it would be good to bring the postgres instance used here into line with that.