### PR TITLE
Enable Brakeman

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,7 +29,8 @@ node("postgresql-9.3") {
 
         runContentStorePactTests(govuk);
       }
-    }
+    },
+    brakeman: true,
   )
 }
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,4 @@
-class ApplicationController < ActionController::Base
+class ApplicationController < ActionController::API
   include GDS::SSO::ControllerMethods
 
   rescue_from ActionController::ParameterMissing, with: :parameter_missing_error

--- a/config/application.rb
+++ b/config/application.rb
@@ -20,6 +20,8 @@ module PublishingAPI
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 5.1
 
+    config.api_only = true
+
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.


### PR DESCRIPTION
This allows us to find any security vulnerabilities. I've also changed the app to be a Rails API only app to remove a CSRF warning.

[Trello Card](https://trello.com/c/JyrOAef3/363-fix-sql-injection-vulnerabilities-in-govuk-applications)