### PR TITLE
Include the root_taxon link type in link expansion

### DIFF
--- a/lib/expansion_rules.rb
+++ b/lib/expansion_rules.rb
@@ -17,7 +17,9 @@ module ExpansionRules
     [:child_taxons.recurring],
     [:parent.recurring],
     [:parent_taxons.recurring],
+    [:parent_taxons.recurring, :root_taxon],
     [:taxons, :parent_taxons.recurring],
+    [:taxons, :parent_taxons.recurring, :root_taxon],
     [:ordered_related_items, :mainstream_browse_pages, :parent.recurring],
     [:ordered_related_items_overrides, :taxons]
   ].freeze


### PR DESCRIPTION
The root_taxon link type is used to connect taxons to the homepage,
which is considered the root of the taxonomy.

Including the homepage in the expanded representation of the links for
taxons and for content tagged to taxons means that it's possible to
get the entire ancestry for the taxons involved just from the expanded
links.