### PR TITLE
Don't expand need fields

### DIFF
--- a/lib/expansion_rules.rb
+++ b/lib/expansion_rules.rb
@@ -58,6 +58,7 @@ module ExpansionRules
   DEFAULT_FIELDS_WITH_DETAILS = (DEFAULT_FIELDS + [:details]).freeze
   ORGANISATION_FIELDS = (DEFAULT_FIELDS + details_fields(:logo, :brand)).freeze
   FINDER_FIELDS = (DEFAULT_FIELDS + details_fields(:facets)).freeze
+  NEED_FIELDS = (DEFAULT_FIELDS + details_fields(:role, :goal, :benefit, :met_when, :justifications)).freeze
 
   CUSTOM_EXPANSION_FIELDS = [
     { document_type: :redirect,                   fields: [] },
@@ -68,7 +69,7 @@ module ExpansionRules
     { document_type: :organisation,               fields: ORGANISATION_FIELDS },
     { document_type: :placeholder_organisation,   fields: ORGANISATION_FIELDS },
     { document_type: :taxon,                      fields: DEFAULT_FIELDS_WITH_DETAILS + [:phase] },
-    { document_type: :need,                       fields: DEFAULT_FIELDS_WITH_DETAILS },
+    { document_type: :need,                       fields: NEED_FIELDS },
     { document_type: :finder, link_type: :finder, fields: FINDER_FIELDS },
     { document_type: :step_by_step_nav,           fields: DEFAULT_FIELDS_WITH_DETAILS },
     { document_type: :travel_advice,              fields: (DEFAULT_FIELDS + details_fields(:country, :change_description)) },

--- a/spec/lib/expansion_rules_spec.rb
+++ b/spec/lib/expansion_rules_spec.rb
@@ -43,6 +43,7 @@ RSpec.describe ExpansionRules do
     let(:default_and_details_fields) { default_fields + [:details] }
     let(:organisation_fields) { default_fields + [%i(details logo), %i(details brand)] }
     let(:finder_fields) { default_fields + [%i(details facets)] }
+    let(:need_fields) { default_fields + [%i(details role), %i(details goal), %i(details benefit), %i(details met_when), %i(details justifications)] }
 
     specify { expect(rules.expansion_fields(:redirect)).to eq([]) }
     specify { expect(rules.expansion_fields(:gone)).to eq([]) }
@@ -50,7 +51,7 @@ RSpec.describe ExpansionRules do
     specify { expect(rules.expansion_fields(:parent)).to eq(default_fields) }
 
     specify { expect(rules.expansion_fields(:contact)).to eq(default_fields + [%i(details description), %i(details title), %i(details contact_form_links), %i(details post_addresses), %i(details email_addresses), %i(details phone_numbers)]) }
-    specify { expect(rules.expansion_fields(:need)).to eq(default_and_details_fields) }
+    specify { expect(rules.expansion_fields(:need)).to eq(need_fields) }
     specify { expect(rules.expansion_fields(:organisation)).to eq(organisation_fields) }
     specify { expect(rules.expansion_fields(:placeholder_organisation)).to eq(organisation_fields) }
     specify { expect(rules.expansion_fields(:placeholder_topical_event)).to eq(default_fields) }


### PR DESCRIPTION
Looking at https://github.com/alphagov/info-frontend/blob/97ea0802b72b03c1974548a3c5f42b260843e14f/app/views/info/_need_details.html.erb we can see that `goal`, `benefit`, `met_when` and `justifications` are the fields used, so I'm explicitly expanding only those (plus defaults).

Trello card: https://trello.com/c/gtsJTl4d/611-do-not-expand-unnecessary-links-for-need

For more context on this, read about `Link Expansion` here: https://github.com/alphagov/publishing-api/blob/master/doc/link-expansion.md