### PR TITLE
Add description to a possible field for expansion

### DIFF
--- a/lib/expansion_rules.rb
+++ b/lib/expansion_rules.rb
@@ -106,7 +106,7 @@ module ExpansionRules
 
   POSSIBLE_FIELDS_FOR_LINK_EXPANSION = DEFAULT_FIELDS +
     %i[details] +
-    %i[id state phase unpublishings.type] -
+    %i[id state phase description unpublishings.type] -
     %i[api_path withdrawn]
 
   def reverse_links


### PR DESCRIPTION
These fields are used to decide which fields to pluck from the database.

We need this for #1569 to work.