### PR TITLE
Remove the last few need_ids references

### DIFF
--- a/app/presenters/edition_presenter.rb
+++ b/app/presenters/edition_presenter.rb
@@ -9,7 +9,6 @@ module Presenters
       id
       last_edited_at
       major_published_at
-      need_ids
       published_at
       publisher_first_published_at
       publisher_major_published_at

--- a/doc/api.md
+++ b/doc/api.md
@@ -124,8 +124,6 @@ presented edition and [warnings](#warnings).
 - `locale` *(optional, default: "en")*
   - Accepts: An available locale from the [Rails I18n gem][i18n-gem]
   - Specifies the locale of the edition.
-- `need_ids` *(optional, deprecated)*
-  - An array of user need ids from the [Maslow application][maslow-repo]
 - `phase` *(optional, default: "live")*
   - Accepts: "alpha", "beta", "live"
 - `previous_version` *(optional, recommended)*

--- a/spec/presenters/edition_diff_presenter_spec.rb
+++ b/spec/presenters/edition_diff_presenter_spec.rb
@@ -33,7 +33,6 @@ RSpec.describe Presenters::EditionDiffPresenter do
     publisher_major_published_at
     publisher_published_at
     publisher_last_edited_at
-    need_ids
   ).freeze
 
   describe "#call" do


### PR DESCRIPTION
This used to store what content meets what user needs. The needs are
now represented by content items, and the meets_user_needs link type.

The database field has now been dropped from the Publishing API, so
this commit just removes redundant code and the docs.