### PR TITLE
Include edition links when presenting to message queue

### DIFF
--- a/app/presenters/edition_presenter.rb
+++ b/app/presenters/edition_presenter.rb
@@ -67,9 +67,8 @@ module Presenters
     attr_reader :draft, :edition
 
     def unexpanded_links
-      Queries::LinkSetPresenter.new(
-        LinkSet.find_by(content_id: edition.content_id)
-      ).links
+      links = ::Queries::LinksForEditionIds.new([edition.id]).merged_links
+      links[edition.id].symbolize_keys
     end
 
     def expanded_links_attributes


### PR DESCRIPTION
Trello: https://trello.com/c/s3FZW2CF/609-investigate-missing-emails-for-dhsc-content

This fixes an inconsistency where we were presenting the full expanded
links (with edition and link set links) to the message queue but were
only sending link set links as unexpanded links.

This caused an issue for Content Publisher that mostly uses edition
links. Since an organisation is tagged to a Content Publisher document
via an edition link, this information was not making it to Email Alert
API. Because of this content published via Content Publisher was not
making it to organisation based email lists.