### PR TITLE
Remove unnecessary "introduction" field from step-by-step links

### DIFF
--- a/lib/expansion_rules.rb
+++ b/lib/expansion_rules.rb
@@ -60,7 +60,7 @@ module ExpansionRules
   TAXON_FIELDS = (DEFAULT_FIELDS + [:details, :phase]).freeze
   NEED_FIELDS = (DEFAULT_FIELDS + details_fields(:role, :goal, :benefit, :met_when, :justifications)).freeze
   FINDER_FIELDS = (DEFAULT_FIELDS + details_fields(:facets)).freeze
-  STEP_BY_STEP_FIELDS = (DEFAULT_FIELDS + [:details]).freeze
+  STEP_BY_STEP_FIELDS = (DEFAULT_FIELDS + [%i(details step_by_step_nav title), %i(details step_by_step_nav steps)]).freeze
   TRAVEL_ADVICE_FIELDS = (DEFAULT_FIELDS + details_fields(:country, :change_description)).freeze
   WORLD_LOCATION_FIELDS = [:content_id, :title, :schema_name, :locale, :analytics_identifier].freeze
 

--- a/spec/lib/expansion_rules_spec.rb
+++ b/spec/lib/expansion_rules_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe ExpansionRules do
     let(:taxon_fields) { default_fields + %i(details phase) }
     let(:need_fields) { default_fields + [%i(details role), %i(details goal), %i(details benefit), %i(details met_when), %i(details justifications)] }
     let(:finder_fields) { default_fields + [%i(details facets)] }
-    let(:step_by_step_fields) { default_fields + [:details] }
+    let(:step_by_step_fields) { default_fields + [%i(details step_by_step_nav title), %i(details step_by_step_nav steps)] }
     let(:travel_advice_fields) { default_fields + [%i(details country), %i(details change_description)] }
     let(:world_location_fields) { %i(content_id title schema_name locale analytics_identifier) }
 


### PR DESCRIPTION
Looking at a page with a [step-by-step displaying][1], I think the title
and all the steps are used, but the introduction is not.
Unfortunately the introduction is very small, so removing it isn't a
significant saving.

[1]: /check-uk-visa?step-by-step-nav=d8f3c2e0-d544-4664-9616-ab71323e4d18

---

[Trello card](https://trello.com/c/NVXZkKEe/641-do-not-expand-unnecessary-links-for-stepbystepnav)