### PR TITLE
Revert "Don't expand details hash for linked organisations"

### DIFF
--- a/lib/expansion_rules.rb
+++ b/lib/expansion_rules.rb
@@ -57,6 +57,8 @@ module ExpansionRules
     { document_type: :gone,                       fields: [] },
     { document_type: :topical_event,              fields: DEFAULT_FIELDS_WITH_DETAILS },
     { document_type: :placeholder_topical_event,  fields: DEFAULT_FIELDS_WITH_DETAILS },
+    { document_type: :organisation,               fields: DEFAULT_FIELDS_WITH_DETAILS },
+    { document_type: :placeholder_organisation,   fields: DEFAULT_FIELDS_WITH_DETAILS },
     { document_type: :taxon,                      fields: DEFAULT_FIELDS_WITH_DETAILS + [:phase] },
     { document_type: :need,                       fields: DEFAULT_FIELDS_WITH_DETAILS },
     { document_type: :finder, link_type: :finder, fields: DEFAULT_FIELDS_WITH_DETAILS },

--- a/spec/lib/expansion_rules_spec.rb
+++ b/spec/lib/expansion_rules_spec.rb
@@ -40,10 +40,11 @@ RSpec.describe ExpansionRules do
 
   describe ".expansion_fields" do
     let(:default_fields) { rules::DEFAULT_FIELDS }
+    let(:organisation_fields) { default_fields + [:details] }
     let(:finder_fields) { default_fields + [:details] }
     specify { expect(rules.expansion_fields(:redirect)).to eq([]) }
     specify { expect(rules.expansion_fields(:parent)).to eq(default_fields) }
-    specify { expect(rules.expansion_fields(:organisation)).to eq(default_fields) }
+    specify { expect(rules.expansion_fields(:organisation)).to eq(organisation_fields) }
     specify { expect(rules.expansion_fields(:finder, :finder)).to eq(finder_fields) }
     specify { expect(rules.expansion_fields(:parent, :finder)).to eq(default_fields) }
   end


### PR DESCRIPTION
Reverts alphagov/publishing-api#1228

It turns out that we need the details hash in linked orgs for things like corporate information pages.  See https://sentry.io/govuk/app-government-frontend/issues/537266974 for an example