### PR TITLE
Add support for organisation access limiting

### DIFF
--- a/app/commands/v2/put_content.rb
+++ b/app/commands/v2/put_content.rb
@@ -100,6 +100,7 @@ module Commands
           AccessLimit.find_or_create_by(edition: edition).tap do |access_limit|
             access_limit.update_attributes!(
               users: (payload[:access_limited][:users] || []),
+              organisations: (payload[:access_limited][:organisations] || []),
               auth_bypass_ids: (payload[:access_limited][:auth_bypass_ids] || []),
             )
           end

--- a/app/models/access_limit.rb
+++ b/app/models/access_limit.rb
@@ -3,6 +3,7 @@ class AccessLimit < ApplicationRecord
 
   validate :user_uids_are_strings
   validate :auth_bypass_ids_are_uuids
+  validate :user_organisations_are_uuids
 
 private
 
@@ -15,6 +16,12 @@ private
   def auth_bypass_ids_are_uuids
     unless auth_bypass_ids.all? { |id| UuidValidator.valid?(id) }
       errors.add(:auth_bypass_ids, ["contains invalid UUIDs"])
+    end
+  end
+
+  def user_organisations_are_uuids
+    unless organisations.all? { |id| UuidValidator.valid?(id) }
+      errors.add(:organisations, ["contains invalid UUIDs"])
     end
   end
 end

--- a/app/presenters/edition_presenter.rb
+++ b/app/presenters/edition_presenter.rb
@@ -88,6 +88,7 @@ module Presenters
         {
           access_limited: {
             users: access_limit.users,
+            organisations: access_limit.organisations,
             auth_bypass_ids: access_limit.auth_bypass_ids,
           }
         }

--- a/db/migrate/20190715104640_add_organisation_id_to_access_limit.rb
+++ b/db/migrate/20190715104640_add_organisation_id_to_access_limit.rb
@@ -1,0 +1,5 @@
+class AddOrganisationIdToAccessLimit < ActiveRecord::Migration[5.2]
+  def change
+    add_column :access_limits, :organisations, :json, null: false, default: []
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -21,6 +21,7 @@ ActiveRecord::Schema.define(version: 2019_07_19_071750) do
     t.datetime "updated_at", null: false
     t.integer "edition_id"
     t.json "auth_bypass_ids", default: [], null: false
+    t.json "organisations", default: [], null: false
     t.index ["edition_id"], name: "index_access_limits_on_edition_id"
   end
 

--- a/spec/factories/access_limit.rb
+++ b/spec/factories/access_limit.rb
@@ -1,6 +1,7 @@
 FactoryBot.define do
   factory :access_limit do
     users { [SecureRandom.uuid] }
+    organisations { [SecureRandom.uuid] }
     edition
   end
 end

--- a/spec/models/access_limit_spec.rb
+++ b/spec/models/access_limit_spec.rb
@@ -4,10 +4,12 @@ RSpec.describe AccessLimit do
   subject do
     build(:access_limit,
       users: users,
+      organisations: organisations,
       auth_bypass_ids: auth_bypass_ids)
   end
 
   let(:users) { [SecureRandom.uuid] }
+  let(:organisations) { [] }
   let(:auth_bypass_ids) { [] }
 
   it { is_expected.to be_valid }
@@ -37,6 +39,18 @@ RSpec.describe AccessLimit do
 
     context "where users has an array with an integer" do
       let(:auth_bypass_ids) { [123] }
+      it { is_expected.to be_invalid }
+    end
+  end
+
+  describe "validates organisation_ids" do
+    context "where organisation_ids has an array with a uuids" do
+      let(:organisations) { [SecureRandom.uuid, SecureRandom.uuid] }
+      it { is_expected.to be_valid }
+    end
+
+    context "where users has an array with an integer" do
+      let(:organisations) { [123] }
       it { is_expected.to be_invalid }
     end
   end

--- a/spec/presenters/edition_presenter_spec.rb
+++ b/spec/presenters/edition_presenter_spec.rb
@@ -280,6 +280,7 @@ RSpec.describe Presenters::EditionPresenter do
 
         it "populates the access_limited hash" do
           expect(result[:access_limited][:users].length).to eq(1)
+          expect(result[:access_limited][:organisations].length).to eq(1)
           expect(result[:access_limited][:auth_bypass_ids].length).to eq(0)
         end
       end


### PR DESCRIPTION
This adds support access limiting by organisation. Changes in this PR include:
- Adding organisations attribute to the access limits model
- Updating access limited organisations via the PutContent endpoint
- Forwarding access limited organisations downstream to the content store