### PR TITLE
Update the public_updated_at documentation

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -130,12 +130,11 @@ presented edition and [warnings](#warnings).
   - Accepts: "alpha", "beta", "live"
 - `previous_version` *(optional, recommended)*
   - Used to ensure that the most recent version of the draft is being updated.
-- `public_updated_at` *(conditionally required)*
-  - Required if `document_type` is not "contact" or "government" and
-    `update_type` is "major".
+- `public_updated_at` *(optional)*
+  - Used to override the `public_updated_at` value that would be set by the
+    Publishing API.
   - An [RFC 3339][rfc-3339] formatted timestamp should be provided, although
     [other formats][to-time-docs] may be accepted.
-  - The publicly shown date that this edition was last edited at.
 - `publishing_app` *(required)*
   - The hostname for the publishing application that has sent this content.
 - `redirects` *(conditionally required)*


### PR DESCRIPTION
I don't think it's conditionally required by the Publishing API, at
least not any more. It's now only useful to set this value if you want
to override the value the Publishing API will set when the content is
published.