### PR TITLE
Enable redirects to the homepage.

### DIFF
--- a/app/validators/routes_and_redirects_validator.rb
+++ b/app/validators/routes_and_redirects_validator.rb
@@ -173,7 +173,7 @@ private
 
     def validate_internal_redirect(destination)
       errors << "internal redirects cannot end with /" if
-        destination.end_with? "/"
+        destination != "/" && (destination.end_with? "/")
     end
 
     def validate_external_redirect(destination)

--- a/spec/support/routes_and_redirects_validator.rb
+++ b/spec/support/routes_and_redirects_validator.rb
@@ -160,6 +160,17 @@ RSpec.shared_examples_for RoutesAndRedirectsValidator do
         ]
         expect(subject).to be_invalid
       end
+
+      it "is valid when it redirects to the homepage" do
+        edition.redirects = [
+            {
+                path: "#{subject.base_path}/foo",
+                type: "exact",
+                destination: "/"
+            }
+        ]
+        expect(subject).to be_valid
+      end
     end
 
     context "when destination is external url" do


### PR DESCRIPTION
The validation that an internal redirect is not allowed to end
with a '/' makes it hard to redirect content to the Gov.uk
homepage.

This change puts an exception to this rule if redirecting to '/'

Related to trello: https://trello.com/c/VERGP1FP/215-remove-and-redirect-policy-area-finder and https://trello.com/c/I3WFXlpg/219-remove-and-redirect-policy-finder