### PR TITLE
Remove logging configuration

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -54,16 +54,6 @@ Rails.application.configure do
   # use memcached on production
   config.cache_store = :dalli_store, nil, { namespace: :publishing_api, compress: true }
 
-  # Use a different logger for distributed setups.
-  # config.logger = ActiveSupport::TaggedLogging.new(SyslogLogger.new)
-  config.logger = ActiveSupport::TaggedLogging.new(Logger.new($stderr))
-
-  $real_stdout = $stdout.clone
-  $stdout.reopen($stderr)
-  config.logstasher.enabled = true
-  config.logstasher.logger = Logger.new($real_stdout)
-  config.logstasher.suppress_app_log = true
-
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
 end


### PR DESCRIPTION
This is now handled by govuk_app_config gem.

We're seeing some strange incorrect logging format which I believe is due to this configuration overriding the one from govuk_app_config.