### PR TITLE
Add notify endpoint

### DIFF
--- a/app/commands/v2/notify.rb
+++ b/app/commands/v2/notify.rb
@@ -27,7 +27,7 @@ module Commands
           edition,
           payload_version,
           draft: false,
-          workflow_message: payload[:workflow_message],
+          notification_attributes: payload.slice(:publishing_app, :workflow_message),
         )
         DownstreamService.broadcast_to_message_queue(downstream_payload, "workflow")
       end

--- a/app/commands/v2/notify.rb
+++ b/app/commands/v2/notify.rb
@@ -1,0 +1,83 @@
+module Commands
+  module V2
+    class Notify < BaseCommand
+      def call
+        @payload_version = Event.maximum_id
+
+        validate
+
+        send_downstream
+
+        Success.new(content_id: document.content_id)
+      end
+
+    private
+
+      attr_reader :payload_version
+
+      def validate
+        check_workflow_message_and_raise_unless_present
+        check_document_and_raise_if_not_exists
+        check_edition_and_raise_if_not_published
+        check_version_and_raise_if_conflicting(document, previous_version_number)
+      end
+
+      def send_downstream
+        downstream_payload = DownstreamPayload.new(
+          edition,
+          payload_version,
+          draft: false,
+          workflow_message: payload[:workflow_message],
+        )
+        DownstreamService.broadcast_to_message_queue(downstream_payload, "workflow")
+      end
+
+      def document
+        @document ||= Document.find_by(
+          content_id: payload[:content_id],
+          locale: payload.fetch(:locale, Edition::DEFAULT_LOCALE),
+        )
+      end
+
+      def edition
+        @edition ||= document.live
+      end
+
+      def previous_version_number
+        payload[:previous_version].to_i if payload[:previous_version]
+      end
+
+      def check_document_and_raise_if_not_exists
+        unless document
+          fields = { fields: { content_id: ["must be valid"] } }
+          friendly_message = "Notifications can only be sent for valid content."
+          raise_command_error(404, "Not found", fields, friendly_message: friendly_message)
+        end
+      end
+
+      def check_edition_and_raise_if_not_published
+        unless edition
+          fields = { fields: { content_id: ["must be published"] } }
+          friendly_message = "Notifications can only be sent for published editions."
+          raise_command_error(422, "Unprocessable entity", fields, friendly_message: friendly_message)
+        end
+      end
+
+      def check_workflow_message_and_raise_unless_present
+        unless payload[:workflow_message]
+          friendly_message = <<-MSG.strip_heredoc
+            Please provide a workflow message for this notification.
+            The workflow message is used to explain why the notification has been sent to the user.
+          MSG
+
+          fields = {
+            fields: {
+              workflow_message: ["must be present"],
+            },
+          }
+          raise_command_error(422, "Unprocessable entity", fields, friendly_message: friendly_message)
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/v2/content_items_controller.rb
+++ b/app/controllers/v2/content_items_controller.rb
@@ -62,6 +62,11 @@ module V2
       render status: response.code, json: response
     end
 
+    def notify
+      response = Commands::V2::Notify.call(edition)
+      render status: response.code, json: response
+    end
+
   private
 
     def edition

--- a/app/downstream_payload.rb
+++ b/app/downstream_payload.rb
@@ -1,11 +1,11 @@
 class DownstreamPayload
-  attr_reader :edition, :payload_version, :draft, :workflow_message
+  attr_reader :edition, :payload_version, :draft, :notification_attributes
 
-  def initialize(edition, payload_version, draft: false, workflow_message: nil)
+  def initialize(edition, payload_version, draft: false, notification_attributes: {})
     @edition = edition
     @payload_version = payload_version
     @draft = draft
-    @workflow_message = workflow_message
+    @notification_attributes = notification_attributes
   end
 
   def state
@@ -55,7 +55,7 @@ private
 
   def downstream_message_queue_presenter
     @downstream_message_queue_presenter ||= Presenters::MessageQueuePresenter.new(
-      edition, draft: draft, workflow_message: workflow_message
+      edition, draft: draft, notification_attributes: notification_attributes
     )
   end
 

--- a/app/presenters/message_queue_presenter.rb
+++ b/app/presenters/message_queue_presenter.rb
@@ -1,25 +1,32 @@
 module Presenters
   class MessageQueuePresenter
-    attr_reader :edition, :draft, :workflow_message, :edition_presenter
+    attr_reader :edition, :draft, :notification_attributes, :edition_presenter
 
-    def initialize(edition, draft: false, workflow_message: nil)
+    def initialize(edition, draft: false, notification_attributes: {})
       @edition = edition
       @draft = draft
-      @workflow_message = workflow_message
+      @notification_attributes = notification_attributes
       @edition_presenter = EditionPresenter.new(edition, draft: draft)
     end
 
     def for_message_queue(payload_version)
       edition_presenter.for_message_queue(payload_version)
+        .merge(presented_publishing_app)
         .merge(presented_workflow_message)
     end
 
   private
 
     def presented_workflow_message
-      return {} unless workflow_message
+      return {} unless notification_attributes[:workflow_message].present?
 
-      { workflow_message: workflow_message }
+      { workflow_message: notification_attributes[:workflow_message] }
+    end
+
+    def presented_publishing_app
+      return {} unless notification_attributes[:publishing_app].present?
+
+      { publishing_app: notification_attributes[:publishing_app] }
     end
   end
 end

--- a/app/presenters/message_queue_presenter.rb
+++ b/app/presenters/message_queue_presenter.rb
@@ -1,0 +1,25 @@
+module Presenters
+  class MessageQueuePresenter
+    attr_reader :edition, :draft, :workflow_message, :edition_presenter
+
+    def initialize(edition, draft: false, workflow_message: nil)
+      @edition = edition
+      @draft = draft
+      @workflow_message = workflow_message
+      @edition_presenter = EditionPresenter.new(edition, draft: draft)
+    end
+
+    def for_message_queue(payload_version)
+      edition_presenter.for_message_queue(payload_version)
+        .merge(presented_workflow_message)
+    end
+
+  private
+
+    def presented_workflow_message
+      return {} unless workflow_message
+
+      { workflow_message: workflow_message }
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,6 +23,7 @@ Rails.application.routes.draw do
         post "/content/:content_id/unpublish", to: "content_items#unpublish"
         post "/content/:content_id/discard-draft", to: "content_items#discard_draft"
         post "/content/:content_id/import", to: "content_items#import"
+        post "/content/:content_id/notify", to: "content_items#notify"
 
         get "/links/:content_id", to: "link_sets#get_links"
         get "/expanded-links/:content_id", to: "link_sets#expanded_links"

--- a/lib/expansion_rules.rb
+++ b/lib/expansion_rules.rb
@@ -65,9 +65,9 @@ module ExpansionRules
   STEP_BY_STEP_FIELDS = (DEFAULT_FIELDS + [%i(details step_by_step_nav title), %i(details step_by_step_nav steps)]).freeze
   TRAVEL_ADVICE_FIELDS = (DEFAULT_FIELDS + details_fields(:country, :change_description)).freeze
   WORLD_LOCATION_FIELDS = [:content_id, :title, :schema_name, :locale, :analytics_identifier].freeze
-  FACET_GROUP_FIELDS = (%i[content_id title schema_name] + details_fields(:name, :description)).freeze
+  FACET_GROUP_FIELDS = (%i[content_id title locale schema_name] + details_fields(:name, :description)).freeze
   FACET_FIELDS = (
-    %i[content_id title schema_name] + details_fields(
+    %i[content_id title locale schema_name] + details_fields(
       :combine_mode,
       :display_as_result_metadata,
       :filterable,
@@ -78,7 +78,7 @@ module ExpansionRules
       :type
     )
   ).freeze
-  FACET_VALUE_FIELDS = (%i[content_id title schema_name] + details_fields(:label, :value)).freeze
+  FACET_VALUE_FIELDS = (%i[content_id title locale schema_name] + details_fields(:label, :value)).freeze
 
   CUSTOM_EXPANSION_FIELDS = [
     { document_type: :redirect,                   fields: [] },

--- a/spec/commands/v2/notify_spec.rb
+++ b/spec/commands/v2/notify_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe Commands::V2::Notify do
         edition,
         payload_version,
         draft: false,
-        workflow_message: workflow_message
+        notification_attributes: { workflow_message: workflow_message }
       ).message_queue_payload
     end
 

--- a/spec/commands/v2/notify_spec.rb
+++ b/spec/commands/v2/notify_spec.rb
@@ -1,0 +1,101 @@
+require "rails_helper"
+
+RSpec.describe Commands::V2::Notify do
+  describe "call" do
+    let(:base_path) { "/vat-rates" }
+    let(:locale) { "en" }
+    let(:user_facing_version) { 3 }
+    let(:major_published_at) { 1.year.ago }
+    let(:public_updated_at) { 1.year.ago }
+    let(:payload_version) { 3 }
+
+    let!(:document) do
+      create(:document,
+        locale: locale,
+        stale_lock_version: 3)
+    end
+
+    let!(:edition) do
+      create(:live_edition,
+        document: document,
+        base_path: base_path,
+        user_facing_version: user_facing_version)
+    end
+
+    let(:payload) do
+      {
+        content_id: document.content_id,
+        previous_version: payload_version,
+        workflow_message: workflow_message,
+      }
+    end
+
+    let(:workflow_message) { "Important changes to important facts about important people." }
+
+    let(:queue_publisher) { PublishingAPI.service(:queue_publisher) }
+
+    let(:expected_payload) do
+      DownstreamPayload.new(
+        edition,
+        payload_version,
+        draft: false,
+        workflow_message: workflow_message
+      ).message_queue_payload
+    end
+
+    before do
+      allow(queue_publisher).to receive(:send_message)
+      allow(Event).to receive(:maximum_id).and_return(payload_version)
+    end
+
+    describe "call" do
+      context "without a workflow message" do
+        let(:workflow_message) { nil }
+
+        it "raises a suitable error" do
+          expect {
+            described_class.call(payload)
+          }.to raise_error(CommandError, "Unprocessable entity")
+        end
+      end
+
+      context "when there's a version conflict" do
+        let(:payload_version) { 2 }
+
+        it "raises a suitable error" do
+          expect {
+            described_class.call(payload)
+          }.to raise_error(CommandError, "Conflict")
+        end
+      end
+
+      context "when no edition has been published" do
+        let!(:edition) { create(:draft_edition) }
+
+        it "raises a suitable error" do
+          expect {
+            described_class.call(payload)
+          }.to raise_error(CommandError, "Unprocessable entity")
+        end
+      end
+
+      context "when no document exists for the payload" do
+        it "raises a suitable error" do
+          expect {
+            described_class.call(payload.merge(content_id: SecureRandom.uuid))
+          }.to raise_error(CommandError, "Not found")
+        end
+      end
+
+      it "sends a message downstream" do
+        described_class.call(payload)
+
+        expect(queue_publisher).to have_received(:send_message).with(expected_payload, event_type: "workflow")
+      end
+
+      it "responses successfully" do
+        expect(described_class.call(payload)).to be_a(Commands::Success)
+      end
+    end
+  end
+end

--- a/spec/controllers/v2/content_items_controller_spec.rb
+++ b/spec/controllers/v2/content_items_controller_spec.rb
@@ -539,4 +539,43 @@ RSpec.describe V2::ContentItemsController do
       expect(items.length).to eq(4)
     end
   end
+
+  describe "notify" do
+    let(:body) { { workflow_message: "notifying" } }
+
+    context "for existing content" do
+      context "with no published edition" do
+        before do
+          post :notify, params: { content_id: content_id }, body: body.to_json
+        end
+
+        it "is unprocessable" do
+          expect(response.status).to eq(422)
+        end
+      end
+
+      context "with a published edition" do
+        before do
+          create(:live_edition, document: document_en)
+          post :notify, params: { content_id: content_id }, body: body.to_json
+        end
+
+        it "responds with the content_id of the published item" do
+          parsed_response_body = parsed_response
+          expect(parsed_response_body.keys).to include("content_id")
+          expect(parsed_response_body["content_id"]).not_to be_nil
+        end
+      end
+    end
+
+    context "for non-existent content" do
+      before do
+        post :notify, params: { content_id: SecureRandom.uuid }, body: body.to_json
+      end
+
+      it "responds with 404" do
+        expect(response.status).to eq(404)
+      end
+    end
+  end
 end

--- a/spec/downstream_payload_spec.rb
+++ b/spec/downstream_payload_spec.rb
@@ -172,5 +172,20 @@ RSpec.describe DownstreamPayload do
         govuk_request_id: anything,
       )
     end
+
+    context "with a workflow message" do
+      subject(:downstream_payload) {
+        DownstreamPayload.new(
+          edition,
+          payload_version,
+          draft: draft,
+          workflow_message: "Something happened",
+        )
+      }
+
+      it "includes the message" do
+        expect(downstream_payload.message_queue_payload[:workflow_message]).to eq("Something happened")
+      end
+    end
   end
 end

--- a/spec/downstream_payload_spec.rb
+++ b/spec/downstream_payload_spec.rb
@@ -173,17 +173,24 @@ RSpec.describe DownstreamPayload do
       )
     end
 
-    context "with a workflow message" do
+    context "with notification attributes" do
       subject(:downstream_payload) {
         DownstreamPayload.new(
           edition,
           payload_version,
           draft: draft,
-          workflow_message: "Something happened",
+          notification_attributes: {
+            publishing_app: "super-publisher",
+            workflow_message: "Something happened",
+          }
         )
       }
 
-      it "includes the message" do
+      it "includes the specified publishing app" do
+        expect(downstream_payload.message_queue_payload[:publishing_app]).to eq("super-publisher")
+      end
+
+      it "includes the workflow message" do
         expect(downstream_payload.message_queue_payload[:workflow_message]).to eq("Something happened")
       end
     end

--- a/spec/lib/expansion_rules_spec.rb
+++ b/spec/lib/expansion_rules_spec.rb
@@ -48,9 +48,9 @@ RSpec.describe ExpansionRules do
     let(:step_by_step_fields) { default_fields + [%i(details step_by_step_nav title), %i(details step_by_step_nav steps)] }
     let(:travel_advice_fields) { default_fields + [%i(details country), %i(details change_description)] }
     let(:world_location_fields) { %i(content_id title schema_name locale analytics_identifier) }
-    let(:facet_group_fields) { %i(content_id title schema_name) + [%i(details name), %i(details description)] }
-    let(:facet_fields) { %i(content_id title schema_name) + facet_details_fields }
-    let(:facet_value_fields) { %i(content_id title schema_name) + [%i(details label), %i(details value)] }
+    let(:facet_group_fields) { %i(content_id title locale schema_name) + [%i(details name), %i(details description)] }
+    let(:facet_fields) { %i(content_id title locale schema_name) + facet_details_fields }
+    let(:facet_value_fields) { %i(content_id title locale schema_name) + [%i(details label), %i(details value)] }
     let(:facet_details_fields) do
       %i[
         combine_mode

--- a/spec/presenters/message_queue_presenter_spec.rb
+++ b/spec/presenters/message_queue_presenter_spec.rb
@@ -1,0 +1,50 @@
+require 'rails_helper'
+
+RSpec.describe Presenters::MessageQueuePresenter do
+  let(:payload_version) { 1 }
+  let(:edition_presenter) { double(:edition_presenter) }
+
+  before do
+    allow(Presenters::EditionPresenter).to receive(:new)
+      .with(edition, draft: false)
+      .and_return(edition_presenter)
+    allow(edition_presenter).to receive(:for_message_queue)
+      .and_return(foo: "foo")
+  end
+
+  describe "#for_message_queue" do
+    let(:update_type) { "minor" }
+    let(:workflow_message) { "Something changed" }
+    let(:edition) {
+      create(:draft_edition,
+        update_type: update_type,
+        schema_name: "calendar",
+        document_type: "calendar")
+    }
+
+    subject(:result) do
+      described_class.new(
+        edition, draft: false, workflow_message: workflow_message,
+      ).for_message_queue(payload_version)
+    end
+
+    it "calls the underlying #for_message_queue method on EditionPresenter" do
+      result
+      expect(edition_presenter).to have_received(:for_message_queue).with(payload_version)
+    end
+
+    context "with a workflow message" do
+      it "presents the workflow message" do
+        expect(result).to eq(foo: "foo", workflow_message: "Something changed")
+      end
+    end
+
+    context "without a workflow message" do
+      let(:workflow_message) { nil }
+
+      it "omits the workflow message key" do
+        expect(result).to eq(foo: "foo")
+      end
+    end
+  end
+end


### PR DESCRIPTION
https://trello.com/c/0wiO10tC/327-email-trigger-mechanism-for-new-content-tagger-process

[RFC relating to this change](https://github.com/alphagov/govuk-rfcs/blob/2cc32ae534d0f30f9702401a31ccd69f73bc4706/rfc-102-add-notification-workflow.md)

#### Use case for this endpoint

[We currently send emails when published content items are first tagged to the business readiness finder](https://github.com/alphagov/rummager/blob/master/lib/indexer/metadata_tagger.rb#L36).

When we start using the new tagging interface in Content Tagger the same email trigger won't exist.
We need a similar mechanism in the publishing pipeline as [tagging content will be handled by patching links in the Publishing API](https://github.com/alphagov/content-tagger/pull/884/files).


This PR adds a `notify` endpoint which can be used to send a message to the message queue (using a distinct message type). This will be used by email alert service to trigger a notification in the email alert api.

The optional key `workflow_message` is merged into the downstream payload, this can be used as a custom transient change note for the notification.


