### PR TITLE
Re-enable authentication in Publishing API

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,6 +5,8 @@ class ApplicationController < ActionController::Base
   rescue_from JSON::ParserError, with: :json_parse_error
   rescue_from CommandError, with: :respond_with_command_error
 
+  before_action :authenticate_user!
+
   Warden::Manager.after_authentication do |user, _, _|
     user.set_app_name!
   end

--- a/app/controllers/debug_controller.rb
+++ b/app/controllers/debug_controller.rb
@@ -1,4 +1,6 @@
 class DebugController < ApplicationController
+  skip_before_action :authenticate_user!
+
   def show
     @presenter = Presenters::DebugPresenter.new(params[:content_id])
   end

--- a/config/initializers/gds-sso.rb
+++ b/config/initializers/gds-sso.rb
@@ -4,4 +4,7 @@ GDS::SSO.config do |config|
   config.oauth_secret = ENV['OAUTH_SECRET'] || "secret"
   config.oauth_root_url = Plek.find("signon")
   config.cache = Rails.cache
+  # FIXME: This app should be switched to be Rails api_only. Once this is done
+  # this setting will be superfluous
+  config.api_only = true
 end

--- a/spec/requests/index_spec.rb
+++ b/spec/requests/index_spec.rb
@@ -32,4 +32,33 @@ RSpec.describe "GET /v2/content", type: :request do
     get "/v2/content", params: { fields: ["title"] }
     expect(JSON.parse(response.body, symbolize_names: true)[:results]).to match_array(expected_result)
   end
+
+  describe "GET /v2/content" do
+    context "when user is signed in" do
+      before { login_as_stub_user }
+
+      it "returns a 200" do
+        get "/v2/content"
+        expect(response.status).to eq(200)
+      end
+    end
+
+    context "when user is not signed in" do
+      around do |spec|
+        previous = ENV['GDS_SSO_MOCK_INVALID']
+        ENV['GDS_SSO_MOCK_INVALID'] = 'true'
+        spec.run
+        ENV['GDS_SSO_MOCK_INVALID'] = previous
+      end
+
+      # Note: this needs to be separate from the above around block as it has
+      # to run after an earlier before block that logs the user in
+      before { logout }
+
+      it "returns a 401" do
+        get "/v2/content"
+        expect(response.status).to eq(401)
+      end
+    end
+  end
 end

--- a/spec/support/authentication_helper.rb
+++ b/spec/support/authentication_helper.rb
@@ -24,5 +24,10 @@ module AuthenticationHelper
       user = create(:user, permissions: ['signin'])
       login_as(user)
     end
+
+    def logout
+      GDS::SSO.test_user = nil
+      User.delete_all
+    end
   end
 end


### PR DESCRIPTION
Due to a misunderstanding of the deprecation message behind the removal
of [require_signin_permission!][1]. Publishing API has had
authentication disabled. This re-introduces it and adds a test to ensure
if something similar happens this issue will be caught.

[1]: https://github.com/alphagov/publishing-api/pull/1112/commits/d59c6c00d0091763c8d5bac63bee0f7c12d1a23b