### PR TITLE
Update pact configuration to avoid multiple runs

### DIFF
--- a/doc/pact_testing.md
+++ b/doc/pact_testing.md
@@ -42,19 +42,15 @@ file to the broker as `branch-<branch-name>` using the `pact:publish:branch`
 rake task. It then checks out the master branch of publishing-api and verifies
 the pact against that branch using the `pact:verify:branch` rake task.
 
-When a new version of gds-api-adapters is released by bumping the version, the
-job will also publish the pact as the released version, by running the
-`pact:publish:released_version` rake task.
-
 In publishing-api itself, the Jenkins job runs the `pact:verify` rake task to
-verify the current branch against both master and that released version pact.
+verify the current branch against the master branch.
 
 
 ## Running the pacts in development
 
 You can use `pact:verify` locally to run the current branch against the master
-and released version pacts stored in Pact Broker. If you need to run them
-against a local version of gds-api-adapters, run the tests in that directory
+branch of pacts stored in Pact Broker. If you need to run them against a local
+version of gds-api-adapters, run the tests in that directory
 and then set the `USE_LOCAL_PACT` env variable:
 
     USE_LOCAL_PACT=1 bundle exec rake pact:verify
@@ -66,14 +62,9 @@ additionally override this location by setting the `GDS_API_PACT_PATH` variable.
 
 ## Making breaking changes
 
-Previously, an updated pact was only published to the pact-broker when the
-gds-api-adapter version was bumped and the gem published to rubygems. This is
-no longer the case, so the released version pact will be updated as soon as the
-change is merged to master.
-
-However, it may still be possible to get into a situation where there are
-mutually dependent branches of gds-api-adapters and publishing-api, neither of
-which will pass their tests on CI until the other is merged. In this case, it is
+It is possible to get into a situation where there are mutually dependent
+branches of gds-api-adapters and publishing-api, neither of which will pass
+their tests on CI until the other is merged. In this case, it is
 possible to run the gds-api-adapters branch on Jenkins against a manually
 specified branch of publishing-api, by manually running the branch build and
 entering the relevant branch name as the `PUBLISHING_API_BRANCH` parameter.

--- a/lib/tasks/pact.rake
+++ b/lib/tasks/pact.rake
@@ -4,24 +4,6 @@ require 'pact/tasks'
 require 'pact_broker/client/tasks'
 require 'pact/tasks/task_helper'
 
-desc "Verifies the pact files for latest release and master"
-task "pact:verify" do
-
-  Pact::TaskHelper.handle_verification_failure do
-    Pact::TaskHelper.execute_pact_verify
-  end
-
-  unless ENV['USE_LOCAL_PACT'] # avoid running twice against the same pact file.
-    ClimateControl.modify(GDS_API_PACT_VERSION: "master") do
-      Pact::TaskHelper.handle_verification_failure do
-        Pact::TaskHelper.execute_pact_verify
-      end
-    end
-  end
-end
-
-task default: "pact:verify"
-
 task "pact:verify:branch", [:branch_name] do |t, args|
   abort "Please provide a branch name. eg rake #{t.name}[my_feature_branch]" unless args[:branch_name]
 

--- a/lib/tasks/pact.rake
+++ b/lib/tasks/pact.rake
@@ -1,62 +1,47 @@
-unless Rails.env.production?
-  require 'pact/tasks'
+return if Rails.env.production?
 
-  desc "Verifies the pact files for latest release and master"
-  task "pact:verify" do
-    require 'pact/tasks/task_helper'
+require 'pact/tasks'
+require 'pact_broker/client/tasks'
+require 'pact/tasks/task_helper'
 
-    Pact::TaskHelper.handle_verification_failure do
-      Pact::TaskHelper.execute_pact_verify
-    end
+desc "Verifies the pact files for latest release and master"
+task "pact:verify" do
 
-    unless ENV['USE_LOCAL_PACT'] # avoid running twice against the same pact file.
-      with_temporary_env('GDS_API_PACT_VERSION', "master") do
-        Pact::TaskHelper.handle_verification_failure do
-          Pact::TaskHelper.execute_pact_verify
-        end
-      end
-    end
+  Pact::TaskHelper.handle_verification_failure do
+    Pact::TaskHelper.execute_pact_verify
   end
 
-  task default: "pact:verify"
-
-  task "pact:verify:branch", [:branch_name] do |t, args|
-    abort "Please provide a branch name. eg rake #{t.name}[my_feature_branch]" unless args[:branch_name]
-
-    pact_version = args[:branch_name] == "master" ? args[:branch_name] : "branch-#{args[:branch_name]}"
-
-    require 'pact/tasks/task_helper'
-
-    with_temporary_env('GDS_API_PACT_VERSION', pact_version) do
+  unless ENV['USE_LOCAL_PACT'] # avoid running twice against the same pact file.
+    ClimateControl.modify(GDS_API_PACT_VERSION: "master") do
       Pact::TaskHelper.handle_verification_failure do
         Pact::TaskHelper.execute_pact_verify
       end
     end
   end
+end
 
-  def with_temporary_env(key, value)
-    original_value = ENV[key]
-    ENV[key] = value
-    yield
-  ensure
-    ENV[key] = original_value
-  end
+task default: "pact:verify"
 
-  require 'pact_broker/client/tasks'
+task "pact:verify:branch", [:branch_name] do |t, args|
+  abort "Please provide a branch name. eg rake #{t.name}[my_feature_branch]" unless args[:branch_name]
 
-  def configure_pact_broker_location(task)
-    task.pact_broker_base_url = ENV.fetch("PACT_BROKER_BASE_URL")
+  pact_version = args[:branch_name] == "master" ? args[:branch_name] : "branch-#{args[:branch_name]}"
 
-    if ENV['PACT_BROKER_USERNAME']
-      task.pact_broker_basic_auth = {
-        username: ENV['PACT_BROKER_USERNAME'],
-        password: ENV['PACT_BROKER_PASSWORD']
-      }
+  ClimateControl.modify(GDS_API_PACT_VERSION: pact_version) do
+    Pact::TaskHelper.handle_verification_failure do
+      Pact::TaskHelper.execute_pact_verify
     end
   end
+end
 
-  PactBroker::Client::PublicationTask.new("branch") do |task|
-    task.consumer_version = ENV.fetch("PACT_TARGET_BRANCH")
-    configure_pact_broker_location(task)
+PactBroker::Client::PublicationTask.new("branch") do |task|
+  task.consumer_version = ENV.fetch("PACT_TARGET_BRANCH")
+  task.pact_broker_base_url = ENV.fetch("PACT_BROKER_BASE_URL")
+
+  if ENV['PACT_BROKER_USERNAME']
+    task.pact_broker_basic_auth = {
+      username: ENV['PACT_BROKER_USERNAME'],
+      password: ENV['PACT_BROKER_PASSWORD']
+    }
   end
 end


### PR DESCRIPTION
Previously the pact would run multiple times for a Publishing API this
seemed to be a result of additional configuration that may have lost
it's original intent.

To update this code I've tried to break this down to be less custom so
to have less challenges. The setup we use for this is a bit weird still
as it only seems to be configured for a single apps pact tests - luckily
this doesn't seem to be the case on any GOV.UK apps currently.