### PR TITLE
Rake task to use high priority queue for represent_downstream

### DIFF
--- a/doc/admin-tasks.md
+++ b/doc/admin-tasks.md
@@ -47,10 +47,21 @@ bundle exec represent_downstream:tagged_to_taxon
 bundle exec represent_downstream:content_id['some-content-id']
 ```
 
+* Represent an individual edition downstream via the high priority queue
+```
+bundle exec represent_downstream:high_priority:content_id['some-content-id']
+```
+
 * Represent multiple editions downstream
 ```
 bundle exec represent_downstream:content_id['some-content-id some-other-content-id']
 ```
+
+* Represent multiple editions downstream via the high priority queue
+```
+bundle exec represent_downstream:high_priority:content_id['some-content-id some-other-content-id']
+```
+
 N.B. The content ids are separated by a space.
 
 ## Populating expanded links into database

--- a/doc/admin-tasks.md
+++ b/doc/admin-tasks.md
@@ -18,48 +18,48 @@ The following tasks will allow you to specify which content items/editions to ad
 
 * Represent all editions downstream
 ```
-bundle exec represent_downstream:all
+bundle exec rake represent_downstream:all
 ```
 N.B. This task will take several hours and should be used with caution.
 
 * Represent downstream for a specific document_type
 ```
-bundle exec represent_downstream:document_type['a-document-type']
+bundle exec rake represent_downstream:document_type['a-document-type']
 ```
 
 * Represent downstream for a rendering application
 ```
-bundle exec represent_downstream:rendering_app['application-name']
+bundle exec rake represent_downstream:rendering_app['application-name']
 ```
 
 * Represent downstream for a publishing application
 ```
-bundle exec represent_downstream:publishing_app['application-name']
+bundle exec rake represent_downstream:publishing_app['application-name']
 ```
 
 * Represent downstream content which has at least one link of type `taxon`
 ```
-bundle exec represent_downstream:tagged_to_taxon
+bundle exec rake represent_downstream:tagged_to_taxon
 ```
 
 * Represent an individual edition downstream
 ```
-bundle exec represent_downstream:content_id['some-content-id']
+bundle exec rake represent_downstream:content_id['some-content-id']
 ```
 
 * Represent an individual edition downstream via the high priority queue
 ```
-bundle exec represent_downstream:high_priority:content_id['some-content-id']
+bundle exec rake represent_downstream:high_priority:content_id['some-content-id']
 ```
 
 * Represent multiple editions downstream
 ```
-bundle exec represent_downstream:content_id['some-content-id some-other-content-id']
+bundle exec rake represent_downstream:content_id['some-content-id some-other-content-id']
 ```
 
 * Represent multiple editions downstream via the high priority queue
 ```
-bundle exec represent_downstream:high_priority:content_id['some-content-id some-other-content-id']
+bundle exec rake represent_downstream:high_priority:content_id['some-content-id some-other-content-id']
 ```
 
 N.B. The content ids are separated by a space.
@@ -75,15 +75,15 @@ It will also be rebuilt any time a piece of content is represented downstream.
 
 * To populate every document (this will take a long time - hours)
 ```
-bundle exec expanded_links:populate
+bundle exec rake expanded_links:populate
 ```
 
 * To populate every document of a document_type
 ```
-bundle exec expanded_links:populate_by_document_type['document-type']
+bundle exec rake expanded_links:populate_by_document_type['document-type']
 ```
 
 * To purge the expanded links cache
 ```
-bundle exec expanded_links:truncate
+bundle exec rake expanded_links:truncate
 ```

--- a/spec/commands/v2/represent_downstream_spec.rb
+++ b/spec/commands/v2/represent_downstream_spec.rb
@@ -86,5 +86,14 @@ RSpec.describe Commands::V2::RepresentDownstream do
         subject.call(Document.pluck(:content_id), with_drafts: false)
       end
     end
+
+    context "queue optional" do
+      it "can be set to use the high priority queue" do
+        expect(DownstreamLiveWorker).to receive(:perform_async_in_queue)
+          .with("downstream_high", a_hash_including(:content_id))
+          .at_least(1).times
+        subject.call(Document.pluck(:content_id), queue: DownstreamQueue::HIGH_QUEUE)
+      end
+    end
   end
 end


### PR DESCRIPTION
This task allows us to resend items to the high priority queue.

I went for a syntax of `represent_downstream:high_priority:content_id`
as we couldn't use a second option in the content_id method and we don't
have a precedent in this app for using env vars for rake tasks. If
this needs extending to other represent_downstream tasks then it
probably makes sense to have some sort of global option for them, but I
don't really anticipate it as we really shouldn't be putting anything
more than the odd thing through the high priority queue.

This feature has been added in response to it being needed during a
period of publishing sensitive documents and it being done via the
console. This will instead allow it to be run through Jenkins.