### PR TITLE
Make explicit the expanded fields for contacts

### DIFF
--- a/lib/expansion_rules.rb
+++ b/lib/expansion_rules.rb
@@ -11,6 +11,10 @@ module ExpansionRules
 
   using RecurringLinks
 
+  def details_fields(*fields)
+    fields.map { |field| [:details, field] }
+  end
+
   MULTI_LEVEL_LINK_PATHS = [
     [:associated_taxons.recurring],
     [:child_taxons, :associated_taxons.recurring],
@@ -52,12 +56,12 @@ module ExpansionRules
   ].freeze
 
   DEFAULT_FIELDS_WITH_DETAILS = (DEFAULT_FIELDS + [:details]).freeze
-  ORGANISATION_FIELDS = (DEFAULT_FIELDS + [[:details, :logo], [:details, :brand]]).freeze
+  ORGANISATION_FIELDS = (DEFAULT_FIELDS + details_fields(:logo, :brand)).freeze
 
   CUSTOM_EXPANSION_FIELDS = [
     { document_type: :redirect,                   fields: [] },
     { document_type: :gone,                       fields: [] },
-    { document_type: :contact,                    fields: DEFAULT_FIELDS + [%i(details description), %i(details title), %i(details contact_form_links), %i(details post_addresses), %i(details email_addresses), %i(details phone_numbers)] },
+    { document_type: :contact,                    fields: (DEFAULT_FIELDS + details_fields(:description, :title, :contact_form_links, :post_addresses, :email_addresses, :phone_numbers)) },
     { document_type: :topical_event,              fields: DEFAULT_FIELDS_WITH_DETAILS },
     { document_type: :placeholder_topical_event,  fields: DEFAULT_FIELDS_WITH_DETAILS },
     { document_type: :organisation,               fields: ORGANISATION_FIELDS },
@@ -66,7 +70,7 @@ module ExpansionRules
     { document_type: :need,                       fields: DEFAULT_FIELDS_WITH_DETAILS },
     { document_type: :finder, link_type: :finder, fields: DEFAULT_FIELDS_WITH_DETAILS },
     { document_type: :step_by_step_nav,           fields: DEFAULT_FIELDS_WITH_DETAILS },
-    { document_type: :travel_advice,              fields: DEFAULT_FIELDS + [[:details, :country], [:details, :change_description]] },
+    { document_type: :travel_advice,              fields: (DEFAULT_FIELDS + details_fields(:country, :change_description)) },
     { document_type: :world_location,             fields: [:content_id, :title, :schema_name, :locale, :analytics_identifier] },
   ].freeze
 

--- a/lib/expansion_rules.rb
+++ b/lib/expansion_rules.rb
@@ -57,7 +57,7 @@ module ExpansionRules
   CUSTOM_EXPANSION_FIELDS = [
     { document_type: :redirect,                   fields: [] },
     { document_type: :gone,                       fields: [] },
-    { document_type: :contact,                    fields: DEFAULT_FIELDS + [%i(details description), %i(details contact_type), %i(details title), %i(details contact_form_links), %i(details post_addresses), %i(details email_addresses), %i(details phone_numbers)] },
+    { document_type: :contact,                    fields: DEFAULT_FIELDS + [%i(details description), %i(details title), %i(details contact_form_links), %i(details post_addresses), %i(details email_addresses), %i(details phone_numbers)] },
     { document_type: :topical_event,              fields: DEFAULT_FIELDS_WITH_DETAILS },
     { document_type: :placeholder_topical_event,  fields: DEFAULT_FIELDS_WITH_DETAILS },
     { document_type: :organisation,               fields: ORGANISATION_FIELDS },

--- a/lib/expansion_rules.rb
+++ b/lib/expansion_rules.rb
@@ -57,7 +57,7 @@ module ExpansionRules
   CUSTOM_EXPANSION_FIELDS = [
     { document_type: :redirect,                   fields: [] },
     { document_type: :gone,                       fields: [] },
-    { document_type: :contact,                    fields: DEFAULT_FIELDS_WITH_DETAILS },
+    { document_type: :contact,                    fields: DEFAULT_FIELDS + [%i(details description), %i(details contact_type), %i(details title), %i(details contact_form_links), %i(details post_addresses), %i(details email_addresses), %i(details phone_numbers)] },
     { document_type: :topical_event,              fields: DEFAULT_FIELDS_WITH_DETAILS },
     { document_type: :placeholder_topical_event,  fields: DEFAULT_FIELDS_WITH_DETAILS },
     { document_type: :organisation,               fields: ORGANISATION_FIELDS },

--- a/spec/lib/expansion_rules_spec.rb
+++ b/spec/lib/expansion_rules_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe ExpansionRules do
 
     specify { expect(rules.expansion_fields(:parent)).to eq(default_fields) }
 
-    specify { expect(rules.expansion_fields(:contact)).to eq(default_and_details_fields) }
+    specify { expect(rules.expansion_fields(:contact)).to eq(default_fields + [%i(details description), %i(details contact_type), %i(details title), %i(details contact_form_links), %i(details post_addresses), %i(details email_addresses), %i(details phone_numbers)]) }
     specify { expect(rules.expansion_fields(:need)).to eq(default_and_details_fields) }
     specify { expect(rules.expansion_fields(:organisation)).to eq(organisation_fields) }
     specify { expect(rules.expansion_fields(:placeholder_organisation)).to eq(organisation_fields) }

--- a/spec/lib/expansion_rules_spec.rb
+++ b/spec/lib/expansion_rules_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe ExpansionRules do
 
     specify { expect(rules.expansion_fields(:parent)).to eq(default_fields) }
 
-    specify { expect(rules.expansion_fields(:contact)).to eq(default_fields + [%i(details description), %i(details contact_type), %i(details title), %i(details contact_form_links), %i(details post_addresses), %i(details email_addresses), %i(details phone_numbers)]) }
+    specify { expect(rules.expansion_fields(:contact)).to eq(default_fields + [%i(details description), %i(details title), %i(details contact_form_links), %i(details post_addresses), %i(details email_addresses), %i(details phone_numbers)]) }
     specify { expect(rules.expansion_fields(:need)).to eq(default_and_details_fields) }
     specify { expect(rules.expansion_fields(:organisation)).to eq(organisation_fields) }
     specify { expect(rules.expansion_fields(:placeholder_organisation)).to eq(organisation_fields) }


### PR DESCRIPTION
To do: try deploying this to staging and republishing all content, see if it breaks.

---

[Trello card](https://trello.com/c/fQsHSPBt/574-do-not-expand-unnecessary-links-for-contact)