### PR TITLE
 Validate messages sent to the message queue

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -57,6 +57,7 @@ group :development, :test do
   gem "simplecov-rcov", "0.2.3", require: false
   gem "factory_bot_rails", "~> 4.8"
   gem "pact_broker-client"
+  gem 'govuk-content-schema-test-helpers', "~> 1.6"
   gem "govuk-lint"
   gem "faker"
   gem "stackprof", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -631,6 +631,8 @@ GEM
       money (~> 6.7)
       nokogiri (~> 1.5)
       sanitize (~> 2.1.0)
+    govuk-content-schema-test-helpers (1.6.0)
+      json-schema (~> 2.8.0)
     govuk-lint (3.5.0)
       rubocop (~> 0.51.0)
       rubocop-rspec (~> 1.19.0)
@@ -942,6 +944,7 @@ DEPENDENCIES
   gds-api-adapters (~> 51.0.0)
   gds-sso (~> 13.5)
   govspeak (~> 5.4.0)
+  govuk-content-schema-test-helpers (~> 1.6)
   govuk-lint
   govuk_app_config (~> 1.2)
   govuk_document_types (~> 0.2)

--- a/app/helpers/redirect_helper.rb
+++ b/app/helpers/redirect_helper.rb
@@ -14,6 +14,7 @@ module RedirectHelper
 
       redirect_payload = RedirectPresenter.new(
         base_path: previous_base_path,
+        content_id: previous_content_id,
         redirects: redirects_for(previous_routes, previous_base_path, payload[:base_path]),
         publishing_app: payload[:publishing_app],
       ).for_redirect_helper(SecureRandom.uuid)
@@ -45,6 +46,11 @@ module RedirectHelper
     def previous_base_path
       previously_published_item.previous_base_path ||
         previously_drafted_item.base_path
+    end
+
+    def previous_content_id
+      previously_published_item.content_id ||
+        previously_drafted_item.content_id
     end
 
     def redirects_for(routes, old_base_path, new_base_path)

--- a/app/models/previously_published_item.rb
+++ b/app/models/previously_published_item.rb
@@ -15,6 +15,10 @@ class PreviouslyPublishedItem
     document.published_or_unpublished
   end
 
+  def content_id
+    previously_published_item.content_id
+  end
+
   def user_facing_version
     previously_published_item.user_facing_version + 1
   end
@@ -77,6 +81,8 @@ class PreviouslyPublishedItem
 
     def routes
     end
+
+    def content_id; end
 
     def first_published_at; end
 

--- a/app/presenters/redirect_presenter.rb
+++ b/app/presenters/redirect_presenter.rb
@@ -1,6 +1,7 @@
 class RedirectPresenter
-  def initialize(base_path:, publishing_app:, public_updated_at: nil, redirects:)
+  def initialize(base_path:, content_id:, publishing_app:, public_updated_at: nil, redirects:)
     @base_path = base_path
+    @content_id = content_id
     @publishing_app = publishing_app
     @public_updated_at = public_updated_at
     @redirects = redirects
@@ -9,6 +10,7 @@ class RedirectPresenter
   def self.from_edition(edition)
     new(
       base_path: edition.base_path,
+      content_id: edition.content_id,
       publishing_app: edition.publishing_app,
       public_updated_at: edition.unpublishing.created_at,
       redirects: edition.unpublishing.redirects,
@@ -21,6 +23,7 @@ class RedirectPresenter
 
   def for_message_queue(payload_version)
     present.merge(
+      content_id: content_id,
       govuk_request_id: GdsApi::GovukHeaders.headers[:govuk_request_id],
       payload_version: payload_version
     )

--- a/app/presenters/vanish_presenter.rb
+++ b/app/presenters/vanish_presenter.rb
@@ -1,5 +1,5 @@
 class VanishPresenter
-  def initialize(base_path:, publishing_app:)
+  def initialize(base_path:, content_id:, publishing_app:)
     @base_path = base_path
     @publishing_app = publishing_app
     @content_id = content_id
@@ -9,6 +9,7 @@ class VanishPresenter
   def self.from_edition(edition)
     new(
       base_path: edition.base_path,
+      content_id: edition.content_id,
       publishing_app: edition.publishing_app,
     )
   end
@@ -19,6 +20,7 @@ class VanishPresenter
 
   def for_message_queue(payload_version)
     present.merge(
+      content_id: content_id,
       govuk_request_id: GdsApi::GovukHeaders.headers[:govuk_request_id],
       payload_version: payload_version
     )

--- a/spec/presenters/edition_presenter_spec.rb
+++ b/spec/presenters/edition_presenter_spec.rb
@@ -26,8 +26,13 @@ RSpec.describe Presenters::EditionPresenter do
   end
 
   describe "#for_message_queue" do
-    let(:update_type) { "moussaka" }
-    let(:edition) { create(:draft_edition, update_type: update_type) }
+    let(:update_type) { "minor" }
+    let(:edition) {
+      create(:draft_edition,
+        update_type: update_type,
+        schema_name: "calendar",
+        document_type: "calendar")
+    }
     let(:target_content_id) { "d16216ce-7487-4bde-b817-ef68317fe3ab" }
 
     before do
@@ -62,6 +67,10 @@ RSpec.describe Presenters::EditionPresenter do
 
     it "includes the version" do
       expect(subject[:payload_version]).to eq 1
+    end
+
+    it "matches the notification schema" do
+      expect(subject).to be_valid_against_schema("calendar")
     end
   end
 

--- a/spec/presenters/gone_presenter_spec.rb
+++ b/spec/presenters/gone_presenter_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+RSpec.describe GonePresenter do
+  describe "#for_message_queue" do
+    let(:payload_version) { 1 }
+    let(:edition) { create(:unpublishing).edition }
+
+    subject(:result) do
+      described_class.from_edition(edition).for_message_queue(payload_version)
+    end
+
+    it "matches the notification schema" do
+      expect(subject).to be_valid_against_schema("gone")
+    end
+  end
+end

--- a/spec/presenters/redirect_presenter_spec.rb
+++ b/spec/presenters/redirect_presenter_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+RSpec.describe RedirectPresenter do
+  describe "#for_message_queue" do
+    let(:payload_version) { 1 }
+    let(:edition) { create(:unpublishing, type: "redirect").edition }
+
+    subject(:result) do
+      described_class.from_edition(edition).for_message_queue(payload_version)
+    end
+
+    it "matches the notification schema" do
+      expect(subject).to be_valid_against_schema("redirect")
+    end
+  end
+end

--- a/spec/presenters/vanish_presenter_spec.rb
+++ b/spec/presenters/vanish_presenter_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+RSpec.describe VanishPresenter do
+  describe "#for_message_queue" do
+    let(:payload_version) { 1 }
+    let(:edition) { create(:unpublishing, type: "vanish").edition }
+
+    subject(:result) do
+      described_class.from_edition(edition).for_message_queue(payload_version)
+    end
+
+    it "matches the notification schema" do
+      expect(subject).to be_valid_against_schema("vanish")
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -22,6 +22,7 @@ Sidekiq::Logging.logger = nil
 Sidekiq::Testing.server_middleware do |chain|
   chain.add GovukSidekiq::APIHeaders::ServerMiddleware
 end
+require 'govuk-content-schema-test-helpers'
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are
@@ -89,4 +90,9 @@ RSpec.configure do |config|
       login_as_stub_user
     end
   end
+end
+
+GovukContentSchemaTestHelpers.configure do |config|
+  config.schema_type = "notification"
+  config.project_root = Rails.root
 end

--- a/spec/support/govuk_content_schemas.rb
+++ b/spec/support/govuk_content_schemas.rb
@@ -1,0 +1,2 @@
+require 'govuk-content-schema-test-helpers/rspec_matchers'
+RSpec.configuration.include GovukContentSchemaTestHelpers::RSpecMatchers


### PR DESCRIPTION
Check that the content sent to the message queue matches the `notification` schemas.

Use factories to generate the editions for now. Using randomly-generated examples would help us catch more regressions, but that can be added later. Even this hard-coded data has caught some existing differences between the publishing API's messages and the schemas.

https://trello.com/c/uV5zDvzu/97-add-schema-tests-to-the-publishing-api

Some of these tests fail because the unpublishing messages (Gone, Vanish, Redirect) don't have all the fields required by the content schemas. We should consider whether we should fix this by updating the publishing API or the schemas.