### PR TITLE
 Compare link expansion version of editions during edition diffing 

### DIFF
--- a/app/commands/v2/publish.rb
+++ b/app/commands/v2/publish.rb
@@ -193,7 +193,7 @@ module Commands
       end
 
       def update_dependencies?
-        EditionDiff.new(edition).field_diff.present?
+        LinkExpansion::EditionDiff.new(edition).should_update_dependencies?
       end
 
       def send_downstream_live

--- a/app/commands/v2/put_content.rb
+++ b/app/commands/v2/put_content.rb
@@ -154,7 +154,7 @@ module Commands
       end
 
       def update_dependencies?(edition)
-        EditionDiff.new(edition, previous_edition: @previous_edition).field_diff.present?
+        LinkExpansion::EditionDiff.new(edition, previous_edition: @previous_edition).should_update_dependencies?
       end
 
       def send_downstream(content_id, locale, update_dependencies, orphaned_links)

--- a/lib/expansion_rules.rb
+++ b/lib/expansion_rules.rb
@@ -126,12 +126,6 @@ module ExpansionRules
       DEFAULT_FIELDS
   end
 
-  def potential_expansion_fields(document_type)
-    (find_custom_expansion_fields(document_type) || DEFAULT_FIELDS).map do |field|
-      Array(field).first
-    end
-  end
-
   module HashWithDigSet
     refine Hash do
       def dig_set(keys, value)

--- a/lib/expansion_rules.rb
+++ b/lib/expansion_rules.rb
@@ -111,7 +111,7 @@ module ExpansionRules
   end
 
   def find_custom_expansion_fields(document_type, options = {})
-    should_check_link_type = options.include?(:link_type)
+    should_check_link_type = options[:link_type]
     link_type = options[:link_type].try(:to_sym)
 
     condition = CUSTOM_EXPANSION_FIELDS.find do |cond|

--- a/lib/link_expansion/edition_diff.rb
+++ b/lib/link_expansion/edition_diff.rb
@@ -8,8 +8,7 @@ class LinkExpansion::EditionDiff
   end
 
   def field_diff
-    ExpansionRules.potential_expansion_fields(current_edition.document_type) &
-      diff.map(&:first)
+    link_expansion_fields & diff.map(&:first)
   end
 
   def should_update_dependencies?
@@ -18,15 +17,28 @@ class LinkExpansion::EditionDiff
 
 private
 
+  def link_expansion_fields
+    ExpansionRules.potential_expansion_fields(current_edition.document_type)
+  end
+
   def diff
     hash_diff(
-      previous_edition.to_h.deep_symbolize_keys,
-      current_edition.to_h.deep_symbolize_keys
+      previous_edition_expanded,
+      current_edition_expanded
     )
   end
 
   def hash_diff(a, b) # rubocop:disable Naming/UncommunicativeMethodParamName
     a.size > b.size ? a.to_a - b.to_a : b.to_a - a.to_a
+  end
+
+  def previous_edition_expanded
+    return {} if previous_edition.blank?
+    ExpansionRules.expand_fields(previous_edition.to_h.deep_symbolize_keys, nil)
+  end
+
+  def current_edition_expanded
+    ExpansionRules.expand_fields(current_edition.to_h.deep_symbolize_keys, nil)
   end
 
   def previous_edition

--- a/lib/link_expansion/edition_diff.rb
+++ b/lib/link_expansion/edition_diff.rb
@@ -7,19 +7,11 @@ class LinkExpansion::EditionDiff
     @version = version
   end
 
-  def field_diff
-    link_expansion_fields & diff.map(&:first)
-  end
-
   def should_update_dependencies?
-    field_diff.present?
+    diff.present?
   end
 
 private
-
-  def link_expansion_fields
-    ExpansionRules.potential_expansion_fields(current_edition.document_type)
-  end
 
   def diff
     hash_diff(

--- a/lib/link_expansion/edition_diff.rb
+++ b/lib/link_expansion/edition_diff.rb
@@ -1,4 +1,4 @@
-class EditionDiff
+class LinkExpansion::EditionDiff
   attr_reader :current_edition, :version
 
   def initialize(current_edition, version: nil, previous_edition: nil)
@@ -12,6 +12,10 @@ class EditionDiff
       diff.map(&:first)
   end
 
+  def should_update_dependencies?
+    field_diff.present?
+  end
+
 private
 
   def diff
@@ -21,8 +25,8 @@ private
     )
   end
 
-  def hash_diff(left, right)
-    left.size > right.size ? left.to_a - right.to_a : right.to_a - left.to_a
+  def hash_diff(a, b) # rubocop:disable Naming/UncommunicativeMethodParamName
+    a.size > b.size ? a.to_a - b.to_a : b.to_a - a.to_a
   end
 
   def previous_edition

--- a/spec/lib/link_expansion/edition_diff_spec.rb
+++ b/spec/lib/link_expansion/edition_diff_spec.rb
@@ -63,6 +63,52 @@ RSpec.describe LinkExpansion::EditionDiff do
     end
   end
 
+  context "diff inside details hash" do
+    let!(:previous_edition) do
+      create(
+        :superseded_edition,
+        document: document,
+        document_type: "travel_advice",
+        base_path: "/foo",
+        details: { country: "en" },
+      )
+    end
+
+    context "with a field that matters" do
+      let!(:current_edition) do
+        create(
+          :live_edition,
+          document: document,
+          user_facing_version: 2,
+          document_type: "travel_advice",
+          base_path: "/foo",
+          details: { country: "fr" },
+        )
+      end
+
+      it "includes the subfield in the diff" do
+        expect(subject.field_diff).to include(:details)
+      end
+    end
+
+    context "with a field that doesn't matter" do
+      let!(:current_edition) do
+        create(
+          :live_edition,
+          document: document,
+          user_facing_version: 2,
+          document_type: "travel_advice",
+          base_path: "/foo",
+          details: { country: "en", unrelated_field: "en" },
+        )
+      end
+
+      it "includes the subfield in the diff" do
+        expect(subject.field_diff).to be_empty
+      end
+    end
+  end
+
   context "multiple versions" do
     it "compares between the previous version" do
       current_edition.supersede

--- a/spec/lib/link_expansion/edition_diff_spec.rb
+++ b/spec/lib/link_expansion/edition_diff_spec.rb
@@ -23,10 +23,20 @@ RSpec.describe LinkExpansion::EditionDiff do
 
   subject { described_class.new(current_edition) }
 
-  context "diff in title" do
-    it "returns the diff between two versions" do
-      expect(subject.field_diff).to eq([:title])
+  shared_examples "should update dependencies" do
+    it "should update dependencies" do
+      expect(subject.should_update_dependencies?).to eq(true)
     end
+  end
+
+  shared_examples "shouldn't update dependencies" do
+    it "shouldn't update dependencies" do
+      expect(subject.should_update_dependencies?).to eq(false)
+    end
+  end
+
+  context "diff in title" do
+    include_examples "should update dependencies"
   end
 
   context "diff in title, document_type and base_path" do
@@ -41,9 +51,7 @@ RSpec.describe LinkExpansion::EditionDiff do
       )
     end
 
-    it "returns the diff between two versions" do
-      expect(subject.field_diff).to include(:base_path, :title, :document_type)
-    end
+    include_examples "should update dependencies"
   end
 
   context "diff in details when a finder" do
@@ -58,9 +66,7 @@ RSpec.describe LinkExpansion::EditionDiff do
       )
     end
 
-    it "returns the diff between two versions" do
-      expect(subject.field_diff).to include(:details, :document_type)
-    end
+    include_examples "should update dependencies"
   end
 
   context "diff inside details hash" do
@@ -86,9 +92,7 @@ RSpec.describe LinkExpansion::EditionDiff do
         )
       end
 
-      it "includes the subfield in the diff" do
-        expect(subject.field_diff).to include(:details)
-      end
+      include_examples "should update dependencies"
     end
 
     context "with a field that doesn't matter" do
@@ -103,47 +107,31 @@ RSpec.describe LinkExpansion::EditionDiff do
         )
       end
 
-      it "includes the subfield in the diff" do
-        expect(subject.field_diff).to be_empty
-      end
+      include_examples "shouldn't update dependencies"
     end
   end
 
   context "multiple versions" do
-    it "compares between the previous version" do
-      current_edition.supersede
-      expect(described_class.new(new_draft_edition).field_diff).to eq([])
-    end
+    before { current_edition.supersede }
+    subject { described_class.new(new_draft_edition) }
+    include_examples "shouldn't update dependencies"
   end
 
   context "no previous item" do
     let!(:previous_edition) { nil }
-    it "returns the diff between two versions" do
-      expect(subject.field_diff).to include(:base_path, :title, :document_type)
-    end
+    include_examples "should update dependencies"
   end
 
   context "provide the edition to compare" do
-    it "compares the two given editions" do
-      expect(
-        described_class.new(
-          new_draft_edition,
-          previous_edition: {},
-        ).field_diff
-      ).to include(:document_type, :title)
+    context "given an empty hash" do
+      subject { described_class.new(new_draft_edition, previous_edition: {}) }
+      include_examples "should update dependencies"
     end
 
-    let(:presented_item) do
-      new_draft_edition.to_h.deep_stringify_keys
-    end
-
-    it "compares the two given editions" do
-      expect(
-        described_class.new(
-          new_draft_edition,
-          previous_edition: presented_item,
-        ).field_diff
-      ).to eq([])
+    context "given an edition" do
+      let(:presented_item) { new_draft_edition.to_h.deep_stringify_keys }
+      subject { described_class.new(new_draft_edition, previous_edition: presented_item) }
+      include_examples "shouldn't update dependencies"
     end
   end
 end

--- a/spec/lib/link_expansion/edition_diff_spec.rb
+++ b/spec/lib/link_expansion/edition_diff_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe EditionDiff do
+RSpec.describe LinkExpansion::EditionDiff do
   let(:content_id) { SecureRandom.uuid }
   let(:document) { create(:document, content_id: content_id) }
 
@@ -80,8 +80,10 @@ RSpec.describe EditionDiff do
   context "provide the edition to compare" do
     it "compares the two given editions" do
       expect(
-        EditionDiff.new(new_draft_edition,
-                        previous_edition: {}).field_diff
+        described_class.new(
+          new_draft_edition,
+          previous_edition: {},
+        ).field_diff
       ).to include(:document_type, :title)
     end
 
@@ -91,8 +93,10 @@ RSpec.describe EditionDiff do
 
     it "compares the two given editions" do
       expect(
-        EditionDiff.new(new_draft_edition,
-                        previous_edition: presented_item).field_diff
+        described_class.new(
+          new_draft_edition,
+          previous_edition: presented_item,
+        ).field_diff
       ).to eq([])
     end
   end


### PR DESCRIPTION
Edition diffing is used to work out whether an update to an item should trigger dependency resolution. At the moment it works by diffing the entire hash of the edition and and then comparing whether the fields that changed might be exposed during link expansion. However, it only works on the first level. This means that if any field deeply nested in the `details` hash has changed regardless of whether it would ever get exposed in link expansion (for example in the case of organisations where [we only expose `details.logo` and `details.brand`](https://github.com/alphagov/publishing-api/blob/master/lib/expansion_rules.rb#L63)), we would detect that as a change to the edition and perform dependency resolution.

This PR changes that logic by first presenting the edition into what it would look like as part of link expansion before doing the process of diffing the hashes.

This should mean that we avoid performing dependency resolution on editions where no relevant fields have changed. I think it will make the queue sizes lower and content will move through the system faster.

This builds on the work in #1351 and combined with https://github.com/alphagov/publishing-api/pull/1349 I'm hopeful that it will reduce the problem we have at the moment related to organisation links.

[Trello Card](https://trello.com/c/EPXyTyeP/520-reduce-number-of-fields-in-organisation-links)