### PR TITLE
Rake tasks to create and publish special routes

### DIFF
--- a/doc/admin-tasks.md
+++ b/doc/admin-tasks.md
@@ -26,38 +26,38 @@ The following tasks will allow you to specify which content items/editions to ad
 
 * Represent all editions downstream
 ```
-bundle exec represent_downstream:all
+bundle exec rake represent_downstream:all
 ```
 N.B. This task will take several hours and should be used with caution.
 
 * Represent downstream for a specific document_type
 ```
-bundle exec represent_downstream:document_type['a-document-type']
+bundle exec rake represent_downstream:document_type['a-document-type']
 ```
 
 * Represent downstream for a rendering application
 ```
-bundle exec represent_downstream:rendering_app['application-name']
+bundle exec rake represent_downstream:rendering_app['application-name']
 ```
 
 * Represent downstream for a publishing application
 ```
-bundle exec represent_downstream:publishing_app['application-name']
+bundle exec rake represent_downstream:publishing_app['application-name']
 ```
 
 * Represent downstream content which has at least one link of type `taxon`
 ```
-bundle exec represent_downstream:tagged_to_taxon
+bundle exec rake represent_downstream:tagged_to_taxon
 ```
 
 * Represent an individual edition downstream
 ```
-bundle exec represent_downstream:content_id['some-content-id']
+bundle exec rake represent_downstream:content_id['some-content-id']
 ```
 
 * Represent multiple editions downstream
 ```
-bundle exec represent_downstream:content_id['some-content-id some-other-content-id']
+bundle exec rake represent_downstream:content_id['some-content-id some-other-content-id']
 ```
 N.B. The content ids are separated by a space.
 
@@ -72,17 +72,17 @@ It will also be rebuilt any time a piece of content is represented downstream.
 
 * To populate every document (this will take a long time - hours)
 ```
-bundle exec expanded_links:populate
+bundle exec rake expanded_links:populate
 ```
 
 * To populate every document of a document_type
 ```
-bundle exec expanded_links:populate_by_document_type['document-type']
+bundle exec rake expanded_links:populate_by_document_type['document-type']
 ```
 
 * To purge the expanded links cache
 ```
-bundle exec expanded_links:truncate
+bundle exec rake expanded_links:truncate
 ```
 
 ## Creating a special route

--- a/doc/admin-tasks.md
+++ b/doc/admin-tasks.md
@@ -84,3 +84,16 @@ bundle exec expanded_links:populate_by_document_type['document-type']
 ```
 bundle exec expanded_links:truncate
 ```
+
+## Creating a special route
+
+Special routes are used for pages or sections of GOV.UK that don't necessarily
+hold content within the Publishing API. For cases where a special route is not
+associated with a publishing application there is a rake task to create them
+for a single route:
+
+```
+bundle exec rake special_route:draft[/route, 'Content Title', rendering-app]
+```
+
+You can then use the [Publish](#publishing-a-draft) task to publish the route.

--- a/doc/admin-tasks.md
+++ b/doc/admin-tasks.md
@@ -10,6 +10,14 @@ If you need to discard a draft of a document, run the `discard_draft` rake task:
 bundle exec rake discard_draft['some-content-id']
 ```
 
+## Publishing a draft
+
+If you need to publish a draft run the `publish` rake task:
+
+```
+bundle exec rake publish['some-content-id']
+```
+
 ## Representing data downstream
 
 Sometimes you need to re-send content to the Content Store to ensure consistency.

--- a/lib/tasks/publish.rake
+++ b/lib/tasks/publish.rake
@@ -1,0 +1,18 @@
+desc "Publish the draft of a a content item"
+task :publish, %i(content_id locale) => :environment do |_, args|
+  payload = {
+    content_id: args.fetch(:content_id),
+    locale: args.fetch(:locale, "en")
+  }
+
+  begin
+    Commands::V2::Publish.call(payload)
+
+    puts ""
+    puts "Published #{payload[:content_id]} / #{payload[:locale]}"
+  rescue CommandError => e
+    puts "Error: #{e.message}"
+    pp e.error_details
+    exit 1
+  end
+end

--- a/lib/tasks/special_route.rake
+++ b/lib/tasks/special_route.rake
@@ -1,0 +1,47 @@
+namespace :special_route do
+  # This task is used to add a special route to the Publishing API
+  # It is only intended for simple ones that have a single route, if you have
+  # more than that you should write a task for that job
+  # It is also only intended to be used in situations where there is not an
+  # actual publishing application associated with the content as otherwise
+  # that publishing application should speak to the Publishing API itself
+  #
+  # To use call rake special_route:draft[/path, 'Content title', app-to-render)
+  #
+  # You can also pass in the route type and content_id if you have those
+  desc "Create a draft special route"
+  # rubocop:disable Metrics/BlockLength
+  task :draft, %i(base_path title rendering_app route_type content_id) => :environment do |_, args|
+    base_path = args.fetch(:base_path)
+    content_id = args.fetch(:content_id, SecureRandom.uuid)
+    begin
+      Commands::V2::PutContent.call(
+        base_path: base_path,
+        content_id: content_id,
+        document_type: "special_route",
+        publishing_app: "publishing-api",
+        rendering_app: args.fetch(:rendering_app),
+        routes: [
+          {
+            path: args.fetch(:base_path),
+            type: args.fetch(:route_type, "prefix"),
+          }
+        ],
+        schema_name: "special_route",
+        title: args.fetch(:title),
+        update_type: "major",
+      )
+
+      puts ""
+      puts "Draft document created with content_id of #{content_id}"
+      puts "This will be available at #{Plek.find('draft-origin', external: true) + base_path}"
+      puts "To publish this run `bundle exec rake publish[#{content_id}]`"
+      puts "To discard this draft this run `bundle exec rake discard_draft[#{content_id}]`"
+    rescue CommandError => e
+      puts "Error: #{e.message}"
+      pp e.error_details
+      exit 1
+    end
+    # rubocop:enable Metrics/BlockLength
+  end
+end

--- a/spec/lib/tasks/publish_spec.rb
+++ b/spec/lib/tasks/publish_spec.rb
@@ -1,0 +1,38 @@
+require "rails_helper"
+
+RSpec.describe "Publish rake task" do
+  before do
+    Rake::Task['publish'].reenable
+    # suppress puts output
+    allow($stdout).to receive(:puts)
+    allow_any_instance_of(Object).to receive(:pp)
+  end
+
+  let(:content_id) { SecureRandom.uuid }
+
+  it "runs the command to publish an edition" do
+    payload = { content_id: content_id, locale: "en" }
+    expect(Commands::V2::Publish).to receive(:call).with(payload)
+
+    Rake::Task['publish'].invoke(content_id)
+  end
+
+  it "can accept a locale argument" do
+    payload = { content_id: content_id, locale: "fr" }
+    expect(Commands::V2::Publish).to receive(:call).with(payload)
+
+    Rake::Task['publish'].invoke(content_id, "fr")
+  end
+
+  it "can handle a command error" do
+    expect(Commands::V2::Publish).to receive(:call)
+      .and_raise(CommandError.new(code: 422, message: "Test"))
+
+    expect { Rake::Task['publish'].invoke(content_id, "en") }
+      .to raise_error(SystemExit)
+  end
+
+  it "raises an error if a content id is not provided" do
+    expect { Rake::Task['publish'].invoke }.to raise_error(KeyError)
+  end
+end

--- a/spec/lib/tasks/special_route_spec.rb
+++ b/spec/lib/tasks/special_route_spec.rb
@@ -1,0 +1,55 @@
+require "rails_helper"
+
+RSpec.describe "Special route rake namespace" do
+  describe "draft task" do
+    before do
+      Rake::Task['special_route:draft'].reenable
+      # suppress output
+      allow($stdout).to receive(:puts)
+      allow_any_instance_of(Object).to receive(:pp)
+    end
+
+    let(:content_id) { SecureRandom.uuid }
+
+    it "runs the command to put content an edition" do
+      payload = a_hash_including(
+        base_path: "/test",
+        title: "Test",
+        rendering_app: "government-frontend",
+        routes: [{ path: "/test", type: "prefix" }],
+      )
+      expect(Commands::V2::PutContent).to receive(:call).with(payload)
+
+      Rake::Task['special_route:draft'].invoke("/test", "Test", "government-frontend")
+    end
+
+    it "can accept a route_type argument" do
+      payload = a_hash_including(
+        routes: [{ path: "/test", type: "exact" }],
+      )
+      expect(Commands::V2::PutContent).to receive(:call).with(payload)
+
+      Rake::Task['special_route:draft'].invoke("/test", "Test", "government-frontend", "exact")
+    end
+
+    it "can handle a command error" do
+      expect(Commands::V2::PutContent).to receive(:call)
+        .and_raise(CommandError.new(code: 422, message: "Test"))
+
+      expect { Rake::Task['special_route:draft'].invoke("/test", "Test", "government-frontend") }
+        .to raise_error(SystemExit)
+    end
+
+    it "raises an error if a base_path is not provided" do
+      expect { Rake::Task['special_route:draft'].invoke }.to raise_error(KeyError)
+    end
+
+    it "raises an error if a title is not provided" do
+      expect { Rake::Task['special_route:draft'].invoke("/test") }.to raise_error(KeyError)
+    end
+
+    it "raises an error if a rendering_app is not provided" do
+      expect { Rake::Task['special_route:draft'].invoke("/test", "Title") }.to raise_error(KeyError)
+    end
+  end
+end


### PR DESCRIPTION
Trello: https://trello.com/c/j3ZOI1fQ/227-add-route-to-the-design-system-at-design-system

This introduces two rake tasks that allow special routes to be created and published.

It is intended to be used for publishing the GOV.UK design system by running the task as `special_route:draft[/design-system, Design System, design-system]` and then a subsequent publish task.

There is a content schemas PR, https://github.com/alphagov/govuk-content-schemas/pull/775, which adds the necessary app names so this can be used. 