### PR TITLE
Don't expand all finder details

### DIFF
--- a/lib/expansion_rules.rb
+++ b/lib/expansion_rules.rb
@@ -57,6 +57,7 @@ module ExpansionRules
 
   DEFAULT_FIELDS_WITH_DETAILS = (DEFAULT_FIELDS + [:details]).freeze
   ORGANISATION_FIELDS = (DEFAULT_FIELDS + details_fields(:logo, :brand)).freeze
+  FINDER_FIELDS = (DEFAULT_FIELDS + details_fields(:facets)).freeze
 
   CUSTOM_EXPANSION_FIELDS = [
     { document_type: :redirect,                   fields: [] },
@@ -68,7 +69,7 @@ module ExpansionRules
     { document_type: :placeholder_organisation,   fields: ORGANISATION_FIELDS },
     { document_type: :taxon,                      fields: DEFAULT_FIELDS_WITH_DETAILS + [:phase] },
     { document_type: :need,                       fields: DEFAULT_FIELDS_WITH_DETAILS },
-    { document_type: :finder, link_type: :finder, fields: DEFAULT_FIELDS_WITH_DETAILS },
+    { document_type: :finder, link_type: :finder, fields: FINDER_FIELDS },
     { document_type: :step_by_step_nav,           fields: DEFAULT_FIELDS_WITH_DETAILS },
     { document_type: :travel_advice,              fields: (DEFAULT_FIELDS + details_fields(:country, :change_description)) },
     { document_type: :world_location,             fields: [:content_id, :title, :schema_name, :locale, :analytics_identifier] },

--- a/spec/lib/expansion_rules_spec.rb
+++ b/spec/lib/expansion_rules_spec.rb
@@ -42,6 +42,7 @@ RSpec.describe ExpansionRules do
     let(:default_fields) { rules::DEFAULT_FIELDS }
     let(:default_and_details_fields) { default_fields + [:details] }
     let(:organisation_fields) { default_fields + [%i(details logo), %i(details brand)] }
+    let(:finder_fields) { default_fields + [%i(details facets)] }
 
     specify { expect(rules.expansion_fields(:redirect)).to eq([]) }
     specify { expect(rules.expansion_fields(:gone)).to eq([]) }
@@ -60,7 +61,7 @@ RSpec.describe ExpansionRules do
     specify { expect(rules.expansion_fields(:travel_advice)).to eq(default_fields + [%i(details country), %i(details change_description)]) }
     specify { expect(rules.expansion_fields(:world_location)).to eq(%i(content_id title schema_name locale analytics_identifier)) }
 
-    specify { expect(rules.expansion_fields(:finder, :finder)).to eq(default_and_details_fields) }
+    specify { expect(rules.expansion_fields(:finder, :finder)).to eq(finder_fields) }
     specify { expect(rules.expansion_fields(:parent, :finder)).to eq(default_fields) }
   end
 


### PR DESCRIPTION
It appears that only one field is being used from the `details` hash for `finder` links.

We are aiming to reduce the number of fields included in link expansion so that the payload size is smaller, and we are only including the ones we actually need.

Trello card: https://trello.com/c/HHBxFrJr/612-do-not-expand-unnecessary-links-for-finder