### PR TITLE
Don't include routes with nil paths in gone payloads

### DIFF
--- a/app/presenters/gone_presenter.rb
+++ b/app/presenters/gone_presenter.rb
@@ -46,12 +46,20 @@ private
         explanation: explanation,
         alternative_path: alternative_path,
       },
-      routes: [
+      routes: routes,
+    }
+  end
+
+  def routes
+    if base_path
+      [
         {
           path: base_path,
           type: "exact",
         }
-      ],
-    }
+      ]
+    else
+      []
+    end
   end
 end

--- a/spec/presenters/gone_presenter_spec.rb
+++ b/spec/presenters/gone_presenter_spec.rb
@@ -12,5 +12,17 @@ RSpec.describe GonePresenter do
     it "matches the notification schema" do
       expect(subject).to be_valid_against_schema("gone")
     end
+
+    context "with a nil base_path" do
+      let(:edition) { create(:gone_unpublished_edition, base_path: nil) }
+
+      subject(:result) do
+        described_class.from_edition(edition).for_message_queue(payload_version)
+      end
+
+      it "matches the notification schema" do
+        expect(subject).to be_valid_against_schema("gone")
+      end
+    end
   end
 end


### PR DESCRIPTION
This can happen for contacts, which don't have a base_path.

This was causing issues with the Cache Clearing Service, as it was
trying to clear a nil path.