### PR TITLE
Task to queue messages for all content

### DIFF
--- a/app/workers/requeue_content.rb
+++ b/app/workers/requeue_content.rb
@@ -4,7 +4,7 @@ class RequeueContent
 
   sidekiq_options queue: :import
 
-  def perform(edition_id, version)
+  def perform(edition_id, version, action = "bulk.reindex")
     edition = Edition.find(edition_id)
     presenter = DownstreamPayload.new(edition, version, draft: false)
     queue_payload = presenter.message_queue_payload
@@ -14,7 +14,7 @@ class RequeueContent
     # because we don't want to send additional email alerts to users.
     service.send_message(
       queue_payload,
-      routing_key: "#{edition.schema_name}.bulk.reindex",
+      routing_key: "#{edition.schema_name}.#{action}",
       persistent: false
     )
   end


### PR DESCRIPTION
Paired with @chao-xian 

Example usage: `rake queue:requeue_all_the_things[bulk.data-warehouse]`

Currently in content performance manager, the way we initially
populate our content data is very different to how we incrementally
update it as content changes. This is because the API returns us
data in a different format to the message queue.

In particular, it doesn't send us links or the details hash,
so we have to make additional calls to the content store to
fully populate the content. These calls are architecturally
undesirable because the content store is supposed to be used
for serving the frontend of the site.

We are thinking that it would be simpler
if we could drive everything from the message queue (this
is the solution previously adopted by search). To do this
we need some way of sending all the live content items through
the system on demand. This is expected to be run only as a developer
task, so we would pause the normal consumer in content performance
manager, run this rake task, and wait for everything to be
processed.

# Next steps
- Update the new CPM consumer to process messages instead of discarding them
- We need to measure how long this takes end to end
- We should write documentation for it

# Trello
- https://trello.com/c/bIKQuMU3/75-content-performance-manager-is-talking-to-content-store
- https://trello.com/c/m3vzLnR5/372-use-only-publishing-api-to-preload-items