### PR TITLE
Use standard buildProject in Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,63 +17,81 @@ node {
       )
     ],
     beforeTest: {
-      govuk.setEnvar("RCOV", "1")
-      govuk.setEnvar("PACT_BROKER_BASE_URL", "https://pact-broker.cloudapps.digital")
+      setExtraEnvVars(govuk);
     },
     publishingE2ETests: true,
     afterTest: {
-      stage("Publish coverage") {
-        publishHTML(target: [
-          allowMissing: false,
-          alwaysLinkToLastBuild: false,
-          keepAll: true,
-          reportDir: "coverage/rcov",
-          reportFiles: "index.html",
-          reportName: "RCov Report"
-        ])
-      }
+      publishCoverage(govuk);
 
-      stage("Verify pact") {
-        sh "bundle exec rake pact:verify"
-      }
+      runPublishingApiPactTests(govuk);
 
-      stage("Publish pacts") {
-        withCredentials([[$class: "UsernamePasswordMultiBinding", credentialsId: "pact-broker-ci-dev",
-          usernameVariable: "PACT_BROKER_USERNAME", passwordVariable: "PACT_BROKER_PASSWORD"]]) {
-          withEnv(["PACT_TARGET_BRANCH=branch-${env.BRANCH_NAME}"]) {
-            sshagent(["govuk-ci-ssh-key"]) {
-              sh "bundle exec rake pact:publish:branch"
-            }
-          }
-        }
-      }
+      runContentStorePactTests(govuk);
+    }
+  )
+}
 
-      stage("Checkout content store") {
-        sh("rm -rf tmp/content-store")
-        sh("git clone https://github.com/alphagov/content-store.git tmp/content-store")
-        dir("tmp/content-store") {
-          sh("git checkout ${env.CONTENT_STORE_BRANCH}")
-          govuk.bundleApp()
-        }
-      }
+def setExtraEnvVars(govuk) {
+  // enable coverage reporting in tests
+  govuk.setEnvar("RCOV", "1")
+  // setup pact broker url for pact tests
+  govuk.setEnvar("PACT_BROKER_BASE_URL", "https://pact-broker.cloudapps.digital")
+}
 
-      lock("content-store-$NODE_NAME-test") {
-        stage("Verify pact with content-store") {
-          dir("tmp/content-store") {
-            sh("bundle exec rake db:mongoid:drop")
-            withCredentials([
-              [
-                $class: "UsernamePasswordMultiBinding",
-                credentialsId: "pact-broker-ci-dev",
-                usernameVariable: "PACT_BROKER_USERNAME",
-                passwordVariable: "PACT_BROKER_PASSWORD"
-              ]
-            ]) {
-              govuk.runRakeTask("pact:verify:branch[${env.BRANCH_NAME}]")
-            }
-          }
+def publishCoverage(_govuk) {
+  stage("Publish coverage") {
+    publishHTML(target: [
+      allowMissing: false,
+      alwaysLinkToLastBuild: false,
+      keepAll: true,
+      reportDir: "coverage/rcov",
+      reportFiles: "index.html",
+      reportName: "RCov Report"
+    ])
+  }
+}
+
+def runPublishingApiPactTests(_govuk) {
+  stage("Verify pact") {
+    sh "bundle exec rake pact:verify"
+  }
+
+  stage("Publish pacts") {
+    withCredentials([[$class: "UsernamePasswordMultiBinding", credentialsId: "pact-broker-ci-dev",
+      usernameVariable: "PACT_BROKER_USERNAME", passwordVariable: "PACT_BROKER_PASSWORD"]]) {
+      withEnv(["PACT_TARGET_BRANCH=branch-${env.BRANCH_NAME}"]) {
+        sshagent(["govuk-ci-ssh-key"]) {
+          sh "bundle exec rake pact:publish:branch"
         }
       }
     }
-  )
+  }
+}
+
+def runContentStorePactTests(govuk) {
+  stage("Checkout content store") {
+    sh("rm -rf tmp/content-store")
+    sh("git clone https://github.com/alphagov/content-store.git tmp/content-store")
+    dir("tmp/content-store") {
+      sh("git checkout ${env.CONTENT_STORE_BRANCH}")
+      govuk.bundleApp()
+    }
+  }
+
+  lock("content-store-$NODE_NAME-test") {
+    stage("Verify pact with content-store") {
+      dir("tmp/content-store") {
+        sh("bundle exec rake db:mongoid:drop")
+        withCredentials([
+          [
+            $class: "UsernamePasswordMultiBinding",
+            credentialsId: "pact-broker-ci-dev",
+            usernameVariable: "PACT_BROKER_USERNAME",
+            passwordVariable: "PACT_BROKER_PASSWORD"
+          ]
+        ]) {
+          govuk.runRakeTask("pact:verify:branch[${env.BRANCH_NAME}]")
+        }
+      }
+    }
+  }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,182 +1,79 @@
 #!/usr/bin/env groovy
 
-REPOSITORY = "publishing-api"
-DEFAULT_SCHEMA_BRANCH = "deployed-to-production"
-DEFAULT_CONTENT_STORE_BRANCH = "deployed-to-production"
-DEFAULT_PUBLISHING_E2E_TESTS_BRANCH = "test-against"
-
 node {
   def govuk = load("/var/lib/jenkins/groovy_scripts/govuk_jenkinslib.groovy")
 
-  properties([
-    buildDiscarder(
-      logRotator(
-        numToKeepStr: "10"
-      )
-    ),
-    parameters([
-      booleanParam(
-        name: "IS_SCHEMA_TEST",
-        defaultValue: false,
-        description: "Identifies whether this build is being triggered to test a change to the content schemas"
-      ),
-      stringParam(
-        name: "SCHEMA_BRANCH",
-        defaultValue: DEFAULT_SCHEMA_BRANCH,
-        description: "The branch of govuk-content-schemas to test against"
-      ),
+  govuk.buildProject(
+    extraParameters: [
       stringParam(
         name: "CONTENT_STORE_BRANCH",
-        defaultValue: DEFAULT_CONTENT_STORE_BRANCH,
+        defaultValue: "deployed-to-production",
         description: "The branch of content-store to test pacts against"
       ),
       stringParam(
         name: "PUBLISHING_E2E_TESTS_BRANCH",
-        defaultValue: DEFAULT_PUBLISHING_E2E_TESTS_BRANCH,
+        defaultValue: "test-against",
         description: "The branch of publishing-e2e-tests to test against"
-      ),
-    ])
-  ])
-
-  try {
-    govuk.initializeParameters([
-      "IS_SCHEMA_TEST": "false",
-      "SCHEMA_BRANCH": DEFAULT_SCHEMA_BRANCH,
-      "CONTENT_STORE_BRANCH": DEFAULT_CONTENT_STORE_BRANCH,
-      "PUBLISHING_E2E_TESTS_BRANCH": DEFAULT_PUBLISHING_E2E_TESTS_BRANCH,
-    ])
-
-    if (!govuk.isAllowedBranchBuild(env.BRANCH_NAME)) {
-      return
-    }
-
-    stage("Build") {
-      checkout(scm)
-      govuk.cleanupGit()
-      govuk.mergeMasterBranch()
-      govuk.bundleApp()
-      govuk.contentSchemaDependency(env.SCHEMA_BRANCH)
-      govuk.setEnvar("GOVUK_CONTENT_SCHEMAS_PATH", "tmp/govuk-content-schemas")
-      govuk.setEnvar("RAILS_ENV", "test")
-      govuk.setEnvar("DISABLE_DATABASE_ENVIRONMENT_CHECK", "1")
+      )
+    ],
+    beforeTest: {
       govuk.setEnvar("RCOV", "1")
       govuk.setEnvar("PACT_BROKER_BASE_URL", "https://pact-broker.cloudapps.digital")
-      govuk.setEnvar("FULL_COMMIT_HASH", sh(
-        script: "git rev-parse HEAD",
-        returnStdout: true
-      ).trim())
-      govuk.buildDockerImage(REPOSITORY, env.BRANCH_NAME)
-    }
-
-    stage("Lint") {
-      govuk.rubyLinter("app config Gemfile lib spec")
-    }
-
-    // Prevent a project's tests from running in parallel on the same node
-    lock("publishing-api-$NODE_NAME-test") {
-      stage("Build DB") {
-        sh("bundle exec rake db:reset")
+    },
+    publishingE2ETests: true,
+    afterTest: {
+      stage("Publish coverage") {
+        publishHTML(target: [
+          allowMissing: false,
+          alwaysLinkToLastBuild: false,
+          keepAll: true,
+          reportDir: "coverage/rcov",
+          reportFiles: "index.html",
+          reportName: "RCov Report"
+        ])
       }
 
-      stage("Test") {
-        sh("bundle exec rspec")
+      stage("Verify pact") {
+        sh "bundle exec rake pact:verify"
       }
-    }
 
-    stage("Publish coverage") {
-      publishHTML(target: [
-        allowMissing: false,
-        alwaysLinkToLastBuild: false,
-        keepAll: true,
-        reportDir: "coverage/rcov",
-        reportFiles: "index.html",
-        reportName: "RCov Report"
-      ])
-    }
-
-    stage("End-to-end tests") {
-      build(
-        job: "publishing-e2e-tests/${env.PUBLISHING_E2E_TESTS_BRANCH}",
-        parameters: [
-          [$class: "StringParameterValue",
-            name: "PUBLISHING_API_COMMITISH",
-            value: env.FULL_COMMIT_HASH],
-          [$class: "StringParameterValue",
-            name: "ORIGIN_REPO",
-            value: "publishing-api"],
-          [$class: "StringParameterValue",
-            name: "ORIGIN_COMMIT",
-            value: env.FULL_COMMIT_HASH]
-        ],
-        wait: false,
-      )
-    }
-
-    stage("Verify pact") {
-      sh "bundle exec rake pact:verify"
-    }
-
-    stage("Publish pacts") {
-      withCredentials([[$class: "UsernamePasswordMultiBinding", credentialsId: "pact-broker-ci-dev",
-        usernameVariable: "PACT_BROKER_USERNAME", passwordVariable: "PACT_BROKER_PASSWORD"]]) {
-        withEnv(["PACT_TARGET_BRANCH=branch-${env.BRANCH_NAME}"]) {
-          sshagent(["govuk-ci-ssh-key"]) {
-            sh "bundle exec rake pact:publish:branch"
+      stage("Publish pacts") {
+        withCredentials([[$class: "UsernamePasswordMultiBinding", credentialsId: "pact-broker-ci-dev",
+          usernameVariable: "PACT_BROKER_USERNAME", passwordVariable: "PACT_BROKER_PASSWORD"]]) {
+          withEnv(["PACT_TARGET_BRANCH=branch-${env.BRANCH_NAME}"]) {
+            sshagent(["govuk-ci-ssh-key"]) {
+              sh "bundle exec rake pact:publish:branch"
+            }
           }
         }
       }
-    }
 
-    stage("Checkout content store") {
-      sh("rm -rf tmp/content-store")
-      sh("git clone https://github.com/alphagov/content-store.git tmp/content-store")
-      dir("tmp/content-store") {
-        sh("git checkout ${env.CONTENT_STORE_BRANCH}")
-        govuk.bundleApp()
-      }
-    }
-
-    lock("content-store-$NODE_NAME-test") {
-      stage("Verify pact with content-store") {
+      stage("Checkout content store") {
+        sh("rm -rf tmp/content-store")
+        sh("git clone https://github.com/alphagov/content-store.git tmp/content-store")
         dir("tmp/content-store") {
-          sh("bundle exec rake db:mongoid:drop")
-          withCredentials([
-            [
-              $class: "UsernamePasswordMultiBinding",
-              credentialsId: "pact-broker-ci-dev",
-              usernameVariable: "PACT_BROKER_USERNAME",
-              passwordVariable: "PACT_BROKER_PASSWORD"
-            ]
-          ]) {
-            govuk.runRakeTask("pact:verify:branch[${env.BRANCH_NAME}]")
+          sh("git checkout ${env.CONTENT_STORE_BRANCH}")
+          govuk.bundleApp()
+        }
+      }
+
+      lock("content-store-$NODE_NAME-test") {
+        stage("Verify pact with content-store") {
+          dir("tmp/content-store") {
+            sh("bundle exec rake db:mongoid:drop")
+            withCredentials([
+              [
+                $class: "UsernamePasswordMultiBinding",
+                credentialsId: "pact-broker-ci-dev",
+                usernameVariable: "PACT_BROKER_USERNAME",
+                passwordVariable: "PACT_BROKER_PASSWORD"
+              ]
+            ]) {
+              govuk.runRakeTask("pact:verify:branch[${env.BRANCH_NAME}]")
+            }
           }
         }
       }
     }
-
-    releaseTag = "release_${env.BUILD_NUMBER}"
-
-    stage("Push Docker image") {
-      tag = env.BRANCH_NAME == "master" ? releaseTag : null
-      govuk.pushDockerImage(REPOSITORY, env.BRANCH_NAME, tag)
-    }
-
-    if (env.BRANCH_NAME == "master") {
-      stage("Push release tag") {
-        govuk.pushTag(REPOSITORY, env.BRANCH_NAME, releaseTag)
-      }
-
-      stage("Deploy on Integration") {
-        govuk.deployIntegration(REPOSITORY, env.BRANCH_NAME, "release", "deploy")
-      }
-    }
-
-  } catch (e) {
-    currentBuild.result = "FAILED"
-    step([$class: "Mailer",
-          notifyEveryUnstableBuild: true,
-          recipients: "govuk-ci-notifications@digital.cabinet-office.gov.uk",
-          sendToIndividuals: true])
-    throw e
-  }
+  )
 }


### PR DESCRIPTION
For: https://trello.com/c/QtpGwa2A/288-improve-feedback-on-github-for-changes-to-govuk-content-schemas

Using the standard buildProject defined in our groovy library means we get
consistent behaviour across all applications, and allows us to improve our
CI process in one place.

We do need to take advantage of some of the customisation hooks to keep
the build behaviour the same though.

1. Add extra parameters to the build for configuring which branches to use
   in the the content-store and publishing end-to-end test jobs
2. use beforeTest to set some extra env vars for coverage and pact tests
3. set publishingE2ETests to true so we always run the publishing
   end-to-end tests (our custom jenkinsfile always ran these but
   buildProject only does it if you tell it to)
4. use afterTest to publish the output of rcov
5. use afterTest to run pact verification and publish the output
6. use afterTest to run pact verification against content-store

The test task in our custom script was to run `rspec` whereas the default
in buildProject is to run `rake default`.  We could use overrideTestTask
here, but it turns out that our `rake default` behaviour is to run rspec
anyway so while it would be marginally faster to run `rspec` directly
rather than go via `rake`, consistency wins out.

There was also some difference between how our custom script ran the
publishing end-to-end tests and how buildProject does it, but as far
as I can tell the eventual outcome is the same.  The major difference
was that we would always run it whereas buildProject is conditional, but
all the parameters come from the same place (or resolve to the same
values).