### PR TITLE
Don't log notification schema failures in production

### DIFF
--- a/lib/queue_publisher.rb
+++ b/lib/queue_publisher.rb
@@ -46,7 +46,7 @@ private
   def validate_edition(edition)
     validator = SchemaValidator.new(payload: edition, schema_type: :notification)
     if !validator.valid?
-      Rails.logger.warn(
+      Rails.logger.debug(
         {
           "message": "Message being sent to the queue does not match the notification schema",
           "error": validator.errors.to_s,


### PR DESCRIPTION
We know we have issues with messages not matching the schema. Logging this in production risks running us out of disk space during large republishes. We'll still want this information when debugging the problem in development.

See https://trello.com/c/wKsKVrmF/443-fix-content-schemas-for-notifications