### PR TITLE
Fixes change note assignment

### DIFF
--- a/db/migrate/20180215112954_fix_whitehall_remove_change_note.rb
+++ b/db/migrate/20180215112954_fix_whitehall_remove_change_note.rb
@@ -6,7 +6,7 @@ class FixWhitehallRemoveChangeNote < ActiveRecord::Migration[5.1]
     d = Document.where(content_id: "b3b96cb9-e7fa-493c-87a5-31d71d79c7a7").first
     if d.present?
       change_notes = d.editions.map(&:change_note).compact
-      change_notes.select{ |change_note| change_note.note == "Added funding allocations for individual LAs for 2018 to 2019."}
+      change_notes.select!{ |change_note| change_note.note == "Added funding allocations for individual LAs for 2018 to 2019."}
   
       # Get rid of change notes
       change_notes.map(&:destroy)


### PR DESCRIPTION
This PR is a continuation of https://github.com/alphagov/publishing-api/pull/1160 where we were deleting a wrongly added change note. However, there is an assignment missing which means that more change notes than initially intended would be deleted. This PR will fix that. 

Previous: https://github.com/alphagov/publishing-api/pull/1160

Trello: https://trello.com/c/sOPRBrrT/63-2-remove-change-note-and-redirect-html-attachment-url
