### PR TITLE
Remove edition_diff column from actions

### DIFF
--- a/app/models/action.rb
+++ b/app/models/action.rb
@@ -1,6 +1,4 @@
 class Action < ActiveRecord::Base
-  self.ignored_columns = %w(edition_diff)
-
   belongs_to :edition, optional: true
   belongs_to :link_set, optional: true
   belongs_to :event

--- a/db/migrate/20190719071750_remove_edition_diff_column_from_actions.rb
+++ b/db/migrate/20190719071750_remove_edition_diff_column_from_actions.rb
@@ -1,0 +1,5 @@
+class RemoveEditionDiffColumnFromActions < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :actions, :edition_diff, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_07_16_195325) do
+ActiveRecord::Schema.define(version: 2019_07_19_071750) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -34,7 +34,6 @@ ActiveRecord::Schema.define(version: 2019_07_16_195325) do
     t.integer "event_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.text "edition_diff"
   end
 
   create_table "change_notes", id: :serial, force: :cascade do |t|


### PR DESCRIPTION
Following on from: https://github.com/alphagov/publishing-api/pull/1547 this removes the column. This is marked as a draft until that PR has made it to prod since it needs to be released afterwards to prevent downtime.