### PR TITLE
Step by step nav edition links

### DIFF
--- a/lib/expansion_rules.rb
+++ b/lib/expansion_rules.rb
@@ -29,7 +29,8 @@ module ExpansionRules
     documents: :document_collections,
     working_groups: :policies,
     parent_taxons: :child_taxons,
-    root_taxon: :level_one_taxons
+    root_taxon: :level_one_taxons,
+    pages_part_of_step_nav: :part_of_step_navs,
   }.freeze
 
   DEFAULT_FIELDS = [


### PR DESCRIPTION
Content that is linked in the `pages_part_of_step_nav` edition link of a step by step
navigation journey should get a reverse `part_of_step_navs` link.

Also see https://github.com/alphagov/govuk-content-schemas/pull/723

https://trello.com/c/qFUxxD0S/439-extend-task-list-schema-to-use-reverse-links-to-tagged-content