### PR TITLE
Document status checker

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,6 +44,7 @@ end
 gem "oj", "~> 3.7"
 
 group :development, :test do
+  gem "climate_control", "~> 0.2"
   gem "database_cleaner"
   gem "factory_bot_rails", "~> 4.11"
   gem "faker"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -600,6 +600,7 @@ GEM
       amq-protocol (~> 2.3, >= 2.3.0)
     byebug (9.1.0)
     chronic (0.10.2)
+    climate_control (0.2.0)
     coderay (1.1.2)
     colorize (0.8.1)
     commander (4.4.7)
@@ -967,6 +968,7 @@ DEPENDENCIES
   arel (~> 9)
   aws-sdk (~> 3)
   bunny (~> 2.13)
+  climate_control (~> 0.2)
   colorize (~> 0.8)
   dalli
   database_cleaner

--- a/lib/data_hygiene/document_status_checker.rb
+++ b/lib/data_hygiene/document_status_checker.rb
@@ -1,0 +1,40 @@
+class DataHygiene::DocumentStatusChecker
+  def initialize(document)
+    @document = document
+  end
+
+  def content_store?
+    routes.each do |route|
+      content_item = GdsApi.content_store.content_item(route[:path])
+      updated_at = DateTime.parse(content_item["updated_at"])
+      return false unless updated_at >= edition.published_at # content-store must be later due to latency
+    end
+
+    true
+  rescue GdsApi::ContentStore::ItemNotFound
+    false
+  end
+
+  def router?
+    routes.each do |route|
+      route = GdsApi.router.get_route(route[:path])
+      return false unless route["backend_id"] == edition.rendering_app
+    end
+
+    true
+  rescue GdsApi::HTTPNotFound
+    false
+  end
+
+private
+
+  attr_reader :document
+
+  def edition
+    @edition ||= document.live
+  end
+
+  def routes
+    @routes ||= edition.routes
+  end
+end

--- a/lib/tasks/data_hygiene.rake
+++ b/lib/tasks/data_hygiene.rake
@@ -23,4 +23,23 @@ namespace :data_hygiene do
       call_change_note_remover(args[:content_id], args[:locale], args[:query], dry_run: false)
     end
   end
+
+  desc "Check the status of a document whether it's in Content Store or Router."
+  task :document_status_check, %i[content_id locale] => :environment do |_, args|
+    document = Document.find_by!(args)
+    status = DataHygiene::DocumentStatusChecker.new(document)
+
+    content_store = status.content_store?
+    router = status.router?
+
+    puts "Has the document made it to:"
+    puts "Content Store? #{content_store ? 'Yes' : 'No'}"
+    puts "Router? #{router ? 'Yes' : 'No'}"
+
+    unless content_store && router
+      puts ""
+      puts "You could try running:"
+      puts "rake 'represent_downstream:content_id[#{args[:content_id]}]'"
+    end
+  end
 end

--- a/spec/lib/data_hygiene/document_status_checker_spec.rb
+++ b/spec/lib/data_hygiene/document_status_checker_spec.rb
@@ -1,0 +1,78 @@
+require 'rails_helper'
+require 'gds_api/test_helpers/content_store'
+require 'gds_api/test_helpers/router'
+
+RSpec.describe DataHygiene::DocumentStatusChecker do
+  include GdsApi::TestHelpers::ContentStore
+  include GdsApi::TestHelpers::Router
+
+  let(:base_path) { "/base-path" }
+
+  describe "content-store status" do
+    subject { described_class.new(document).content_store? }
+
+    context "with a published live edition" do
+      let(:edition) { create(:live_edition, base_path: base_path) }
+      let(:document) { edition.document }
+
+      context "and there is no content item" do
+        before { stub_content_store_does_not_have_item(base_path) }
+        it { is_expected.to be false }
+      end
+
+      context "and there is an old content item" do
+        let(:content_item) do
+          content_item_for_base_path(base_path).merge(
+            "updated_at" => (edition.published_at - 1).iso8601
+          )
+        end
+        before { stub_content_store_has_item(base_path, content_item) }
+        it { is_expected.to be false }
+      end
+
+      context "and there is a recent content item" do
+        let(:content_item) do
+          content_item_for_base_path(base_path).merge(
+            "updated_at" => (edition.published_at + 1).iso8601
+          )
+        end
+        before { stub_content_store_has_item(base_path, content_item) }
+        it { is_expected.to be true }
+      end
+    end
+  end
+
+  describe "router status" do
+    subject { described_class.new(document).router? }
+
+    around do |example|
+      ClimateControl.modify ROUTER_API_BEARER_TOKEN: "token" do
+        example.run
+      end
+    end
+
+    context "with a published live edition" do
+      let(:edition) { create(:live_edition, base_path: base_path) }
+      let(:document) { edition.document }
+
+      context "and there is no content item" do
+        before { stub_router_doesnt_have_route(base_path) }
+        it { is_expected.to be false }
+      end
+
+      context "and there is a content item" do
+        before { stub_router_has_backend_route(base_path, backend_id: backend_id) }
+
+        context "with the same backend_id" do
+          let(:backend_id) { edition.rendering_app }
+          it { is_expected.to be true }
+        end
+
+        context "with a different backend_id" do
+          let(:backend_id) { "nothing" }
+          it { is_expected.to be false }
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is a Rake task that will check the status of a document and tell you if it has made it to the Publishing API, Content Store and Router.

This is intentionally different from the existing "Content Consistency Checker" because it does a much simpler check, but also because this Rake task is a bit of an experiment. The idea is that the we would encourage 2nd line to run this task when dealing with publishing problems to get some data about where documents get stuck. Using the results from the "Content Consistency Checker" can be incredibly unwieldy as it's complicated to run and there are so many inconsistencies that might not be relevant to "the page isn't visible on the website and I just pressed publish" type of query that often arrives on 2nd line.

Depends on https://github.com/alphagov/govuk-puppet/pull/8597 https://github.com/alphagov/gds-api-adapters/pull/896 https://github.com/alphagov/gds-api-adapters/pull/897

[Trello Card](https://trello.com/c/dskGorBB/737-rake-task-to-check-where-content-has-ended-up)