### PR TITLE
Rake task to bulk tag the primary organisation for manuals

### DIFF
--- a/lib/tasks/sanitize_data.rake
+++ b/lib/tasks/sanitize_data.rake
@@ -100,3 +100,27 @@ task :assign_primary_organisation_for_document_type, %i[primary_publishing_organ
     primary_publishing_organisation: primary_publishing_organisation
   )
 end
+
+desc "Assign primary organisation to a list of content items"
+task bulk_assign_primary_organisation_from_stdin: [:environment] do |_, _args|
+  puts "Please paste CSV file into STDIN with format:"
+  puts "content_id1,primary_org_content_id1"
+  puts "content_id2,primary_org_content_id2"
+  puts "..."
+
+  rows = []
+  CSV.new(STDIN).each do |row|
+    raise ValueError if row.length != 2
+    rows << row
+  end
+
+  rows.each do |row|
+    content_id, primary_org_content_id = row
+    puts "Tagging #{content_id} -> #{primary_org_content_id}"
+
+    Tasks::LinkSetter.set_primary_publishing_organisation(
+      content_ids: [content_id],
+      primary_publishing_organisation: primary_org_content_id
+    )
+  end
+end


### PR DESCRIPTION
We're gradually setting the primary organisation link type for all content on GOV.UK, so that we can help publishers manage their content.

Manuals are owned by various organisations, but they're already tagged to a single organisation using the `organisations` link type. It's straightforward to extract a CSV of this so I'm creating a general purpose rake task for bulk tagging primary organisations using this data. We may reuse this for some other document types but this task can be removed once we're done tagging.

Trello: https://trello.com/c/M1nn3D9Q/378-2-set-primary-organisation-for-existing-manuals-publisher-documents

Manual title | Organisation | Content id | Org content id
-- | -- | -- | --
2016 Early years foundation stage: assessment and reporting arrangements (ARA) | Standards and Testing Agency | 805d33e9-bd18-48d4-a3fc-1db37f832a2b | 863ffacd-d313-49c1-b856-58fe0799fd41
2016 Key stage 1: assessment and reporting arrangements (ARA) | Standards and Testing Agency | 8998fdf4-a09d-4f10-87e3-7cfffb00cdc8 | 863ffacd-d313-49c1-b856-58fe0799fd41
2016 Key stage 2: assessment and reporting arrangements (ARA) | Standards and Testing Agency | 1ab27bc7-6100-4b1f-98d9-21cf879a88a5 | 863ffacd-d313-49c1-b856-58fe0799fd41
Basic Payment Scheme (BPS) in England: rules for 2016 | Rural Payments Agency | c3ed3b6b-235b-4cae-869c-a5d65fcb3f7e | e8fae147-6232-4163-a3f1-1c15b755a8a4
Buying for schools | Department for Education | 4454be00-fc09-48ed-8642-2eb6c5db4309 | ebd15ade-73b2-4eaf-b1c3-43034a42eb37
Capital Funding Guide | Homes England | 206fba73-5bc8-4f87-bce6-222b27f333f5 | ad6f059a-f36c-48eb-a07f-4a6856f08f7f
Capital Gains and other taxes manual | Valuation Office Agency | 6511c54a-7a19-4b23-bc28-49e7d2aac999 | ae98edb5-87b4-4a69-a31a-e0e5298f949d
Care and support statutory guidance | Department of Health and Social Care | 79a23304-dbe9-44d6-b6da-0827b4fa8bdf | 7cd6bf12-bbe9-4118-8523-f927b0442156
Carrying out driving tests: examiner guidance | Driver and Vehicle Standards Agency | b1dc075f-d946-4bcb-a5eb-941f8c8188cf | d39237a5-678b-4bb5-a372-eb2cb036933d
Compulsory basic training (CBT) syllabus and guidance notes | Driver and Vehicle Standards Agency | ccf91c4f-6a0f-4498-8ddd-6be537df296c | d39237a5-678b-4bb5-a372-eb2cb036933d
Content design: planning, writing and managing content | Government Digital Service | 1326d2a4-849f-44d6-b84a-f81728e62483 | af07d5a5-df63-4ddc-9383-6a666845ebe9
Convert to an academy: guide for schools | Department for Education | edc94e47-89af-4b7f-9a88-c3df71874021 | ebd15ade-73b2-4eaf-b1c3-43034a42eb37
Council Tax Manual | Valuation Office Agency | f7b71b2e-8940-4d3d-b6b3-9dc114d62e3b | ae98edb5-87b4-4a69-a31a-e0e5298f949d
Countryside Stewardship manual | Natural England | c763d9e0-3228-4fde-9b30-a4f69f656468 | d3ce4ba7-bc75-46b4-89d9-38cb3240376d
Digital and technology skills | Cabinet Office | c894580a-a7db-48e2-9287-737e97a63871 | 96ae61d6-c2a1-48cb-8e67-da9d105ae381
Drivers’ hours and tachographs: buses and coaches | Driver and Vehicle Standards Agency | ed8fcfbf-760b-4b6c-95ba-f42fe5bdceb6 | d39237a5-678b-4bb5-a372-eb2cb036933d
Drivers’ hours and tachographs: goods vehicles | Driver and Vehicle Standards Agency | e23ceb73-38b9-4fb0-b27e-1de121937a84 | d39237a5-678b-4bb5-a372-eb2cb036933d
Formalities Manual (online version) | Intellectual Property Office | 8ae183dd-f42c-4c89-a87f-e2b4a0fe07ea | 5d6f9583-991f-413d-ae83-be7274e5eae4
Good estate management for schools | Department for Education | dcd02b57-eb4a-4432-9ec5-9e8dd817d490 | ebd15ade-73b2-4eaf-b1c3-43034a42eb37
Guide to cross compliance in England: 2016 | Rural Payments Agency | 5df13d4b-9ed5-4205-8540-96c9e93a3b12 | e8fae147-6232-4163-a3f1-1c15b755a8a4
Homelessness code of guidance for local authorities | Ministry of Housing, Communities & Local Government | 7558dfbe-8088-4a22-84cd-8d700e652e7c | 2e7868a8-38f5-4ff6-b62f-9a15d1c22d28
How to publish on GOV.UK | Government Digital Service | 2606097c-e82a-4f5d-920a-5f360dcff626 | af07d5a5-df63-4ddc-9383-6a666845ebe9
Immigration Rules | Home Office | 87e2748f-2e9b-4681-8baa-778b6d326a8a | 06056197-bc69-4147-aa28-070bca132178
Inheritance Tax Manual | Valuation Office Agency | 727ad81d-ab4e-4698-8c5b-75c9c0f34417 | ae98edb5-87b4-4a69-a31a-e0e5298f949d
Manual of Patent Practice | Intellectual Property Office | b59056ac-f7e9-4415-96b5-79cc5cfb0a76 | 5d6f9583-991f-413d-ae83-be7274e5eae4
National Planning Policy Framework | Ministry of Housing, Communities & Local Government | 29b0144a-5005-4a68-bf5d-985add7d3fc5 | 2e7868a8-38f5-4ff6-b62f-9a15d1c22d28
National standard for driving cars and light vans | Driver and Vehicle Standards Agency | 46de3824-b745-41f2-ad62-4a33bc6e29c7 | d39237a5-678b-4bb5-a372-eb2cb036933d
Ofqual Handbook | Ofqual | 9d453d4b-a04d-48fc-99f4-3f4ec395c324 | 83f6e93f-bb2c-46ab-9b02-394f972b7030
Open Document Format (ODF): guidance for UK government | Cabinet Office | fbe8509c-9ac9-4363-a60d-cf2869c945cd | 96ae61d6-c2a1-48cb-8e67-da9d105ae381
Open Policy Making Manual | Cabinet Office | c4310685-cce1-426b-94dc-c0cba4c84f2f | 96ae61d6-c2a1-48cb-8e67-da9d105ae381
Open Policy Making toolkit | Cabinet Office | 4e5c3196-f503-4c43-a966-04a4d0175c43 | 96ae61d6-c2a1-48cb-8e67-da9d105ae381
Prevent groundwater pollution from underground fuel storage tanks | Department for Environment, Food & Rural Affairs | 82929e4e-c467-48dc-b408-115c9c0e577c | de4e9dc6-cca4-43af-a594-682023b84d6c
Rating Manual section 1: statutory authority and legal background | Valuation Office Agency | e9ba080f-2877-4a50-b59f-60e4dbb38c2b | ae98edb5-87b4-4a69-a31a-e0e5298f949d
Rating Manual section 2: maintaining the rating list | Valuation Office Agency | 87447cf5-7f17-47b5-a060-e17f3763ab50 | ae98edb5-87b4-4a69-a31a-e0e5298f949d
Rating Manual section 3: valuation principles | Valuation Office Agency | 5ac0b50c-4bc0-4b94-b48c-1fb20d5ae739 | ae98edb5-87b4-4a69-a31a-e0e5298f949d
Rating Manual section 4: valuation methods | Valuation Office Agency | e05ac12d-f7f8-4808-9003-28ac9c0375bd | ae98edb5-87b4-4a69-a31a-e0e5298f949d
Rating Manual section 5: certificates issued by the VOA | Valuation Office Agency | e94eb4dd-a79c-4cf2-8d21-a0b2a4d0b1c2 | ae98edb5-87b4-4a69-a31a-e0e5298f949d
Rating Manual section 6 part 3: valuation of all property classes | Valuation Office Agency | 76696274-50aa-4f65-b60f-8c7cf802b0ce | ae98edb5-87b4-4a69-a31a-e0e5298f949d
Rating Manual section 6: valuation practice | Valuation Office Agency | 128ac786-12ef-44dd-96f9-0c8f8e23c639 | ae98edb5-87b4-4a69-a31a-e0e5298f949d
Rating Manual section 7: challenges to the rating list | Valuation Office Agency | ae9a7afa-631b-4147-8301-3508e7b4e775 | ae98edb5-87b4-4a69-a31a-e0e5298f949d
Rating Manual section 8: litigation | Valuation Office Agency | ed691892-3627-41d8-a0f8-69f744e9c6af | ae98edb5-87b4-4a69-a31a-e0e5298f949d
Registered Designs Examination Practice guide | Intellectual Property Office | b37ad376-d66c-4228-9849-3b3d091b6873 | 5d6f9583-991f-413d-ae83-be7274e5eae4
Regulating GCSEs, AS and A levels: guide for schools and colleges | Ofqual | 656de4af-b836-4ca1-8973-2a1786c26be8 | 83f6e93f-bb2c-46ab-9b02-394f972b7030
Rent Officer Handbook: fair rent registration | Valuation Office Agency | 3a8610c5-e30d-4724-8240-3009a2d98541 | ae98edb5-87b4-4a69-a31a-e0e5298f949d
Rent Officer Handbook: general matters related to all Rent Officer work | Valuation Office Agency | 1c59d773-c588-4f9d-ad37-6f2c8c06b4c2 | ae98edb5-87b4-4a69-a31a-e0e5298f949d
Rent Officer Handbook: Housing Benefit referral | Valuation Office Agency | 8756e319-2e7b-4b04-87cc-73a203b288cd | ae98edb5-87b4-4a69-a31a-e0e5298f949d
Rent Officer Handbook: lettings research | Valuation Office Agency | ed56bc92-2a7b-4922-b687-8c010bf7f65c | ae98edb5-87b4-4a69-a31a-e0e5298f949d
Rent Officer Handbook: Local Housing Allowance | Valuation Office Agency | 9b0d5e50-1056-4793-8e4e-5df7d1281bbe | ae98edb5-87b4-4a69-a31a-e0e5298f949d
Restorations and post grant section manual | Intellectual Property Office | ce5493cb-90e3-492e-b241-e741e24ab45d | 5d6f9583-991f-413d-ae83-be7274e5eae4
Social care common inspection framework (SCCIF): adoption support agencies | Ofsted | 370aaa43-6cc2-4dd8-a535-59a5c58ee0e2 | ad5f6169-ac7b-4382-9eb6-e58af71a2f00
Social care common inspection framework (SCCIF): boarding schools and residential special schools | Ofsted | 9c3153dd-4f94-4730-aa10-1a38e0741b5d | ad5f6169-ac7b-4382-9eb6-e58af71a2f00
Social care common inspection framework (SCCIF): children’s homes, including secure children’s homes | Ofsted | 42d69bba-d0fe-43ce-afa6-99407386d5b9 | ad5f6169-ac7b-4382-9eb6-e58af71a2f00
Social care common inspection framework (SCCIF): independent fostering agencies | Ofsted | 9fbb617d-869a-4a4b-b781-c80b296062c7 | ad5f6169-ac7b-4382-9eb6-e58af71a2f00
Social care common inspection framework (SCCIF): residential family centres | Ofsted | 9a259af0-b07b-4cc0-a436-8399e4eb97cf | ad5f6169-ac7b-4382-9eb6-e58af71a2f00
Social care common inspection framework (SCCIF): residential holiday schemes for disabled children | Ofsted | 9d1f335c-6b2e-48d1-9984-7ea2e461f5d6 | ad5f6169-ac7b-4382-9eb6-e58af71a2f00
Social care common inspection framework (SCCIF): residential provision of further education colleges | Ofsted | 64edf75e-7c37-45e9-927f-c116d7ded396 | ad5f6169-ac7b-4382-9eb6-e58af71a2f00
Social care common inspection framework (SCCIF): voluntary adoption agencies | Ofsted | 2410e8d1-2d41-4f4d-a5a9-158bf14b6490 | ad5f6169-ac7b-4382-9eb6-e58af71a2f00
Style guide | Government Digital Service | 6d1e2424-f2dd-4db1-930e-e3c1a0cae5c3 | af07d5a5-df63-4ddc-9383-6a666845ebe9
Support for government publishers | Government Digital Service | f6489e06-f349-4f31-b5b3-049ea66bfc60 | af07d5a5-df63-4ddc-9383-6a666845ebe9
The Highway Code | Department for Transport | bbf6c11a-7dc6-4fe6-8dd8-68c09bdbe562 | 4c717efc-f47b-478e-a76d-ce1ae0af1946
Tribunal Patents Manual (online version) | Intellectual Property Office | 839f7393-d70b-4cbd-a8c2-d9ec33575e81 | 5d6f9583-991f-413d-ae83-be7274e5eae4
```