### PR TITLE
Do not parse payload

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,7 +2,6 @@ class ApplicationController < ActionController::API
   include GDS::SSO::ControllerMethods
 
   rescue_from ActionController::ParameterMissing, with: :parameter_missing_error
-  rescue_from JSON::ParserError, with: :json_parse_error
   rescue_from CommandError, with: :respond_with_command_error
 
   before_action :authenticate_user!
@@ -24,17 +23,6 @@ private
     respond_with_command_error(error)
   end
 
-  def json_parse_error(e)
-    error = CommandError.new(code: 400, error_details: {
-      error: {
-        code: 400,
-        message: e.message
-      }
-    })
-
-    respond_with_command_error(error)
-  end
-
   def respond_with_command_error(error)
     error = error.cause unless error.is_a?(CommandError)
     render status: error.code, json: error
@@ -45,7 +33,7 @@ private
   end
 
   def payload
-    @payload ||= JSON.parse(request.body.read).deep_symbolize_keys
+    request.request_parameters.deep_symbolize_keys
   end
 
   def query_params

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ Rails.application.routes.draw do
     UuidValidator.valid?(request.params[:content_id])
   end
 
-  scope format: false do
+  scope format: false, defaults: { format: :json } do
     put "/publish-intent(/*base_path)", to: "publish_intents#create_or_update"
     get "/publish-intent(/*base_path)", to: "publish_intents#show"
     delete "/publish-intent(/*base_path)", to: "publish_intents#destroy"


### PR DESCRIPTION
As long as an appropriate content-type is sent, Rails will decode the
request body for us.  So by decoding it ourselves, we're doing this
twice!