### PR TITLE
Exempt roles and role appointments from base paths/rendering apps

### DIFF
--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -31,8 +31,26 @@ class Edition < ApplicationRecord
   ].freeze
 
   NON_RENDERABLE_FORMATS = %w(redirect gone).freeze
-  NO_RENDERING_APP_FORMATS = %w(contact external_content).freeze
-  EMPTY_BASE_PATH_FORMATS = %w(contact external_content government world_location).freeze
+  NO_RENDERING_APP_FORMATS = %w(contact external_content role_appointment).freeze
+  EMPTY_BASE_PATH_FORMATS = %w(
+    ambassador_role
+    board_member_role
+    chief_professional_officer_role
+    chief_scientific_officer_role
+    contact
+    deputy_head_of_mission_role
+    external_content
+    government
+    governor_role
+    high_commissioner_role
+    military_role
+    role_appointment
+    special_representative_role
+    traffic_commissioner_role
+    world_location
+    worldwide_office_staff_role
+  ).freeze
+
   belongs_to :document
   has_one :unpublishing
   has_one :change_note

--- a/spec/models/edition_spec.rb
+++ b/spec/models/edition_spec.rb
@@ -257,7 +257,24 @@ RSpec.describe Edition do
   context "EMPTY_BASE_PATH_FORMATS" do
     it "defines formats not requiring a base_path attibute" do
       expect(Edition::EMPTY_BASE_PATH_FORMATS).to eq(
-        %w(contact external_content government world_location)
+        %w(
+          ambassador_role
+          board_member_role
+          chief_professional_officer_role
+          chief_scientific_officer_role
+          contact
+          deputy_head_of_mission_role
+          external_content
+          government
+          governor_role
+          high_commissioner_role
+          military_role
+          role_appointment
+          special_representative_role
+          traffic_commissioner_role
+          world_location
+          worldwide_office_staff_role
+        )
       )
     end
   end


### PR DESCRIPTION
This commit adds `role_appointments` and the various role document types (excluding `ministerial_role`, which is rendered), to the list of document types that are exempt from having base paths and rendering apps.