### PR TITLE
Add a legacy_taxons expansion rule

### DIFF
--- a/lib/expansion_rules.rb
+++ b/lib/expansion_rules.rb
@@ -14,6 +14,7 @@ module ExpansionRules
   MULTI_LEVEL_LINK_PATHS = [
     [:associated_taxons.recurring],
     [:child_taxons, :associated_taxons.recurring],
+    [:child_taxons.recurring, :legacy_taxons],
     [:child_taxons.recurring],
     [:parent.recurring],
     [:parent_taxons.recurring],


### PR DESCRIPTION
Whitehall loads the Topic Taxonomy through expanded links for each
level 1 taxon, so this means it will be included in the response.