### PR TITLE
Add descriptions to service manual topics link expansion

### DIFF
--- a/lib/expansion_rules.rb
+++ b/lib/expansion_rules.rb
@@ -127,6 +127,7 @@ module ExpansionRules
 
   def reverse_to_direct_link_types(link_types)
     return unless link_types
+
     link_types.map { |type| reverse_to_direct_link_type(type) }.compact
   end
 
@@ -151,8 +152,10 @@ module ExpansionRules
 
     condition = CUSTOM_EXPANSION_FIELDS.find do |cond|
       next if should_check_link_type && cond.fetch(:link_type, link_type) != link_type
+
       cond[:document_type] == document_type.to_sym
     end
+
     condition[:fields] if condition
   end
 
@@ -200,6 +203,7 @@ module ExpansionRules
   def next_allowed_reverse_link_types(next_allowed_link_types, reverse_to_direct: false)
     next_allowed_link_types.each_with_object({}) do |(link_type, allowed_links), memo|
       next if allowed_links.empty?
+
       link_type = (reverse_to_direct_link_type(link_type) || link_type) if reverse_to_direct
 
       links = allowed_links.select { |link| is_reverse_link_type?(link) }

--- a/lib/expansion_rules.rb
+++ b/lib/expansion_rules.rb
@@ -63,6 +63,7 @@ module ExpansionRules
   NEED_FIELDS = (DEFAULT_FIELDS + details_fields(:role, :goal, :benefit, :met_when, :justifications)).freeze
   FINDER_FIELDS = (DEFAULT_FIELDS + details_fields(:facets)).freeze
   ROLE_APPOINTMENT_FIELDS = (DEFAULT_FIELDS + details_fields(:started_on, :ended_on)).freeze
+  SERVICE_MANUAL_TOPIC_FIELDS = (DEFAULT_FIELDS + [:description]).freeze
   STEP_BY_STEP_FIELDS = (DEFAULT_FIELDS + [%i(details step_by_step_nav title), %i(details step_by_step_nav steps)]).freeze
   TRAVEL_ADVICE_FIELDS = (DEFAULT_FIELDS + details_fields(:country, :change_description)).freeze
   WORLD_LOCATION_FIELDS = [:content_id, :title, :schema_name, :locale, :analytics_identifier].freeze
@@ -94,6 +95,7 @@ module ExpansionRules
     { document_type: :need,                       fields: NEED_FIELDS },
     { document_type: :finder, link_type: :finder, fields: FINDER_FIELDS },
     { document_type: :role_appointment,           fields: ROLE_APPOINTMENT_FIELDS },
+    { document_type: :service_manual_topic,       fields: SERVICE_MANUAL_TOPIC_FIELDS },
     { document_type: :step_by_step_nav,           fields: STEP_BY_STEP_FIELDS },
     { document_type: :travel_advice,              fields: TRAVEL_ADVICE_FIELDS },
     { document_type: :world_location,             fields: WORLD_LOCATION_FIELDS },

--- a/spec/lib/expansion_rules_spec.rb
+++ b/spec/lib/expansion_rules_spec.rb
@@ -46,6 +46,7 @@ RSpec.describe ExpansionRules do
     let(:need_fields) { default_fields + [%i(details role), %i(details goal), %i(details benefit), %i(details met_when), %i(details justifications)] }
     let(:finder_fields) { default_fields + [%i(details facets)] }
     let(:role_appointment_fields) { default_fields + [%i(details started_on), %i(details ended_on)] }
+    let(:service_manual_topic_fields) { default_fields + %i(description) }
     let(:step_by_step_fields) { default_fields + [%i(details step_by_step_nav title), %i(details step_by_step_nav steps)] }
     let(:travel_advice_fields) { default_fields + [%i(details country), %i(details change_description)] }
     let(:world_location_fields) { %i(content_id title schema_name locale analytics_identifier) }
@@ -77,6 +78,7 @@ RSpec.describe ExpansionRules do
     specify { expect(rules.expansion_fields(:placeholder_organisation)).to eq(organisation_fields) }
     specify { expect(rules.expansion_fields(:placeholder_topical_event)).to eq(default_fields) }
     specify { expect(rules.expansion_fields(:role_appointment)).to eq(role_appointment_fields) }
+    specify { expect(rules.expansion_fields(:service_manual_topic)).to eq(service_manual_topic_fields) }
     specify { expect(rules.expansion_fields(:step_by_step_nav)).to eq(step_by_step_fields) }
     specify { expect(rules.expansion_fields(:pages_secondary_to_step_nav)).to eq(default_fields) }
     specify { expect(rules.expansion_fields(:topical_event)).to eq(default_fields) }


### PR DESCRIPTION
These descriptions are used on the service manual homepage under the topic headers so we need to make sure they're exposed in the content item.