### PR TITLE
Use rabbbitmq hosts defined in an environment variable.

### DIFF
--- a/config/rabbitmq.yml
+++ b/config/rabbitmq.yml
@@ -16,9 +16,10 @@ test:
 
 production:
   hosts:
-    - rabbitmq-1.backend
-    - rabbitmq-2.backend
-    - rabbitmq-3.backend
+    <% hosts = ENV['RABBITMQ_HOSTS'] || 'localhost' %>
+    <% hosts.split(",").each do |host| %>
+    - <% host %>
+    <% end %>
   user: publishing_api
   pass: <%= ENV['RABBITMQ_PASSWORD'] %>
   port: 5672


### PR DESCRIPTION
We now access these via different naming schemes in different environments
so accept the values provided by puppet rather than the hard coded
ones. CC /@kevindew 

This a subset of the changes made here - https://github.com/alphagov/email-alert-service/pull/80/files#diff-64f27c9e1694187fb14d1429cd7d409fR21