### PR TITLE
Add a Rake task for removing change notes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,7 @@ gem "govuk_sidekiq", "~> 3.0"
 gem "aws-sdk", "~> 3"
 gem 'bunny', '~> 2.13'
 gem "diffy", "~> 3.3", require: false
+gem "fuzzy_match", "~> 2.1"
 gem "govspeak", "~> 5.9.0"
 gem "hashdiff", "~> 0.3.8"
 gem "json-schema", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -629,6 +629,7 @@ GEM
     ffi (1.9.25)
     filelock (1.1.1)
     find_a_port (1.0.1)
+    fuzzy_match (2.1.0)
     gds-api-adapters (57.0.0)
       addressable
       link_header
@@ -972,6 +973,7 @@ DEPENDENCIES
   diffy (~> 3.3)
   factory_bot_rails (~> 4.11)
   faker
+  fuzzy_match (~> 2.1)
   gds-api-adapters (~> 57)
   gds-sso (~> 14.0)
   govspeak (~> 5.9.0)
@@ -1006,4 +1008,4 @@ DEPENDENCIES
   with_advisory_lock (~> 4.0)
 
 BUNDLED WITH
-   1.16.2
+   1.16.6

--- a/lib/data_hygiene/change_note_remover.rb
+++ b/lib/data_hygiene/change_note_remover.rb
@@ -1,0 +1,62 @@
+module DataHygiene
+  class ChangeNoteNotFound < StandardError; end
+
+  class ChangeNoteRemover
+    def initialize(content_id, locale, change_note_search, dry_run:)
+      @content_id = content_id
+      @locale = locale
+      @change_note_search = change_note_search
+      @dry_run = dry_run
+    end
+
+    def call
+      raise ChangeNoteNotFound.new unless change_note
+      return change_note if dry_run
+
+      destroy_change_note
+      remove_change_history
+      represent_downstream
+
+      change_note
+    end
+
+    def self.call(*args)
+      new(*args).call
+    end
+
+    private_class_method :new
+
+  private
+
+    attr_reader :content_id, :locale, :change_note_search, :dry_run
+
+    def document
+      @document ||= Document.find_by(content_id: content_id, locale: locale)
+    end
+
+    def find_change_note
+      change_notes = document.editions.map(&:change_note).compact
+      fuzzy_match = FuzzyMatch.new(change_notes, read: :note)
+      fuzzy_match.find(change_note_search, must_match_at_least_one_word: true)
+    end
+
+    def change_note
+      @change_note ||= find_change_note
+    end
+
+    def destroy_change_note
+      change_note.destroy
+    end
+
+    def remove_change_history
+      edition = document.live
+      edition_details = edition.details
+      edition_details.delete(:change_history)
+      edition.update!(details: edition_details)
+    end
+
+    def represent_downstream
+      Commands::V2::RepresentDownstream.new.call([content_id])
+    end
+  end
+end

--- a/lib/data_hygiene/change_note_remover.rb
+++ b/lib/data_hygiene/change_note_remover.rb
@@ -49,6 +49,12 @@ module DataHygiene
     end
 
     def remove_change_history
+      # We need to do this for legacy reasons - some publishing apps,
+      # specifically Whitehall, sends the change history directly in
+      # the details hash and Publishing API won't regenerate it if it sees
+      # one already there. Instead of manually fixing it, we can remove it,
+      # forcing Publishing API to generate a new one when representing
+      # to the Content Store.
       edition = document.live
       edition_details = edition.details
       edition_details.delete(:change_history)

--- a/lib/tasks/data_hygiene.rake
+++ b/lib/tasks/data_hygiene.rake
@@ -1,0 +1,26 @@
+namespace :data_hygiene do
+  desc "Remove a change note from a document and represent to the content store."
+  namespace :remove_change_note do
+    def call_change_note_remover(content_id, locale, query, dry_run:)
+      change_note = DataHygiene::ChangeNoteRemover.call(
+        content_id, locale, query, dry_run: dry_run
+      )
+
+      if dry_run
+        puts "Would have removed: #{change_note.inspect}"
+      else
+        puts "Removed: #{change_note.inspect}"
+      end
+    rescue DataHygiene::ChangeNoteNotFound
+      puts "Could not find a change note."
+    end
+
+    task :dry, %i[content_id locale query] => :environment do |_, args|
+      call_change_note_remover(args[:content_id], args[:locale], args[:query], dry_run: true)
+    end
+
+    task :real, %i[content_id locale query] => :environment do |_, args|
+      call_change_note_remover(args[:content_id], args[:locale], args[:query], dry_run: false)
+    end
+  end
+end

--- a/spec/lib/data_hygiene/change_note_remover_spec.rb
+++ b/spec/lib/data_hygiene/change_note_remover_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe DataHygiene::ChangeNoteRemover do
       it "removes change_history from the edition" do
         live_edition.update!(details: { change_history: [1, 2, 3], something_else: true })
         call_change_note_remover
-        expect(live_edition.reload.details).to eq({ something_else: true })
+        expect(live_edition.reload.details).to eq(something_else: true)
       end
 
       it "represents to the content store" do

--- a/spec/lib/data_hygiene/change_note_remover_spec.rb
+++ b/spec/lib/data_hygiene/change_note_remover_spec.rb
@@ -1,0 +1,78 @@
+require 'rails_helper'
+
+RSpec.describe DataHygiene::ChangeNoteRemover do
+  let(:document) { create(:document) }
+  let!(:superseded_edition) { create(:superseded_edition, document: document, change_note: "First change note.", update_type: "major") }
+  let!(:live_edition) { create(:live_edition, document: document, change_note: "Second change note.", update_type: "major", user_facing_version: 2) }
+
+  let(:query) { nil }
+
+  def call_change_note_remover
+    described_class.call(document.content_id, document.locale, query, dry_run: dry_run)
+  end
+
+  subject(:deleted_change_note) { call_change_note_remover }
+
+  context "during a dry run" do
+    let(:dry_run) { true }
+
+    context "the query matches a change note" do
+      let(:query) { "second" }
+
+      it "doesn't delete the change note" do
+        expect(superseded_edition.reload.change_note).to_not be_nil
+        expect(live_edition.reload.change_note).to_not be_nil
+      end
+
+      it "returns the change note" do
+        expect(deleted_change_note).to eq(live_edition.change_note)
+      end
+    end
+  end
+
+  context "during a real run" do
+    let(:dry_run) { false }
+
+    context "the query doesn't match a change note" do
+      let(:query) { "nonexistent" }
+
+      it "raises an exception" do
+        expect { call_change_note_remover }.to raise_error(DataHygiene::ChangeNoteNotFound)
+      end
+    end
+
+    context "the query matches a change note" do
+      let(:query) { "second" }
+
+      let(:represent_downstream) { double }
+      before do
+        allow(represent_downstream).to receive(:call)
+        allow(Commands::V2::RepresentDownstream)
+          .to receive(:new).and_return(represent_downstream)
+      end
+
+      it "deletes the change note" do
+        call_change_note_remover
+        expect(superseded_edition.reload.change_note).to_not be_nil
+        expect(live_edition.reload.change_note).to be_nil
+      end
+
+      it "removes change_history from the edition" do
+        live_edition.update!(details: { change_history: [1, 2, 3], something_else: true })
+        call_change_note_remover
+        expect(live_edition.reload.details).to eq({ something_else: true })
+      end
+
+      it "represents to the content store" do
+        expect(represent_downstream)
+          .to receive(:call).with([live_edition.content_id])
+
+        call_change_note_remover
+      end
+
+      it "returns the change note" do
+        expect(deleted_change_note).to eq(live_edition.change_note)
+      end
+    end
+  end
+end


### PR DESCRIPTION
While on 2nd line, it's often the case that you may be asked to remove a change note from a document. This is poorly documented and can take a long time to figure out what to do. It also requires writing migrations which aren't easy to test and often don't work the first time.

Instead, we can provide a Rake task which enables developers to complete this task easily.

It provides two interfaces and uses fuzzy searching to match a users query with a specific change note:

```
data_hygiene:remove_change_note:dry[content_id,locale,query]
data_hygiene:remove_change_note:real[content_id,locale,query]
```

It doesn't change the update type of an edition from minor to major since we want to preserve history as best we can, plus email subscribers will have already received an email about content with the change note.

[Trello Card](https://trello.com/c/eE4pp5Zm/721-rake-task-for-removing-changenotes-in-whitehall)