### PR TITLE
Use bulk_publishing param for patch_links

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -471,6 +471,8 @@ in the request is preserved.
 ```
 - `previous_version` *(optional, recommended)*
   - Used to ensure that we are updating the current version of the link set.
+- `bulk_publishing` *(optional, default: false)*
+  - Set this to true when making multiple requests. Publishing API will use a lower priority queue to avoid delays to standard publishing activity.
 
 ### State changes
 

--- a/lib/tasks/link_setter.rb
+++ b/lib/tasks/link_setter.rb
@@ -10,7 +10,8 @@ module Tasks
           content_id: content_id,
           links: {
             primary_publishing_organisation: [primary_publishing_organisation]
-          }
+          },
+          bulk_publishing: true
         )
       end
     end


### PR DESCRIPTION
There is a previously undocumented parameter for patch-links that
forces it to use a low priority queue. Use it when setting primary
organisation.

Part of https://trello.com/c/i04E3Dnd/332-2-set-primary-org-for-existing-specialist-documents