### PR TITLE
Add content ID to message queue payload for Gone documents

### DIFF
--- a/app/presenters/gone_presenter.rb
+++ b/app/presenters/gone_presenter.rb
@@ -1,6 +1,7 @@
 class GonePresenter
-  def initialize(base_path:, publishing_app:, alternative_path:, explanation:)
+  def initialize(base_path:, content_id:, publishing_app:, alternative_path:, explanation:)
     @base_path = base_path
+    @content_id = content_id
     @publishing_app = publishing_app
     @alternative_path = alternative_path
     @explanation = explanation
@@ -9,6 +10,7 @@ class GonePresenter
   def self.from_edition(edition)
     new(
       base_path: edition.base_path,
+      content_id: edition.content_id,
       publishing_app: edition.publishing_app,
       alternative_path: edition.unpublishing.alternative_path,
       explanation: edition.unpublishing.explanation,
@@ -21,6 +23,7 @@ class GonePresenter
 
   def for_message_queue(payload_version)
     present.merge(
+      content_id: content_id,
       govuk_request_id: GdsApi::GovukHeaders.headers[:govuk_request_id],
       payload_version: payload_version
     )
@@ -28,7 +31,7 @@ class GonePresenter
 
 private
 
-  attr_reader :base_path, :publishing_app, :alternative_path, :explanation
+  attr_reader :base_path, :content_id, :publishing_app, :alternative_path, :explanation
 
   def present
     {

--- a/spec/requests/unpublishing_spec.rb
+++ b/spec/requests/unpublishing_spec.rb
@@ -255,6 +255,7 @@ RSpec.describe "POST /v2/content/:content_id/unpublish", type: :request do
         .with(
           a_hash_including(
             document_type: "gone",
+            content_id: content_id,
             details: a_hash_including(alternative_path: "/new-path"),
           ),
           event_type: "unpublish"


### PR DESCRIPTION
This will allow downstream apps such as rummager identify unpublished documents which do not have base paths, such as external content.

https://trello.com/c/mwqMqK8s/542-allow-external-content-to-be-unpublished