### PR TITLE
Create a multi-column index on edition id and content_store

### DIFF
--- a/db/migrate/20180907102237_add_index_to_edition_id_and_content_store.rb
+++ b/db/migrate/20180907102237_add_index_to_edition_id_and_content_store.rb
@@ -1,0 +1,7 @@
+class AddIndexToEditionIdAndContentStore < ActiveRecord::Migration[5.1]
+  disable_ddl_transaction!
+
+  def change
+    add_index :editions, [:id, :content_store], algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180801195938) do
+ActiveRecord::Schema.define(version: 20180907102237) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -96,6 +96,7 @@ ActiveRecord::Schema.define(version: 20180801195938) do
     t.index ["document_id"], name: "index_editions_on_document_id"
     t.index ["document_type", "state"], name: "index_editions_on_document_type_and_state"
     t.index ["document_type", "updated_at"], name: "index_editions_on_document_type_and_updated_at"
+    t.index ["id", "content_store"], name: "index_editions_on_id_and_content_store"
     t.index ["publishing_app"], name: "index_editions_on_publishing_app"
     t.index ["state", "base_path"], name: "index_editions_on_state_and_base_path"
     t.index ["updated_at", "id"], name: "index_editions_on_updated_at_and_id"


### PR DESCRIPTION
There are quite a few examples of a query being run which uses both of these fields, for example:

```sql
SELECT  "editions"."id"
FROM "editions"
INNER JOIN "documents" ON "documents"."id" = "editions"."document_id"
WHERE "editions"."content_store" = 'live' AND ("editions"."id" > 1308589)
ORDER BY "editions"."id" ASC LIMIT 1000
```

I'm unable to find in the code where the query is coming from, but it is happening. It currently takes about 45 seconds to run from cold (a few seconds when run subsequently) because although there is an index on `content_store` it's not being used, instead the primary key index is used with a filter on the `content_store` field. By adding a multi-column index on both of those fields, it gets utilised in this query taking the speed down to under a second.

[Trello Card](https://trello.com/c/VztlS695/447-investigate-options-for-reducing-load-on-the-production-postgres-primary)