### PR TITLE
Fix unsupported argument type in rake task

### DIFF
--- a/lib/tasks/data_hygiene.rake
+++ b/lib/tasks/data_hygiene.rake
@@ -26,7 +26,7 @@ namespace :data_hygiene do
 
   desc "Check the status of a document whether it's in Content Store or Router."
   task :document_status_check, %i[content_id locale] => :environment do |_, args|
-    document = Document.find_by!(args)
+    document = Document.find_by!(args.to_hash)
     status = DataHygiene::DocumentStatusChecker.new(document)
 
     content_store = status.content_store?


### PR DESCRIPTION
Passing the args from a rake task directly in to `Document#find_by!`
results in an "Unsupported argument type" error. I think this is because
rake `args` are actually an object of type `Rake::TaskArguments` rather
than a hash that `Document#find_by!` expects.

Converting the arguments into a hash by calling `#to_hash` on them seems
to fix this.