### PR TITLE
Option to include links with edition endpoint

### DIFF
--- a/app/presenters/keyset_pagination_presenter.rb
+++ b/app/presenters/keyset_pagination_presenter.rb
@@ -1,7 +1,7 @@
 module Presenters
   class KeysetPaginationPresenter
     def initialize(pagination_query, request_url)
-      @results = pagination_query.call
+      @results = pagination_query.results
       @pagination_query = pagination_query
       @request_url = request_url.to_s
     end

--- a/app/queries/links_for_edition_ids.rb
+++ b/app/queries/links_for_edition_ids.rb
@@ -1,0 +1,56 @@
+module Queries
+  class LinksForEditionIds
+    attr_reader :edition_ids
+
+    def initialize(edition_ids)
+      @edition_ids = edition_ids
+    end
+
+    def merged_links
+      @merged_links ||= begin
+                          keys = (edition_links.keys + link_set_links.keys).uniq
+                          keys.each_with_object(Hash.new({})) do |id, memo|
+                            memo[id] = link_set_links[id].merge(edition_links[id])
+                          end
+                        end
+    end
+
+    def edition_links
+      @edition_links ||= group_by_edition_id_and_link_type(query_edition_links)
+    end
+
+    def link_set_links
+      @link_set_links ||= group_by_edition_id_and_link_type(query_link_set_links)
+    end
+
+  private
+
+    def query_edition_links
+      Link
+        .where(edition_id: edition_ids)
+        .order(:edition_id, :link_type, :position)
+        .pluck(:edition_id, :link_type, :target_content_id)
+    end
+
+    def query_link_set_links
+      Link
+        .joins(:link_set)
+        .joins("INNER JOIN documents ON documents.content_id = link_sets.content_id")
+        .joins("INNER JOIN editions ON editions.document_id = documents.id")
+        .where("editions.id": edition_ids)
+        .order("editions.id", :link_type, :position)
+        .pluck("editions.id", :link_type, :target_content_id)
+    end
+
+    def group_by_edition_id_and_link_type(links)
+      hash = links.group_by(&:first)
+      hash.default = {}
+      hash.transform_values! do |value|
+        value.each_with_object({}) do |(_, type, content_id), memo|
+          memo[type] ||= []
+          memo[type] << content_id
+        end
+      end
+    end
+  end
+end

--- a/doc/api.md
+++ b/doc/api.md
@@ -611,7 +611,7 @@ parameters.
     first_published_at, last_edited_at, phase, public_updated_at,
     publishing_app, redirects, rendering_app, routes, schema_name,
     state, title, user_facing_version, update_type, state, content_id,
-    locale, stale_lock_version, updated_at, created_at
+    locale, stale_lock_version, updated_at, created_at, links
   - Determines which fields will be returned in the response, if omitted all
     fields will be returned.
 - `locale` *(optional)*
@@ -621,7 +621,7 @@ parameters.
   - The field to sort the results by.
   - Returned in an ascending order unless prefixed with a hyphen, e.g.
     "-created_at".
-  - Accepts fields of: updated_at, public_updated_at, created_at
+  - Accepts fields of: updated_at, public_updated_at, created_at, id
 - `before` and `after` *(optional)*
   - The pagination key of the previous page to pagination before or after.
   - Usually, you do not need to work this out manually, since it will be given

--- a/spec/controllers/v2/editions_controller_spec.rb
+++ b/spec/controllers/v2/editions_controller_spec.rb
@@ -186,5 +186,25 @@ RSpec.describe V2::EditionsController do
         ])
       end
     end
+
+    context "when there are links" do
+      let!(:link) do
+        create(:link, edition_id: Edition.first.id, link_set: nil, link_type: "test")
+      end
+
+      it "can include links in response" do
+        get :index, params: { fields: %w(content_id links), per_page: 1, order: "id" }
+        expect(parsed_response["results"].first.keys)
+          .to eq(%w(content_id links))
+        expect(parsed_response["results"].first["links"]).to match(
+          "test" => [link.target_content_id]
+        )
+      end
+
+      it "doesn't include links by default" do
+        get :index
+        expect(parsed_response["results"].first.keys).not_to include("links")
+      end
+    end
   end
 end

--- a/spec/queries/links_for_edition_ids_spec.rb
+++ b/spec/queries/links_for_edition_ids_spec.rb
@@ -1,0 +1,113 @@
+require "rails_helper"
+
+RSpec.describe Queries::LinksForEditionIds do
+  def create_edition_link(edition, link_type)
+    create(:link, edition_id: edition.id, link_set: nil, link_type: link_type)
+  end
+
+  def create_link_set_link(edition, link_type)
+    link_set = LinkSet.find_or_create_by(content_id: edition.document.content_id)
+    create(:link, edition_id: nil, link_set: link_set, link_type: link_type)
+  end
+
+  let(:edition) { create(:edition) }
+  let(:edition_ids) { [edition.id] }
+
+  describe "#merged_links" do
+    subject(:merged_links) { described_class.new(edition_ids).merged_links }
+
+    context "when there are no links" do
+      it { is_expected.to be_empty }
+    end
+
+    context "when there are differing edition links and link set links" do
+      let!(:edition_link) { create_edition_link(edition, "edition") }
+      let!(:link_set_link) { create_link_set_link(edition, "link_set") }
+
+      it "merges the links together" do
+        expect(merged_links).to match(
+          edition.id => {
+            "edition" => [edition_link.target_content_id],
+            "link_set" => [link_set_link.target_content_id],
+          }
+        )
+      end
+    end
+
+    context "when there are the same link type for edition and link set links" do
+      let!(:edition_link) { create_edition_link(edition, "same") }
+      let!(:link_set_link) { create_link_set_link(edition, "same") }
+
+      it "only returns the edition links" do
+        expect(merged_links).to match(
+          edition.id => { "same" => [edition_link.target_content_id] }
+        )
+      end
+    end
+
+    context "when an edition has multiple links of the same type" do
+      let!(:link_1) { create_edition_link(edition, "same") }
+      let!(:link_2) { create_edition_link(edition, "same") }
+
+      it "returns all the links" do
+        expect(merged_links).to match(
+          edition.id => { "same" => [link_1.target_content_id, link_2.target_content_id] }
+        )
+      end
+    end
+
+    context "when there are links for multiple editions" do
+      let(:edition_1) { create(:edition) }
+      let(:edition_2) { create(:edition) }
+      let(:edition_ids) { [edition_1.id, edition_2.id] }
+
+      let!(:link_1) { create_edition_link(edition_1, "link") }
+      let!(:link_2) { create_edition_link(edition_2, "link") }
+
+      it "returns links for each edition" do
+        expect(merged_links).to match(
+          edition_1.id => { "link" => [link_1.target_content_id] },
+          edition_2.id => { "link" => [link_2.target_content_id] },
+        )
+      end
+    end
+  end
+
+  describe "#edition_links" do
+    subject(:edition_links) { described_class.new(edition_ids).edition_links }
+
+    context "when there are no links" do
+      it { is_expected.to be_empty }
+    end
+
+    context "when there are edition links and link set links" do
+      let!(:edition_link) { create_edition_link(edition, "edition") }
+      let!(:link_set_link) { create_link_set_link(edition, "link_set") }
+
+      it "only returns the edition links" do
+        expect(edition_links).to match(
+          edition.id => { "edition" => [edition_link.target_content_id] }
+        )
+      end
+    end
+  end
+
+  describe "#link_set_links" do
+    subject(:link_set_links) { described_class.new(edition_ids).link_set_links }
+
+    context "when there are no links" do
+      it { is_expected.to be_empty }
+    end
+
+    context "when there are edition links and link set links" do
+      let!(:edition_link) { create_edition_link(edition, "edition") }
+      let!(:link_set_link) { create_link_set_link(edition, "link_set") }
+
+      it "only returns the link set links" do
+        expect(link_set_links).to match(
+          edition.id => { "link_set" => [link_set_link.target_content_id] }
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
Trello: https://trello.com/c/a80pDKyV/412-browse-and-insert-a-contact-into-markdown

This is flagged as a WIP as I don't want to merge it in until I'm happy it solves our Content Publisher problem (which is associating contacts with organisations). I may also add some more tests as there doesn't seem to be much for keyset pagination classes.

It can be very difficult to traverse through a collection of data from the Publishing API when you want to have information on links it is associated. This PR amends the edition endpoint so that links can be returned as part of the result. 

It does this by adding a post_pagination hook as part of keyset pagination to allow you to do a query based on the paginated block of data.

More details in individual commits.

