### PR TITLE
Update Oj JSON-parsing gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,7 +38,9 @@ group :development do
   gem "web-console", "~> 3"
 end
 
-gem "oj", "~> 2.16.1"
+# Lock to 2.18.3 because later patch versions are not listed in the oj changelog
+# and cause test failures.
+gem "oj", "2.18.3"
 gem "oj_mimic_json", "~> 1.0.1"
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -702,7 +702,7 @@ GEM
       multi_json (~> 1.3)
       multi_xml (~> 0.5)
       rack (>= 1.2, < 3)
-    oj (2.16.1)
+    oj (2.18.3)
     oj_mimic_json (1.0.1)
     omniauth (1.7.1)
       hashie (>= 3.4.6, < 3.6.0)
@@ -948,7 +948,7 @@ DEPENDENCIES
   govuk_sidekiq (~> 3.0)
   hashdiff (~> 0.3.6)
   json-schema
-  oj (~> 2.16.1)
+  oj (= 2.18.3)
   oj_mimic_json (~> 1.0.1)
   pact
   pact_broker-client


### PR DESCRIPTION
Update to the latest working version of Oj 2.

Using Oj 2.18 fixes a bug when parsing the JSON schema: publishing-api uses `oj_mimic_json`, which makes Oj behave like the json gem. In older versions, this mode caused the wrong exception to be thrown when parsing invalid JSON. See https://github.com/ruby-json-schema/json-schema/issues/305

Fixing that bug will let us use govuk-content-schema-test-helpers. It depends on json-schema, which uses Oj for JSON parsing when Oj is available.

This does not upgrade Oj to the very latest version:

- Oj 3 causes a lot of test failures, so may need some work to upgrade.
- Oj 2.18.5 exists on RubyGems, but it is not documented in the Oj changelogs, and breaks the error handling for invalid JSON in the ContentItemsController.

https://trello.com/c/uV5zDvzu/97-add-schema-tests-to-the-publishing-api