### PR TITLE
Determine payload_version number in worker

### DIFF
--- a/app/commands/v2/discard_draft.rb
+++ b/app/commands/v2/discard_draft.rb
@@ -45,7 +45,6 @@ module Commands
           base_path: path_used,
           content_id: content_id,
           locale: locale,
-          payload_version: event.id,
           update_dependencies: true,
         )
       end

--- a/app/commands/v2/patch_link_set.rb
+++ b/app/commands/v2/patch_link_set.rb
@@ -93,7 +93,6 @@ module Commands
           queue,
           content_id: content_id,
           locale: locale,
-          payload_version: event.id,
           orphaned_content_ids: orphaned_content_ids,
         )
       end
@@ -105,7 +104,6 @@ module Commands
           content_id: content_id,
           locale: locale,
           message_queue_event_type: "links",
-          payload_version: event.id,
           orphaned_content_ids: orphaned_content_ids,
         )
       end

--- a/app/commands/v2/publish.rb
+++ b/app/commands/v2/publish.rb
@@ -222,7 +222,6 @@ module Commands
         {
           content_id: content_id,
           locale: locale,
-          payload_version: event.id,
         }
       end
     end

--- a/app/commands/v2/put_content.rb
+++ b/app/commands/v2/put_content.rb
@@ -174,7 +174,6 @@ module Commands
           queue,
           content_id: content_id,
           locale: locale,
-          payload_version: event.id,
           update_dependencies: update_dependencies,
           orphaned_content_ids: orphaned_links,
         )

--- a/app/commands/v2/represent_downstream.rb
+++ b/app/commands/v2/represent_downstream.rb
@@ -29,7 +29,6 @@ module Commands
             DownstreamDraftWorker::LOW_QUEUE,
             content_id: content_id,
             locale: locale,
-            payload_version: event.id,
             update_dependencies: false,
           )
         end
@@ -47,7 +46,6 @@ module Commands
             DownstreamLiveWorker::LOW_QUEUE,
             content_id: content_id,
             locale: locale,
-            payload_version: event.id,
             message_queue_event_type: "links",
             update_dependencies: false,
           )

--- a/app/commands/v2/unpublish.rb
+++ b/app/commands/v2/unpublish.rb
@@ -115,7 +115,6 @@ module Commands
           DownstreamDraftWorker::HIGH_QUEUE,
           content_id: document.content_id,
           locale: document.locale,
-          payload_version: event.id,
           update_dependencies: true,
         )
 
@@ -123,7 +122,6 @@ module Commands
           DownstreamLiveWorker::HIGH_QUEUE,
           content_id: document.content_id,
           locale: document.locale,
-          payload_version: event.id,
           update_dependencies: true,
           orphaned_content_ids: orphaned_content_ids,
           message_queue_event_type: "unpublish",

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -4,4 +4,8 @@ class Event < ApplicationRecord
   def as_csv
     attributes.merge("payload" => payload.to_json)
   end
+
+  def self.payload_version(content_id)
+    Event.where(content_id: content_id).maximum(:id) || 0
+  end
 end

--- a/app/workers/dependency_resolution_worker.rb
+++ b/app/workers/dependency_resolution_worker.rb
@@ -16,13 +16,12 @@ class DependencyResolutionWorker
 
 private
 
-  attr_reader :content_id, :locale, :fields, :content_store, :payload_version, :orphaned_content_ids
+  attr_reader :content_id, :locale, :fields, :content_store, :orphaned_content_ids
 
   def assign_attributes(args)
     @content_id = args.fetch(:content_id)
     @locale = args.fetch(:locale)
     @content_store = args.fetch(:content_store).constantize
-    @payload_version = args.fetch(:payload_version)
     @orphaned_content_ids = args.fetch(:orphaned_content_ids, [])
   end
 
@@ -50,7 +49,6 @@ private
       DownstreamDraftWorker::LOW_QUEUE,
       content_id: dependent_content_id,
       locale: locale,
-      payload_version: payload_version,
       update_dependencies: false,
       dependency_resolution_source_content_id: content_id,
     )
@@ -64,7 +62,6 @@ private
       content_id: dependent_content_id,
       locale: locale,
       message_queue_event_type: "links",
-      payload_version: payload_version,
       update_dependencies: false,
       dependency_resolution_source_content_id: content_id,
     )

--- a/app/workers/downstream_discard_draft_worker.rb
+++ b/app/workers/downstream_discard_draft_worker.rb
@@ -35,11 +35,10 @@ private
     @base_path = attributes.fetch(:base_path)
     @content_id = attributes.fetch(:content_id)
     @locale = attributes.fetch(:locale)
+    @payload_version = Event.payload_version(content_id)
     @edition = Queries::GetEditionForContentStore.(content_id, locale, true)
-    @payload_version = attributes.fetch(:payload_version)
     @update_dependencies = attributes.fetch(:update_dependencies, true)
   end
-
 
   def enqueue_dependencies
     DependencyResolutionWorker.perform_async(
@@ -47,7 +46,6 @@ private
       fields: [:content_id],
       content_id: content_id,
       locale: locale,
-      payload_version: payload_version,
     )
   end
 

--- a/app/workers/downstream_draft_worker.rb
+++ b/app/workers/downstream_draft_worker.rb
@@ -54,7 +54,7 @@ private
     @content_id = attributes.fetch(:content_id)
     @locale = attributes.fetch(:locale)
     @edition = Queries::GetEditionForContentStore.(content_id, locale, true)
-    @payload_version = attributes.fetch(:payload_version)
+    @payload_version = Event.payload_version(content_id)
     @orphaned_content_ids = attributes.fetch(:orphaned_content_ids, [])
     @update_dependencies = attributes.fetch(:update_dependencies, true)
     @dependency_resolution_source_content_id = attributes.fetch(
@@ -69,7 +69,6 @@ private
       fields: [:content_id],
       content_id: content_id,
       locale: locale,
-      payload_version: payload_version,
       orphaned_content_ids: orphaned_content_ids,
     )
   end

--- a/app/workers/downstream_live_worker.rb
+++ b/app/workers/downstream_live_worker.rb
@@ -57,8 +57,8 @@ private
   def assign_attributes(attributes)
     @content_id = attributes.fetch(:content_id)
     @locale = attributes.fetch(:locale)
+    @payload_version = Event.payload_version(content_id)
     @edition = Queries::GetEditionForContentStore.(content_id, locale, false)
-    @payload_version = attributes.fetch(:payload_version)
     @orphaned_content_ids = attributes.fetch(:orphaned_content_ids, [])
     @message_queue_event_type = attributes.fetch(:message_queue_event_type, nil)
     @update_dependencies = attributes.fetch(:update_dependencies, true)
@@ -74,7 +74,6 @@ private
       fields: [:content_id],
       content_id: content_id,
       locale: locale,
-      payload_version: payload_version,
       orphaned_content_ids: orphaned_content_ids,
     )
   end

--- a/spec/commands/v2/patch_link_set_spec.rb
+++ b/spec/commands/v2/patch_link_set_spec.rb
@@ -224,7 +224,7 @@ RSpec.describe Commands::V2::PatchLinkSet do
       expect(DownstreamDraftWorker).to receive(:perform_async_in_queue)
         .with(
           "downstream_high",
-          a_hash_including(:content_id, :locale, :payload_version),
+          a_hash_including(:content_id, :locale),
         )
 
       described_class.call(payload)
@@ -254,7 +254,6 @@ RSpec.describe Commands::V2::PatchLinkSet do
               a_hash_including(
                 content_id: content_id,
                 locale: locale,
-                payload_version: an_instance_of(Integer),
               ),
             )
         end
@@ -287,7 +286,6 @@ RSpec.describe Commands::V2::PatchLinkSet do
           a_hash_including(
             :content_id,
             :locale,
-            :payload_version,
             message_queue_event_type: "links",
           ),
         )
@@ -302,7 +300,6 @@ RSpec.describe Commands::V2::PatchLinkSet do
           a_hash_including(
             :content_id,
             :locale,
-            :payload_version,
             message_queue_event_type: "links",
           ),
         )
@@ -327,7 +324,6 @@ RSpec.describe Commands::V2::PatchLinkSet do
               content_id: content_id,
               locale: locale,
               message_queue_event_type: "links",
-              payload_version: an_instance_of(Integer),
               orphaned_content_ids: [],
             )
         end
@@ -365,7 +361,6 @@ RSpec.describe Commands::V2::PatchLinkSet do
           a_hash_including(
             :content_id,
             :locale,
-            :payload_version
           ),
         )
 
@@ -379,7 +374,6 @@ RSpec.describe Commands::V2::PatchLinkSet do
           a_hash_including(
             :content_id,
             :locale,
-            :payload_version,
             message_queue_event_type: "links",
           ),
         )

--- a/spec/commands/v2/publish_spec.rb
+++ b/spec/commands/v2/publish_spec.rb
@@ -286,7 +286,7 @@ RSpec.describe Commands::V2::Publish do
           .to receive(:perform_async_in_queue)
           .with(
             "downstream_high",
-            a_hash_including(:content_id, :locale, :payload_version),
+            a_hash_including(:content_id, :locale),
           )
 
         described_class.call(payload)

--- a/spec/commands/v2/put_content_spec.rb
+++ b/spec/commands/v2/put_content_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe Commands::V2::PutContent do
       expect(DownstreamDraftWorker).to receive(:perform_async_in_queue)
         .with(
           "downstream_high",
-          a_hash_including(:content_id, :locale, :payload_version, update_dependencies: true),
+          a_hash_including(:content_id, :locale, update_dependencies: true),
         )
 
       described_class.call(payload)

--- a/spec/commands/v2/represent_downstream_spec.rb
+++ b/spec/commands/v2/represent_downstream_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe Commands::V2::RepresentDownstream do
     context "scope" do
       it "can specify a scope" do
         expect(DownstreamLiveWorker).to receive(:perform_async_in_queue)
-          .with("downstream_low", a_hash_including(:content_id, :locale, :payload_version))
+          .with("downstream_low", a_hash_including(:content_id, :locale))
           .exactly(2).times
         subject.call(
           Edition.with_document.where(document_type: "nonexistent-schema").pluck('documents.content_id'),
@@ -75,7 +75,7 @@ RSpec.describe Commands::V2::RepresentDownstream do
         expect(DownstreamDraftWorker).to receive(:perform_async_in_queue)
           .with(
             "downstream_low",
-            a_hash_including(:content_id, :locale, :payload_version, update_dependencies: false)
+            a_hash_including(:content_id, :locale, update_dependencies: false)
           )
           .exactly(5).times
         subject.call(Document.pluck(:content_id), with_drafts: true)

--- a/spec/workers/dependency_resolution_worker_spec.rb
+++ b/spec/workers/dependency_resolution_worker_spec.rb
@@ -11,7 +11,6 @@ RSpec.describe DependencyResolutionWorker, :perform do
       content_id: content_id,
       locale: locale,
       content_store: "Adapters::ContentStore",
-      payload_version: "123",
     )
   end
 
@@ -42,7 +41,6 @@ RSpec.describe DependencyResolutionWorker, :perform do
       a_hash_including(
         :content_id,
         :locale,
-        :payload_version,
         message_queue_event_type: "links",
         update_dependencies: false,
       ),
@@ -71,7 +69,6 @@ RSpec.describe DependencyResolutionWorker, :perform do
         content_id: "123",
         locale: "en",
         content_store: "Adapters::ContentStore",
-        payload_version: "123",
       )
     end
 
@@ -88,7 +85,6 @@ RSpec.describe DependencyResolutionWorker, :perform do
         content_id: "123",
         locale: "en",
         content_store: "Adapters::DraftContentStore",
-        payload_version: "123",
       )
     end
   end
@@ -107,7 +103,6 @@ RSpec.describe DependencyResolutionWorker, :perform do
           content_id: content_id,
           locale: "en",
           content_store: "Adapters::ContentStore",
-          payload_version: "123",
         )
       end
 
@@ -137,7 +132,6 @@ RSpec.describe DependencyResolutionWorker, :perform do
           content_id: content_id,
           content_store: "Adapters::ContentStore",
           locale: "en",
-          payload_version: "123",
         )
       end
 

--- a/spec/workers/downstream_discard_draft_worker_spec.rb
+++ b/spec/workers/downstream_discard_draft_worker_spec.rb
@@ -17,7 +17,6 @@ RSpec.describe DownstreamDiscardDraftWorker do
       "base_path" => base_path,
       "content_id" => content_id,
       "locale" => "en",
-      "payload_version" => 1,
       "update_dependencies" => true,
       "alert_on_base_path_conflict" => false
     }
@@ -45,12 +44,6 @@ RSpec.describe DownstreamDiscardDraftWorker do
     it "requires locale" do
       expect {
         subject.perform(arguments.except("locale"))
-      }.to raise_error(KeyError)
-    end
-
-    it "requires payload_version" do
-      expect {
-        subject.perform(arguments.except("payload_version"))
       }.to raise_error(KeyError)
     end
 
@@ -182,6 +175,7 @@ RSpec.describe DownstreamDiscardDraftWorker do
     context "when there is not an edition" do
       before do
         create(:expanded_links, content_id: content_id, with_drafts: true)
+        create(:event, content_id: content_id)
       end
 
       it "deletes the expanded links" do

--- a/spec/workers/downstream_draft_worker_spec.rb
+++ b/spec/workers/downstream_draft_worker_spec.rb
@@ -10,7 +10,6 @@ RSpec.describe DownstreamDraftWorker do
     {
       "content_id" => content_id,
       "locale" => "en",
-      "payload_version" => 1,
       "update_dependencies" => true,
     }
   end
@@ -29,12 +28,6 @@ RSpec.describe DownstreamDraftWorker do
       expect {
         subject.perform(arguments.merge("content_item_id" => edition.id))
       }.not_to raise_error
-    end
-
-    it "requires payload_version" do
-      expect {
-        subject.perform(arguments.except("payload_version"))
-      }.to raise_error(KeyError)
     end
 
     it "doesn't require update_dependencies" do

--- a/spec/workers/downstream_live_worker_spec.rb
+++ b/spec/workers/downstream_live_worker_spec.rb
@@ -11,7 +11,6 @@ RSpec.describe DownstreamLiveWorker do
     {
       "content_id" => content_id,
       "locale" => "en",
-      "payload_version" => 1,
       "message_queue_event_type" => "major",
       "update_dependencies" => true,
     }
@@ -31,12 +30,6 @@ RSpec.describe DownstreamLiveWorker do
       expect {
         subject.perform(arguments.merge("content_item_id" => edition.id))
       }.not_to raise_error
-    end
-
-    it "requires payload_version" do
-      expect {
-        subject.perform(arguments.except("payload_version"))
-      }.to raise_error(KeyError)
     end
 
     it "doesn't require message_queue_event_type" do


### PR DESCRIPTION
This is to address an issue in the Publishing API where the content
store is not updated due to conflicts.

What can happen is that an item can be in the queue for downstreaming
with an older payload_version than the current one. Any updates to the
item will trigger a new queuing with a newer payload version - however
because of sidekiq jobs these will be discarded. Thus when the job
eventually runs it may present an up to date representation of a
document but it will still contain an old payload_version id which
causes the content store to ignore it with a 409.

The approach to fix this is to calculate the payload version at the time
we generate the document for downstreaming and we can do this by pulling
out the last id in the event table for this content id (it could even be
the last id in the entire table though as it doesn't matter if this is
associated with the edition or not).

The passing of payload_version as part of downstreaming made more sense
when we were constructing the downstream representation at runtime. This
is now no longer the case and thus risks problems.

The only thing I think we lose by doing this is having the payload
version associated with the sidekiq job as a means to trace back to
the event. I'm not aware that anyone used this for tracing though.