### PR TITLE
Ignore errors sending published content to replace more recent drafts

### DIFF
--- a/app/errors/downstream_draft_exists_error.rb
+++ b/app/errors/downstream_draft_exists_error.rb
@@ -1,0 +1,2 @@
+class DownstreamDraftExistsError < DownstreamInvalidStateError
+end

--- a/app/services/downstream_service.rb
+++ b/app/services/downstream_service.rb
@@ -20,7 +20,7 @@ module DownstreamService
     end
     if downstream_payload.state != "draft" && draft_at_base_path?(downstream_payload.base_path)
       message = "Can't send #{downstream_payload.state} item to draft content store, as there is a draft occupying the same base path"
-      raise DownstreamInvalidStateError.new(message)
+      raise DownstreamDraftExistsError.new(message)
     end
 
 

--- a/config/initializers/govuk_error.rb
+++ b/config/initializers/govuk_error.rb
@@ -1,0 +1,3 @@
+GovukError.configure do |config|
+  config.excluded_exceptions << "DownstreamDraftExistsError"
+end

--- a/spec/services/downstream_service_spec.rb
+++ b/spec/services/downstream_service_spec.rb
@@ -117,7 +117,7 @@ RSpec.describe DownstreamService do
         it "raises an error" do
           expect {
             DownstreamService.update_draft_content_store(downstream_payload)
-          }.to raise_error(DownstreamInvalidStateError, message_matcher)
+          }.to raise_error(DownstreamDraftExistsError, message_matcher)
         end
       end
 
@@ -127,7 +127,7 @@ RSpec.describe DownstreamService do
         it "raises an error" do
           expect {
             DownstreamService.update_draft_content_store(downstream_payload)
-          }.to raise_error(DownstreamInvalidStateError, message_matcher)
+          }.to raise_error(DownstreamDraftExistsError, message_matcher)
         end
       end
     end


### PR DESCRIPTION
It's a common and valid occurrence in the Publishing API for a piece of content to be re-rendered and try to replace a newer draft. This is a safeguard that stops that happening, and not an error. The other types of `DownstreamInvalidStateError` are ones we want to know about, so instead we should use a new subclass here and ignore that instead.