### PR TITLE
Bump govuk_document_type gem version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,7 +18,7 @@ end
 
 gem "gds-sso", "~> 13.6"
 gem "govuk_app_config", "~> 1.3"
-gem "govuk_document_types", "~> 0.2"
+gem "govuk_document_types", "~> 0.3.0"
 gem "govuk_schemas", "~> 3.1"
 gem "govuk_sidekiq", "~> 3.0"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -654,7 +654,7 @@ GEM
       sentry-raven (~> 2.7.1)
       statsd-ruby (~> 1.4.0)
       unicorn (~> 5.4.0)
-    govuk_document_types (0.2.0)
+    govuk_document_types (0.3.0)
     govuk_schemas (3.1.0)
       json-schema (~> 2.8.0)
     govuk_sidekiq (3.0.0)
@@ -959,7 +959,7 @@ DEPENDENCIES
   govuk-content-schema-test-helpers (~> 1.6)
   govuk-lint
   govuk_app_config (~> 1.3)
-  govuk_document_types (~> 0.2)
+  govuk_document_types (~> 0.3.0)
   govuk_schemas (~> 3.1)
   govuk_sidekiq (~> 3.0)
   hashdiff (~> 0.3.6)


### PR DESCRIPTION
The new version of the gem has the newly added
content_purpose_supergroup and content_purpose_subgroup content item fields

https://trello.com/c/IsIQwZzn/93-republish-content-items-to-pickup-subgroup-and-supergroup