### PR TITLE
Echo host in rabbitmq config

### DIFF
--- a/config/rabbitmq.yml
+++ b/config/rabbitmq.yml
@@ -18,7 +18,7 @@ production:
   hosts:
     <% hosts = ENV['RABBITMQ_HOSTS'] || 'localhost' %>
     <% hosts.split(",").each do |host| %>
-    - <% host %>
+    - <%= host %>
     <% end %>
   user: publishing_api
   pass: <%= ENV['RABBITMQ_PASSWORD'] %>


### PR DESCRIPTION
This fixes the previous code that looped through the collection of hosts
but didn't actually echo out the hostname, meaning we had an array of
nil hosts.