### PR TITLE
Add step nav reverse link

### DIFF
--- a/lib/expansion_rules.rb
+++ b/lib/expansion_rules.rb
@@ -32,6 +32,7 @@ module ExpansionRules
     parent_taxons: :child_taxons,
     root_taxon: :level_one_taxons,
     pages_part_of_step_nav: :part_of_step_navs,
+    pages_related_to_step_nav: :related_to_step_navs,
     legacy_taxons: :topic_taxonomy_taxons,
   }.freeze
 


### PR DESCRIPTION
Related to https://github.com/alphagov/govuk-content-schemas/pull/740

We want to be able to differentiate between content that should show step by
step navigation, and that content that is in the step by step navigation but
should not show the navigation.

An example of where we might want this is on a page which we know is part of
lots of journeys (such as https://www.gov.uk/check-legal-aid) but we may have
implemented only one or two of them. It would be disengaging for users to see
only one option of navigation that is almost certainly not relevant.

We still want to be able to track where a content item is linked but not used,
so we'll include it as a separate link type.

To be clear:

"part_of_step_navs" will be used to power the step by step navigation
components
"related_to_step_navs" will be used to track related step by step navigation
journeys that are not to be used with the navigation at this point

https://trello.com/c/VDKP6zpq/524-build-a-the-backend-of-the-rules-functionality-that-allows-users-to-manually-chose-where-the-step-nav-appears

https://trello.com/c/CLjtEHGh/570-set-up-new-reverse-link-in-publishing-api