### PR TITLE
Add secondary_to_step_by_steps as reverse links

### DIFF
--- a/lib/expansion_rules.rb
+++ b/lib/expansion_rules.rb
@@ -41,6 +41,7 @@ module ExpansionRules
     pages_part_of_step_nav: :part_of_step_navs,
     pages_related_to_step_nav: :related_to_step_navs,
     legacy_taxons: :topic_taxonomy_taxons,
+    pages_secondary_to_step_nav: :secondary_to_step_navs
   }.freeze
 
   DEFAULT_FIELDS = [

--- a/spec/lib/expansion_rules_spec.rb
+++ b/spec/lib/expansion_rules_spec.rb
@@ -76,6 +76,7 @@ RSpec.describe ExpansionRules do
     specify { expect(rules.expansion_fields(:placeholder_organisation)).to eq(organisation_fields) }
     specify { expect(rules.expansion_fields(:placeholder_topical_event)).to eq(default_fields) }
     specify { expect(rules.expansion_fields(:step_by_step_nav)).to eq(step_by_step_fields) }
+    specify { expect(rules.expansion_fields(:pages_secondary_to_step_nav)).to eq(default_fields) }
     specify { expect(rules.expansion_fields(:topical_event)).to eq(default_fields) }
 
     specify { expect(rules.expansion_fields(:taxon)).to eq(taxon_fields) }


### PR DESCRIPTION
So a content item can link to a step by step as it
may be a part of the process but it is not
essential to completing it.

Trello: https://trello.com/c/5zRe5f7F/96-step-by-step-update-the-content-schemas-to-allow-secondary-content-to-be-linked-to-a-step-by-step