### PR TITLE
Change a represent_downstream:document_types task

### DIFF
--- a/lib/tasks/represent_downstream.rake
+++ b/lib/tasks/represent_downstream.rake
@@ -15,13 +15,14 @@ namespace :represent_downstream do
   end
 
   desc "
-  Represent downstream for a specific document_type
+  Represent downstream for individual or multiple document_types
   Usage
-  rake 'represent_downstream:document_type[:document_type]'
+  rake 'represent_downstream:document_type[:document_types]'
   "
-  task :document_type, [:document_type] => :environment do |_t, args|
+  task :document_type, [:document_types] => :environment do |_t, args|
+    document_types = args[:document_types].split(" ")
     represent_downstream(
-      Document.joins(:editions).where(editions: { document_type: args[:document_type] })
+      Document.joins(:editions).where(editions: { document_type: document_types })
     )
   end
 


### PR DESCRIPTION
An update to the rake task so that it accepts a list of multiple
document types as a parameter. This change was made in order to
republish content items in batches to include the new supergroup and subgroup
fields.

https://trello.com/c/IsIQwZzn/93-republish-content-items-to-pickup-subgroup-and-supergroup