### PR TITLE
Remove fields argument from DependencyResolutionWorker

### DIFF
--- a/app/workers/dependency_resolution_worker.rb
+++ b/app/workers/dependency_resolution_worker.rb
@@ -16,7 +16,7 @@ class DependencyResolutionWorker
 
 private
 
-  attr_reader :content_id, :locale, :fields, :content_store, :orphaned_content_ids
+  attr_reader :content_id, :locale, :content_store, :orphaned_content_ids
 
   def assign_attributes(args)
     @content_id = args.fetch(:content_id)

--- a/app/workers/downstream_discard_draft_worker.rb
+++ b/app/workers/downstream_discard_draft_worker.rb
@@ -43,7 +43,6 @@ private
   def enqueue_dependencies
     DependencyResolutionWorker.perform_async(
       content_store: Adapters::DraftContentStore,
-      fields: [:content_id],
       content_id: content_id,
       locale: locale,
     )

--- a/app/workers/downstream_draft_worker.rb
+++ b/app/workers/downstream_draft_worker.rb
@@ -66,7 +66,6 @@ private
   def enqueue_dependencies
     DependencyResolutionWorker.perform_async(
       content_store: Adapters::DraftContentStore,
-      fields: [:content_id],
       content_id: content_id,
       locale: locale,
       orphaned_content_ids: orphaned_content_ids,

--- a/app/workers/downstream_live_worker.rb
+++ b/app/workers/downstream_live_worker.rb
@@ -71,7 +71,6 @@ private
   def enqueue_dependencies
     DependencyResolutionWorker.perform_async(
       content_store: Adapters::ContentStore,
-      fields: [:content_id],
       content_id: content_id,
       locale: locale,
       orphaned_content_ids: orphaned_content_ids,


### PR DESCRIPTION
It's not used anywhere and we're currently always passing a hard coded `[:content_id]` value.

To quote Kevin:

> it was an idea that never followed through and should be cut down