### PR TITLE
Increase ActiveRecord connections pool to 12

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -1,7 +1,7 @@
 default: &default
   adapter: postgresql
   encoding: unicode
-  pool: 10
+  pool: 12
   template: template0
 
 development:


### PR DESCRIPTION
We've been getting sporadic spikes in activerecord connection errors because
all pooled connections were in use.  This is a sticking plaster for a bit
while we consider what the alternative solutions are.

https://sentry.io/govuk/app-publishing-api/issues/533025026/?query=is:unresolved