### PR TITLE
Add external_content to list of formats without base paths

### DIFF
--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -32,7 +32,7 @@ class Edition < ApplicationRecord
   ].freeze
 
   NON_RENDERABLE_FORMATS = %w(redirect gone).freeze
-  EMPTY_BASE_PATH_FORMATS = %w(contact government world_location).freeze
+  EMPTY_BASE_PATH_FORMATS = %w(contact external_content government world_location).freeze
   belongs_to :document
   has_one :unpublishing
   has_one :change_note

--- a/spec/models/edition_spec.rb
+++ b/spec/models/edition_spec.rb
@@ -257,7 +257,7 @@ RSpec.describe Edition do
   context "EMPTY_BASE_PATH_FORMATS" do
     it "defines formats not requiring a base_path attibute" do
       expect(Edition::EMPTY_BASE_PATH_FORMATS).to eq(
-        %w(contact government world_location)
+        %w(contact external_content government world_location)
       )
     end
   end


### PR DESCRIPTION
The `external_content` schema and document type represent a non-GOV.UK URL which will be used for things like search indexing. Items of this type have a URL but no base_path.

See [RFC 88](https://github.com/alphagov/govuk-rfcs/pull/88) for more details.

https://trello.com/c/rDurYmt8/525-send-external-links-from-search-admin-to-the-publishing-api