### PR TITLE
Adds the root-taxon link to the expansion rules

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,3 +7,7 @@ AllCops:
 
 Style/ConditionalAssignment:
   Enabled: false
+
+Style/SymbolArray:
+  Exclude:
+    - lib/expansion_rules.rb

--- a/lib/expansion_rules.rb
+++ b/lib/expansion_rules.rb
@@ -18,6 +18,7 @@ module ExpansionRules
     [:parent.recurring],
     [:parent_taxons.recurring],
     [:parent_taxons.recurring, :root_taxon],
+    [:taxons, :root_taxon],
     [:taxons, :parent_taxons.recurring],
     [:taxons, :parent_taxons.recurring, :root_taxon],
     [:ordered_related_items, :mainstream_browse_pages, :parent.recurring],


### PR DESCRIPTION
Level one taxons do not have any links to parent taxons but do have a link to the root taxon. This change adds a

`links->taxons->links->root_taxon`

link to the expanded links of all content that is directly linked to a level one taxon.