### PR TITLE
Add external_content to list of formats without rendering apps

### DIFF
--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -32,6 +32,7 @@ class Edition < ApplicationRecord
   ].freeze
 
   NON_RENDERABLE_FORMATS = %w(redirect gone).freeze
+  NO_RENDERING_APP_FORMATS = %w(contact external_content).freeze
   EMPTY_BASE_PATH_FORMATS = %w(contact external_content government world_location).freeze
   belongs_to :document
   has_one :unpublishing
@@ -237,6 +238,6 @@ private
   end
 
   def requires_rendering_app?
-    renderable_content? && document_type != "contact"
+    renderable_content? && NO_RENDERING_APP_FORMATS.exclude?(document_type)
   end
 end


### PR DESCRIPTION
The `external_content` schema and document type represent a non-GOV.UK URL which will be used for things like search indexing. Items of this type have a URL but no rendering_app.

See [RFC 88](https://github.com/alphagov/govuk-rfcs/pull/88) for more details.

https://trello.com/c/rDurYmt8/525-send-external-links-from-search-admin-to-the-publishing-api

This is very similar to #1100. Should the publishing API be validating payloads against the schema rather than relying on these ad-hoc rules?