### PR TITLE
Remove change note

### DIFF
--- a/db/migrate/20180724140319_remove_change_note.rb
+++ b/db/migrate/20180724140319_remove_change_note.rb
@@ -1,33 +1,8 @@
+# This has now been replaced by a newer migration: 20180727140643_remove_change_note_v2
+
 # Remove a public change note (dated 20 July 2018) for "VAT Notice 708: buildings and construction"
 # Ticket: https://govuk.zendesk.com/agent/tickets/2927623
 # Page: https://www.gov.uk/government/publications/vat-notice-708-buildings-and-construction
 #
 # Prior steps:
 # Queried `Document` for the `content_id: "5f623c6e-7631-11e4-a3cb-005056011aef"`
-
-class RemoveChangeNote < ActiveRecord::Migration[5.1]
-  disable_ddl_transaction!
-
-  def up
-    # Find document
-    document = Document.where(content_id: "5f623c6e-7631-11e4-a3cb-005056011aef").first
-
-    if document.present?
-      live_edition = document.live
-      details = live_edition.details
-      change_history = details[:change_history]
-
-      details[:change_history] = change_history.drop(1)
-
-      live_edition.save
-
-      if Rails.env.production?
-        Commands::V2::RepresentDownstream.new.call(document.content_id)
-      end
-    end
-  end
-
-  def down
-    # This migration is not reversible
-  end
-end

--- a/db/migrate/20180727140643_remove_change_note_v2.rb
+++ b/db/migrate/20180727140643_remove_change_note_v2.rb
@@ -1,0 +1,40 @@
+# Remove a public change note (dated 20 July 2018) for "VAT Notice 708: buildings and construction"
+# Ticket: https://govuk.zendesk.com/agent/tickets/2927623
+# Page: https://www.gov.uk/government/publications/vat-notice-708-buildings-and-construction
+#
+# This was previously attempted in #1293 but didn't work when run on integration or staging.
+# This is designed to replace that failed migration
+#
+# Prior steps:
+# Queried `Document` for the `content_id: "5f623c6e-7631-11e4-a3cb-005056011aef"`
+
+class RemoveChangeNoteV2 < ActiveRecord::Migration[5.1]
+  disable_ddl_transaction!
+
+  change_note_to_delete = "VAT Notice 308 has been amended to show that a dwelling can consist of more than one building."
+
+  def up
+    # Find document
+    document = Document.where(content_id: "5f623c6e-7631-11e4-a3cb-005056011aef").first
+
+    if document.present?
+      edition_id = document.live.id
+      edition = Edition.find(edition_id)
+
+      if edition.present?
+        edition_details = edition.details
+        new_details = edition_details
+        new_details[:change_history] = new_details[:change_history].delete_if { |history| history[:note] == change_note_to_delete }
+        edition.update!(details: new_details)
+
+        if Rails.env.production?
+          Commands::V2::RepresentDownstream.new.call(document.content_id)
+        end
+      end
+    end
+  end
+
+  def down
+    # This migration is not reversible
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180727121831) do
+ActiveRecord::Schema.define(version: 20180727140643) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
Removes the following change note for https://gov.uk/government/publications/vat-notice-708-buildings-and-construction

> 20 July 2018
> VAT Notice 308 has been amended to show that a dwelling can consist of more than one building.

This has been tested on integration and seems to work.

