### PR TITLE
Remove description from link expansion

### DIFF
--- a/lib/expansion_rules.rb
+++ b/lib/expansion_rules.rb
@@ -49,7 +49,6 @@ module ExpansionRules
     :api_path,
     :base_path,
     :content_id,
-    :description,
     :document_type,
     :locale,
     :public_updated_at,

--- a/spec/lib/expansion_rules_spec.rb
+++ b/spec/lib/expansion_rules_spec.rb
@@ -273,7 +273,6 @@ RSpec.describe ExpansionRules do
           api_path: nil,
           base_path: nil,
           content_id: nil,
-          description: nil,
           locale: nil,
           public_updated_at: nil,
           schema_name: nil,


### PR DESCRIPTION
I can't see that it gets used anywhere on the frontend and it's often the thing about an organisation that changes (which then causes many many documents to be represented) so hopefully this change should keep the low queue length down.