### PR TITLE
Clears change note history together with deletion

### DIFF
--- a/db/migrate/20180216150252_remove_change_history_for_edition.rb
+++ b/db/migrate/20180216150252_remove_change_history_for_edition.rb
@@ -1,0 +1,21 @@
+class RemoveChangeHistoryForEdition < ActiveRecord::Migration[5.1]
+  disable_ddl_transaction!
+  
+  def change
+    begin
+      edition = Edition.find(2975826)
+  
+      if edition.present?
+        edition_details = edition.details
+        edition_details.delete(:change_history)
+        edition.update!(details: edition_details)
+    
+        if Rails.env.production?
+          Commands::V2::RepresentDownstream.new.call(edition.content_id)
+        end
+      end
+    rescue StandardError => e
+      puts "Could not find edition. Error: #{e.message}"
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180215112954) do
+ActiveRecord::Schema.define(version: 20180216150252) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
Change note history does not get regenerated when you delete a change note and represent it downstream to content store.

This has to be cleared manually.

For: https://trello.com/c/sOPRBrrT/63-2-remove-change-note-and-redirect-html-attachment-url