### PR TITLE
Don't expand all organisation details

### DIFF
--- a/lib/expansion_rules.rb
+++ b/lib/expansion_rules.rb
@@ -52,6 +52,7 @@ module ExpansionRules
   ].freeze
 
   DEFAULT_FIELDS_WITH_DETAILS = (DEFAULT_FIELDS + [:details]).freeze
+  ORGANISATION_FIELDS = (DEFAULT_FIELDS + [[:details, :logo], [:details, :brand]]).freeze
 
   CUSTOM_EXPANSION_FIELDS = [
     { document_type: :redirect,                   fields: [] },
@@ -59,8 +60,8 @@ module ExpansionRules
     { document_type: :contact,                    fields: DEFAULT_FIELDS_WITH_DETAILS },
     { document_type: :topical_event,              fields: DEFAULT_FIELDS_WITH_DETAILS },
     { document_type: :placeholder_topical_event,  fields: DEFAULT_FIELDS_WITH_DETAILS },
-    { document_type: :organisation,               fields: DEFAULT_FIELDS_WITH_DETAILS },
-    { document_type: :placeholder_organisation,   fields: DEFAULT_FIELDS_WITH_DETAILS },
+    { document_type: :organisation,               fields: ORGANISATION_FIELDS },
+    { document_type: :placeholder_organisation,   fields: ORGANISATION_FIELDS },
     { document_type: :taxon,                      fields: DEFAULT_FIELDS_WITH_DETAILS + [:phase] },
     { document_type: :need,                       fields: DEFAULT_FIELDS_WITH_DETAILS },
     { document_type: :finder, link_type: :finder, fields: DEFAULT_FIELDS_WITH_DETAILS },

--- a/spec/lib/expansion_rules_spec.rb
+++ b/spec/lib/expansion_rules_spec.rb
@@ -41,6 +41,7 @@ RSpec.describe ExpansionRules do
   describe ".expansion_fields" do
     let(:default_fields) { rules::DEFAULT_FIELDS }
     let(:default_and_details_fields) { default_fields + [:details] }
+    let(:organisation_fields) { default_fields + [%i(details logo), %i(details brand)] }
 
     specify { expect(rules.expansion_fields(:redirect)).to eq([]) }
     specify { expect(rules.expansion_fields(:gone)).to eq([]) }
@@ -49,8 +50,8 @@ RSpec.describe ExpansionRules do
 
     specify { expect(rules.expansion_fields(:contact)).to eq(default_and_details_fields) }
     specify { expect(rules.expansion_fields(:need)).to eq(default_and_details_fields) }
-    specify { expect(rules.expansion_fields(:organisation)).to eq(default_and_details_fields) }
-    specify { expect(rules.expansion_fields(:placeholder_organisation)).to eq(default_and_details_fields) }
+    specify { expect(rules.expansion_fields(:organisation)).to eq(organisation_fields) }
+    specify { expect(rules.expansion_fields(:placeholder_organisation)).to eq(organisation_fields) }
     specify { expect(rules.expansion_fields(:placeholder_topical_event)).to eq(default_and_details_fields) }
     specify { expect(rules.expansion_fields(:step_by_step_nav)).to eq(default_and_details_fields) }
     specify { expect(rules.expansion_fields(:topical_event)).to eq(default_and_details_fields) }


### PR DESCRIPTION
I've identified that these fields are the only ones being used, so we don't need to present the entire details hash.

We should limit the number of fields being included in link expansion to reduce the size of content items being presented.

If we were to make dependency resolution work on second level fields, this would also help to reduce the amount of activity that happens when organisations change as there would be a limited number of fields which when changed cause updates to the dependencies.