### PR TITLE
Fix first_published_at for hmrc-manuals-api editions

### DIFF
--- a/db/migrate/20171117150443_fix_hmrc_manuals_api_first_published_at.rb
+++ b/db/migrate/20171117150443_fix_hmrc_manuals_api_first_published_at.rb
@@ -1,0 +1,34 @@
+require_relative "helpers/february29th2016"
+
+class FixHmrcManualsApiFirstPublishedAt < ActiveRecord::Migration[5.1]
+  def up
+    publishing_app = "hmrc-manuals-api"
+
+    manual_dates = {
+      "vat-government-and-public-bodies"                 => "24 August 2012",
+      "business-income-manual"                           => "22 November 2013",
+      "employment-income-manual"                         => "22 May 2014",
+      "pensions-tax-manual"                              => "27 March 2015",
+      "employee-tax-advantaged-share-scheme-user-manual" => "26 August 2015",
+      "scottish-taxpayer-technical-guidance"             => "26 October 2015",
+    }
+
+    manual_dates.each do |manual, date|
+      puts manual
+
+      content_ids = Edition
+        .where(publishing_app: publishing_app)
+        .where("base_path like '/hmrc-internal-manuals/#{manual}%'")
+        .joins(:document)
+        .pluck(:content_id)
+        .uniq
+
+      datetime = DateTime.parse("9am on #{date}")
+
+      Helpers::February29th2016.replace_first_published_at(
+        content_ids.map { |c| [c, datetime] },
+        where_conditions: { publishing_app: publishing_app },
+      )
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171107190821) do
+ActiveRecord::Schema.define(version: 20171117150443) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
https://trello.com/c/EQTHkveY/358-fix-hmrc-manuals-api-firstpublishedat

Tested on integration:

```
vat-government-and-public-bodies
1732 editions updated.
business-income-manual
12004 editions updated.
employment-income-manual
21043 editions updated.
pensions-tax-manual
8964 editions updated.
employee-tax-advantaged-share-scheme-user-manual
1262 editions updated.
scottish-taxpayer-technical-guidance
36 editions updated.
```

(https://deploy.integration.publishing.service.gov.uk/job/Deploy_App/4959/console)