### PR TITLE
Revert "Turn down concurrency on Sidekiq"

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,6 +1,6 @@
 ---
 :verbose: false
-:concurrency: 4
+:concurrency: 10
 :logfile: ./log/sidekiq.json.log
 :queues:
   - downstream_high


### PR DESCRIPTION
Reverts alphagov/publishing-api#1271

We've upgraded Postgres now, and we think it might be able to cope with the extra load?