### PR TITLE
Add indexes to speed up linkable lookups

### DIFF
--- a/db/migrate/20180801195938_add_indexes_for_linkables.rb
+++ b/db/migrate/20180801195938_add_indexes_for_linkables.rb
@@ -1,0 +1,7 @@
+class AddIndexesForLinkables < ActiveRecord::Migration[5.1]
+  disable_ddl_transaction!
+  def change
+    add_index :editions, [:document_type, :state], algorithm: :concurrently
+    add_index :documents, [:id, :locale], algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180727140643) do
+ActiveRecord::Schema.define(version: 20180801195938) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -54,6 +54,7 @@ ActiveRecord::Schema.define(version: 20180727140643) do
     t.datetime "updated_at", null: false
     t.integer "owning_document_id"
     t.index ["content_id", "locale"], name: "index_documents_on_content_id_and_locale", unique: true
+    t.index ["id", "locale"], name: "index_documents_on_id_and_locale"
   end
 
   create_table "editions", id: :serial, force: :cascade do |t|
@@ -93,6 +94,7 @@ ActiveRecord::Schema.define(version: 20180727140643) do
     t.index ["document_id", "state"], name: "index_editions_on_document_id_and_state"
     t.index ["document_id", "user_facing_version"], name: "index_editions_on_document_id_and_user_facing_version", unique: true
     t.index ["document_id"], name: "index_editions_on_document_id"
+    t.index ["document_type", "state"], name: "index_editions_on_document_type_and_state"
     t.index ["document_type", "updated_at"], name: "index_editions_on_document_type_and_updated_at"
     t.index ["publishing_app"], name: "index_editions_on_publishing_app"
     t.index ["state", "base_path"], name: "index_editions_on_state_and_base_path"


### PR DESCRIPTION
Hello :wave: I feel bad raising this so soon after https://github.com/alphagov/publishing-api/pull/1296 but hopefully this should be a pretty significant speed boost.

This adds indexes so that the linkables query can look up all it's data
to filter record entirely by indexes.

The query plan prior to this was:

```
publishing_api_production=# EXPLAIN ANALYZE SELECT DISTINCT ON (documents.content_id) documents.content_id, "editions"."title", "editions"."state", "editions"."base_path" FROM "editions" INNER JOIN "documents" ON "documents"."id" = "editions"."document_id" WHERE "editions"."document_type" IN ('organisation', 'placeholder_organisation') AND "editions"."state" IN ('draft', 'published') AND "documents"."locale" = 'en' ORDER BY documents.content_id ASC, CASE editions.state WHEN 'published' THEN 0 ELSE 1 END;
                                                                                        QUERY PLAN
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Unique  (cost=83709.21..83740.79 rows=6316 width=161) (actual time=26029.280..26029.524 rows=1064 loops=1)
   ->  Sort  (cost=83709.21..83725.00 rows=6316 width=161) (actual time=26029.278..26029.342 rows=1074 loops=1)
         Sort Key: documents.content_id, (CASE editions.state WHEN 'published'::text THEN 0 ELSE 1 END)
         Sort Method: quicksort  Memory: 279kB
         ->  Nested Loop  (cost=34183.09..82789.02 rows=6316 width=161) (actual time=649.735..26027.189 rows=1074 loops=1)
               ->  Bitmap Heap Scan on editions  (cost=34182.67..57449.89 rows=6486 width=149) (actual time=642.943..24993.418 rows=1086 loops=1)
                     Recheck Cond: (((document_type)::text = ANY ('{organisation,placeholder_organisation}'::text[])) AND ((state)::text = ANY ('{draft,published}'::text[])))
                     Rows Removed by Index Recheck: 126017
                     ->  BitmapAnd  (cost=34182.67..34182.67 rows=6486 width=0) (actual time=386.400..386.400 rows=0 loops=1)
                           ->  Bitmap Index Scan on index_editions_on_document_type_and_updated_at  (cost=0.00..1159.03 rows=38691 width=0) (actual time=9.766..9.766 rows=37533 loops=1)
                                 Index Cond: ((document_type)::text = ANY ('{organisation,placeholder_organisation}'::text[]))
                           ->  Bitmap Index Scan on index_editions_on_state_and_base_path  (cost=0.00..33020.14 rows=536403 width=0) (actual time=373.770..373.770 rows=543295 loops=1)
                                 Index Cond: ((state)::text = ANY ('{draft,published}'::text[]))
               ->  Index Scan using documents_pkey on documents  (cost=0.42..3.89 rows=1 width=20) (actual time=0.948..0.949 rows=1 loops=1086)
                     Index Cond: (id = editions.document_id)
                     Filter: ((locale)::text = 'en'::text)
                     Rows Removed by Filter: 0
 Total runtime: 26029.805 ms
```

And after it is:

```
publishing_api_production=# EXPLAIN ANALYZE SELECT DISTINCT ON (documents.content_id) documents.content_id, "editions"."title", "editions"."state", "editions"."base_path" FROM "editions" INNER JOIN "documents" ON "documents"."id" = "editions"."document_id" WHERE "editions"."document_type" IN ('organisation', 'placeholder_organisation') AND "editions"."state" IN ('draft', 'published') AND "documents"."locale" = 'en' ORDER BY documents.content_id ASC, CASE editions.state WHEN 'published' THEN 0 ELSE 1 END;
                                                                                    QUERY PLAN
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Unique  (cost=49393.41..49424.72 rows=6262 width=161) (actual time=15.905..16.086 rows=1064 loops=1)
   ->  Sort  (cost=49393.41..49409.07 rows=6262 width=161) (actual time=15.905..15.947 rows=1074 loops=1)
         Sort Key: documents.content_id, (CASE editions.state WHEN 'published'::text THEN 0 ELSE 1 END)
         Sort Method: quicksort  Memory: 279kB
         ->  Nested Loop  (cost=212.03..48484.02 rows=6262 width=161) (actual time=0.622..15.162 rows=1074 loops=1)
               ->  Bitmap Heap Scan on editions  (cost=211.61..23290.64 rows=6430 width=149) (actual time=0.581..2.596 rows=1086 loops=1)
                     Recheck Cond: (((document_type)::text = ANY ('{organisation,placeholder_organisation}'::text[])) AND ((state)::text = ANY ('{draft,published}'::text[])))
                     ->  Bitmap Index Scan on editions_document_type_state  (cost=0.00..210.00 rows=6430 width=0) (actual time=0.448..0.448 rows=1086 loops=1)
                           Index Cond: (((document_type)::text = ANY ('{organisation,placeholder_organisation}'::text[])) AND ((state)::text = ANY ('{draft,published}'::text[])))
               ->  Index Scan using document_id_locale on documents  (cost=0.42..3.91 rows=1 width=20) (actual time=0.010..0.010 rows=1 loops=1086)
                     Index Cond: ((id = editions.document_id) AND ((locale)::text = 'en'::text))
 Total runtime: 16.225 ms
```

Benchmarks are from postgresql-primary-1.staging where I devopsed them.

Linkables seem to have become a performance issue recently since some
work was done to migrate organisations - they seem to be edited much
more frequently and this means our cache is often stale.