### PR TITLE
GET /v2/editions can now filter on document_types

### DIFF
--- a/app/controllers/v2/editions_controller.rb
+++ b/app/controllers/v2/editions_controller.rb
@@ -16,8 +16,8 @@ module V2
     def edition_params
       params
         .permit(
-          :order, :locale, :publishing_app, :per_page, :before, :after,
-          fields: [], states: []
+          :order, :locale, :publishing_app, :per_page,
+          :before, :after, document_types: [], fields: [], states: []
         )
     end
 

--- a/app/queries/keyset_pagination.rb
+++ b/app/queries/keyset_pagination.rb
@@ -55,15 +55,17 @@ module Queries
     end
 
     def is_first_page?
-      @is_first_page ||= KeysetPagination.new(
-        client, per_page: 1, before: next_before_key
-      ).call.empty?
+      @is_first_page ||= results.empty? ||
+        KeysetPagination.new(
+          client, per_page: 1, before: next_before_key
+        ).call.empty?
     end
 
     def is_last_page?
-      @is_last_page ||= KeysetPagination.new(
-        client, per_page: 1, after: next_after_key
-      ).call.empty?
+      @is_last_page ||= results.empty? ||
+        KeysetPagination.new(
+          client, per_page: 1, after: next_after_key
+        ).call.empty?
     end
 
     def key_fields

--- a/app/queries/keyset_pagination/get_editions.rb
+++ b/app/queries/keyset_pagination/get_editions.rb
@@ -9,6 +9,7 @@ module Queries
         states: params[:states] || %i(draft published unpublished),
         locale: params[:locale],
         publishing_app: params[:publishing_app],
+        document_types: params[:document_types],
       }
 
       validate_fields!
@@ -65,7 +66,7 @@ module Queries
 
       query = query.where("documents.locale": filters[:locale]) if filters[:locale]
       query = query.where(publishing_app: filters[:publishing_app]) if filters[:publishing_app]
-
+      query = query.where(document_type: filters[:document_types]) if filters[:document_types]
       query
     end
 

--- a/doc/api.md
+++ b/doc/api.md
@@ -600,6 +600,8 @@ parameters.
 
 ### Query string parameters
 
+- `document_type` *(optional)*
+  - The type of editions to return.
 - `fields[]` *(optional)*
   - Accepts an array of: analytics_identifier, base_path,
     content_store, description, details, document_type,

--- a/spec/controllers/v2/editions_controller_spec.rb
+++ b/spec/controllers/v2/editions_controller_spec.rb
@@ -124,6 +124,16 @@ RSpec.describe V2::EditionsController do
       end
     end
 
+    context "filtered so that the result set is empty" do
+      it "returns an empty set" do
+        get :index, params: { locale: "nowhere" }
+        expect(parsed_response["results"].count).to eq(0)
+        expect(parsed_response["links"]).to eq([
+          { "href" => "http://test.host/v2/editions?locale=nowhere", "rel" => "self" },
+        ])
+      end
+    end
+
     context "filtered by state" do
       it "returns only published editions" do
         get :index, params: { states: %w(published) }

--- a/spec/controllers/v2/editions_controller_spec.rb
+++ b/spec/controllers/v2/editions_controller_spec.rb
@@ -134,6 +134,17 @@ RSpec.describe V2::EditionsController do
       end
     end
 
+    context "filtered by document type" do
+      it "returns only the document type specified" do
+        create(:draft_edition, document_type: 'taxon', id: 10000)
+        get :index, params: { document_types: %w(taxon) }
+        expect(parsed_response["results"].count).to eq(1)
+        expect(parsed_response["links"]).to eq([
+          { "href" => "http://test.host/v2/editions?document_types%5B%5D=taxon", "rel" => "self" },
+        ])
+      end
+    end
+
     context "filtered by state" do
       it "returns only published editions" do
         get :index, params: { states: %w(published) }


### PR DESCRIPTION
- Allow GET /v2/editions to return empty sets
- GET /v2/editions can now filter on document_types