### PR TITLE
Log invalid publishing queue messages

### DIFF
--- a/app/commands/v2/patch_link_set.rb
+++ b/app/commands/v2/patch_link_set.rb
@@ -122,8 +122,8 @@ module Commands
       def schema_validator
         @schema_validator ||= SchemaValidator.new(
           payload: payload[:links],
-          links: true,
-          schema_name: schema_name
+          schema_name: schema_name,
+          schema_type: :links,
         )
       end
 

--- a/app/validators/schema_validator.rb
+++ b/app/validators/schema_validator.rb
@@ -4,11 +4,11 @@ require 'govuk_schemas'
 class SchemaValidator
   attr_reader :errors
 
-  def initialize(payload:, links: false, schema: nil, schema_name: nil)
+  def initialize(payload:, schema: nil, schema_name: nil, schema_type: :publisher)
     @payload = payload
-    @links = links
     @schema = schema
     @schema_name = schema_name
+    @schema_type = schema_type
     @errors = []
   end
 
@@ -24,7 +24,7 @@ class SchemaValidator
 
 private
 
-  attr_reader :payload, :links
+  attr_reader :payload, :schema_type
 
   def schema
     @schema || find_schema
@@ -52,15 +52,11 @@ private
 
   def find_type
     raise NoSchemaNameError.new("No schema name provided") unless schema_name.present?
-    if links?
-      { links_schema: schema_name }
-    else
-      { publisher_schema: schema_name }
-    end
+    { schema_type_key => schema_name }
   end
 
-  def links?
-    links
+  def schema_type_key
+    (schema_type.to_s + "_schema").to_sym
   end
 
   def schema_name

--- a/lib/queue_publisher.rb
+++ b/lib/queue_publisher.rb
@@ -20,6 +20,7 @@ class QueuePublisher
 
   def send_message(edition, event_type: nil, routing_key: nil, persistent: true)
     return if @noop
+    validate_edition(edition)
     routing_key ||= routing_key(edition, event_type)
     publish_message(routing_key, edition, content_type: 'application/json', persistent: persistent)
   end
@@ -41,6 +42,19 @@ class QueuePublisher
   end
 
 private
+
+  def validate_edition(edition)
+    validator = SchemaValidator.new(payload: edition, schema_type: :notification)
+    if !validator.valid?
+      Rails.logger.warn(
+        {
+          "message": "Message being sent to the queue does not match the notification schema",
+          "error": validator.errors.to_s,
+          "edition": edition,
+        }.to_json
+      )
+    end
+  end
 
   def publish_message(routing_key, message_data, options = {})
     # we should only have one channel per thread

--- a/spec/lib/queue_publisher_spec.rb
+++ b/spec/lib/queue_publisher_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe QueuePublisher do
           title: "VAT Rates",
           description: "VAT rates for goods and services",
           document_type: "nonexistent-schema",
-          schema_name: "nonexistent-schema",
+          schema_name: "answer",
           publishing_app: "publisher",
           locale: "en",
           details: {


### PR DESCRIPTION
Log messages which don't match the relevant notification schema to help us find inconsistencies between the publishing API and the content schemas.

Apps which consume these messages rely on the schemas to know what fields to expect.

Just log to a file for now. We may log to Sentry once we have an idea of the error volume and we have fixed the most common errors.

It would be good to get these logs into Kibana too, but I couldn't figure out how to do it. Does anyone know? I tried formatting them as JSON, but it didn't help. It might be because they end up in the Sidekiq lots in procfile_worker.err.log rather than app.err.log. Do we send Sidekiq logs to Kibana at all?

https://trello.com/c/uV5zDvzu/97-add-schema-tests-to-the-publishing-api

cc @kevindew 