### PR TITLE
Change RabbitMQ config

### DIFF
--- a/config/rabbitmq.yml
+++ b/config/rabbitmq.yml
@@ -5,6 +5,7 @@ defaults: &defaults
   pass: publishing_api
   exchange: published_documents
   recover_from_connection_close: true
+  automatically_recover: false
 
 development:
   <<: *defaults

--- a/config/rabbitmq.yml
+++ b/config/rabbitmq.yml
@@ -1,5 +1,4 @@
 defaults: &defaults
-  host: localhost
   port: 5672
   vhost: /
   user: publishing_api
@@ -8,13 +7,16 @@ defaults: &defaults
 
 development:
   <<: *defaults
+  host: localhost
   exchange: published_documents
 
 test:
   <<: *defaults
+  host: localhost
   exchange: published_documents_test
 
 production:
+  <<: *defaults
   hosts:
     <% hosts = ENV['RABBITMQ_HOSTS'] || 'localhost' %>
     <% hosts.split(",").each do |host| %>

--- a/config/rabbitmq.yml
+++ b/config/rabbitmq.yml
@@ -22,9 +22,5 @@ production:
     <% hosts.split(",").each do |host| %>
     - <%= host %>
     <% end %>
-  user: publishing_api
   pass: <%= ENV['RABBITMQ_PASSWORD'] %>
-  port: 5672
-  vhost: /
   exchange: published_documents
-  recover_from_connection_close: true

--- a/config/rabbitmq.yml
+++ b/config/rabbitmq.yml
@@ -3,12 +3,12 @@ defaults: &defaults
   vhost: /
   user: publishing_api
   pass: publishing_api
+  exchange: published_documents
   recover_from_connection_close: true
 
 development:
   <<: *defaults
   host: localhost
-  exchange: published_documents
 
 test:
   <<: *defaults
@@ -23,4 +23,3 @@ production:
     - <%= host %>
     <% end %>
   pass: <%= ENV['RABBITMQ_PASSWORD'] %>
-  exchange: published_documents


### PR DESCRIPTION
A few minor refactorings, plus disable RabbitMQ automatic recovery.

The Publishing API uses Sidekiq for retrying jobs, and there has
potentially been issues with mixing the indefinite retrying from
Bunny, with Sidekiq workers [1]. As Sidekiq handles retrying, stop
RabbitMQ from doing so, and instead use the Sidekiq retrying methods.

1: 2018-07-05:
There was a incident involving Sidekiq using up too many threads,
potentially because the indefinite retrying for connection issues was
causing issues with Sidekiq workers.