### PR TITLE
Use Oj.load instead of JSON.parse

### DIFF
--- a/app/controllers/debug_controller.rb
+++ b/app/controllers/debug_controller.rb
@@ -11,7 +11,7 @@ class DebugController < ApplicationController
     }
 
     @mismatched_responses = mismatched_responses.map { |json|
-      parsed = JSON.parse(json)
+      parsed = Oj.load(json)
 
       missing, other = parsed.partition {|(operator, _, _)|
         operator == "-"

--- a/app/presenters/queries/content_item_presenter.rb
+++ b/app/presenters/queries/content_item_presenter.rb
@@ -233,7 +233,7 @@ module Presenters
       def parse_json_column(result, column)
         return unless result.key?(column)
         return if result[column].nil?
-        result[column] = JSON.parse(result[column])
+        result[column] = Oj.load(result[column])
       end
 
       def parse_int_column(result, column)

--- a/lib/events/s3_importer.rb
+++ b/lib/events/s3_importer.rb
@@ -36,7 +36,7 @@ module Events
     def attributes(row)
       json_fields = Event.columns.select { |e| e.type == :json }.map(&:name)
       json = row.each_with_object({}) do |(field, value), memo|
-        memo[field] = JSON.parse(value) if json_fields.include?(field)
+        memo[field] = Oj.load(value) if json_fields.include?(field)
       end
       row.to_hash.merge(json)
     end


### PR DESCRIPTION
It seems like oj, after the upgrasde, is no longer monkey-patching
JSON.parse.  Rather than try to get that working again, just be
explicit and call Oj.load directly.