### PR TITLE
Set published_at date in factories

### DIFF
--- a/spec/factories/edition.rb
+++ b/spec/factories/edition.rb
@@ -8,6 +8,7 @@ FactoryBot.define do
     public_updated_at { "2014-05-14T13:00:06Z" }
     first_published_at { "2014-01-02T03:04:05Z" }
     last_edited_at { "2014-05-14T13:00:06Z" }
+    published_at { nil }
     publishing_app { "publisher" }
     rendering_app { "frontend" }
     details { {} }

--- a/spec/factories/live_edition.rb
+++ b/spec/factories/live_edition.rb
@@ -23,6 +23,12 @@ FactoryBot.define do
     trait :with_draft_version do
       with_draft
     end
+
+    after(:create) do |live_edition, evaluator|
+      unless evaluator.published_at
+        live_edition.update!(published_at: live_edition.created_at)
+      end
+    end
   end
 
   factory :redirect_live_edition, parent: :live_edition do

--- a/spec/service_consumers/pact_helper.rb
+++ b/spec/service_consumers/pact_helper.rb
@@ -501,10 +501,10 @@ Pact.provider_states_for "GDS API Adapters" do
       document3 = create(:document, content_id: '271d4270-9186-4d60-b2ca-1d7dae7e0f73')
       document4 = create(:document, content_id: '638af19c-27fc-4cc9-a914-4cca49028688')
 
-      create(:live_edition, base_path: '/1', document: document1, updated_at: '2017-01-01T00:00:00Z')
-      create(:live_edition, base_path: '/2', document: document2, updated_at: '2017-02-01T00:00:00Z')
-      create(:live_edition, base_path: '/3', document: document3, updated_at: '2017-03-01T00:00:00Z')
-      create(:live_edition, base_path: '/4', document: document4, updated_at: '2017-04-01T00:00:00Z')
+      create(:live_edition, base_path: '/1', document: document1, updated_at: '2017-01-01T00:00:00Z', published_at: '2017-01-01T00:00:00Z')
+      create(:live_edition, base_path: '/2', document: document2, updated_at: '2017-02-01T00:00:00Z', published_at: '2017-02-01T00:00:00Z')
+      create(:live_edition, base_path: '/3', document: document3, updated_at: '2017-03-01T00:00:00Z', published_at: '2017-03-01T00:00:00Z')
+      create(:live_edition, base_path: '/4', document: document4, updated_at: '2017-04-01T00:00:00Z', published_at: '2017-04-01T00:00:00Z')
     end
   end
 end


### PR DESCRIPTION
This is a precursor to #1432 separated out into a PR to make it easier to review.

We want to make it possible to set the `published_at` date on factory objects (automatically if the edition is published, or manually), which means the pact tests need to be updated with `published_at` dates as the controller will now start to use that date when filtering and ordering.