### PR TITLE
Specify a branch for our fork of sidekiq-unique-jobs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,7 +31,7 @@ gem "json-schema", require: false
 # We can't use v5 of this because it requires redis 3 and we use 2.8
 # We use our own fork because the latest 4.x release has a bug with
 # removing jobs from the uniquejobs hash in redis
-gem "sidekiq-unique-jobs", git: "https://github.com/alphagov/sidekiq-unique-jobs", require: false
+gem "sidekiq-unique-jobs", git: "https://github.com/alphagov/sidekiq-unique-jobs", branch: "fix-for-upstream-195-backported-to-4-x-branch", require: false
 gem 'whenever', '0.10.0', require: false
 gem "with_advisory_lock", "~> 3.1"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,7 @@
 GIT
   remote: https://github.com/alphagov/sidekiq-unique-jobs
   revision: 6c03e39c3ad6ba1468d567c22bb99908f6fdb317
+  branch: fix-for-upstream-195-backported-to-4-x-branch
   specs:
     sidekiq-unique-jobs (4.0.18)
       sidekiq (>= 2.6)


### PR DESCRIPTION
As suggested by @suzannehamilton, this makes it more explicit what commits
we're using.  It also removes any risk of us merging the upstream master
back into our fork and losing the actual fix we want.

See https://github.com/alphagov/link-checker-api/pull/148#pullrequestreview-103885874
for discussion.