### PR TITLE
Update govuk_schemas gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,7 @@ end
 
 gem "gds-sso", "13.0.0"
 gem "govuk_app_config", "~> 0.2"
-gem "govuk_schemas", "~> 2.1.1"
+gem "govuk_schemas", "~> 3.0.1"
 gem "govuk_document_types", "~> 0.1"
 
 gem 'bunny', '~> 2.6'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -122,7 +122,7 @@ GEM
       sentry-raven (~> 2.6.3)
       statsd-ruby (~> 1.4.0)
     govuk_document_types (0.1.11)
-    govuk_schemas (2.1.1)
+    govuk_schemas (3.0.1)
       json-schema (~> 2.5.0)
     govuk_sidekiq (2.0.0)
       gds-api-adapters (>= 19.1.0)
@@ -423,7 +423,7 @@ DEPENDENCIES
   govuk-lint
   govuk_app_config (~> 0.2)
   govuk_document_types (~> 0.1)
-  govuk_schemas (~> 2.1.1)
+  govuk_schemas (~> 3.0.1)
   govuk_sidekiq (~> 2.0)
   hashdiff (~> 0.3.6)
   json-schema

--- a/spec/support/random_content_helpers.rb
+++ b/spec/support/random_content_helpers.rb
@@ -8,10 +8,7 @@ module RandomContentHelpers
       base_path: base_path,
       update_type: "major",
 
-      # TODOs:
       title: "Something not empty", # TODO: make schemas validate title length
-      rendering_app: "government-frontend", # TODO: remove after https://github.com/alphagov/govuk-content-schemas/pull/575
-      publishing_app: "publisher", # TODO: remove after https://github.com/alphagov/govuk-content-schemas/pull/575
       routes: [
         { path: base_path, type: "prefix" },
       ],

--- a/spec/support/random_content_helpers.rb
+++ b/spec/support/random_content_helpers.rb
@@ -2,18 +2,18 @@ require "govuk_schemas"
 
 module RandomContentHelpers
   def generate_random_edition(base_path)
-    random = GovukSchemas::RandomExample.for_schema(publisher_schema: "placeholder")
+    GovukSchemas::RandomExample.for_schema(publisher_schema: "placeholder") do |content|
+      content.merge(
+        base_path: base_path,
+        update_type: "major",
 
-    random.merge_and_validate(
-      base_path: base_path,
-      update_type: "major",
-
-      title: "Something not empty", # TODO: make schemas validate title length
-      routes: [
-        { path: base_path, type: "prefix" },
-      ],
-      redirects: []
-    )
+        title: "Something not empty", # TODO: make schemas validate title length
+        routes: [
+          { path: base_path, type: "prefix" },
+        ],
+        redirects: []
+      )
+    end
   end
 
   def random_content_failure_message(response, edition)


### PR DESCRIPTION
Update the random example generation to use the gem's new syntax. Also clean up a couple of TODOs.

Updating this gem will make it easier for us to update the json-schema gem, which is causing deprecation warnings in Ruby 2.4 apps.