### PR TITLE
Add deferred priority Sidekiq queue

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -6,6 +6,7 @@
   - downstream_high
   - dependency_resolution
   - downstream_low
+  - downstream_deferred
   - experiments
   - default
   - import

--- a/lib/downstream_queue.rb
+++ b/lib/downstream_queue.rb
@@ -1,4 +1,5 @@
 module DownstreamQueue
   HIGH_QUEUE = "downstream_high".freeze
   LOW_QUEUE = "downstream_low".freeze
+  DEFERRED_QUEUE = "downstream_deferred".freeze
 end

--- a/spec/commands/v2/patch_link_set_spec.rb
+++ b/spec/commands/v2/patch_link_set_spec.rb
@@ -231,6 +231,13 @@ RSpec.describe Commands::V2::PatchLinkSet do
       described_class.call(payload.merge(bulk_publishing: true))
     end
 
+    it "sends a deferred priority request to the downstream draft worker for publishing" do
+      expect(DownstreamDraftWorker).to receive(:perform_async_in_queue)
+        .with("downstream_deferred", anything)
+
+      described_class.call(payload.merge(deferred_publishing: true))
+    end
+
     context "when a draft edition has multiple translations" do
       before do
         create(:draft_edition,
@@ -297,6 +304,13 @@ RSpec.describe Commands::V2::PatchLinkSet do
         )
 
       described_class.call(payload.merge(bulk_publishing: true))
+    end
+
+    it "sends a deferred priority request to the downstream live worker for publishing" do
+      expect(DownstreamDraftWorker).to receive(:perform_async_in_queue)
+                                         .with("downstream_deferred", anything)
+
+      described_class.call(payload.merge(deferred_publishing: true))
     end
 
     context "when a live edition has multiple translations" do


### PR DESCRIPTION
This PR adds a new `deferred` priority Sidekiq queue. Currently, the majority of publishing requests to publishing-api are placed on the `low` queue, which includes both departmental and automated, bulk publishing requests. The result is that departmental edits can get "stuck" behind less urgent updates - a problem exacerbated through dependency resolution of bulk publishing updates added back to the `low` queue.

Recently, we have introduced more load to this queue in the form of publishing related links (albeit on an infrequent basis). This adds yet more load to the `low queue`.

To start and abate some of these problems, we have decided to add a new, lower-priority `deferred` queue to the publishing-api. This queue will be primarily used by related links updates, but can and should be used for any publishing which can operate whenever there is free capacity within the publishing-api to do so (think of it like an AWS EC2 spot instance).

As related links is only concerned with patching link sets, this is the only place where the new queue is being used at present.