### PR TITLE
Decrease Sidekiq concurrency from 10 to 6

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,6 +1,6 @@
 ---
 :verbose: false
-:concurrency: 10
+:concurrency: 6
 :logfile: ./log/sidekiq.json.log
 :queues:
   - downstream_high


### PR DESCRIPTION
Currently the load on the PostgreSQL primary machine is often in the
mid 20s. This is a bit too high for a machine with now 8 cores, and it
looks like the culprit is the Publishing API Sidekiq workers.

Drop the connections back down to 6, to hopefully reduce the load on
the machine.