### PR TITLE
Don't expand details hash for linked organisations

### DIFF
--- a/lib/expansion_rules.rb
+++ b/lib/expansion_rules.rb
@@ -57,8 +57,6 @@ module ExpansionRules
     { document_type: :gone,                       fields: [] },
     { document_type: :topical_event,              fields: DEFAULT_FIELDS_WITH_DETAILS },
     { document_type: :placeholder_topical_event,  fields: DEFAULT_FIELDS_WITH_DETAILS },
-    { document_type: :organisation,               fields: DEFAULT_FIELDS_WITH_DETAILS },
-    { document_type: :placeholder_organisation,   fields: DEFAULT_FIELDS_WITH_DETAILS },
     { document_type: :taxon,                      fields: DEFAULT_FIELDS_WITH_DETAILS + [:phase] },
     { document_type: :need,                       fields: DEFAULT_FIELDS_WITH_DETAILS },
     { document_type: :finder, link_type: :finder, fields: DEFAULT_FIELDS_WITH_DETAILS },

--- a/spec/lib/expansion_rules_spec.rb
+++ b/spec/lib/expansion_rules_spec.rb
@@ -40,11 +40,10 @@ RSpec.describe ExpansionRules do
 
   describe ".expansion_fields" do
     let(:default_fields) { rules::DEFAULT_FIELDS }
-    let(:organisation_fields) { default_fields + [:details] }
     let(:finder_fields) { default_fields + [:details] }
     specify { expect(rules.expansion_fields(:redirect)).to eq([]) }
     specify { expect(rules.expansion_fields(:parent)).to eq(default_fields) }
-    specify { expect(rules.expansion_fields(:organisation)).to eq(organisation_fields) }
+    specify { expect(rules.expansion_fields(:organisation)).to eq(default_fields) }
     specify { expect(rules.expansion_fields(:finder, :finder)).to eq(finder_fields) }
     specify { expect(rules.expansion_fields(:parent, :finder)).to eq(default_fields) }
   end


### PR DESCRIPTION
There is now a lot of information in the details hash of organisations that is not required when they are linked to from other organisations.