### PR TITLE
Expand subfields with the same nesting as the input

### DIFF
--- a/lib/expansion_rules.rb
+++ b/lib/expansion_rules.rb
@@ -131,10 +131,27 @@ module ExpansionRules
     end
   end
 
+  module HashWithDigSet
+    refine Hash do
+      def dig_set(keys, value)
+        keys.each_with_index.inject(self) do |hash, (key, index)|
+          if keys.count - 1 == index
+            hash[key] = value
+          else
+            hash[key] ||= {}
+          end
+        end
+      end
+    end
+  end
+
+  using HashWithDigSet
+
   def expand_fields(edition_hash, link_type)
     expansion_fields(edition_hash[:document_type], link_type).each_with_object({}) do |field, expanded|
       field = Array(field)
-      expanded[field.last] = edition_hash.dig(*field)
+      # equivelant to: expanded.dig(*field) = edition_hash.dig(*field)
+      expanded.dig_set(field, edition_hash.dig(*field))
     end
   end
 

--- a/spec/lib/expansion_rules_spec.rb
+++ b/spec/lib/expansion_rules_spec.rb
@@ -217,4 +217,38 @@ RSpec.describe ExpansionRules do
       end
     end
   end
+
+  describe ".expand_fields" do
+    context "with a format that expands subfields of the details hash" do
+      let(:edition_hash) do
+        {
+          document_type: "travel_advice",
+          details: {
+            country: "fr",
+            other_field: "test",
+          }
+        }
+      end
+
+      it "expands into a new details hash" do
+        expect(described_class.expand_fields(edition_hash, nil)).to eq(
+          document_type: "travel_advice",
+          details: {
+            country: "fr",
+            change_description: nil,
+          },
+          analytics_identifier: nil,
+          api_path: nil,
+          base_path: nil,
+          content_id: nil,
+          description: nil,
+          locale: nil,
+          public_updated_at: nil,
+          schema_name: nil,
+          title: nil,
+          withdrawn: nil,
+        )
+      end
+    end
+  end
 end


### PR DESCRIPTION
It was surprising to me to learn that when specifying specific subfields to expand during link expansion, only the last part of key is used in the output. This means for a travel advice with a details field of `country`, it would appear in the link expansion output under the root (not within a `details` hash).

This makes it harder to migrate formats that are currently presenting the entire details hash as they expect the fields to be inside a details hash.

Luckily, there are currently no links to the only document type using subfields (`travel_advice`) so I think we can probably get away with making this breaking change fairly easily:

```
irb(main):011:0> Link.where(target_content_id: Edition.where(document_type: 'travel_advice').joins(:document).pluck(:"documents.content_id")).count
=> 0
```

This is also required to do #1349 without modifying all the frontend apps.