### PR TITLE
Add locale to redirect messages

### DIFF
--- a/app/helpers/redirect_helper.rb
+++ b/app/helpers/redirect_helper.rb
@@ -15,6 +15,7 @@ module RedirectHelper
       redirect_payload = RedirectPresenter.new(
         base_path: previous_base_path,
         content_id: previous_content_id,
+        locale: owning_document.locale,
         redirects: redirects_for(previous_routes, previous_base_path, payload[:base_path]),
         publishing_app: payload[:publishing_app],
       ).for_redirect_helper(SecureRandom.uuid)

--- a/app/presenters/redirect_presenter.rb
+++ b/app/presenters/redirect_presenter.rb
@@ -1,10 +1,11 @@
 class RedirectPresenter
-  def initialize(base_path:, content_id:, publishing_app:, public_updated_at: nil, redirects:)
+  def initialize(base_path:, content_id:, publishing_app:, public_updated_at: nil, redirects:, locale:)
     @base_path = base_path
     @content_id = content_id
     @publishing_app = publishing_app
     @public_updated_at = public_updated_at
     @redirects = redirects
+    @locale = locale
   end
 
   def self.from_edition(edition)
@@ -14,6 +15,7 @@ class RedirectPresenter
       publishing_app: edition.publishing_app,
       public_updated_at: edition.unpublishing.created_at,
       redirects: edition.unpublishing.redirects,
+      locale: edition.locale,
     )
   end
 
@@ -43,6 +45,7 @@ private
                     document_type: "redirect",
                     schema_name: "redirect",
                     base_path: base_path,
+                    locale: locale,
                     publishing_app: publishing_app,
                     redirects: redirects,
                  }

--- a/lib/tasks/queue.rake
+++ b/lib/tasks/queue.rake
@@ -60,7 +60,7 @@ namespace :queue do
 
     raise(StandardError, "expecting action") unless action.present?
 
-    if action =~ /major/
+    if /major/.match?(action)
       raise(StandardError, "resending major updates is a bad idea: it will spam everyone with email alerts")
     end
 

--- a/spec/requests/unpublishing_spec.rb
+++ b/spec/requests/unpublishing_spec.rb
@@ -105,6 +105,7 @@ RSpec.describe "POST /v2/content/:content_id/unpublish", type: :request do
           document_type: "redirect",
           schema_name: "redirect",
           base_path: base_path,
+          locale: edition.locale,
           publishing_app: edition.publishing_app,
           public_updated_at: Time.zone.now.iso8601,
           redirects: [


### PR DESCRIPTION
Extract the locale from the edition and add to redirect messages for the message queue. Locales are needed by the content performance manager to properly track editions.