### PR TITLE
Turn down concurrency on Sidekiq

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,6 +1,6 @@
 ---
 :verbose: false
-:concurrency: 10
+:concurrency: 4
 :logfile: ./log/sidekiq.json.log
 :queues:
   - downstream_high


### PR DESCRIPTION
We're currently hammering Postgres with large republishings.
We need to decrease the load while we work out more strategic
options.