### PR TITLE
Include required locale field in facet link expansion

### DIFF
--- a/lib/expansion_rules.rb
+++ b/lib/expansion_rules.rb
@@ -65,9 +65,9 @@ module ExpansionRules
   STEP_BY_STEP_FIELDS = (DEFAULT_FIELDS + [%i(details step_by_step_nav title), %i(details step_by_step_nav steps)]).freeze
   TRAVEL_ADVICE_FIELDS = (DEFAULT_FIELDS + details_fields(:country, :change_description)).freeze
   WORLD_LOCATION_FIELDS = [:content_id, :title, :schema_name, :locale, :analytics_identifier].freeze
-  FACET_GROUP_FIELDS = (%i[content_id title schema_name] + details_fields(:name, :description)).freeze
+  FACET_GROUP_FIELDS = (%i[content_id title locale schema_name] + details_fields(:name, :description)).freeze
   FACET_FIELDS = (
-    %i[content_id title schema_name] + details_fields(
+    %i[content_id title locale schema_name] + details_fields(
       :combine_mode,
       :display_as_result_metadata,
       :filterable,
@@ -79,7 +79,7 @@ module ExpansionRules
       :type
     )
   ).freeze
-  FACET_VALUE_FIELDS = (%i[content_id title schema_name] + details_fields(:label, :value)).freeze
+  FACET_VALUE_FIELDS = (%i[content_id title locale schema_name] + details_fields(:label, :value)).freeze
 
   CUSTOM_EXPANSION_FIELDS = [
     { document_type: :redirect,                   fields: [] },

--- a/spec/lib/expansion_rules_spec.rb
+++ b/spec/lib/expansion_rules_spec.rb
@@ -48,9 +48,9 @@ RSpec.describe ExpansionRules do
     let(:step_by_step_fields) { default_fields + [%i(details step_by_step_nav title), %i(details step_by_step_nav steps)] }
     let(:travel_advice_fields) { default_fields + [%i(details country), %i(details change_description)] }
     let(:world_location_fields) { %i(content_id title schema_name locale analytics_identifier) }
-    let(:facet_group_fields) { %i(content_id title schema_name) + [%i(details name), %i(details description)] }
-    let(:facet_fields) { %i(content_id title schema_name) + facet_details_fields }
-    let(:facet_value_fields) { %i(content_id title schema_name) + [%i(details label), %i(details value)] }
+    let(:facet_group_fields) { %i(content_id title locale schema_name) + [%i(details name), %i(details description)] }
+    let(:facet_fields) { %i(content_id title locale schema_name) + facet_details_fields }
+    let(:facet_value_fields) { %i(content_id title locale schema_name) + [%i(details label), %i(details value)] }
     let(:facet_details_fields) do
       %i[
         combine_mode


### PR DESCRIPTION
Trello: https://trello.com/c/uR7v1Rri

Related to: https://github.com/alphagov/govuk-content-schemas/pull/891

Locale is not required in the publisher_v2 links schema, but it is required in the [frontend-links schema](https://github.com/alphagov/govuk-content-schemas/blob/master/formats/shared/definitions/frontend_links.jsonnet#L9), so it needs to be added to the expansion rules.
