### PR TITLE
Upgrade gds-sso to latest version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,7 @@ else
   gem 'gds-api-adapters', "~> 50.5.0"
 end
 
-gem "gds-sso", "13.0.0"
+gem "gds-sso", "~> 13.4"
 gem "govuk_app_config", "~> 0.2"
 gem "govuk_schemas", "~> 3.1.0"
 gem "govuk_document_types", "~> 0.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -610,7 +610,7 @@ GEM
       plek (>= 1.9.0)
       rack-cache
       rest-client (~> 2.0)
-    gds-sso (13.0.0)
+    gds-sso (13.4.0)
       multi_json (~> 1.0)
       oauth2 (~> 1.0)
       omniauth (~> 1.2)
@@ -936,7 +936,7 @@ DEPENDENCIES
   factory_girl_rails (= 4.7.0)
   faker
   gds-api-adapters (~> 50.5.0)
-  gds-sso (= 13.0.0)
+  gds-sso (~> 13.4)
   govspeak (~> 5.2.2)
   govuk-lint
   govuk_app_config (~> 0.2)


### PR DESCRIPTION
This didn't get picked up by dependabot and is needed by the E2E tests to run signon in mock mode while the applications run in production.