### PR TITLE
Delete translated content items with the wrong locale

### DIFF
--- a/db/migrate/20180116105811_delete_translation_with_wrong_locale.rb
+++ b/db/migrate/20180116105811_delete_translation_with_wrong_locale.rb
@@ -1,0 +1,14 @@
+require_relative "helpers/delete_content"
+
+class DeleteTranslationWithWrongLocale < ActiveRecord::Migration[5.1]
+  def up
+    content_ids = [
+      #/government/publications/flexibly-accessed-pension-payment-repayment-claim-tax-year-p55.cy
+      "a6599b02-ca7f-4a1f-bcfb-a7b54b71a030",
+      #/government/publications/flexibly-accessed-pension-payment-repayment-claim-tax-year-2015-2016-p55.cy
+      "7b01d966-2bb2-4be8-9ee4-0da8a4f8c010",
+    ]
+
+    Helpers::DeleteContent.destroy_documents_with_links(content_ids)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180102152030) do
+ActiveRecord::Schema.define(version: 20180116105811) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
Delete two drafts which have got into a bad state: they have the wrong locale (`en` rather than `cy`) and have different content IDs to the published version of the document (/government/publications/flexibly-accessed-pension-payment-repayment-claim-tax-year-p55.cy).

This clean-up will let us republish these documents without errors. Currently the publishing API will reject republishing messages for the Welsh translations because the locales do not match.