### PR TITLE
Expand contacts details

### DIFF
--- a/lib/expansion_rules.rb
+++ b/lib/expansion_rules.rb
@@ -56,6 +56,7 @@ module ExpansionRules
   CUSTOM_EXPANSION_FIELDS = [
     { document_type: :redirect,                   fields: [] },
     { document_type: :gone,                       fields: [] },
+    { document_type: :contact,                    fields: DEFAULT_FIELDS_WITH_DETAILS },
     { document_type: :topical_event,              fields: DEFAULT_FIELDS_WITH_DETAILS },
     { document_type: :placeholder_topical_event,  fields: DEFAULT_FIELDS_WITH_DETAILS },
     { document_type: :organisation,               fields: DEFAULT_FIELDS_WITH_DETAILS },

--- a/spec/lib/expansion_rules_spec.rb
+++ b/spec/lib/expansion_rules_spec.rb
@@ -40,12 +40,26 @@ RSpec.describe ExpansionRules do
 
   describe ".expansion_fields" do
     let(:default_fields) { rules::DEFAULT_FIELDS }
-    let(:organisation_fields) { default_fields + [:details] }
-    let(:finder_fields) { default_fields + [:details] }
+    let(:default_and_details_fields) { default_fields + [:details] }
+
     specify { expect(rules.expansion_fields(:redirect)).to eq([]) }
+    specify { expect(rules.expansion_fields(:gone)).to eq([]) }
+
     specify { expect(rules.expansion_fields(:parent)).to eq(default_fields) }
-    specify { expect(rules.expansion_fields(:organisation)).to eq(organisation_fields) }
-    specify { expect(rules.expansion_fields(:finder, :finder)).to eq(finder_fields) }
+
+    specify { expect(rules.expansion_fields(:contact)).to eq(default_and_details_fields) }
+    specify { expect(rules.expansion_fields(:need)).to eq(default_and_details_fields) }
+    specify { expect(rules.expansion_fields(:organisation)).to eq(default_and_details_fields) }
+    specify { expect(rules.expansion_fields(:placeholder_organisation)).to eq(default_and_details_fields) }
+    specify { expect(rules.expansion_fields(:placeholder_topical_event)).to eq(default_and_details_fields) }
+    specify { expect(rules.expansion_fields(:step_by_step_nav)).to eq(default_and_details_fields) }
+    specify { expect(rules.expansion_fields(:topical_event)).to eq(default_and_details_fields) }
+
+    specify { expect(rules.expansion_fields(:taxon)).to eq(default_and_details_fields + [:phase]) }
+    specify { expect(rules.expansion_fields(:travel_advice)).to eq(default_fields + [%i(details country), %i(details change_description)]) }
+    specify { expect(rules.expansion_fields(:world_location)).to eq(%i(content_id title schema_name locale analytics_identifier)) }
+
+    specify { expect(rules.expansion_fields(:finder, :finder)).to eq(default_and_details_fields) }
     specify { expect(rules.expansion_fields(:parent, :finder)).to eq(default_fields) }
   end
 


### PR DESCRIPTION
We need linked contacts to show their details in order to show them on migrated
organisation pages.

I've also added in tests for those things with custom link expansion fields.

Part of https://trello.com/c/k74yKHtG/107-present-data-on-organisations-show-view