### PR TITLE
Refactor and fixup ContentCache

### DIFF
--- a/lib/expansion_rules.rb
+++ b/lib/expansion_rules.rb
@@ -63,7 +63,7 @@ module ExpansionRules
   ].freeze
 
   POSSIBLE_FIELDS_FOR_LINK_EXPANSION = DEFAULT_FIELDS_WITH_DETAILS +
-    %i[id state unpublishings.type] -
+    %i[id state phase unpublishings.type] -
     %i[api_path withdrawn]
 
   def reverse_links

--- a/lib/expansion_rules.rb
+++ b/lib/expansion_rules.rb
@@ -62,6 +62,10 @@ module ExpansionRules
     { document_type: :world_location,             fields: [:content_id, :title, :schema_name, :locale, :analytics_identifier] },
   ].freeze
 
+  POSSIBLE_FIELDS_FOR_LINK_EXPANSION = DEFAULT_FIELDS_WITH_DETAILS +
+    %i[id state unpublishings.type] -
+    %i[api_path withdrawn]
+
   def reverse_links
     REVERSE_LINKS.values
   end

--- a/lib/link_expansion/content_cache.rb
+++ b/lib/link_expansion/content_cache.rb
@@ -18,11 +18,11 @@ private
   attr_reader :store, :with_drafts, :locale
 
   def build_store(editions, content_ids)
-    store = Hash[editions.map { |edition| [edition.content_id, edition_hash.from(edition)] }]
+    store = Hash[editions.map { |edition| [edition.content_id, LinkExpansion::EditionHash.from(edition)] }]
 
     to_preload = content_ids - editions.map(&:content_id)
     editions(to_preload).each_with_object(store) do |edition_values, hash|
-      attrs = edition_hash.from(edition_values)
+      attrs = LinkExpansion::EditionHash.from(edition_values)
       hash[attrs[:content_id]] = attrs
     end
 
@@ -33,7 +33,7 @@ private
   end
 
   def edition(content_id)
-    edition_hash.from(editions([content_id]).first)
+    LinkExpansion::EditionHash.from(editions([content_id]).first)
   end
 
   def locale_fallback_order
@@ -57,14 +57,10 @@ private
       )
       .with_document
       .where(id: edition_ids)
-      .pluck(*edition_hash.edition_fields)
+      .pluck(*LinkExpansion::EditionHash.edition_fields)
   end
 
   def state_fallback_order
     with_drafts ? %i[draft published withdrawn] : %i[published withdrawn]
-  end
-
-  def edition_hash
-    LinkExpansion::EditionHash
   end
 end

--- a/lib/link_expansion/content_cache.rb
+++ b/lib/link_expansion/content_cache.rb
@@ -17,10 +17,10 @@ private
 
   attr_reader :store, :with_drafts, :locale
 
-  def build_store(editions, content_ids)
-    store = Hash[editions.map { |edition| [edition.content_id, LinkExpansion::EditionHash.from(edition)] }]
+  def build_store(preload_editions, preload_content_ids)
+    store = Hash[preload_editions.map { |edition| [edition.content_id, LinkExpansion::EditionHash.from(edition)] }]
 
-    to_preload = content_ids - editions.map(&:content_id)
+    to_preload = preload_content_ids - preload_editions.map(&:content_id)
     editions(to_preload).each_with_object(store) do |edition_values, hash|
       attrs = LinkExpansion::EditionHash.from(edition_values)
       hash[attrs[:content_id]] = attrs

--- a/lib/link_expansion/content_cache.rb
+++ b/lib/link_expansion/content_cache.rb
@@ -57,7 +57,7 @@ private
       )
       .with_document
       .where(id: edition_ids)
-      .pluck(*LinkExpansion::EditionHash.edition_fields)
+      .pluck(*ExpansionRules::POSSIBLE_FIELDS_FOR_LINK_EXPANSION)
   end
 
   def state_fallback_order

--- a/lib/link_expansion/edition_hash.rb
+++ b/lib/link_expansion/edition_hash.rb
@@ -4,16 +4,10 @@ class LinkExpansion::EditionHash
       return nil unless values.present?
       hash = hash_for(values)
       hash = SymbolizeJSON.symbolize(hash)
-      hash = hash.slice(*edition_fields)
+      hash = hash.slice(*ExpansionRules::POSSIBLE_FIELDS_FOR_LINK_EXPANSION)
       hash[:api_path] = api_path(hash) unless hash[:base_path].nil?
       hash[:withdrawn] = withdrawn?(hash)
       hash.except(:id, :"unpublishings.type")
-    end
-
-    def edition_fields
-      ExpansionRules::DEFAULT_FIELDS_WITH_DETAILS +
-        %i[id state unpublishings.type] -
-        %i[api_path withdrawn]
     end
 
   private
@@ -22,7 +16,7 @@ class LinkExpansion::EditionHash
       return nil unless values.present?
       case values
       when Array
-        Hash[edition_fields.zip(values)]
+        Hash[ExpansionRules::POSSIBLE_FIELDS_FOR_LINK_EXPANSION.zip(values)]
       when Edition
         values.attributes.merge(
           content_id: values.content_id,


### PR DESCRIPTION
This refactors `ContentCache` a bit to try to make it clearer what's going on. 

The last commit fixes a bug where the `phase` isn't included in the link expansion, even though it's in the link expansion fields. There's more to be done here to avoid the bug from re-occurring, but hopefully the refactor makes that easier.

https://trello.com/c/xeSbEHnT 