### PR TITLE
Increase the number of Sidekiq workers

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,6 +1,6 @@
 ---
 :verbose: false
-:concurrency: 6
+:concurrency: 10
 :logfile: ./log/sidekiq.json.log
 :queues:
   - downstream_high


### PR DESCRIPTION
The queues are often very long so increasing the number of workers might help to push content downstream quicker.

The [last time we tried this the load on our PostgreSQL machine went up too much](https://github.com/alphagov/publishing-api/pull/1284), but since then we've upgraded the machine from 8 cores to 16 cores so it might cope better this time.