### PR TITLE
Pagination can use multiple sort fields.

### DIFF
--- a/app/pagination.rb
+++ b/app/pagination.rb
@@ -28,19 +28,21 @@ private
   end
 
   def order_from_options(options)
-    order = options.fetch(:order, "-public_updated_at")
+    order_string = options.fetch(:order, '-public_updated_at')
 
-    if order.start_with?("-")
-      field = order[1..-1].to_sym
-      direction = :desc
-    else
-      field = order.to_sym
-      direction = :asc
+    orders = order_string.split(',').map(&:strip)
+
+    orders.map do |order|
+      if order.start_with?("-")
+        field = order[1..-1].to_sym
+        direction = :desc
+      else
+        field = order.to_sym
+        direction = :asc
+      end
+      raise_unless_valid_order_field(field)
+      [field, direction]
     end
-
-    raise_unless_valid_order_field(field)
-
-    { field => direction }
   end
 
   def raise_unless_valid_order_field(field)
@@ -66,6 +68,7 @@ private
   # will be hampered.
   def valid_order_fields
     [
+      :id,
       :base_path,
       :content_id,
       :document_type,

--- a/app/pagination.rb
+++ b/app/pagination.rb
@@ -31,6 +31,7 @@ private
     order_string = options.fetch(:order, '-public_updated_at')
 
     orders = order_string.split(',').map(&:strip)
+    orders << 'id' if orders.none? { |o| o.match('-?id') }
 
     orders.map do |order|
       if order.start_with?("-")

--- a/app/presenters/queries/content_item_presenter.rb
+++ b/app/presenters/queries/content_item_presenter.rb
@@ -101,9 +101,8 @@ module Presenters
         "CASE state #{priorities.map { |k, v| "WHEN '#{k}' THEN #{v} " }.join} END"
       end
 
-      def select_fields(scope)
-        fields_to_select = (fields + order.map(&:first)).map do |field|
-          case field
+      def field_selector(field)
+        case field
           when :publication_state
             "editions.state AS publication_state"
           when :user_facing_version
@@ -134,7 +133,12 @@ module Presenters
             nil
           else
             field
-          end
+        end
+      end
+
+      def select_fields(scope)
+        fields_to_select = (fields + order.map(&:first)).map do |field|
+          field_selector(field)
         end
 
         fields = [

--- a/app/presenters/queries/content_item_presenter.rb
+++ b/app/presenters/queries/content_item_presenter.rb
@@ -61,7 +61,7 @@ module Presenters
 
       def query
         ordering_query = Edition.select("*, COUNT(*) OVER () as total").from(fetch_items_query)
-        ordering_query = ordering_query.order(order.to_a.join(" ")) if order
+        ordering_query = ordering_query.order(order.map { |o| o.join(' ') }.join(', ')) if order
         ordering_query = ordering_query.limit(limit) if limit
         ordering_query = ordering_query.offset(offset) if offset
         ordering_query
@@ -102,7 +102,7 @@ module Presenters
       end
 
       def select_fields(scope)
-        fields_to_select = (fields + order.keys).map do |field|
+        fields_to_select = (fields + order.map(&:first)).map do |field|
           case field
           when :publication_state
             "editions.state AS publication_state"

--- a/spec/pagination_spec.rb
+++ b/spec/pagination_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe Pagination do
       subject { described_class.new }
 
       it "uses the default order" do
-        expect(subject.order).to eq(public_updated_at: :desc)
+        expect(subject.order).to eq([%i[public_updated_at desc]])
       end
     end
 

--- a/spec/pagination_spec.rb
+++ b/spec/pagination_spec.rb
@@ -40,9 +40,14 @@ RSpec.describe Pagination do
 
     context "default order option" do
       subject { described_class.new }
-
       it "uses the default order" do
-        expect(subject.order).to eq([%i[public_updated_at desc]])
+        expect(subject.order).to eq([%i[public_updated_at desc], %i[id asc]])
+      end
+      it "appends the id field to the ordering" do
+        expect(Pagination.new(order: "").order).to eq([%i[id asc]])
+      end
+      it "do not append the id field  if it already exists" do
+        expect(Pagination.new(order: "-id, public_updated_at").order).to eq([%i[id desc], %i[public_updated_at asc]])
       end
     end
 

--- a/spec/service_consumers/pact_helper.rb
+++ b/spec/service_consumers/pact_helper.rb
@@ -290,10 +290,11 @@ Pact.provider_states_for "GDS API Adapters" do
     set_up do
       (1..4).each do |index|
         create(:live_edition,
-                           title: "title_#{index}",
-                           document: create(:document),
-                           base_path: "/path_#{index}",
-                           document_type: "topic")
+                 title: "title_#{index}",
+                 document: create(:document),
+                 base_path: "/path_#{index}",
+                 document_type: "topic",
+                 public_updated_at: Time.local(2018, 12 - index, 1, 12, 0, 0))
       end
     end
   end


### PR DESCRIPTION
Pagination now allows multiple fields to be specified to order results. They should be separated by
commas; i.e. "-public_updated_at, id".

Previously pagination used just public_updated_at as a default field to sort results. As this field is not guaranteed to be unique, this can (and does) cause unexpected results where duplicates are returned.

This PR adds 'id' as second default sort field.