### PR TITLE
Dates extra timestamps

### DIFF
--- a/app/models/edition/timestamps.rb
+++ b/app/models/edition/timestamps.rb
@@ -35,6 +35,10 @@ class Edition::Timestamps
     # If the payload value is nil, we rely on publish to populate public_updated_at
     edition.public_updated_at = payload[:public_updated_at]
 
+    # populate transitory timestamps
+    edition.publishing_api_first_published_at = edition.temporary_first_published_at
+    edition.publishing_api_last_edited_at = edition.temporary_last_edited_at
+
     edition.save!
   end
 
@@ -72,6 +76,9 @@ class Edition::Timestamps
         edition.public_updated_at = previous_live_version&.public_updated_at || now
       end
     end
+
+    # populate transitory timestamps
+    edition.publishing_api_first_published_at = edition.temporary_first_published_at
 
     edition.save!
   end

--- a/app/presenters/edition_presenter.rb
+++ b/app/presenters/edition_presenter.rb
@@ -15,6 +15,8 @@ module Presenters
       publisher_published_at
       publisher_last_edited_at
       publishing_request_id
+      publishing_api_first_published_at
+      publishing_api_last_edited_at
       state
       temporary_first_published_at
       temporary_last_edited_at

--- a/db/migrate/20190703210757_add_publishing_api_timestamp_fields.rb
+++ b/db/migrate/20190703210757_add_publishing_api_timestamp_fields.rb
@@ -1,0 +1,8 @@
+class AddPublishingApiTimestampFields < ActiveRecord::Migration[5.2]
+  def change
+    change_table :editions, bulk: true do |t|
+      t.datetime :publishing_api_first_published_at
+      t.datetime :publishing_api_last_edited_at
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180907102237) do
+ActiveRecord::Schema.define(version: 2019_07_03_210757) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -89,6 +89,8 @@ ActiveRecord::Schema.define(version: 20180907102237) do
     t.datetime "publisher_major_published_at"
     t.datetime "publisher_published_at"
     t.datetime "publisher_last_edited_at"
+    t.datetime "publishing_api_first_published_at"
+    t.datetime "publishing_api_last_edited_at"
     t.index ["base_path", "content_store"], name: "index_editions_on_base_path_and_content_store", unique: true
     t.index ["document_id", "content_store"], name: "index_editions_on_document_id_and_content_store", unique: true
     t.index ["document_id", "state"], name: "index_editions_on_document_id_and_state"

--- a/lib/tasks/split_dates.rake
+++ b/lib/tasks/split_dates.rake
@@ -10,4 +10,34 @@ namespace :split_dates do
   task validate: :environment do
     Tasks::SplitDates.validate
   end
+
+  desc "Backfill publishing_api_* dates using temporary_* dates"
+  task backfill: :environment do
+    scope = Edition.select(:id,
+                           :temporary_first_published_at,
+                           :publishing_api_first_published_at,
+                           :temporary_last_edited_at,
+                           :publishing_api_last_edited_at)
+
+    total = Edition.count
+    start_time = Time.current
+    done = 0
+
+    scope.find_in_batches(batch_size: 10_000) do |batch|
+      batch.each do |e|
+        if e.temporary_first_published_at != e.publishing_api_first_published_at ||
+            e.temporary_last_edited_at != e.publishing_api_last_edited_at
+
+          e.update_columns(
+            publishing_api_first_published_at: e.temporary_first_published_at,
+            publishing_api_last_edited_at: e.temporary_last_edited_at,
+          )
+        end
+      end
+
+      done += batch.count
+      time_elapsed = Time.at(Time.current - start_time).utc.strftime("%H:%M:%S")
+      puts "Processed #{done}/#{total} - time elapsed: #{time_elapsed}"
+    end
+  end
 end

--- a/spec/presenters/edition_diff_presenter_spec.rb
+++ b/spec/presenters/edition_diff_presenter_spec.rb
@@ -33,6 +33,8 @@ RSpec.describe Presenters::EditionDiffPresenter do
     publisher_major_published_at
     publisher_published_at
     publisher_last_edited_at
+    publishing_api_first_published_at
+    publishing_api_last_edited_at
   ).freeze
 
   describe "#call" do


### PR DESCRIPTION
Trello: https://trello.com/c/colkZywn/43-complete-publishing-api-date-migration

Building on from the work in https://github.com/alphagov/publishing-api/pull/1532 this introduces two extra date fields to replace the `temporary_*` ones and a task to populate them.

I've got some of the next work for this in: https://github.com/alphagov/publishing-api/tree/dates-switch