### PR TITLE
Add a healthcheck for queue latency

### DIFF
--- a/app/models/healthcheck/queue_latency.rb
+++ b/app/models/healthcheck/queue_latency.rb
@@ -1,0 +1,16 @@
+class Healthcheck::QueueLatency < GovukHealthcheck::SidekiqQueueLatencyCheck
+  QUEUES = {
+    'downstream_high' => {
+      warning: 20, # seconds
+      critical: 60 # seconds
+    }
+  }.freeze
+
+  def warning_threshold(queue:)
+    QUEUES.dig(queue, :warning) || Float::INFINITY
+  end
+
+  def critical_threshold(queue:)
+    QUEUES.dig(queue, :critical) || Float::INFINITY
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -60,6 +60,7 @@ Rails.application.routes.draw do
   get "/healthcheck", to: GovukHealthcheck.rack_response(
     GovukHealthcheck::SidekiqRedis,
     GovukHealthcheck::ActiveRecord,
+    Healthcheck::QueueLatency,
   )
 
   if Rails.env.development?

--- a/spec/models/healthcheck/queue_latency_spec.rb
+++ b/spec/models/healthcheck/queue_latency_spec.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+
+RSpec.describe Healthcheck::QueueLatency do
+  describe "QUEUES" do
+    it "contains string keys" do
+      Healthcheck::QueueLatency::QUEUES.each_key do |key|
+        expect(key).to be_a String
+      end
+    end
+
+    it "has valid values" do
+      Healthcheck::QueueLatency::QUEUES.each_value do |value|
+        expect(value[:warning]).to be_a(Integer)
+        expect(value[:critical]).to be_a(Integer)
+      end
+    end
+  end
+
+  it "handles unknown queues without alerting" do
+    high_latency = 999
+    expect(high_latency < subject.critical_threshold(queue: "that_doesnt_exist"))
+  end
+end


### PR DESCRIPTION
Any significant latency in the downstream_high queue is cause for
alarm, as that means that updating content is being delayed.