### PR TITLE
Increase the sidekiq concurrency to 10

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,6 +1,6 @@
 ---
 :verbose: false
-:concurrency:  6
+:concurrency: 10
 :logfile: ./log/sidekiq.json.log
 :queues:
   - downstream_high


### PR DESCRIPTION
The load on the machines in production and integration looks low
enough that the concurrency can be increased. The load on the machines
is less than half the number of cores, and less than half the memory
is being used by userspace processes.

This will increase the connections to PostgreSQL by 12 (extra 4
connections across 3 machines). Currently there is some extra capacity
as the max_connections is 300, and the rough number of used
connections is ~220.