### PR TITLE
Add task to setup exchange for RabbitMQ

### DIFF
--- a/lib/tasks/setup_exchange.rake
+++ b/lib/tasks/setup_exchange.rake
@@ -1,0 +1,7 @@
+task :setup_exchange do
+  config = YAML.load_file(Rails.root.join("config", "rabbitmq.yml"))[Rails.env].symbolize_keys
+
+  bunny = Bunny.new(ENV["RABBITMQ_URL"])
+  channel = bunny.start.create_channel
+  Bunny::Exchange.new(channel, :topic, config[:exchange])
+end


### PR DESCRIPTION
We need the exchange and it's queues in E2E testing this rake task
allows for them to be setup using the existing config in publishing-api.