### PR TITLE
Ensure related link resets are pushed to the high priority queue

### DIFF
--- a/lib/tasks/reset_related_links_for_pages.rake
+++ b/lib/tasks/reset_related_links_for_pages.rake
@@ -24,8 +24,7 @@ namespace :content do
       content_id: content_id,
       links: {
         suggested_ordered_related_items: []
-      },
-      bulk_publishing: true
+      }
     )
 
     if response.code == 200


### PR DESCRIPTION
This PR ensures that related link resets are pushed to the high priority Sidekiq queue. This will enable us to quickly remove related links if and when the need arises.