### PR TITLE
Bump govuk_app_config to 1.10.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -658,7 +658,7 @@ GEM
       rubocop (~> 0.58)
       rubocop-rspec (~> 1.28)
       scss_lint
-    govuk_app_config (1.9.3)
+    govuk_app_config (1.10.0)
       aws-xray-sdk (~> 0.10.0)
       logstasher (~> 1.2.2)
       sentry-raven (~> 2.7.1)


### PR DESCRIPTION
Don't wait for dependabot because this is using a lot of memory right
now.