### PR TITLE
Increase number of sidekiq workers (again)

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,6 +1,6 @@
 ---
 :verbose: false
-:concurrency: 10
+:concurrency: 12
 :logfile: ./log/sidekiq.json.log
 :queues:
   - downstream_high


### PR DESCRIPTION
The [load hasn't significantly increased](https://grafana.publishing.service.gov.uk/dashboard/file/machine.json?refresh=1m&orgId=1&var-hostname=postgresql-primary-1_backend&var-cpmetrics=cpu-system&var-cpmetrics=cpu-user&var-filesystem=All&var-disk=All&var-tcpconnslocal=All&var-tcpconnsremote=All&from=now-6h&to=now) since deploying 2141566132ce6cb3d9e9fbf47c02853d64b59d93 so I reckon we can probably go a bit higher.

We can leave it on this number for a week and see if it causes any problems.