### PR TITLE
Add locale to gone messages

### DIFF
--- a/app/presenters/gone_presenter.rb
+++ b/app/presenters/gone_presenter.rb
@@ -1,10 +1,11 @@
 class GonePresenter
-  def initialize(base_path:, content_id:, publishing_app:, alternative_path:, explanation:)
+  def initialize(base_path:, content_id:, publishing_app:, alternative_path:, explanation:, locale:)
     @base_path = base_path
     @content_id = content_id
     @publishing_app = publishing_app
     @alternative_path = alternative_path
     @explanation = explanation
+    @locale = locale
   end
 
   def self.from_edition(edition)
@@ -14,6 +15,7 @@ class GonePresenter
       publishing_app: edition.publishing_app,
       alternative_path: edition.unpublishing.alternative_path,
       explanation: edition.unpublishing.explanation,
+      locale: edition.locale,
     )
   end
 
@@ -31,13 +33,14 @@ class GonePresenter
 
 private
 
-  attr_reader :base_path, :content_id, :publishing_app, :alternative_path, :explanation
+  attr_reader :base_path, :content_id, :publishing_app, :alternative_path, :explanation, :locale
 
   def present
     {
       document_type: "gone",
       schema_name: "gone",
       base_path: base_path,
+      locale: locale,
       publishing_app: publishing_app,
       details: {
         explanation: explanation,

--- a/spec/requests/unpublishing_spec.rb
+++ b/spec/requests/unpublishing_spec.rb
@@ -198,6 +198,7 @@ RSpec.describe "POST /v2/content/:content_id/unpublish", type: :request do
           base_path: base_path,
           document_type: "gone",
           schema_name: "gone",
+          locale: "en",
           publishing_app: edition.publishing_app,
           details: {
             explanation: "Test gone",


### PR DESCRIPTION
Extract the locale from the edition and is added to gone messages for the message queue. Locales are needed by the content performace manager to properly track editions.