### PR TITLE
Removes change note

### DIFF
--- a/db/migrate/20180215112954_fix_whitehall_remove_change_note.rb
+++ b/db/migrate/20180215112954_fix_whitehall_remove_change_note.rb
@@ -1,0 +1,27 @@
+class FixWhitehallRemoveChangeNote < ActiveRecord::Migration[5.1]
+  disable_ddl_transaction!
+  
+  def up
+    # Find change notes
+    d = Document.where(content_id: "b3b96cb9-e7fa-493c-87a5-31d71d79c7a7").first
+    if d.present?
+      change_notes = d.editions.map(&:change_note).compact
+      change_notes.select{ |change_note| change_note.note == "Added funding allocations for individual LAs for 2018 to 2019."}
+  
+      # Get rid of change notes
+      change_notes.map(&:destroy)
+  
+      # Re-present editions to content store
+      content_ids = change_notes.map(&:edition_id)
+      puts "The editions that need to be represented downstream are: #{content_ids}"
+  
+      if Rails.env.production?
+        Commands::V2::RepresentDownstream.new.call(content_ids)
+      end
+    end
+  end
+  
+  def down
+    # This migration is not reversible
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180116105811) do
+ActiveRecord::Schema.define(version: 20180215112954) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
This will remove a change note added in error on a publication:

https://www.gov.uk/government/publications/sen-and-disability-reform-s31-grant-determinations#history

The change was requested in this zendesk ticket: https://govuk.zendesk.com/agent/tickets/2566949

For: https://trello.com/c/sOPRBrrT/63-2-remove-change-note-and-redirect-html-attachment-url