### PR TITLE
Use public updated at for change note time

### DIFF
--- a/app/models/change_note.rb
+++ b/app/models/change_note.rb
@@ -26,7 +26,7 @@ private
   def create_from_top_level_change_note
     return unless change_note
     change_note_instance.update!(
-      public_timestamp: Time.zone.now,
+      public_timestamp: payload[:public_updated_at] || Time.zone.now,
       note: change_note,
     )
   end

--- a/app/models/change_note.rb
+++ b/app/models/change_note.rb
@@ -34,7 +34,7 @@ private
   def create_from_details_hash_change_note
     return unless note
     change_note_instance.update!(
-      public_timestamp: edition.updated_at,
+      public_timestamp: edition.public_updated_at,
       note: note,
     )
   end

--- a/spec/models/change_note_spec.rb
+++ b/spec/models/change_note_spec.rb
@@ -41,6 +41,16 @@ RSpec.describe ChangeNote do
           }.to_not change { ChangeNote.count }
         end
       end
+
+      context "payload contains public_updated_at" do
+        it "sets the change note public_timestamp to public_updated_at time" do
+          time = Time.zone.yesterday
+          payload[:public_updated_at] = time
+          described_class.create_from_edition(payload, edition)
+
+          expect(ChangeNote.last.public_timestamp).to eq(time)
+        end
+      end
     end
 
     context "edition has change_note entry in details hash" do

--- a/spec/models/change_note_spec.rb
+++ b/spec/models/change_note_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe ChangeNote do
     create(:edition,
       update_type: update_type,
       details: details,
+      public_updated_at: Time.zone.yesterday,
       change_note: nil)
   end
 
@@ -58,6 +59,7 @@ RSpec.describe ChangeNote do
       it "populates change note from details hash" do
         expect { subject }.to change { ChangeNote.count }.by(1)
         expect(ChangeNote.last.note).to eq "Marvellous"
+        expect(ChangeNote.last.public_timestamp).to eq(edition.public_updated_at)
       end
     end
 


### PR DESCRIPTION
For https://trello.com/c/CnWIubp8/955-publishing-api-to-use-publicupdatedat-for-change-note-times

This updates the Publishing API to set a change note's timestamp to the `public_updated_at` value, whether that's provided in the payload for a PUT content request or derived from the edition's `public_updated_at` attribute when a publish request is made.  The rationale behind this is that a change note's timestamp should be consistent with the `public_updated_at` value for an edition, otherwise they could get out of sync which would be confusing to users.  For example, under the current logic if a document was published today but was backdated to yesterday in its publishing app, then on the frontend the document's 'updated at' timestamp would be yesterday, but the change note's timestamp would be today.