### PR TITLE
Drop unused indexes

### DIFF
--- a/db/migrate/20180727121831_drop_unused_indexes.rb
+++ b/db/migrate/20180727121831_drop_unused_indexes.rb
@@ -1,0 +1,14 @@
+class DropUnusedIndexes < ActiveRecord::Migration[5.1]
+  def up
+    remove_index :actions, name: :index_actions_on_edition_id
+    remove_index :actions, name: :index_actions_on_event_id
+    remove_index :actions, name: :index_actions_on_link_set_id
+    remove_index :editions, name: :index_editions_on_created_at_and_id
+    remove_index :editions, name: :index_editions_on_last_edited_at
+    remove_index :editions, name: :index_editions_on_public_updated_at
+    remove_index :editions, name: :index_editions_on_public_updated_at_and_id
+    remove_index :editions, name: :index_editions_on_rendering_app
+    remove_index :events, name: :index_events_on_content_id
+    remove_index :link_changes, name: :index_link_changes_on_action_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180724140319) do
+ActiveRecord::Schema.define(version: 20180727121831) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -35,9 +35,6 @@ ActiveRecord::Schema.define(version: 20180724140319) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.text "edition_diff"
-    t.index ["edition_id"], name: "index_actions_on_edition_id"
-    t.index ["event_id"], name: "index_actions_on_event_id"
-    t.index ["link_set_id"], name: "index_actions_on_link_set_id"
   end
 
   create_table "change_notes", id: :serial, force: :cascade do |t|
@@ -92,17 +89,12 @@ ActiveRecord::Schema.define(version: 20180724140319) do
     t.datetime "publisher_published_at"
     t.datetime "publisher_last_edited_at"
     t.index ["base_path", "content_store"], name: "index_editions_on_base_path_and_content_store", unique: true
-    t.index ["created_at", "id"], name: "index_editions_on_created_at_and_id"
     t.index ["document_id", "content_store"], name: "index_editions_on_document_id_and_content_store", unique: true
     t.index ["document_id", "state"], name: "index_editions_on_document_id_and_state"
     t.index ["document_id", "user_facing_version"], name: "index_editions_on_document_id_and_user_facing_version", unique: true
     t.index ["document_id"], name: "index_editions_on_document_id"
     t.index ["document_type", "updated_at"], name: "index_editions_on_document_type_and_updated_at"
-    t.index ["last_edited_at"], name: "index_editions_on_last_edited_at"
-    t.index ["public_updated_at", "id"], name: "index_editions_on_public_updated_at_and_id"
-    t.index ["public_updated_at"], name: "index_editions_on_public_updated_at"
     t.index ["publishing_app"], name: "index_editions_on_publishing_app"
-    t.index ["rendering_app"], name: "index_editions_on_rendering_app"
     t.index ["state", "base_path"], name: "index_editions_on_state_and_base_path"
     t.index ["updated_at", "id"], name: "index_editions_on_updated_at_and_id"
     t.index ["updated_at"], name: "index_editions_on_updated_at"
@@ -116,7 +108,6 @@ ActiveRecord::Schema.define(version: 20180724140319) do
     t.datetime "updated_at"
     t.string "request_id"
     t.uuid "content_id"
-    t.index ["content_id"], name: "index_events_on_content_id"
   end
 
   create_table "expanded_links", force: :cascade do |t|
@@ -138,7 +129,6 @@ ActiveRecord::Schema.define(version: 20180724140319) do
     t.bigint "action_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["action_id"], name: "index_link_changes_on_action_id"
   end
 
   create_table "link_sets", id: :serial, force: :cascade do |t|


### PR DESCRIPTION
This removes unused indexes saving about 3 GB of space. These were identified by using https://wiki.postgresql.org/wiki/Index_Maintenance#Index_size.2Fusage_statistics and the results are available at https://gist.github.com/boffbowsh/b52630ddebd51ec4af8ff0dd18ab70e5.

[Trello Card](https://trello.com/c/xY0pugQi/352-remove-unused-indices-in-publishing-api)