### PR TITLE
Remove change note 157789

### DIFF
--- a/db/migrate/20180724140319_remove_change_note.rb
+++ b/db/migrate/20180724140319_remove_change_note.rb
@@ -1,0 +1,33 @@
+# Remove a public change note (dated 20 July 2018) for "VAT Notice 708: buildings and construction"
+# Ticket: https://govuk.zendesk.com/agent/tickets/2927623
+# Page: https://www.gov.uk/government/publications/vat-notice-708-buildings-and-construction
+#
+# Prior steps:
+# Queried `Document` for the `content_id: "5f623c6e-7631-11e4-a3cb-005056011aef"`
+
+class RemoveChangeNote < ActiveRecord::Migration[5.1]
+  disable_ddl_transaction!
+
+  def up
+    # Find document
+    document = Document.where(content_id: "5f623c6e-7631-11e4-a3cb-005056011aef").first
+
+    if document.present?
+      live_edition = document.live
+      details = live_edition.details
+      change_history = details[:change_history]
+
+      details[:change_history] = change_history.drop(1)
+
+      live_edition.save
+
+      if Rails.env.production?
+        Commands::V2::RepresentDownstream.new.call(document.content_id)
+      end
+    end
+  end
+
+  def down
+    # This migration is not reversible
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180719125727) do
+ActiveRecord::Schema.define(version: 20180724140319) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
This PR remove a public change note (dated 20 July 2018) for [VAT Notice 708: buildings and construction](https://www.gov.uk/government/publications/vat-notice-708-buildings-and-construction)

This request comes from the following ticket: https://govuk.zendesk.com/agent/tickets/2927623

