### PR TITLE
Revert using foreman in dev environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM ruby:2.4.2
 RUN apt-get update -qq && apt-get upgrade -y && apt-get install -y build-essential libpq-dev libxml2-dev libxslt1-dev && apt-get clean
+RUN gem install foreman
 
 ENV DATABASE_URL postgresql://postgres@postgres/publishing-api
 ENV GOVUK_APP_NAME publishing-api
@@ -19,4 +20,4 @@ ADD Gemfile* $APP_HOME/
 RUN bundle install
 ADD . $APP_HOME
 
-CMD bundle exec foreman run web
+CMD foreman run web

--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,6 @@ gem "govuk_sidekiq", "~> 3.0"
 gem "aws-sdk", "~> 3"
 gem 'bunny', '~> 2.9'
 gem "diffy", "~> 3.1", require: false
-gem "foreman", "~> 0.84.0"
 gem "govspeak", "~> 5.5.0"
 gem "hashdiff", "~> 0.3.6"
 gem "json-schema", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -615,8 +615,6 @@ GEM
     ffi (1.9.18)
     filelock (1.1.1)
     find_a_port (1.0.1)
-    foreman (0.84.0)
-      thor (~> 0.19.1)
     gds-api-adapters (51.2.0)
       addressable
       link_header
@@ -906,7 +904,7 @@ GEM
     table_print (1.5.6)
     term-ansicolor (1.6.0)
       tins (~> 1.0)
-    thor (0.19.4)
+    thor (0.20.0)
     thread_safe (0.3.6)
     timecop (0.9.1)
     tins (1.16.3)
@@ -954,7 +952,6 @@ DEPENDENCIES
   diffy (~> 3.1)
   factory_bot_rails (~> 4.8)
   faker
-  foreman (~> 0.84.0)
   gds-api-adapters (~> 51.2.0)
   gds-sso (~> 13.6)
   govspeak (~> 5.5.0)

--- a/startup.sh
+++ b/startup.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 bundle install
-bundle exec foreman run web
+bundle exec rails server -p 3093


### PR DESCRIPTION
Wider context: https://github.com/alphagov/publishing-e2e-tests/pull/202

This removes foreman from the Gemfile and from the startup.sh usage and
instead installs foreman separately via `gem install` in the Dockerfile
so that it can be used in the docker environment.

The reason for this is that running everything via unicorn in dev can
cause some wtfs (such as breaking better_errors) and installing foreman
via Gemfile does contradict some contenious advice given by the foreman
gem maintainer.