### PR TITLE
Expand facet_group links

### DIFF
--- a/lib/expansion_rules.rb
+++ b/lib/expansion_rules.rb
@@ -29,6 +29,7 @@ module ExpansionRules
     [:ordered_related_items, :mainstream_browse_pages, :parent.recurring],
     [:ordered_related_items_overrides, :taxons],
     [:facets, :facet_values, :facet_group],
+    [:facet_group, :facets, :facet_values],
   ].freeze
 
   REVERSE_LINKS = {

--- a/spec/lib/expansion_rules_spec.rb
+++ b/spec/lib/expansion_rules_spec.rb
@@ -48,6 +48,9 @@ RSpec.describe ExpansionRules do
     let(:step_by_step_fields) { default_fields + [%i(details step_by_step_nav title), %i(details step_by_step_nav steps)] }
     let(:travel_advice_fields) { default_fields + [%i(details country), %i(details change_description)] }
     let(:world_location_fields) { %i(content_id title schema_name locale analytics_identifier) }
+    let(:facet_group_fields) { %i(content_id title schema_name) + [%i(details name), %i(details description)] }
+    let(:facet_fields) { %i(content_id title schema_name) + [%i(details key)] }
+    let(:facet_value_fields) { %i(content_id title schema_name) + [%i(details label), %i(details value)] }
 
     specify { expect(rules.expansion_fields(:redirect)).to eq([]) }
     specify { expect(rules.expansion_fields(:gone)).to eq([]) }
@@ -68,6 +71,10 @@ RSpec.describe ExpansionRules do
 
     specify { expect(rules.expansion_fields(:finder, :finder)).to eq(finder_fields) }
     specify { expect(rules.expansion_fields(:parent, :finder)).to eq(default_fields) }
+
+    specify { expect(rules.expansion_fields(:facet_group)).to eq(facet_group_fields) }
+    specify { expect(rules.expansion_fields(:facet)).to eq(facet_fields) }
+    specify { expect(rules.expansion_fields(:facet_value)).to eq(facet_value_fields) }
   end
 
   describe ".next_allowed_direct_link_types" do


### PR DESCRIPTION
https://trello.com/c/ZTNhqTpb/282-finders-get-facet-definition-from-publishing-api

Finders may link to a facet_group, this definition can be used to
replace the static finder `details['facets']` definition. The 3 levels of
group, facet and facet value need to be expanded.


```
:facet_group=>
  [{:content_id=>"52435175-82ed-4a04-adef-74c0199d0f46",
    :title=>"Find EU Exit guidance business",
    :schema_name=>"facet_group",
    :details=>{:name=>"Find EU Exit guidance business", :description=>"Facets for use with content relating to EU Exit business guidance."},
    :links=>
     {:facets=>
       [{:content_id=>"b2f525e8-ba7d-4737-a8b2-e4168c138aea",
         :title=>"Sector / Business area",
         :schema_name=>"facet",
         :details=>{:key=>"sector_business_area"},
         :links=>
          {:facet_values=>
            [{:content_id=>"894a7c88-40bb-4ba6-a234-b7e15d8a0c21",
              :title=>"Accommodation, restaurants and catering services",
              :schema_name=>"facet_value",
              :details=>{:label=>"Accommodation, restaurants and catering services", :value=>"accommodation-restaurants-and-catering-services"},
              :links=>{}},
             {:content_id=>"24fd50fa-6619-46ca-96cd-8ce90fa076ce",
              :title=>"Aerospace",
              :schema_name=>"facet_value",
              :details=>{:label=>"Aerospace", :value=>"aerospace"},
              :links=>{}},
```