### PR TITLE
Switch to using RSpecMatches from the govuk_schemas gem

### DIFF
--- a/spec/support/govuk_content_schemas.rb
+++ b/spec/support/govuk_content_schemas.rb
@@ -1,2 +1,2 @@
-require 'govuk-content-schema-test-helpers/rspec_matchers'
-RSpec.configuration.include GovukContentSchemaTestHelpers::RSpecMatchers
+require 'govuk_schemas/rspec_matchers'
+RSpec.configuration.include GovukSchemas::RSpecMatchers


### PR DESCRIPTION
As it looks like these were copied there in an effort to remove the
need for the govuk-content-schemas-test-helpers gem.