### PR TITLE
Migration to update publisher_first_published_at dates

### DIFF
--- a/db/migrate/20180102152030_update_missing_publisher_first_published_at_dates.rb
+++ b/db/migrate/20180102152030_update_missing_publisher_first_published_at_dates.rb
@@ -1,0 +1,13 @@
+class UpdateMissingPublisherFirstPublishedAtDates < ActiveRecord::Migration[5.1]
+  disable_ddl_transaction!
+
+  def up
+    Edition
+      .where.not(temporary_first_published_at: nil, first_published_at: nil)
+      .where("temporary_first_published_at != first_published_at")
+      .where("publisher_first_published_at IS NULL OR publisher_first_published_at != first_published_at")
+      .find_each do |edition|
+        edition.update(publisher_first_published_at: edition.first_published_at)
+      end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171228212521) do
+ActiveRecord::Schema.define(version: 20180102152030) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
Trello: https://trello.com/c/M7w63J9U/478-backfill-new-date-fields-for-publishing-api

This follows the work in https://github.com/alphagov/publishing-api/pull/1120 which changed how
dates were handled. This migration backfills this change to affected editions.

Took ~23 mins on integration:

```
18:20:43 Migrating to UpdateMissingPublisherFirstPublishedAtDates (20180102152030)
18:20:43 == 20180102152030 UpdateMissingPublisherFirstPublishedAtDates: migrating ======
18:43:51 == 20180102152030 UpdateMissingPublisherFirstPublishedAtDates: migrated (1387.9882s) 
```