### PR TITLE
Fix change note migration

### DIFF
--- a/db/migrate/20180727140643_remove_change_note_v2.rb
+++ b/db/migrate/20180727140643_remove_change_note_v2.rb
@@ -11,10 +11,9 @@
 class RemoveChangeNoteV2 < ActiveRecord::Migration[5.1]
   disable_ddl_transaction!
 
-  change_note_to_delete = "VAT Notice 308 has been amended to show that a dwelling can consist of more than one building."
-
   def up
     # Find document
+    change_note_to_delete = "VAT Notice 308 has been amended to show that a dwelling can consist of more than one building."
     document = Document.where(content_id: "5f623c6e-7631-11e4-a3cb-005056011aef").first
 
     if document.present?


### PR DESCRIPTION
The [previous commit to add this migration](https://github.com/alphagov/publishing-api/pull/1297) was failing to run because change_note_to_delete was defined outside the up method. This has been tested on integration and ran fine.