### PR TITLE
Add reverse legacy_taxons link

### DIFF
--- a/lib/expansion_rules.rb
+++ b/lib/expansion_rules.rb
@@ -32,6 +32,7 @@ module ExpansionRules
     parent_taxons: :child_taxons,
     root_taxon: :level_one_taxons,
     pages_part_of_step_nav: :part_of_step_navs,
+    legacy_taxons: :topic_taxonomy_taxons,
   }.freeze
 
   DEFAULT_FIELDS = [


### PR DESCRIPTION
We are about to capture the link between merged taxon (in Content Tagger) and legacy taxons from documents such as topics, policy areas, etc. but before doing so, we need to also capture the reverse link.

Trello: https://trello.com/c/2n0C0KdR/151-map-legacy-taxons-to-merged-taxons