### PR TITLE
Update govuk_app_config to 1.9.1 and oj to 3.6.10

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ else
 end
 
 gem "gds-sso", "~> 13.6"
-gem "govuk_app_config", "~> 1.8"
+gem "govuk_app_config", "~> 1.9"
 gem "govuk_document_types", "~> 0.8.0"
 gem "govuk_schemas", "~> 3.2"
 gem "govuk_sidekiq", "~> 3.0"
@@ -40,10 +40,7 @@ group :development do
   gem "web-console", "~> 3"
 end
 
-# Lock to 2.18.3 because later patch versions are not listed in the oj changelog
-# and cause test failures.
-gem "oj", "2.18.3"
-gem "oj_mimic_json", "~> 1.0.1"
+gem "oj", "~> 3.0"
 
 group :development, :test do
   gem "database_cleaner"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -588,6 +588,8 @@ GEM
       aws-sigv4 (~> 1.0)
     aws-sigv2 (1.0.1)
     aws-sigv4 (1.0.2)
+    aws-xray-sdk (0.10.2)
+      oj (~> 3.0)
     bindex (0.5.0)
     builder (3.2.3)
     bunny (2.12.0)
@@ -656,7 +658,8 @@ GEM
       rubocop (~> 0.58)
       rubocop-rspec (~> 1.28)
       scss_lint
-    govuk_app_config (1.8.0)
+    govuk_app_config (1.9.1)
+      aws-xray-sdk (~> 0.10.0)
       logstasher (~> 1.2.2)
       sentry-raven (~> 2.7.1)
       statsd-ruby (~> 1.4.0)
@@ -725,8 +728,7 @@ GEM
       multi_json (~> 1.3)
       multi_xml (~> 0.5)
       rack (>= 1.2, < 3)
-    oj (2.18.3)
-    oj_mimic_json (1.0.1)
+    oj (3.6.10)
     omniauth (1.8.1)
       hashie (>= 3.4.6, < 3.6.0)
       rack (>= 1.6.2, < 3)
@@ -966,14 +968,13 @@ DEPENDENCIES
   govspeak (~> 5.6.0)
   govuk-content-schema-test-helpers (~> 1.6)
   govuk-lint
-  govuk_app_config (~> 1.8)
+  govuk_app_config (~> 1.9)
   govuk_document_types (~> 0.8.0)
   govuk_schemas (~> 3.2)
   govuk_sidekiq (~> 3.0)
   hashdiff (~> 0.3.6)
   json-schema
-  oj (= 2.18.3)
-  oj_mimic_json (~> 1.0.1)
+  oj (~> 3.0)
   pact
   pact_broker-client
   pg (~> 0.21.0)

--- a/app/presenters/queries/content_item_presenter.rb
+++ b/app/presenters/queries/content_item_presenter.rb
@@ -232,6 +232,7 @@ module Presenters
 
       def parse_json_column(result, column)
         return unless result.key?(column)
+        return if result[column].nil?
         result[column] = JSON.parse(result[column])
       end
 

--- a/config/initializers/oj.rb
+++ b/config/initializers/oj.rb
@@ -1,0 +1,1 @@
+Oj.optimize_rails

--- a/spec/controllers/v2/content_items_controller_spec.rb
+++ b/spec/controllers/v2/content_items_controller_spec.rb
@@ -447,18 +447,6 @@ RSpec.describe V2::ContentItemsController do
         expect(parsed_response_body["content_id"]).to eq(content_id)
       end
     end
-
-    context "with invalid request body" do
-      before do
-        request.env["CONTENT_TYPE"] = "application/json"
-        request.env["RAW_POST_DATA"] = ""
-        put :put_content, params: { content_id: content_id }
-      end
-
-      it "responds with 400" do
-        expect(response.status).to eq(400)
-      end
-    end
   end
 
   describe "publish" do


### PR DESCRIPTION
Dependabot can't automatically update govuk_app_config because the
version constraint on oj is too restrictive.

---

[Trello card](https://trello.com/c/hMj68z21/509-update-oj-gem-in-publishing-api)