### PR TITLE
Default to running the master branch of GDS API Adapter pacts

### DIFF
--- a/spec/service_consumers/pact_helper.rb
+++ b/spec/service_consumers/pact_helper.rb
@@ -23,9 +23,8 @@ Pact.service_provider "Publishing API" do
     else
       base_url = ENV.fetch("PACT_BROKER_BASE_URL", "https://pact-broker.cloudapps.digital")
       url = "#{base_url}/pacts/provider/#{url_encode(name)}/consumer/#{url_encode(consumer_name)}"
-      version_part = ENV['GDS_API_PACT_VERSION'] ? "versions/#{url_encode(ENV['GDS_API_PACT_VERSION'])}" : 'latest'
 
-      pact_uri "#{url}/#{version_part}"
+      pact_uri "#{url}/versions/#{url_encode(ENV.fetch('GDS_API_PACT_VERSION', 'master'))}"
     end
   end
 end


### PR DESCRIPTION
This changes this from the latest published pacts by default. It's
actually unusual that we'd want to do that as that just reflects
whatever the last published branch of GDS API Adapters is. Instead it
makes more sense to run against the master branch by default, which I
believe is what was originally intended by latest.