### PR TITLE
Small link and dependency resolution improvements

### DIFF
--- a/app/commands/v2/publish.rb
+++ b/app/commands/v2/publish.rb
@@ -193,7 +193,7 @@ module Commands
       end
 
       def update_dependencies?
-        LinkExpansion::EditionDiff.new(edition).should_update_dependencies?
+        LinkExpansion::EditionDiff.new(edition, previous_edition: previous_edition).should_update_dependencies?
       end
 
       def send_downstream_live

--- a/app/commands/v2/publish.rb
+++ b/app/commands/v2/publish.rb
@@ -20,7 +20,7 @@ module Commands
 
       def publish_edition
         delete_change_notes unless update_type == "major"
-        previous_item.supersede if previous_item
+        previous_edition.supersede if previous_edition
 
         unless edition.pathless?
           redirect_old_base_path
@@ -37,8 +37,8 @@ module Commands
       end
 
       def orphaned_content_ids
-        return [] unless previous_item
-        previous_links = previous_item.links.map(&:target_content_id)
+        return [] unless previous_edition
+        previous_links = previous_edition.links.map(&:target_content_id)
         current_links = edition.links.map(&:target_content_id)
         previous_links - current_links
       end
@@ -73,13 +73,13 @@ module Commands
         document.draft
       end
 
-      def previous_item
+      def previous_edition
         document.published_or_unpublished
       end
 
       def redirect_old_base_path
-        return unless previous_item
-        previous_base_path = previous_item.base_path
+        return unless previous_edition
+        previous_base_path = previous_edition.base_path
 
         if previous_base_path != edition.base_path
           publish_redirect(previous_base_path, document.locale)
@@ -153,7 +153,7 @@ module Commands
       end
 
       def set_timestamps
-        Edition::Timestamps.live_transition(edition, update_type, previous_item)
+        Edition::Timestamps.live_transition(edition, update_type, previous_edition)
       end
 
       def default_datetime

--- a/app/commands/v2/publish.rb
+++ b/app/commands/v2/publish.rb
@@ -193,7 +193,9 @@ module Commands
       end
 
       def update_dependencies?
-        LinkExpansion::EditionDiff.new(edition, previous_edition: previous_edition).should_update_dependencies?
+        @update_dependencies ||= LinkExpansion::EditionDiff.new(
+          edition, previous_edition: previous_edition
+        ).should_update_dependencies?
       end
 
       def send_downstream_live
@@ -213,17 +215,17 @@ module Commands
       end
 
       def live_worker_params
-        {
+        worker_params.merge(
           message_queue_event_type: update_type,
-          update_dependencies: update_dependencies?,
           orphaned_content_ids: orphaned_content_ids,
-        }.merge(worker_params)
+        )
       end
 
       def worker_params
         {
           content_id: content_id,
           locale: locale,
+          update_dependencies: update_dependencies?,
         }
       end
     end

--- a/app/commands/v2/publish.rb
+++ b/app/commands/v2/publish.rb
@@ -38,6 +38,7 @@ module Commands
 
       def orphaned_content_ids
         return [] unless previous_edition
+
         previous_links = previous_edition.links.map(&:target_content_id)
         current_links = edition.links.map(&:target_content_id)
         previous_links - current_links
@@ -79,6 +80,7 @@ module Commands
 
       def redirect_old_base_path
         return unless previous_edition
+
         previous_base_path = previous_edition.base_path
 
         if previous_base_path != edition.base_path


### PR DESCRIPTION
This PR introduces a number of small improvements to dependency resolution and link expansion related services.

It refactors some of the code to make it easier to read, and it also changes the publish command to only perform dependency resolution on draft editions if necessary (currently a draft edition that needs to be represented will always perform dependency resolution).

Probably easiest to review commit by commit as they're not really related to each other.