### PR TITLE
Copy publisher_first_published_at from edition to edition

### DIFF
--- a/app/models/edition/timestamps.rb
+++ b/app/models/edition/timestamps.rb
@@ -12,7 +12,8 @@ class Edition::Timestamps
     # first_published_at should eventually be associated with a document model,
     # therefore avoiding the need to copy between editions as this is fragile
     edition.temporary_first_published_at = previous_live_version&.temporary_first_published_at
-    edition.publisher_first_published_at = payload[:first_published_at]
+    edition.publisher_first_published_at = payload[:first_published_at] ||
+      previous_live_version&.publisher_first_published_at
     edition.first_published_at = payload[:first_published_at] ||
       previous_live_version&.first_published_at
 

--- a/app/models/previously_published_item.rb
+++ b/app/models/previously_published_item.rb
@@ -27,6 +27,10 @@ class PreviouslyPublishedItem
     previously_published_item.temporary_first_published_at
   end
 
+  def publisher_first_published_at
+    previously_published_item.publisher_first_published_at
+  end
+
   def last_edited_at
     previously_published_item.last_edited_at
   end
@@ -77,6 +81,8 @@ class PreviouslyPublishedItem
     def first_published_at; end
 
     def temporary_first_published_at; end
+
+    def publisher_first_published_at; end
 
     def major_published_at; end
 

--- a/spec/models/edition/timestamps_spec.rb
+++ b/spec/models/edition/timestamps_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe Edition::Timestamps do
     let(:previous_live_version) do
       build(:edition,
         temporary_first_published_at: "2017-01-01",
+        publisher_first_published_at: "2017-04-01",
         first_published_at: "2017-04-01",
         major_published_at: "2017-11-11",
       )
@@ -70,6 +71,10 @@ RSpec.describe Edition::Timestamps do
 
       it "sets first_published_at to previous_live_version" do
         expect(edition.first_published_at).to eq previous_live_version.first_published_at
+      end
+
+      it "sets publisher_first_published_at to previous_live_version" do
+        expect(edition.publisher_first_published_at).to eq previous_live_version.publisher_first_published_at
       end
     end
 


### PR DESCRIPTION
Trello: https://trello.com/c/M7w63J9U/478-backfill-new-date-fields-for-publishing-api

This fixes some data accuracy issues that were encountered with the
backfill script in: https://github.com/alphagov/publishing-api/pull/1042

The logic when writing this initially was that we should set the
`publisher_first_published_at` field if a user specifies it and whilst
this logic is sound it is not compatible with `first_published_at` field
where once a publisher has set this once the next value will be copied
each time. This led to backfilling the dates to not being compatible
with current behaviour.