### PR TITLE
Remove jenkins-schema.sh

### DIFF
--- a/jenkins-schema.sh
+++ b/jenkins-schema.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-export REPO_NAME="alphagov/govuk-content-schemas"
-export CONTEXT_MESSAGE="Verify publishing-api against content schemas"
-
-exec ./jenkins.sh


### PR DESCRIPTION
This file is no longer used since the migration to Jenkins 2.