### PR TITLE
Add short_name to facet expansion rules

### DIFF
--- a/lib/expansion_rules.rb
+++ b/lib/expansion_rules.rb
@@ -75,6 +75,7 @@ module ExpansionRules
       :key,
       :name,
       :preposition,
+      :short_name,
       :type
     )
   ).freeze

--- a/spec/lib/expansion_rules_spec.rb
+++ b/spec/lib/expansion_rules_spec.rb
@@ -60,6 +60,7 @@ RSpec.describe ExpansionRules do
         key
         name
         preposition
+        short_name
         type
       ].map { |key| [:details, key] }
     end


### PR DESCRIPTION
`short_name` has been added to the facet values in https://github.com/alphagov/content-tagger/pull/906.  This ensures `publishing_api` adds this value when expanding the facet values.