### PR TITLE
Don't include public_updated_at in organisation links

### DIFF
--- a/lib/expansion_rules.rb
+++ b/lib/expansion_rules.rb
@@ -56,7 +56,7 @@ module ExpansionRules
   ].freeze
 
   DEFAULT_FIELDS_WITH_DETAILS = (DEFAULT_FIELDS + [:details]).freeze
-  ORGANISATION_FIELDS = (DEFAULT_FIELDS + details_fields(:logo, :brand)).freeze
+  ORGANISATION_FIELDS = (DEFAULT_FIELDS - [:public_updated_at] + details_fields(:logo, :brand)).freeze
   FINDER_FIELDS = (DEFAULT_FIELDS + details_fields(:facets)).freeze
   NEED_FIELDS = (DEFAULT_FIELDS + details_fields(:role, :goal, :benefit, :met_when, :justifications)).freeze
 

--- a/spec/lib/expansion_rules_spec.rb
+++ b/spec/lib/expansion_rules_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe ExpansionRules do
   describe ".expansion_fields" do
     let(:default_fields) { rules::DEFAULT_FIELDS }
     let(:default_and_details_fields) { default_fields + [:details] }
-    let(:organisation_fields) { default_fields + [%i(details logo), %i(details brand)] }
+    let(:organisation_fields) { default_fields - [:public_updated_at] + [%i(details logo), %i(details brand)] }
     let(:finder_fields) { default_fields + [%i(details facets)] }
     let(:need_fields) { default_fields + [%i(details role), %i(details goal), %i(details benefit), %i(details met_when), %i(details justifications)] }
 


### PR DESCRIPTION
When organisations are published in Whitehall, they are always updated as a major update. This means that the `public_updated_at` field gets updated every time meaning dependency resolution and link expansion is always happening.

I don't think this field is being used anywhere so I think we can probably drop it.