### PR TITLE
Create a republish endpoint

### DIFF
--- a/app/commands/v2/republish.rb
+++ b/app/commands/v2/republish.rb
@@ -1,0 +1,75 @@
+module Commands
+  module V2
+    class Republish < BaseCommand
+      delegate :content_id, :locale, to: :document
+
+      def call
+        validate
+        republish_edition
+        after_transaction_commit { send_downstream } if downstream
+
+        Success.new(content_id: content_id)
+      end
+
+    private
+
+      def document
+        @document ||= Document.find_or_create_locked(
+          content_id: payload[:content_id],
+          locale: payload.fetch(:locale, Edition::DEFAULT_LOCALE),
+        )
+      end
+
+      def edition
+        document.live
+      end
+
+      def validate
+        no_republishable_item_exists unless edition
+        previous_version_number = payload[:previous_version].to_i if payload[:previous_version]
+        check_version_and_raise_if_conflicting(document, previous_version_number)
+      end
+
+      def no_republishable_item_exists
+        message = "A live item with content_id #{content_id} and locale #{locale} does not exist"
+        raise_command_error(404, message, fields: {})
+      end
+
+      def republish_edition
+        overwrite_publishing_request_id
+        edition.unpublishing.destroy if edition.unpublishing
+        edition.publish
+        create_republish_action
+      end
+
+      def overwrite_publishing_request_id
+        edition.update_attributes!(
+          publishing_request_id: GdsApi::GovukHeaders.headers[:govuk_request_id]
+        )
+      end
+
+      def create_republish_action
+        Action.create_republish_action(edition, document.locale, event)
+      end
+
+      def send_downstream
+        unless document.draft
+          DownstreamDraftWorker.perform_async_in_queue(
+            DownstreamDraftWorker::HIGH_QUEUE,
+            content_id: content_id,
+            locale: locale,
+            update_dependencies: true,
+          )
+        end
+
+        DownstreamLiveWorker.perform_async_in_queue(
+          DownstreamLiveWorker::HIGH_QUEUE,
+          content_id: content_id,
+          locale: locale,
+          message_queue_event_type: "republish",
+          update_dependencies: true,
+        )
+      end
+    end
+  end
+end

--- a/app/controllers/v2/content_items_controller.rb
+++ b/app/controllers/v2/content_items_controller.rb
@@ -47,6 +47,11 @@ module V2
       render status: response.code, json: response
     end
 
+    def republish
+      response = Commands::V2::Republish.call(edition)
+      render status: response.code, json: response
+    end
+
     def unpublish
       response = Commands::V2::Unpublish.call(edition)
       render status: response.code, json: response

--- a/app/models/action.rb
+++ b/app/models/action.rb
@@ -15,6 +15,10 @@ class Action < ActiveRecord::Base
     create_publishing_action("Publish", edition, locale, event)
   end
 
+  def self.create_republish_action(edition, locale, event)
+    create_publishing_action("Republish", edition, locale, event)
+  end
+
   def self.create_unpublish_action(edition, unpublishing_type, locale, event)
     action = "Unpublish#{unpublishing_type.camelize}"
     create_publishing_action(action, edition, locale, event)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,7 @@ Rails.application.routes.draw do
         put "/content/:content_id", to: "content_items#put_content"
         get "/content/:content_id", to: "content_items#show"
         post "/content/:content_id/publish", to: "content_items#publish"
+        post "/content/:content_id/republish", to: "content_items#republish"
         post "/content/:content_id/unpublish", to: "content_items#unpublish"
         post "/content/:content_id/discard-draft", to: "content_items#discard_draft"
         post "/content/:content_id/import", to: "content_items#import"

--- a/doc/api.md
+++ b/doc/api.md
@@ -12,6 +12,7 @@ message queue for other apps (e.g. `email-alert-service`) to consume.
 
 - [`PUT /v2/content/:content_id`](#put-v2contentcontent_id)
 - [`POST /v2/content/:content_id/publish`](#post-v2contentcontent_idpublish)
+- [`POST /v2/content/:content_id/republish`](#post-v2contentcontent_idrepublish)
 - [`POST /v2/content/:content_id/unpublish`](#post-v2contentcontent_idunpublish)
 - [`POST /v2/content/:content_id/discard-draft`](#post-v2contentcontent_iddiscard-draft)
 - [`POST /v2/content/:content_id/import`](#post-v2contentcontent_idimport)
@@ -224,6 +225,36 @@ will be presented in the live content store. Uses
     associated redirects.
   - All published editions that link to this item (directly or through a
     recursive chain of links) will be updated in the live content store.
+
+## `POST /v2/content/:content_id/publish`
+
+Used to set a live edition to a published state, used to remove unpublishing
+or to re-send published data downstream. Uses
+[optimistic-locking](#optimistic-locking-previous_version).
+
+### Path parameters
+
+- [`content_id`](model.md#content_id)
+  - Identifies the document which has an edition to republish.
+
+### JSON attributes
+
+- `locale` *(optional, default: "en")*
+  - Accepts: An available locale from the [Rails I18n gem][i18n-gem]
+  - Specifies the locale of the document.
+- `previous_version` *(optional, recommended)*
+  - Used to ensure that the version being published is the most recent draft
+    update to the document.
+
+### State changes
+
+- Any unpublished editions will have their status set back to published
+- The publishing_request_id for an edition will be updated
+- The live content store will be updated with the published edition
+- The draft content store will be updated unless the document has a draft
+  edition
+- All published editions that link to this item (directly or through a
+  recursive chain of links) will be updated in the live content store.
 
 ## `POST /v2/content/:content_id/unpublish`
 

--- a/spec/commands/v2/republish_spec.rb
+++ b/spec/commands/v2/republish_spec.rb
@@ -1,0 +1,130 @@
+require "rails_helper"
+
+RSpec.describe Commands::V2::Republish do
+  describe "call" do
+    before do
+      stub_request(:put, %r{.*content-store.*/content/.*})
+
+      allow(DependencyResolutionWorker).to receive(:perform_async)
+    end
+
+    let!(:published_edition) { create(:live_edition) }
+
+    let(:payload) do
+      {
+        content_id: published_edition.content_id,
+        previous_version: 1,
+      }
+    end
+
+    it "overwrites the publishing_request_id" do
+      request_id = SecureRandom.uuid
+      GdsApi::GovukHeaders.set_header(:govuk_request_id, request_id)
+      expect { described_class.call(payload) }
+        .to change { published_edition.reload.publishing_request_id }
+        .to(request_id)
+    end
+
+    it "creates an action" do
+      expect { described_class.call(payload) }
+        .to change { Action.count }.by(1)
+
+      action = Action.last
+      expect(action.action).to eq("Republish")
+      expect(action.content_id).to eq(published_edition.content_id)
+    end
+
+    it "calls the DownstreamLiveWorker" do
+      expect(DownstreamLiveWorker)
+        .to receive(:perform_async_in_queue)
+        .with(
+          "downstream_high",
+          content_id: published_edition.content_id,
+          locale: published_edition.locale,
+          message_queue_event_type: "republish",
+          update_dependencies: true,
+        )
+
+      described_class.call(payload)
+    end
+
+    it "calls the DownstreamDraftWorker" do
+      expect(DownstreamDraftWorker)
+        .to receive(:perform_async_in_queue)
+        .with(
+          "downstream_high",
+          content_id: published_edition.content_id,
+          locale: published_edition.locale,
+          update_dependencies: true,
+        )
+
+      described_class.call(payload)
+    end
+
+    context "when the edition is unpublished" do
+      let(:edition) { create(:unpublished_edition) }
+
+      it "sets the edition state to published" do
+        expect { described_class.call(content_id: edition.content_id) }
+          .to change { edition.reload.state }
+          .from("unpublished")
+          .to("published")
+      end
+
+      it "deletes the unpublishing" do
+        expect { described_class.call(content_id: edition.content_id) }
+          .to change { edition.reload.unpublishing }
+          .to(nil)
+      end
+    end
+
+    context "when previous_version is old" do
+      let(:edition) do
+        create(:live_edition, document: build(:document, stale_lock_version: 2))
+      end
+
+      it "sets the edition state to published" do
+        payload = { content_id: edition.content_id, previous_version: 1 }
+        expect { described_class.call(payload) }
+          .to raise_error(CommandError, /Conflict/)
+      end
+    end
+
+    context "when the edition isn't live" do
+      let(:edition) { create(:draft_edition) }
+
+      it "raises an error" do
+        expect { described_class.call(content_id: edition.content_id) }
+          .to raise_error(CommandError, /does not exist/)
+      end
+    end
+
+    context "when the document also has a draft edition" do
+      let(:document) { create(:document) }
+
+      before do
+        create(:live_edition, document: document)
+        create(:draft_edition, document: document, user_facing_version: 2)
+      end
+
+      it "doesn't call the DownstreamDraftWorker" do
+        expect(DownstreamDraftWorker).not_to receive(:perform_async_in_queue)
+        described_class.call(content_id: document.content_id)
+      end
+    end
+
+    context "when the downstream parameter is false" do
+      it "doesn't call the DownstreamDraftWorker" do
+        expect(DownstreamDraftWorker).not_to receive(:perform_async_in_queue)
+        described_class.call(payload, downstream: false)
+      end
+
+      it "doesn't call the DownstreamLiveWorker" do
+        expect(DownstreamLiveWorker).not_to receive(:perform_async_in_queue)
+        described_class.call(payload, downstream: false)
+      end
+    end
+
+    it_behaves_like TransactionalCommand
+  end
+end

--- a/spec/controllers/v2/content_items_controller_spec.rb
+++ b/spec/controllers/v2/content_items_controller_spec.rb
@@ -476,6 +476,32 @@ RSpec.describe V2::ContentItemsController do
     end
   end
 
+  describe "republish" do
+    context "for an existing live edition" do
+      let(:live_edition) { create(:live_edition) }
+      before do
+        put :republish, params: { content_id: live_edition.content_id }, body: {}.to_json
+      end
+
+      it "is successful" do
+        expect(response.status).to eq(200)
+      end
+
+      it "responds with the content_id of the published item" do
+        parsed_response_body = parsed_response
+        expect(parsed_response_body).to eq("content_id" => live_edition.content_id)
+      end
+    end
+
+    context "for a non-existent edition" do
+      it "responds with 404" do
+        post :publish, params: { content_id: SecureRandom.uuid }, body: {}.to_json
+
+        expect(response.status).to eq(404)
+      end
+    end
+  end
+
   describe "index" do
     before do
       create(:draft_edition, publishing_app: 'publisher', base_path: '/content', document_type: "nonexistent-schema")


### PR DESCRIPTION
Trello: https://trello.com/c/yhcKNEWr/587-allow-users-undo-withdraw

This endpoint is to fulfill a need Content Publisher has in the ability
to transition an unpublished item back to being published. At the time
of writing this is specifically for the ability to revert a withdrawal.

This provides an endpoint called republish that can be used by any live
edition and will update the content store and message queue with the
updated document using the existing update_type of "republish".

Editions that are published won't have their state changed, just the
publishing_request_id updated. Whereas unpublished editions will have
their state set back to published.

Initially this endpoint was going to be part of the publish endpoint to
work in a similar way to the unpublish one where it can be called
multiple times to change states. However this proved to just make
something complex more complicated and raised questions about how to
indicate whether you're dealing with draft or live editions.