### PR TITLE
 Add 'with_draft' option to '/lookup-by-base-path' endpoint

### DIFF
--- a/app/controllers/lookups_controller.rb
+++ b/app/controllers/lookups_controller.rb
@@ -1,9 +1,16 @@
 class LookupsController < ApplicationController
   def by_base_path
-    # return content_ids for content that is visible on the live site
-    # withdrawn items are still visible
-    states = %w(published unpublished)
     base_paths = params.fetch(:base_paths)
+
+    if with_drafts
+      states = %w(draft published unpublished)
+      content_stores = %w(draft live)
+    else
+      # return content_ids for content that is visible on the live site
+      # withdrawn items are still visible
+      states = %w(published unpublished)
+      content_stores = 'live'
+    end
 
     scope = Edition.left_outer_joins(:unpublishing)
 
@@ -13,12 +20,18 @@ class LookupsController < ApplicationController
     )
 
     scope = scope.with_document
-      .where(state: states, content_store: 'live', base_path: base_paths)
+      .where(state: states, content_store: content_stores, base_path: base_paths)
       .where.not(document_type: params.fetch('exclude_document_types', %w{gone redirect}))
 
     base_paths_and_content_ids = scope.distinct.pluck(:base_path, 'documents.content_id')
 
     response = Hash[base_paths_and_content_ids]
     render json: response
+  end
+
+private
+
+  def with_drafts
+    ActiveModel::Type::Boolean.new.cast(params.fetch(:with_drafts, false))
   end
 end

--- a/app/controllers/lookups_controller.rb
+++ b/app/controllers/lookups_controller.rb
@@ -22,8 +22,11 @@ class LookupsController < ApplicationController
     scope = scope.with_document
       .where(state: states, content_store: content_stores, base_path: base_paths)
       .where.not(document_type: params.fetch('exclude_document_types', %w{gone redirect}))
+      .order(state: :desc)
 
-    base_paths_and_content_ids = scope.distinct.pluck(:base_path, 'documents.content_id')
+    base_paths_and_content_ids = scope.pluck(
+      "distinct on (editions.base_path, editions.state) editions.base_path, documents.content_id"
+    )
 
     response = Hash[base_paths_and_content_ids]
     render json: response

--- a/spec/requests/lookups_spec.rb
+++ b/spec/requests/lookups_spec.rb
@@ -24,6 +24,20 @@ RSpec.describe "POST /lookup-by-base-path", type: :request do
       )
     end
 
+    it "returns content_ids including drafts with 'with_draft' option" do
+      create_test_content
+
+      post "/lookup-by-base-path", params: { base_paths: test_base_paths, with_drafts: true }
+
+      expect(parsed_response).to eql(
+        "/published-and-draft-page" => "aa491126-77ed-4e81-91fa-8dc7f74e9657",
+        "/only-draft-page" => "a4038b29-b332-4f13-98b1-1c9709e216bc",
+        "/only-published-page" => "bbabcd3c-7c45-4403-8490-db51e4bfc4f6",
+        "/superseded-and-draft-page" => "dd1bf833-f91c-4e45-9f97-87b165808176",
+        "/withdrawn-page" => "00abcd3c-7c45-4403-8490-db51e4bfc4f6",
+      )
+    end
+
     it "excludes redirect content items" do
       FactoryGirl.create(:redirect_edition, state: "published", base_path: "/redirect-page", user_facing_version: 1)
 
@@ -94,6 +108,7 @@ RSpec.describe "POST /lookup-by-base-path", type: :request do
     doc4 = FactoryGirl.create(:document, content_id: "ee491126-77ed-4e81-91fa-8dc7f74e9657")
     doc5 = FactoryGirl.create(:document, content_id: "ffabcd3c-7c45-4403-8490-db51e4bfc4f6")
     doc6 = FactoryGirl.create(:document, content_id: "00abcd3c-7c45-4403-8490-db51e4bfc4f6")
+    doc7 = FactoryGirl.create(:document, content_id: "a4038b29-b332-4f13-98b1-1c9709e216bc")
 
     FactoryGirl.create(:live_edition, state: "published", base_path: "/published-and-draft-page", document: doc1, user_facing_version: 1)
     FactoryGirl.create(:edition, state: "draft", base_path: "/published-and-draft-page", document: doc1, user_facing_version: 2)
@@ -109,6 +124,8 @@ RSpec.describe "POST /lookup-by-base-path", type: :request do
 
     unpublished3 = FactoryGirl.create(:live_edition, state: "published", base_path: "/withdrawn-page", document: doc6, user_facing_version: 1)
     unpublished3.unpublish(type: "withdrawal", explanation: "Consolidated into another page")
+
+    FactoryGirl.create(:edition, state: "draft", base_path: "/only-draft-page", document: doc7, user_facing_version: 1)
   end
 
   def test_base_paths
@@ -119,7 +136,8 @@ RSpec.describe "POST /lookup-by-base-path", type: :request do
       "/does-not-exist",
       "/redirected-from-page",
       "/gone-page",
-      "/withdrawn-page"
+      "/withdrawn-page",
+      "/only-draft-page",
     ]
   end
 end

--- a/spec/requests/lookups_spec.rb
+++ b/spec/requests/lookups_spec.rb
@@ -38,6 +38,28 @@ RSpec.describe "POST /lookup-by-base-path", type: :request do
       )
     end
 
+    it "returns most relevant content by publishing state for the given parameters" do
+      doc1 = FactoryGirl.create(:document, content_id: "cbb460a7-60de-4a74-b5be-0b27c6d6af9b")
+      doc2 = FactoryGirl.create(:document, content_id: "18020103-122d-459d-90b1-0f3284c1b5cb")
+
+      FactoryGirl.create(:edition, state: "draft", content_store: "draft",
+        base_path: "/unique-base-path", document: doc1, user_facing_version: 1)
+      FactoryGirl.create(:edition, state: "published", content_store: "live",
+        base_path: "/unique-base-path", document: doc2, user_facing_version: 1)
+
+      post "/lookup-by-base-path", params: { base_paths: "/unique-base-path", with_drafts: true }
+
+      expect(parsed_response).to eql(
+        "/unique-base-path" => "cbb460a7-60de-4a74-b5be-0b27c6d6af9b",
+      )
+
+      post "/lookup-by-base-path", params: { base_paths: "/unique-base-path" }
+
+      expect(parsed_response).to eql(
+        "/unique-base-path" => "18020103-122d-459d-90b1-0f3284c1b5cb",
+      )
+    end
+
     it "excludes redirect content items" do
       FactoryGirl.create(:redirect_edition, state: "published", base_path: "/redirect-page", user_facing_version: 1)
 

--- a/spec/requests/lookups_spec.rb
+++ b/spec/requests/lookups_spec.rb
@@ -98,8 +98,8 @@ RSpec.describe "POST /lookup-by-base-path", type: :request do
     FactoryGirl.create(:live_edition, state: "published", base_path: "/published-and-draft-page", document: doc1, user_facing_version: 1)
     FactoryGirl.create(:edition, state: "draft", base_path: "/published-and-draft-page", document: doc1, user_facing_version: 2)
     FactoryGirl.create(:live_edition, state: "published", base_path: "/only-published-page", document: doc2)
-    FactoryGirl.create(:edition, state: "draft", base_path: "/draft-and-superseded-page", document: doc3, user_facing_version: 2)
-    FactoryGirl.create(:superseded_edition, state: "superseded", base_path: "/draft-and-superseded-page", document: doc3, user_facing_version: 1)
+    FactoryGirl.create(:superseded_edition, state: "superseded", base_path: "/superseded-and-draft-page", document: doc3, user_facing_version: 1)
+    FactoryGirl.create(:edition, state: "draft", base_path: "/superseded-and-draft-page", document: doc3, user_facing_version: 2)
 
     unpublished1 = FactoryGirl.create(:live_edition, state: "published", base_path: "/redirected-from-page", document: doc4, user_facing_version: 1)
     unpublished1.unpublish(type: "redirect", redirects: [{ path: unpublished1.base_path, type: :exact, destination: "/redirected-to-page" }])
@@ -115,7 +115,7 @@ RSpec.describe "POST /lookup-by-base-path", type: :request do
     [
       "/published-and-draft-page",
       "/only-published-page",
-      "/draft-and-superseded-page",
+      "/superseded-and-draft-page",
       "/does-not-exist",
       "/redirected-from-page",
       "/gone-page",


### PR DESCRIPTION
During the development of the Topic Taxonomy in Content Tagger, a lot of
taxons are still in their draft states. Recently, we've had the
requirement to lookup taxons by their base path to provide an
informative error message when attempting to create a taxon with a
conflicting base path.

By introducing the 'with_draft' parameter, we can optionally include
draft states and content from both the live and draft content stores.

Trello: https://trello.com/c/WVTtiLie/150-provide-a-useful-error-message-in-content-tagger-when-you-try-to-create-or-move-a-taxon-where-one-already-exists