### PR TITLE
Fix linting issues

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -840,7 +840,7 @@ GEM
       thor (>= 0.19.0, < 2.0)
     rainbow (3.0.0)
     raindrops (0.19.0)
-    rake (12.3.2)
+    rake (12.3.3)
     randexp (0.1.7)
     rb-fsevent (0.10.3)
     rb-inotify (0.10.0)
@@ -877,17 +877,17 @@ GEM
       rspec-mocks (~> 3.8.0)
       rspec-support (~> 3.8.0)
     rspec-support (3.8.0)
-    rubocop (0.72.0)
+    rubocop (0.74.0)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
       parser (>= 2.6)
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 1.7)
-    rubocop-rails (2.2.0)
+    rubocop-rails (2.2.1)
       rack (>= 1.1)
       rubocop (>= 0.72.0)
-    rubocop-rspec (1.33.0)
+    rubocop-rspec (1.35.0)
       rubocop (>= 0.60.0)
     ruby-progressbar (1.10.1)
     safe_yaml (1.0.5)
@@ -1030,4 +1030,4 @@ DEPENDENCIES
   with_advisory_lock (~> 4.0)
 
 BUNDLED WITH
-   1.16.6
+   1.17.2

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -31,6 +31,7 @@ node("postgresql-9.3") {
       }
     },
     brakeman: true,
+    rubyLintDiff: false,
   )
 }
 

--- a/app/commands/v2/publish.rb
+++ b/app/commands/v2/publish.rb
@@ -170,6 +170,7 @@ module Commands
 
       def set_update_type
         return if edition.update_type
+
         edition.update_attributes!(update_type: update_type)
       end
 

--- a/app/commands/v2/put_content.rb
+++ b/app/commands/v2/put_content.rb
@@ -44,6 +44,7 @@ module Commands
 
       def prepare_content_with_base_path
         return unless payload[:base_path]
+
         PathReservation.reserve_base_path!(payload[:base_path], payload[:publishing_app])
         clear_draft_items_of_same_locale_and_base_path
       end
@@ -72,6 +73,7 @@ module Commands
 
       def create_links(edition)
         return if payload[:links].nil?
+
         payload[:links].each do |link_type, target_link_ids|
           edition.links.create!(
             target_link_ids.map.with_index do |target_link_id, i|
@@ -83,6 +85,7 @@ module Commands
 
       def create_redirect
         return unless payload[:base_path]
+
         RedirectHelper::Redirect.new(previously_published_edition,
                                      @previous_edition,
                                      payload, callbacks).create

--- a/app/commands/v2/put_content_validator.rb
+++ b/app/commands/v2/put_content_validator.rb
@@ -17,6 +17,7 @@ module Commands
 
       def validate_schema
         return if schema_validator.valid?
+
         message = "The payload did not conform to the schema"
         raise CommandError.new(
           code: 422,
@@ -27,6 +28,7 @@ module Commands
 
       def validate_publishing_app
         return unless payload[:publishing_app].blank?
+
         code = 422
         message = "publishing_app is required"
         raise CommandError.new(

--- a/app/commands/v2/unpublish.rb
+++ b/app/commands/v2/unpublish.rb
@@ -134,6 +134,7 @@ module Commands
 
       def orphaned_content_ids
         return [] if !payload[:allow_draft] || !previous
+
         previous_links = previous.links.map(&:target_content_id)
         current_links = find_unpublishable_edition.links.map(&:target_content_id)
         previous_links - current_links

--- a/app/controllers/content_api_prototype/content_items/content_controller.rb
+++ b/app/controllers/content_api_prototype/content_items/content_controller.rb
@@ -46,6 +46,7 @@ module ContentApiPrototype
       def user_facing_version_for(edition, position)
         return edition.user_facing_version + 1 if position == :next
         return edition.user_facing_version - 1 if position == :prev
+
         raise "Invalid position, must be :next or :prev"
       end
 
@@ -59,6 +60,7 @@ module ContentApiPrototype
       def link_to_sibling(edition, position)
         other_edition = sibling_edition(edition, position)
         return unless other_edition
+
         "/content/#{other_edition.document.content_id}/#{other_edition.document.locale}/#{other_edition.user_facing_version}"
       end
 

--- a/app/errors/command_error.rb
+++ b/app/errors/command_error.rb
@@ -35,6 +35,7 @@ class CommandError < StandardError
   # error_details: Hash(field_name: String => [error_messages]: Array(String))
   def initialize(code:, message: nil, error_details: nil)
     raise "Invalid code #{code}" unless valid_code?(code)
+
     @code = code
     @error_details = if error_details
                        error_details

--- a/app/event_logger.rb
+++ b/app/event_logger.rb
@@ -17,11 +17,11 @@ module EventLogger
       end
 
       response
-    rescue CommandRetryableError => error
+    rescue CommandRetryableError => e
       if (tries -= 1).positive?
         retry
       else
-        raise CommandError.new(code: 400, message: "Too many retries - #{error.message}")
+        raise CommandError.new(code: 400, message: "Too many retries - #{e.message}")
       end
     end
   end

--- a/app/helpers/redirect_helper.rb
+++ b/app/helpers/redirect_helper.rb
@@ -36,6 +36,7 @@ module RedirectHelper
 
     def previously_drafted_item_base_path_changed?
       return false unless previously_drafted_item
+
       previously_drafted_item.base_path != payload[:base_path]
     end
 

--- a/app/models/change_note.rb
+++ b/app/models/change_note.rb
@@ -14,6 +14,7 @@ class ChangeNoteFactory
 
   def build
     return unless update_type == "major"
+
     create_from_top_level_change_note ||
       create_from_details_hash_change_note ||
       create_from_details_hash_change_history
@@ -25,6 +26,7 @@ private
 
   def create_from_top_level_change_note
     return unless change_note
+
     change_note_instance.update!(
       public_timestamp: payload[:public_updated_at] || Time.zone.now,
       note: change_note,
@@ -33,6 +35,7 @@ private
 
   def create_from_details_hash_change_note
     return unless note
+
     change_note_instance.update!(
       public_timestamp: edition.public_updated_at,
       note: note,
@@ -41,6 +44,7 @@ private
 
   def create_from_details_hash_change_history
     return unless change_history.present?
+
     history_element = change_history.max_by { |h| h[:public_timestamp] }
     change_note_instance.update!(
       public_timestamp: history_element.fetch(:public_timestamp),

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -217,16 +217,19 @@ class Edition < ApplicationRecord
 
   def api_path
     return unless base_path
+
     "/api/content" + base_path
   end
 
   def api_url
     return unless api_path
+
     Plek.current.website_root + api_path
   end
 
   def web_url
     return unless base_path
+
     Plek.current.website_root + base_path
   end
 

--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -26,7 +26,7 @@ class Link < ApplicationRecord
 
 private
 
-  VALID_LINK_TYPE_REGEX = /\A[a-z0-9_]+\z/
+  VALID_LINK_TYPE_REGEX = /\A[a-z0-9_]+\z/.freeze
   AUTOMATIC_LINK_TYPES = %w[available_translations].freeze
 
   def association_presence

--- a/app/presenters/edition_presenter.rb
+++ b/app/presenters/edition_presenter.rb
@@ -77,6 +77,7 @@ module Presenters
 
     def access_limited
       return {} unless access_limit
+
       if edition.state != 'draft'
         GovukError.notify(
           "Tried to send non-draft item with access_limited data",

--- a/app/presenters/queries/available_translations.rb
+++ b/app/presenters/queries/available_translations.rb
@@ -16,6 +16,7 @@ module Presenters
 
       def translations
         return {} unless expanded_translations.present?
+
         { available_translations: expanded_translations }
       end
 
@@ -43,6 +44,7 @@ module Presenters
 
       def edition_for_id(id)
         return edition if edition && edition.id == id
+
         Edition.find_by(id: id)
       end
 
@@ -58,6 +60,7 @@ module Presenters
 
       def state_fallback_order
         return %i[draft published unpublished] if with_drafts
+
         %i[published unpublished]
       end
 

--- a/app/presenters/queries/content_item_presenter.rb
+++ b/app/presenters/queries/content_item_presenter.rb
@@ -2,7 +2,7 @@ module Presenters
   module Queries
     class ContentItemPresenter
       attr_reader :edition_scope, :fields, :order, :limit, :offset,
-        :search_query, :search_in, :states, :include_warnings
+                  :search_query, :search_in, :states, :include_warnings
 
       DEFAULT_FIELDS = ([
         *Edition::TOP_LEVEL_FIELDS,
@@ -84,6 +84,7 @@ module Presenters
 
       def search(scope)
         return scope unless search_query.present?
+
         conditions = search_in.map { |search_field| "#{search_field} ilike :query" }
         scope.where(conditions.join(" OR "), query: "%#{search_query}%")
       end
@@ -98,6 +99,7 @@ module Presenters
       def state_order_clause
         priorities = { draft: 0, published: 1, unpublished: 1, superseded: 2 }.slice(*states)
         return unless priorities.values.uniq.count > 1
+
         Arel.sql("CASE state #{priorities.map { |k, v| "WHEN '#{k}' THEN #{v} " }.join} END")
       end
 
@@ -181,6 +183,7 @@ module Presenters
       def join_lateral_aggregates(scope)
         LATERAL_AGGREGATES.each do |field, sql|
           next unless fields.include?(field)
+
           scope = scope.joins("LEFT JOIN LATERAL #{sql} ON TRUE")
         end
         scope
@@ -241,11 +244,13 @@ module Presenters
       def parse_json_column(result, column)
         return unless result.key?(column)
         return if result[column].nil?
+
         result[column] = Oj.load(result[column])
       end
 
       def parse_int_column(result, column)
         return unless result.key?(column)
+
         result[column] = result[column].to_i
       end
 
@@ -262,6 +267,7 @@ module Presenters
       def parse_state_history(result)
         column = "state_history"
         return unless result.key?(column)
+
         result[column] = result[column].map(&:values).to_h
       end
 

--- a/app/presenters/queries/link_set_presenter.rb
+++ b/app/presenters/queries/link_set_presenter.rb
@@ -19,6 +19,7 @@ module Presenters
 
       def links
         return {} unless link_set
+
         @links ||= link_set.links.pluck(:link_type, :target_content_id).map.with_object({}) do |link, hash|
           type = link[0].to_sym
 

--- a/app/presenters/redirect_presenter.rb
+++ b/app/presenters/redirect_presenter.rb
@@ -38,7 +38,7 @@ class RedirectPresenter
 private
 
   attr_reader :base_path, :publishing_app, :public_updated_at, :redirects,
-    :content_id, :locale
+              :content_id, :locale
 
   def present
     attributes = {

--- a/app/presenters/results_presenter.rb
+++ b/app/presenters/results_presenter.rb
@@ -35,6 +35,7 @@ module Presenters
 
     def previous_link
       return unless previous_page?
+
       {
         href: page_href(-1),
         rel: "previous"
@@ -43,6 +44,7 @@ module Presenters
 
     def next_link
       return unless next_page?
+
       {
         href: page_href(1),
         rel: "next"

--- a/app/queries/base_path_for_state.rb
+++ b/app/queries/base_path_for_state.rb
@@ -24,6 +24,7 @@ module Queries
     def has_no_conflicts?(state, edition_id)
       return true if state == "superseded"
       return true if state == "unpublished" && Unpublishing.is_substitute?(edition_id)
+
       false
     end
 
@@ -41,6 +42,7 @@ module Queries
 
     def limit_scope_to_unpublishing(scope, state)
       return scope unless %w(published unpublished).include?(state)
+
       scope
         .with_unpublishing
         .where("unpublishings.type IS NULL OR unpublishings.type != 'substitute'")

--- a/app/queries/edition_links.rb
+++ b/app/queries/edition_links.rb
@@ -74,6 +74,7 @@ module Queries
 
     def draft_condition
       return { editions: { content_store: "live" } } unless with_drafts
+
       <<-SQL.strip_heredoc
         CASE WHEN EXISTS (
             SELECT 1 FROM editions AS e

--- a/app/queries/get_content_collection.rb
+++ b/app/queries/get_content_collection.rb
@@ -91,18 +91,21 @@ module Queries
 
     def search_fields
       return default_search_fields if search_in.blank?
+
       search_in.map { |field| search_field_for_query(field) }
     end
 
     def search_field_for_query(field)
       raise_error("Invalid search field: #{field}") unless valid_search_field?(field)
       return field unless field.include?(".")
+
       elements = field.split(".")
       "#{elements[0]}->>'#{escape_nested_field(elements[1])}'"
     end
 
     def valid_search_field?(field)
       return true if allowed_search_fields.include?(field)
+
       elements = field.split(".")
       allowed_nested_search_fields.include?(elements[0]) && elements.length == 2
     end

--- a/app/queries/keyset_pagination.rb
+++ b/app/queries/keyset_pagination.rb
@@ -85,6 +85,7 @@ module Queries
       key_fields.map do |k|
         value = record[k]
         next value.iso8601(6) if value.respond_to?(:iso8601)
+
         value.to_s
       end
     end

--- a/app/queries/links.rb
+++ b/app/queries/links.rb
@@ -80,7 +80,7 @@ module Queries
   private
 
     attr_reader :content_id, :mode, :allowed_link_types, :parent_content_ids,
-      :next_allowed_link_types_from, :next_allowed_link_types_to
+                :next_allowed_link_types_from, :next_allowed_link_types_to
 
     def initialize(
       content_id:,
@@ -151,11 +151,13 @@ module Queries
 
     def has_own_links_result(row)
       return false unless could_have_from_children?
+
       check_for_from_children? ? row[2] : nil
     end
 
     def is_linked_to_result(row)
       return false unless could_have_to_children?
+
       check_for_from_children? ? row[3] : row[2]
     end
 

--- a/app/services/downstream_service.rb
+++ b/app/services/downstream_service.rb
@@ -45,6 +45,7 @@ module DownstreamService
 
   def self.discard_from_draft_content_store(base_path)
     return unless base_path
+
     if discard_draft_base_path_conflict?(base_path)
       message = "Cannot discard '#{base_path}' as there is an item occupying that base path"
       raise DiscardDraftBasePathConflictError.new(message)
@@ -54,11 +55,13 @@ module DownstreamService
 
   def self.draft_at_base_path?(base_path)
     return false unless base_path
+
     Edition.exists?(base_path: base_path, state: "draft")
   end
 
   def self.discard_draft_base_path_conflict?(base_path)
     return false unless base_path
+
     Edition.exists?(
       base_path: base_path,
       state: %w(draft published unpublished),

--- a/app/substitution_helper.rb
+++ b/app/substitution_helper.rb
@@ -69,6 +69,7 @@ private
 
   def can_substitute?(edition)
     return true if edition.unpublished? && can_substitute_unpublishing_type?(edition.unpublishing.type)
+
     can_substitute_document_type?(edition.document_type)
   end
 

--- a/app/validators/base_path_for_state_validator.rb
+++ b/app/validators/base_path_for_state_validator.rb
@@ -1,6 +1,7 @@
 class BasePathForStateValidator < ActiveModel::Validator
   def validate(record)
     return unless record.state && record.base_path
+
     check_conflict(record)
   end
 

--- a/app/validators/dns_hostname_validator.rb
+++ b/app/validators/dns_hostname_validator.rb
@@ -1,5 +1,5 @@
 class DnsHostnameValidator < ActiveModel::EachValidator
-  DNS_HOSTNAME_PATTERN = /\A[a-z0-9\-_]*\z/
+  DNS_HOSTNAME_PATTERN = /\A[a-z0-9\-_]*\z/.freeze
 
   def validate_each(record, attribute, value)
     unless value && value.match(DNS_HOSTNAME_PATTERN)

--- a/app/validators/routes_and_redirects_validator.rb
+++ b/app/validators/routes_and_redirects_validator.rb
@@ -29,6 +29,7 @@ private
 
   def check_redirects?(record)
     return record.schema_name == "redirect" if record.respond_to?(:schema_name)
+
     record.redirect?
   end
 

--- a/app/validators/schema_validator.rb
+++ b/app/validators/schema_validator.rb
@@ -14,6 +14,7 @@ class SchemaValidator
 
   def valid?
     return true if schema_name_exception?
+
     @errors += JSON::Validator.fully_validate(
       schema,
       payload,
@@ -42,6 +43,7 @@ private
 
   def find_type
     raise NoSchemaNameError.new("No schema name provided") unless schema_name.present?
+
     { schema_type_key => schema_name }
   end
 

--- a/app/validators/uuid_validator.rb
+++ b/app/validators/uuid_validator.rb
@@ -20,7 +20,7 @@ class UuidValidator < ActiveModel::EachValidator
     -
     [a-f\d]{12}
     \z
-  }x
+  }x.freeze
 
   def validate_each(record, attribute, value)
     unless self.class.valid?(value)

--- a/app/validators/well_formed_content_types_validator.rb
+++ b/app/validators/well_formed_content_types_validator.rb
@@ -85,6 +85,7 @@ private
 
   def validate_that_one_of_the_mandatory_content_types_is_present!(array, optional_content_types)
     return true if optional_content_types.empty?
+
     no_matches = array.none? { |h| optional_content_types.include?(h[:content_type]) }
 
     if no_matches

--- a/app/workers/downstream_discard_draft_worker.rb
+++ b/app/workers/downstream_discard_draft_worker.rb
@@ -29,7 +29,7 @@ class DownstreamDiscardDraftWorker
 private
 
   attr_reader :base_path, :content_id, :locale, :edition,
-    :payload_version, :update_dependencies
+              :payload_version, :update_dependencies
 
   def assign_attributes(attributes)
     @base_path = attributes.fetch(:base_path)

--- a/app/workers/downstream_draft_worker.rb
+++ b/app/workers/downstream_draft_worker.rb
@@ -48,7 +48,7 @@ class DownstreamDraftWorker
 private
 
   attr_reader :content_id, :locale, :edition, :payload_version,
-    :update_dependencies, :dependency_resolution_source_content_id, :orphaned_content_ids
+              :update_dependencies, :dependency_resolution_source_content_id, :orphaned_content_ids
 
   def assign_attributes(attributes)
     @content_id = attributes.fetch(:content_id)
@@ -88,8 +88,8 @@ private
     # When a document is only in draft it's expanded links can still be
     # accessed without drafts, so this is generates them as well.
     live_links = Presenters::Queries::ExpandedLinkSet.by_content_id(content_id,
-      locale: locale,
-      with_drafts: false)
+                                                                    locale: locale,
+                                                                    with_drafts: false)
     ExpandedLinks.locked_update(
       content_id: content_id,
       locale: locale,

--- a/app/workers/downstream_live_worker.rb
+++ b/app/workers/downstream_live_worker.rb
@@ -51,8 +51,8 @@ class DownstreamLiveWorker
 private
 
   attr_reader :content_id, :locale, :edition, :payload_version,
-    :message_queue_event_type, :update_dependencies,
-    :dependency_resolution_source_content_id, :orphaned_content_ids
+              :message_queue_event_type, :update_dependencies,
+              :dependency_resolution_source_content_id, :orphaned_content_ids
 
   def assign_attributes(attributes)
     @content_id = attributes.fetch(:content_id)

--- a/config/initializers/services.rb
+++ b/config/initializers/services.rb
@@ -19,7 +19,7 @@ PublishingAPI.register_service(
   name: :draft_content_store,
   client: ContentStoreWriter.new(
     Plek.find('draft-content-store'),
-    { bearer_token: ENV['DRAFT_CONTENT_STORE_BEARER_TOKEN'] },
+    bearer_token: ENV['DRAFT_CONTENT_STORE_BEARER_TOKEN'],
   )
 )
 
@@ -27,7 +27,7 @@ PublishingAPI.register_service(
   name: :live_content_store,
   client: ContentStoreWriter.new(
     Plek.find('content-store'),
-    { bearer_token: ENV['CONTENT_STORE_BEARER_TOKEN'] },
+    bearer_token: ENV['CONTENT_STORE_BEARER_TOKEN'],
   )
 )
 

--- a/lib/data_hygiene/govspeak_compare.rb
+++ b/lib/data_hygiene/govspeak_compare.rb
@@ -32,6 +32,7 @@ module DataHygiene
 
     def pretty_much_same_html?
       return true if same_html?
+
       diffs.all? { |_, diff| diff == [] }
     end
 
@@ -58,6 +59,7 @@ module DataHygiene
 
     def apply_old_html_common_changes(html)
       return unless html
+
       # In specialist publisher we have a lot of new lines in inline attachments
       # which causes us trouble as we only allow inline attachments to be on a single line
       regex = %r{<a (rel="external" )?href="https:\/\/assets.digital.cabinet-office.gov.uk\/.*?">((?:.|\n)*?)<\/a>}

--- a/lib/dependency_resolution/link_reference.rb
+++ b/lib/dependency_resolution/link_reference.rb
@@ -56,10 +56,10 @@ private
       .next_allowed_direct_link_types(allowed_link_types, link_types_path, reverse_to_direct: true)
 
     links = Queries::Links.from(content_id,
-      allowed_link_types: rules.reverse_to_direct_link_types(allowed_link_types),
-      parent_content_ids: parent_content_ids,
-      next_allowed_link_types_from: next_allowed_link_types_from,
-      next_allowed_link_types_to: next_allowed_link_types_to)
+                                allowed_link_types: rules.reverse_to_direct_link_types(allowed_link_types),
+                                parent_content_ids: parent_content_ids,
+                                next_allowed_link_types_from: next_allowed_link_types_from,
+                                next_allowed_link_types_to: next_allowed_link_types_to)
 
     rules.reverse_link_types_hash(links)
   end
@@ -80,22 +80,22 @@ private
       .next_allowed_direct_link_types(allowed_link_types, link_types_path, reverse_to_direct: true)
 
     Queries::Links.to(content_id,
-      allowed_link_types: allowed_link_types,
-      parent_content_ids: parent_content_ids,
-      next_allowed_link_types_from: next_allowed_link_types_from,
-      next_allowed_link_types_to: next_allowed_link_types_to)
+                      allowed_link_types: allowed_link_types,
+                      parent_content_ids: parent_content_ids,
+                      next_allowed_link_types_from: next_allowed_link_types_from,
+                      next_allowed_link_types_to: next_allowed_link_types_to)
   end
 
   def edition_links(content_id, locale, with_drafts)
     to_links = Queries::EditionLinks.to(content_id,
-      locale: locale,
-      with_drafts: with_drafts,
-      allowed_link_types: nil)
+                                        locale: locale,
+                                        with_drafts: with_drafts,
+                                        allowed_link_types: nil)
 
     from_links = Queries::EditionLinks.from(content_id,
-      locale: locale,
-      with_drafts: with_drafts,
-      allowed_link_types: rules.reverse_to_direct_link_types(rules.reverse_links))
+                                            locale: locale,
+                                            with_drafts: with_drafts,
+                                            allowed_link_types: rules.reverse_to_direct_link_types(rules.reverse_links))
 
     from_links = rules.reverse_link_types_hash(from_links)
 

--- a/lib/distributed_lock.rb
+++ b/lib/distributed_lock.rb
@@ -28,6 +28,7 @@ class DistributedLock
     end
 
     raise FailedToAcquireLock unless @has_run
+
     result
   end
 

--- a/lib/events/s3_exporter.rb
+++ b/lib/events/s3_exporter.rb
@@ -26,6 +26,7 @@ module Events
     def bucket
       bucket_name = Rails.application.config.s3_export.bucket
       raise BucketNotConfiguredError.new("A bucket has not been configured") unless bucket_name.present?
+
       @bucket ||= s3.bucket(bucket_name)
     end
 
@@ -53,6 +54,7 @@ module Events
     def upload(file)
       object = bucket.object(s3_key)
       raise EventsExportExistsError.new("S3 already has an export for #{object.key}") if object.exists?
+
       object.put(body: file, server_side_encryption: "AES256")
     end
 

--- a/lib/events/s3_importer.rb
+++ b/lib/events/s3_importer.rb
@@ -26,6 +26,7 @@ module Events
     def bucket
       bucket_name = Rails.application.config.s3_export.bucket
       raise BucketNotConfiguredError.new("A bucket has not been configured") unless bucket_name.present?
+
       @bucket ||= s3.bucket(bucket_name)
     end
 

--- a/lib/expansion_rules/multi_level_links.rb
+++ b/lib/expansion_rules/multi_level_links.rb
@@ -8,6 +8,7 @@ class ExpansionRules::MultiLevelLinks
     @next_cache ||= {}
     @next_cache[link_types_path.to_s] ||= begin
       raise "Can't operate on an empty link_types_path" if link_types_path.empty?
+
       # look up all the paths for the next level and the level beyond it
       extra_item1 = paths(length: link_types_path.length + 1)
       extra_item2 = paths(length: link_types_path.length + 2)
@@ -32,6 +33,7 @@ class ExpansionRules::MultiLevelLinks
       paths = multi_level_link_paths.map do |path|
         recurring = path.count { |a| a.is_a?(Array) }
         raise "Only 1 recurring item supported" if recurring > 1
+
         non_recurring = path.count - recurring
         cycles = [1, length - non_recurring].max
         path.flat_map { |item| item.is_a?(Array) ? item.cycle(cycles).to_a : item }

--- a/lib/link_expansion.rb
+++ b/lib/link_expansion.rb
@@ -66,6 +66,7 @@ private
   def link_content(node)
     edition_hash = content_cache.find(node.content_id)
     return if !edition_hash || !should_link?(node.link_type, edition_hash)
+
     rules.expand_fields(edition_hash, node.link_type).tap do |expanded|
       links = populate_links(node.links)
       auto_reverse = auto_reverse_link(node)
@@ -77,8 +78,10 @@ private
     if node.link_types_path.length != 1 || !rules.is_reverse_link_type?(node.link_types_path.first)
       return {}
     end
+
     edition_hash = content_cache.find(content_id)
     return if !edition_hash || !should_link?(node.link_type, edition_hash)
+
     reverse_to_direct_link_type = rules.reverse_to_direct_link_type(node.link_types_path.first)
     { reverse_to_direct_link_type => [rules.expand_fields(edition_hash, reverse_to_direct_link_type).merge(links: {})] }
   end

--- a/lib/link_expansion/content_cache.rb
+++ b/lib/link_expansion/content_cache.rb
@@ -42,10 +42,12 @@ private
 
   def fetch_editions_from_database(content_ids)
     return [] unless content_ids.present?
+
     edition_ids = Queries::GetEditionIdsWithFallbacks.(content_ids,
-      locale_fallback_order: locale_fallback_order,
-      state_fallback_order: state_fallback_order)
+                                                       locale_fallback_order: locale_fallback_order,
+                                                       state_fallback_order: state_fallback_order)
     return [] unless edition_ids
+
     Edition
       .joins(
         <<-SQL.strip_heredoc

--- a/lib/link_expansion/edition_diff.rb
+++ b/lib/link_expansion/edition_diff.rb
@@ -26,6 +26,7 @@ private
 
   def previous_edition_expanded
     return {} if previous_edition.blank?
+
     ExpansionRules.expand_fields(previous_edition.to_h.deep_symbolize_keys, nil)
   end
 

--- a/lib/link_expansion/edition_hash.rb
+++ b/lib/link_expansion/edition_hash.rb
@@ -2,6 +2,7 @@ class LinkExpansion::EditionHash
   class << self
     def from(values)
       return nil unless values.present?
+
       hash = hash_for(values)
       hash = SymbolizeJSON.symbolize(hash)
       hash = hash.slice(*ExpansionRules::POSSIBLE_FIELDS_FOR_LINK_EXPANSION)
@@ -14,6 +15,7 @@ class LinkExpansion::EditionHash
 
     def hash_for(values)
       return nil unless values.present?
+
       case values
       when Array
         Hash[ExpansionRules::POSSIBLE_FIELDS_FOR_LINK_EXPANSION.zip(values)]
@@ -38,6 +40,7 @@ class LinkExpansion::EditionHash
     def withdrawn?(hash)
       unpublishing_type = hash[:"unpublishings.type"]
       return false if unpublishing_type.nil?
+
       unpublishing_type == "withdrawal"
     end
   end

--- a/lib/link_expansion/link_reference.rb
+++ b/lib/link_expansion/link_reference.rb
@@ -53,10 +53,10 @@ private
       .next_allowed_reverse_link_types(allowed_link_types, link_types_path, reverse_to_direct: true)
 
     Queries::Links.from(content_id,
-      allowed_link_types: allowed_link_types,
-      parent_content_ids: parent_content_ids,
-      next_allowed_link_types_from: next_allowed_link_types_from,
-      next_allowed_link_types_to: next_allowed_link_types_to)
+                        allowed_link_types: allowed_link_types,
+                        parent_content_ids: parent_content_ids,
+                        next_allowed_link_types_from: next_allowed_link_types_from,
+                        next_allowed_link_types_to: next_allowed_link_types_to)
   end
 
   def child_linked_to(content_id, link_types_path = [], parent_content_ids = [])
@@ -75,24 +75,24 @@ private
       .next_allowed_reverse_link_types(allowed_link_types, link_types_path, reverse_to_direct: true)
 
     links = Queries::Links.to(content_id,
-      allowed_link_types: rules.reverse_to_direct_link_types(allowed_link_types),
-      parent_content_ids: parent_content_ids,
-      next_allowed_link_types_from: next_allowed_link_types_from,
-      next_allowed_link_types_to: next_allowed_link_types_to)
+                              allowed_link_types: rules.reverse_to_direct_link_types(allowed_link_types),
+                              parent_content_ids: parent_content_ids,
+                              next_allowed_link_types_from: next_allowed_link_types_from,
+                              next_allowed_link_types_to: next_allowed_link_types_to)
 
     rules.reverse_link_types_hash(links)
   end
 
   def edition_links(content_id, locale, with_drafts)
     from_links = Queries::EditionLinks.from(content_id,
-      locale: locale,
-      with_drafts: with_drafts,
-      allowed_link_types: nil)
+                                            locale: locale,
+                                            with_drafts: with_drafts,
+                                            allowed_link_types: nil)
 
     to_links = Queries::EditionLinks.to(content_id,
-      locale: locale,
-      with_drafts: with_drafts,
-      allowed_link_types: rules.reverse_to_direct_link_types(rules.reverse_links))
+                                        locale: locale,
+                                        with_drafts: with_drafts,
+                                        allowed_link_types: rules.reverse_to_direct_link_types(rules.reverse_links))
 
     to_links = rules.reverse_link_types_hash(to_links)
     to_links.merge(from_links)

--- a/lib/queue_publisher.rb
+++ b/lib/queue_publisher.rb
@@ -20,6 +20,7 @@ class QueuePublisher
 
   def send_message(edition, event_type: nil, routing_key: nil, persistent: true)
     return if @noop
+
     validate_edition(edition)
     routing_key ||= routing_key(edition, event_type)
     publish_message(routing_key, edition, content_type: 'application/json', persistent: persistent)
@@ -33,6 +34,7 @@ class QueuePublisher
 
   def send_heartbeat
     return if @noop
+
     body = {
       timestamp: Time.now.utc.iso8601,
       hostname: Socket.gethostname,

--- a/lib/tasks/corporate_info_fix.rake
+++ b/lib/tasks/corporate_info_fix.rake
@@ -26,6 +26,7 @@ task corporate_info_fix: :environment do
       documents = Document.where(content_id: content_id)
 
       raise "didn't expect more than one doc" if documents.count > 1
+
       document = documents.first
 
       editions = document.editions

--- a/lib/tasks/govspeak.rake
+++ b/lib/tasks/govspeak.rake
@@ -16,9 +16,11 @@ namespace :govspeak do
       same_html += 1 if comparer.same_html?
       trivial_differences += 1 if !comparer.same_html? && comparer.pretty_much_same_html?
       next if comparer.pretty_much_same_html?
+
       puts "Edition #{edition.id} #{edition.document.content_id} #{edition.state} #{edition.base_path}"
       comparer.diffs.each do |field, diff|
         next if diff == []
+
         puts field
         diff.each do |item|
           print item.red if item[0] == "-"

--- a/lib/tasks/sanitize_data.rake
+++ b/lib/tasks/sanitize_data.rake
@@ -111,6 +111,7 @@ task bulk_assign_primary_organisation_from_stdin: [:environment] do |_, _args|
   rows = []
   CSV.new(STDIN).each do |row|
     raise ValueError if row.length != 2
+
     rows << row
   end
 

--- a/lib/tasks/version_validator.rb
+++ b/lib/tasks/version_validator.rb
@@ -73,6 +73,7 @@ module Tasks
         return 1 if left.second == "draft" && right.second == "superseded"
         return -1 if left.second == "published" && right.second == "draft"
         return 1 if left.second == "draft" && right.second == "published"
+
         left.first <=> right.first
       end
     end

--- a/spec/commands/v2/discard_draft_spec.rb
+++ b/spec/commands/v2/discard_draft_spec.rb
@@ -11,8 +11,8 @@ RSpec.describe Commands::V2::DiscardDraft do
     let(:locale) { "en" }
     let(:document) do
       create(:document,
-        locale: "en",
-        stale_lock_version: stale_lock_version)
+             locale: "en",
+             stale_lock_version: stale_lock_version)
     end
     let(:stale_lock_version) { 1 }
     let(:base_path) { "/vat-rates" }
@@ -28,9 +28,9 @@ RSpec.describe Commands::V2::DiscardDraft do
       let(:user_facing_version) { 2 }
       let!(:existing_draft_item) do
         create(:access_limited_draft_edition,
-          document: document,
-          base_path: base_path,
-          user_facing_version: user_facing_version)
+               document: document,
+               base_path: base_path,
+               user_facing_version: user_facing_version)
       end
       let!(:change_note) { ChangeNote.create(edition: existing_draft_item) }
 
@@ -99,9 +99,9 @@ RSpec.describe Commands::V2::DiscardDraft do
         let(:stale_lock_version) { 3 }
         let!(:published_item) do
           create(:live_edition,
-            document: document,
-            base_path: base_path,
-            user_facing_version: user_facing_version - 1)
+                 document: document,
+                 base_path: base_path,
+                 user_facing_version: user_facing_version - 1)
         end
 
         it "increments the lock version of the published item" do
@@ -140,9 +140,9 @@ RSpec.describe Commands::V2::DiscardDraft do
       context "a published edition exists with a different base_path" do
         let!(:published_item) do
           create(:live_edition,
-            document: document,
-            base_path: "/hat-rates",
-            user_facing_version: user_facing_version - 1)
+                 document: document,
+                 base_path: "/hat-rates",
+                 user_facing_version: user_facing_version - 1)
         end
 
         it "it uses downstream discard draft worker" do
@@ -162,9 +162,9 @@ RSpec.describe Commands::V2::DiscardDraft do
       context "an unpublished edition exits" do
         let(:unpublished_item) do
           create(:unpublished_edition,
-            document: document,
-            base_path: base_path,
-            user_facing_version: user_facing_version - 1)
+                 document: document,
+                 base_path: base_path,
+                 user_facing_version: user_facing_version - 1)
         end
 
         it "it uses downstream discard draft worker" do
@@ -187,8 +187,8 @@ RSpec.describe Commands::V2::DiscardDraft do
         end
         let!(:french_draft_item) do
           create(:draft_edition,
-            document: french_document,
-            base_path: "#{base_path}.fr")
+                 document: french_document,
+                 base_path: "#{base_path}.fr")
         end
 
         before do

--- a/spec/commands/v2/patch_link_set_spec.rb
+++ b/spec/commands/v2/patch_link_set_spec.rb
@@ -59,9 +59,9 @@ RSpec.describe Commands::V2::PatchLinkSet do
 
     it "doesn't reject an empty links hash, but doesn't delete links either" do
       link_set = create(:link_set,
-        links: [
-          create(:link)
-        ])
+                        links: [
+                          create(:link)
+                        ])
 
       described_class.call(
         content_id: link_set.content_id,
@@ -111,19 +111,19 @@ RSpec.describe Commands::V2::PatchLinkSet do
 
     before do
       create(:link_set,
-        content_id: content_id,
-        stale_lock_version: 1,
-        links: [
-          create(:link,
-            link_type: "topics",
-            target_content_id: topics.first),
-          create(:link,
-            link_type: "topics",
-            target_content_id: topics.second),
-          create(:link,
-            link_type: "related",
-            target_content_id: related.first),
-        ])
+             content_id: content_id,
+             stale_lock_version: 1,
+             links: [
+               create(:link,
+                      link_type: "topics",
+                      target_content_id: topics.first),
+               create(:link,
+                      link_type: "topics",
+                      target_content_id: topics.second),
+               create(:link,
+                      link_type: "related",
+                      target_content_id: related.first),
+             ])
     end
 
     include_examples "creates an action"
@@ -209,9 +209,9 @@ RSpec.describe Commands::V2::PatchLinkSet do
   context "when a draft edition exists for the content_id" do
     before do
       create(:draft_edition,
-        document: create(:document, content_id: content_id),
-        base_path: "/some-path",
-        title: "Some Title")
+             document: create(:document, content_id: content_id),
+             base_path: "/some-path",
+             title: "Some Title")
     end
 
     it "sends to the downstream draft worker" do
@@ -234,9 +234,9 @@ RSpec.describe Commands::V2::PatchLinkSet do
     context "when a draft edition has multiple translations" do
       before do
         create(:draft_edition,
-          document: create(:document, content_id: content_id, locale: "fr"),
-          base_path: "/french-path",
-          title: "French Title")
+               document: create(:document, content_id: content_id, locale: "fr"),
+               base_path: "/french-path",
+               title: "French Title")
       end
 
       it "sends the draft editions for all locales downstream" do
@@ -266,9 +266,9 @@ RSpec.describe Commands::V2::PatchLinkSet do
   context "when a live edition exists for the content_id" do
     before do
       create(:live_edition,
-        document: create(:document, content_id: content_id),
-        base_path: "/some-path",
-        title: "Some Title")
+             document: create(:document, content_id: content_id),
+             base_path: "/some-path",
+             title: "Some Title")
     end
 
     it "sends to downstream live worker" do
@@ -302,9 +302,9 @@ RSpec.describe Commands::V2::PatchLinkSet do
     context "when a live edition has multiple translations" do
       before do
         create(:live_edition,
-          document: create(:document, content_id: content_id, locale: "fr"),
-          base_path: "/french-path",
-          title: "French Title")
+               document: create(:document, content_id: content_id, locale: "fr"),
+               base_path: "/french-path",
+               title: "French Title")
       end
 
       it "sends the live edition for all locales downstream" do
@@ -339,9 +339,9 @@ RSpec.describe Commands::V2::PatchLinkSet do
   context "when an unpublished edition exists for the content_id" do
     before do
       create(:unpublished_edition,
-        document: create(:document, content_id: content_id),
-        base_path: "/some-path",
-        title: "Some Title")
+             document: create(:document, content_id: content_id),
+             base_path: "/some-path",
+             title: "Some Title")
     end
 
     it "sends to downstream draft worker" do
@@ -384,8 +384,8 @@ RSpec.describe Commands::V2::PatchLinkSet do
 
     before do
       create(:link_set,
-        content_id: content_id,
-        links_hash: { topics: [link_a] })
+             content_id: content_id,
+             links_hash: { topics: [link_a] })
     end
 
     it "sends link_a downstream as an orphaned content_id when replaced by link_b" do

--- a/spec/commands/v2/post_action_spec.rb
+++ b/spec/commands/v2/post_action_spec.rb
@@ -4,9 +4,9 @@ RSpec.describe Commands::V2::PostAction do
   describe ".call" do
     let(:document) do
       create(:document,
-        content_id: SecureRandom.uuid,
-        locale: "en",
-        stale_lock_version: 6)
+             content_id: SecureRandom.uuid,
+             locale: "en",
+             stale_lock_version: 6)
     end
     let(:action) { "AuthBypass" }
     let(:draft) { nil }

--- a/spec/commands/v2/publish_spec.rb
+++ b/spec/commands/v2/publish_spec.rb
@@ -18,15 +18,15 @@ RSpec.describe Commands::V2::Publish do
 
     let!(:document) do
       create(:document,
-        locale: locale,
-        stale_lock_version: 2)
+             locale: locale,
+             stale_lock_version: 2)
     end
 
     let!(:draft_item) do
       create(:draft_edition,
-        document: document,
-        base_path: base_path,
-        user_facing_version: user_facing_version)
+             document: document,
+             base_path: base_path,
+             user_facing_version: user_facing_version)
     end
 
     let(:expected_content_store_payload) { { base_path: base_path } }
@@ -100,10 +100,10 @@ RSpec.describe Commands::V2::Publish do
 
       let!(:draft_item) do
         create(:draft_edition,
-          document: document,
-          base_path: existing_base_path,
-          title: "foo",
-          user_facing_version: user_facing_version)
+               document: document,
+               base_path: existing_base_path,
+               title: "foo",
+               user_facing_version: user_facing_version)
       end
 
       it "updates the dependencies" do
@@ -136,10 +136,10 @@ RSpec.describe Commands::V2::Publish do
       context "and update_type is minor" do
         before do
           create(:live_edition,
-            document: document,
-            base_path: existing_base_path,
-            user_facing_version: user_facing_version - 1,
-            major_published_at: major_published_at)
+                 document: document,
+                 base_path: existing_base_path,
+                 user_facing_version: user_facing_version - 1,
+                 major_published_at: major_published_at)
         end
 
         it "sets major_published_at to previous live version's value" do
@@ -157,10 +157,10 @@ RSpec.describe Commands::V2::Publish do
 
       let!(:live_item) do
         create(:live_edition,
-          document: document,
-          base_path: existing_base_path,
-          title: "foo",
-          user_facing_version: user_facing_version - 1)
+               document: document,
+               base_path: existing_base_path,
+               title: "foo",
+               user_facing_version: user_facing_version - 1)
       end
 
       it "updates the dependencies" do
@@ -177,9 +177,9 @@ RSpec.describe Commands::V2::Publish do
 
       let!(:live_item) do
         create(:live_edition,
-          document: document,
-          base_path: existing_base_path,
-          user_facing_version: user_facing_version - 1)
+               document: document,
+               base_path: existing_base_path,
+               user_facing_version: user_facing_version - 1)
       end
 
       before do
@@ -213,10 +213,10 @@ RSpec.describe Commands::V2::Publish do
       let(:first_published_at) { 1.year.ago }
       let!(:live_item) do
         create(:live_edition,
-          document: document,
-          base_path: existing_base_path,
-          user_facing_version: user_facing_version - 1,
-          first_published_at: first_published_at)
+               document: document,
+               base_path: existing_base_path,
+               user_facing_version: user_facing_version - 1,
+               first_published_at: first_published_at)
       end
 
       it "marks the previously published item as 'superseded'" do
@@ -237,9 +237,9 @@ RSpec.describe Commands::V2::Publish do
     context "when the edition was previously unpublished" do
       let!(:live_item) do
         create(:unpublished_edition,
-          document: draft_item.document,
-          base_path: base_path,
-          user_facing_version: user_facing_version - 1)
+               document: draft_item.document,
+               base_path: base_path,
+               user_facing_version: user_facing_version - 1)
       end
 
       it "marks the previously unpublished item as 'superseded'" do
@@ -255,8 +255,8 @@ RSpec.describe Commands::V2::Publish do
 
       let!(:other_edition) do
         create(:redirect_live_edition,
-          document: create(:document, locale: draft_locale),
-          base_path: base_path)
+               document: create(:document, locale: draft_locale),
+               base_path: base_path)
       end
 
       it "unpublishes the edition which is in the way" do
@@ -343,9 +343,9 @@ RSpec.describe Commands::V2::Publish do
         context "and the update_type is minor" do
           let!(:live_item) do
             create(:live_edition,
-            document: document,
-            base_path: base_path,
-            user_facing_version: user_facing_version - 1)
+                   document: document,
+                   base_path: base_path,
+                   user_facing_version: user_facing_version - 1)
           end
           before do
             payload[:update_type] = "minor"
@@ -411,13 +411,13 @@ RSpec.describe Commands::V2::Publish do
     context "when the base_path differs from the previously published item" do
       let!(:live_item) do
         create(:live_edition,
-          document: draft_item.document,
-          base_path: "/hat-rates")
+               document: draft_item.document,
+               base_path: "/hat-rates")
       end
 
       before do
         create(:redirect_draft_edition,
-          base_path: "/hat-rates")
+               base_path: "/hat-rates")
       end
 
       it "publishes the redirect already created, from the old location to the new location" do
@@ -447,15 +447,15 @@ RSpec.describe Commands::V2::Publish do
 
       let!(:live_item) do
         create(:live_edition,
-          document: document,
-          links_hash: { topics: [link_a] })
+               document: document,
+               links_hash: { topics: [link_a] })
       end
 
       let!(:draft_item) do
         create(:draft_edition,
-          document: document,
-          links_hash: { topics: [link_b] },
-          user_facing_version: 2)
+               document: document,
+               links_hash: { topics: [link_b] },
+               user_facing_version: 2)
       end
 
       it "sends link_a downstream as an orphaned content_id when draft item is published" do
@@ -513,8 +513,8 @@ RSpec.describe Commands::V2::Publish do
       context "but a published item does exist" do
         before do
           create(:live_edition,
-            document: document,
-            base_path: base_path)
+                 document: document,
+                 base_path: base_path)
         end
 
         it "raises an error to indicate it has already been published" do

--- a/spec/commands/v2/represent_downstream_spec.rb
+++ b/spec/commands/v2/represent_downstream_spec.rb
@@ -9,11 +9,11 @@ RSpec.describe Commands::V2::RepresentDownstream do
     before do
       2.times { create(:draft_edition) }
       create(:live_edition,
-        document: create(:document, locale: "en"),
-        document_type: "nonexistent-schema")
+             document: create(:document, locale: "en"),
+             document_type: "nonexistent-schema")
       create(:live_edition,
-        document: create(:document, locale: "fr"),
-        document_type: "nonexistent-schema")
+             document: create(:document, locale: "fr"),
+             document_type: "nonexistent-schema")
       create(:live_edition, document_type: "press_release")
     end
 

--- a/spec/commands/v2/unpublish_spec.rb
+++ b/spec/commands/v2/unpublish_spec.rb
@@ -14,8 +14,8 @@ RSpec.describe Commands::V2::Unpublish do
   let(:locale) { "en" }
   let(:document) do
     create(:document,
-      content_id: content_id,
-      locale: locale)
+           content_id: content_id,
+           locale: locale)
   end
 
   describe "call" do
@@ -37,8 +37,8 @@ RSpec.describe Commands::V2::Unpublish do
     context "when unpublishing is invalid" do
       let!(:live_edition) do
         create(:live_edition,
-          document: document,
-          base_path: base_path)
+               document: document,
+               base_path: base_path)
       end
 
       let(:payload) do
@@ -70,8 +70,8 @@ RSpec.describe Commands::V2::Unpublish do
     context "when passing redirects" do
       let!(:live_edition) do
         create(:live_edition,
-          document: document,
-          base_path: base_path)
+               document: document,
+               base_path: base_path)
       end
 
       let(:payload) do
@@ -144,8 +144,8 @@ RSpec.describe Commands::V2::Unpublish do
     context "when the document is published" do
       let!(:live_edition) do
         create(:live_edition,
-          document: document,
-          base_path: base_path)
+               document: document,
+               base_path: base_path)
       end
 
       include_examples "creates an action"
@@ -238,8 +238,8 @@ RSpec.describe Commands::V2::Unpublish do
     context "when only a draft is present" do
       let!(:draft_edition) do
         create(:draft_edition,
-          document: document,
-          user_facing_version: 3)
+               document: document,
+               user_facing_version: 3)
       end
 
       it "rejects the request with a 404" do
@@ -327,14 +327,14 @@ RSpec.describe Commands::V2::Unpublish do
         context "when there is a previously unpublished edition" do
           let!(:previous_edition) do
             create(:unpublished_edition,
-              document: document,
-              base_path: base_path,
-              user_facing_version: 1)
+                   document: document,
+                   base_path: base_path,
+                   user_facing_version: 1)
           end
           let(:french_document) do
             create(:document,
-              content_id: document.content_id,
-              locale: "fr")
+                   content_id: document.content_id,
+                   locale: "fr")
           end
 
           it "supersedes the unpublished item" do
@@ -356,14 +356,14 @@ RSpec.describe Commands::V2::Unpublish do
         context "when there is a previously published edition" do
           let!(:previous_edition) do
             create(:live_edition,
-              document: document,
-              base_path: base_path,
-              user_facing_version: 1)
+                   document: document,
+                   base_path: base_path,
+                   user_facing_version: 1)
           end
           let(:french_document) do
             create(:document,
-              content_id: document.content_id,
-              locale: "fr")
+                   content_id: document.content_id,
+                   locale: "fr")
           end
 
           it "supersedes the published item" do
@@ -389,15 +389,15 @@ RSpec.describe Commands::V2::Unpublish do
       let(:link_b) { SecureRandom.uuid }
       let!(:draft_edition) do
         create(:draft_edition,
-          document: document,
-          user_facing_version: 2,
-          links_hash: { topics: [link_b] })
+               document: document,
+               user_facing_version: 2,
+               links_hash: { topics: [link_b] })
       end
 
       let!(:live_edition) do
         create(:live_edition,
-          document: document,
-          links_hash: { topics: [link_a] })
+               document: document,
+               links_hash: { topics: [link_a] })
       end
 
       after do
@@ -418,8 +418,8 @@ RSpec.describe Commands::V2::Unpublish do
     context "when the document is redrafted" do
       let!(:live_edition) do
         create(:live_edition,
-          :with_draft,
-          document: document)
+               :with_draft,
+               document: document)
       end
 
       it "rejects the request with a 422" do
@@ -465,10 +465,10 @@ RSpec.describe Commands::V2::Unpublish do
     context "when the document is already unpublished" do
       let!(:unpublished_edition) do
         create(:unpublished_edition,
-          document: document,
-          base_path: base_path,
-          explanation: "This explnatin has a typo",
-          alternative_path: "/new-path")
+               document: document,
+               base_path: base_path,
+               explanation: "This explnatin has a typo",
+               alternative_path: "/new-path")
       end
 
       let(:payload) do
@@ -531,7 +531,7 @@ RSpec.describe Commands::V2::Unpublish do
       context "when the unpublishing type is substitute" do
         let!(:unpublished_edition) do
           create(:substitute_unpublished_edition,
-            document: document)
+                 document: document)
         end
 
         it "rejects the request with a 404" do
@@ -598,8 +598,8 @@ RSpec.describe Commands::V2::Unpublish do
     context "when the document has no location" do
       let!(:live_edition) do
         create(:live_edition,
-          document: document,
-          base_path: nil)
+               document: document,
+               base_path: nil)
       end
 
       include_examples "creates an action"

--- a/spec/controllers/v2/actions_controller_spec.rb
+++ b/spec/controllers/v2/actions_controller_spec.rb
@@ -4,9 +4,9 @@ RSpec.describe V2::ActionsController do
   describe ".create" do
     let(:document) do
       create(:document,
-        content_id: SecureRandom.uuid,
-        locale: "en",
-        stale_lock_version: 5)
+             content_id: SecureRandom.uuid,
+             locale: "en",
+             stale_lock_version: 5)
     end
     let(:action) { "AuthBypass" }
 

--- a/spec/controllers/v2/content_items_controller_spec.rb
+++ b/spec/controllers/v2/content_items_controller_spec.rb
@@ -17,54 +17,54 @@ RSpec.describe V2::ContentItemsController do
     stub_request(:any, /content-store/)
 
     @draft = create(:draft_edition,
-      document: document_en,
-      base_path: "/content.en",
-      document_type: "topic",
-      schema_name: "topic",
-      user_facing_version: 2)
+                    document: document_en,
+                    base_path: "/content.en",
+                    document_type: "topic",
+                    schema_name: "topic",
+                    user_facing_version: 2)
   end
 
   describe "index" do
     before do
       @en_draft_content = @draft
       @ar_draft_content = create(:draft_edition,
-        document: document_ar,
-        base_path: "/content.ar",
-        document_type: "topic",
-        schema_name: "topic",
-        user_facing_version: 2)
+                                 document: document_ar,
+                                 base_path: "/content.ar",
+                                 document_type: "topic",
+                                 schema_name: "topic",
+                                 user_facing_version: 2)
       @en_live_content = create(:live_edition,
-        document: document_en,
-        base_path: "/content.en",
-        document_type: "guide",
-        schema_name: "topic",
-        user_facing_version: 1)
+                                document: document_en,
+                                base_path: "/content.en",
+                                document_type: "guide",
+                                schema_name: "topic",
+                                user_facing_version: 1)
       @ar_live_content = create(:live_edition,
-        document: document_ar,
-        base_path: "/content.ar",
-        document_type: "topic",
-        schema_name: "topic",
-        user_facing_version: 1)
+                                document: document_ar,
+                                base_path: "/content.ar",
+                                document_type: "topic",
+                                schema_name: "topic",
+                                user_facing_version: 1)
     end
 
     context "searching a field" do
       let(:previous_live_version) do
         create(:superseded_edition,
-          base_path: "/foo",
-          document_type: "topic",
-          schema_name: "topic",
-          title: "zip",
-          user_facing_version: 1)
+               base_path: "/foo",
+               document_type: "topic",
+               schema_name: "topic",
+               title: "zip",
+               user_facing_version: 1)
       end
       let!(:edition) do
         create(:live_edition,
-          base_path: "/foo",
-          document: previous_live_version.document,
-          document_type: "topic",
-          schema_name: "topic",
-          title: "bar",
-          description: "stuff",
-          user_facing_version: 2)
+               base_path: "/foo",
+               document: previous_live_version.document,
+               document_type: "topic",
+               schema_name: "topic",
+               title: "bar",
+               description: "stuff",
+               user_facing_version: 2)
       end
 
       context "when there is a valid query" do
@@ -371,10 +371,10 @@ RSpec.describe V2::ContentItemsController do
     context "with edition links" do
       before do
         create(:draft_edition,
-          document: document_ar,
-          base_path: "/content.ar",
-          schema_name: "topic",
-          user_facing_version: 2)
+               document: document_ar,
+               base_path: "/content.ar",
+               schema_name: "topic",
+               user_facing_version: 2)
 
         @draft.links.create(link_type: "organisation",
                             target_content_id: document_ar.content_id)
@@ -512,11 +512,11 @@ RSpec.describe V2::ContentItemsController do
 
     it "displays items filtered by publishing_app parameter" do
       get :index,
-        params: {
-          document_type: "nonexistent-schema",
-          fields: %w(base_path publishing_app),
-          publishing_app: "whitehall"
-        }
+          params: {
+            document_type: "nonexistent-schema",
+            fields: %w(base_path publishing_app),
+            publishing_app: "whitehall"
+          }
       items = parsed_response["results"]
       expect(items.length).to eq(2)
       expect(items.all? { |i| i["publishing_app"] == "whitehall" }).to be true

--- a/spec/factories/content_item_requests.rb
+++ b/spec/factories/content_item_requests.rb
@@ -21,7 +21,7 @@ FactoryBot.define do
     skip_create
 
     trait :access_limited do
-      access_limited { { "users" => ["3fa46076-2dfd-4169-bcb0-141e2e4bc9b0"] } }
+      access_limited { { "users" => %w[3fa46076-2dfd-4169-bcb0-141e2e4bc9b0] } }
     end
   end
 end

--- a/spec/factories/edition.rb
+++ b/spec/factories/edition.rb
@@ -49,11 +49,11 @@ FactoryBot.define do
         evaluator.links_hash.each do |link_type, target_content_ids|
           target_content_ids.each_with_index do |target_content_id, index|
             create(:link,
-              edition: item,
-              link_type: link_type,
-              link_set: nil,
-              position: index,
-              target_content_id: target_content_id)
+                   edition: item,
+                   link_type: link_type,
+                   link_set: nil,
+                   position: index,
+                   target_content_id: target_content_id)
           end
         end
       end

--- a/spec/factories/link_set.rb
+++ b/spec/factories/link_set.rb
@@ -10,10 +10,10 @@ FactoryBot.define do
       evaluator.links_hash.each do |link_type, target_content_ids|
         target_content_ids.each_with_index do |target_content_id, index|
           create(:link,
-            link_type: link_type,
-            link_set: link_set,
-            target_content_id: target_content_id,
-            position: index)
+                 link_type: link_type,
+                 link_set: link_set,
+                 target_content_id: target_content_id,
+                 position: index)
         end
       end
     end

--- a/spec/factories/live_edition.rb
+++ b/spec/factories/live_edition.rb
@@ -13,10 +13,10 @@ FactoryBot.define do
     trait :with_draft do
       after(:create) do |live_edition, evaluator|
         draft = create(:draft_edition,
-          live_edition.as_json(only: %i[title document_id schema_name document_type routes redirects]).merge(
-            base_path: evaluator.base_path,
-            user_facing_version: evaluator.draft_version_number,
-          ))
+                       live_edition.as_json(only: %i[title document_id schema_name document_type routes redirects]).merge(
+                         base_path: evaluator.base_path,
+                         user_facing_version: evaluator.draft_version_number,
+                       ))
 
         raise "Draft is not valid: #{draft.errors.full_messages}" unless draft.valid?
       end

--- a/spec/factories/unpublished_edition.rb
+++ b/spec/factories/unpublished_edition.rb
@@ -13,11 +13,11 @@ FactoryBot.define do
 
     after(:create) do |edition, evaluator|
       create(:unpublishing,
-        edition: edition,
-        type: evaluator.unpublishing_type,
-        explanation: evaluator.explanation,
-        redirects: [{ path: edition.base_path, type: :exact, destination: evaluator.alternative_path }],
-        unpublished_at: evaluator.unpublished_at)
+             edition: edition,
+             type: evaluator.unpublishing_type,
+             explanation: evaluator.explanation,
+             redirects: [{ path: edition.base_path, type: :exact, destination: evaluator.alternative_path }],
+             unpublished_at: evaluator.unpublished_at)
     end
   end
 

--- a/spec/integration/dependency_resolution_spec.rb
+++ b/spec/integration/dependency_resolution_spec.rb
@@ -5,8 +5,8 @@ RSpec.describe "Dependency Resolution" do
 
   subject(:dependency_resolution) do
     DependencyResolution.new(content_id,
-      locale: locale,
-      with_drafts: with_drafts).dependencies
+                             locale: locale,
+                             with_drafts: with_drafts).dependencies
   end
 
   let(:content_id) { SecureRandom.uuid }
@@ -165,9 +165,9 @@ RSpec.describe "Dependency Resolution" do
     let(:link_type) { :organistion }
     before do
       create_edition(edition_content_id, "/edition-links",
-        factory: edition_factory,
-        locale: edition_locale,
-        links_hash: { link_type => [content_id] })
+                     factory: edition_factory,
+                     locale: edition_locale,
+                     links_hash: { link_type => [content_id] })
     end
 
     context "and the edition is a draft" do
@@ -220,7 +220,7 @@ RSpec.describe "Dependency Resolution" do
 
       before do
         create_link_set(links_to_content_id,
-          links_hash: { link_type => [content_id] })
+                        links_hash: { link_type => [content_id] })
       end
 
       it "merges the links to return both" do
@@ -237,7 +237,7 @@ RSpec.describe "Dependency Resolution" do
     before do
       create_link_set(link_content_id, links_hash: { link_type => [content_id] })
       create_edition(edition_content_id, "/edition-links",
-        links_hash: { link_type => [link_content_id] })
+                     links_hash: { link_type => [link_content_id] })
     end
 
     it "only has a dependency of the link as recusive edition links aren't supported" do

--- a/spec/integration/edition_links_spec.rb
+++ b/spec/integration/edition_links_spec.rb
@@ -48,13 +48,13 @@ RSpec.describe "Edition Links" do
 
     before do
       create_edition(source_content_id, "/source",
-        factory: source_factory,
-        locale: source_locale,
-        links_hash: { test: [target_content_id] })
+                     factory: source_factory,
+                     locale: source_locale,
+                     links_hash: { test: [target_content_id] })
 
       create_edition(target_content_id, "/target",
-        locale: target_locale,
-        factory: target_factory)
+                     locale: target_locale,
+                     factory: target_factory)
     end
 
     context "when target is published" do
@@ -93,8 +93,8 @@ RSpec.describe "Edition Links" do
     context "with a draft and published target" do
       before do
         create_edition(target_content_id, "/target.draft",
-          factory: :draft_edition,
-          version: 2)
+                       factory: :draft_edition,
+                       version: 2)
       end
 
       include_examples "has link"
@@ -129,7 +129,7 @@ RSpec.describe "Edition Links" do
 
     before do
       create_edition(child_content_id, "/child",
-        links_hash: { parent: [parent_content_id] })
+                     links_hash: { parent: [parent_content_id] })
 
       create_edition(parent_content_id, "/parent")
     end
@@ -160,7 +160,7 @@ RSpec.describe "Edition Links" do
 
     before do
       create_edition(child_content_id, "/child",
-        links_hash: { parent: [parent_content_id] })
+                     links_hash: { parent: [parent_content_id] })
 
       create_edition(parent_content_id, "/parent")
       create_edition(grandparent_content_id, "/grandparent")
@@ -182,7 +182,7 @@ RSpec.describe "Edition Links" do
 
     before do
       create_edition(source_content_id, "/source",
-        links_hash: { edition_link_type => [edition_target_content_id] })
+                     links_hash: { edition_link_type => [edition_target_content_id] })
 
       create_edition(edition_target_content_id, "/target")
       create_edition(linkset_target_content_id, "/other-target")

--- a/spec/integration/pagination_spec.rb
+++ b/spec/integration/pagination_spec.rb
@@ -4,10 +4,10 @@ RSpec.describe "Paging through editions" do
   before do
     5.times do |n|
       create(:draft_edition,
-        base_path: "/content-#{n}",
-        document_type: "nonexistent-schema",
-        schema_name: "nonexistent-schema",
-        public_updated_at: n.minutes.ago)
+             base_path: "/content-#{n}",
+             document_type: "nonexistent-schema",
+             schema_name: "nonexistent-schema",
+             public_updated_at: n.minutes.ago)
     end
   end
 
@@ -31,12 +31,12 @@ RSpec.describe "Paging through editions" do
   context "when pagination params are supplied" do
     before do
       get "/v2/content",
-        params: {
-          content_format: "nonexistent-schema",
-          fields: %w(base_path publishing_app),
-          offset: "3",
-          per_page: "2"
-        }
+          params: {
+            content_format: "nonexistent-schema",
+            fields: %w(base_path publishing_app),
+            offset: "3",
+            per_page: "2"
+          }
     end
 
     it "responds successfully" do

--- a/spec/integration/pathless_content_spec.rb
+++ b/spec/integration/pathless_content_spec.rb
@@ -77,8 +77,8 @@ RSpec.describe "pathless content" do
         context "for an existing draft edition" do
           let!(:draft_edition) do
             create(:draft_edition,
-              document: create(:document, content_id: content_id),
-              title: "Old Title")
+                   document: create(:document, content_id: content_id),
+                   title: "Old Title")
           end
 
           it "updates the draft" do
@@ -90,8 +90,8 @@ RSpec.describe "pathless content" do
         context "for an existing live edition" do
           let!(:live_edition) do
             create(:live_edition,
-              document: create(:document, content_id: content_id),
-              title: "Old Title")
+                   document: create(:document, content_id: content_id),
+                   title: "Old Title")
           end
 
           it "creates a new draft" do
@@ -122,10 +122,10 @@ RSpec.describe "pathless content" do
         context "with other similar pathless items" do
           before do
             create(:draft_edition,
-              base_path: nil,
-              schema_name: "contact",
-              document_type: "contact",
-              user_facing_version: 3)
+                   base_path: nil,
+                   schema_name: "contact",
+                   document_type: "contact",
+                   user_facing_version: 3)
           end
 
           it "doesn't conflict" do
@@ -138,10 +138,10 @@ RSpec.describe "pathless content" do
         context "when there's a conflicting edition" do
           before do
             create(:draft_edition,
-              base_path: base_path,
-              schema_name: "contact",
-              document_type: "contact",
-              user_facing_version: 3)
+                   base_path: base_path,
+                   schema_name: "contact",
+                   document_type: "contact",
+                   user_facing_version: 3)
           end
 
           it "conflicts" do
@@ -157,9 +157,9 @@ RSpec.describe "pathless content" do
   describe Commands::V2::Publish do
     let(:pathless_edition) do
       create(:draft_edition,
-        document_type: "contact",
-        user_facing_version: 2,
-        base_path: nil)
+             document_type: "contact",
+             user_facing_version: 2,
+             base_path: nil)
     end
 
     let(:payload) do
@@ -181,9 +181,9 @@ RSpec.describe "pathless content" do
       context "with a previously published item" do
         let!(:live_edition) do
           create(:live_edition,
-            document: pathless_edition.document,
-            document_type: "contact",
-            user_facing_version: 1)
+                 document: pathless_edition.document,
+                 document_type: "contact",
+                 user_facing_version: 1)
         end
 
         it "publishes the draft" do

--- a/spec/integration/put_content/content_with_a_previous_draft_spec.rb
+++ b/spec/integration/put_content/content_with_a_previous_draft_spec.rb
@@ -17,11 +17,11 @@ RSpec.describe "PUT /v2/content when the payload is for an already drafted editi
   end
   let!(:previously_drafted_item) do
     create(:draft_edition,
-      document: document,
-      base_path: base_path,
-      title: "Old Title",
-      publishing_app: "publisher",
-      update_type: "major")
+           document: document,
+           base_path: base_path,
+           title: "Old Title",
+           publishing_app: "publisher",
+           update_type: "major")
   end
 
   it "updates the edition" do
@@ -164,10 +164,10 @@ RSpec.describe "PUT /v2/content when the payload is for an already drafted editi
     context "when there is a draft at the new base path" do
       let!(:substitute_item) do
         create(:draft_edition,
-          base_path: base_path,
-          title: "Substitute Content",
-          publishing_app: "publisher",
-          document_type: "coming_soon")
+               base_path: base_path,
+               title: "Substitute Content",
+               publishing_app: "publisher",
+               document_type: "coming_soon")
       end
 
       it "deletes the substitute item" do
@@ -225,7 +225,7 @@ RSpec.describe "PUT /v2/content when the payload is for an already drafted editi
 
   context "when the previous draft has an access limit" do
     let!(:access_limit) do
-      create(:access_limit, edition: previously_drafted_item, users: ["old-user"])
+      create(:access_limit, edition: previously_drafted_item, users: %w[old-user])
     end
 
     context "when the params includes an access limit" do
@@ -233,7 +233,7 @@ RSpec.describe "PUT /v2/content when the payload is for an already drafted editi
       before do
         payload.merge!(
           access_limited: {
-            users: ["new-user"],
+            users: %w[new-user],
             auth_bypass_ids: [auth_bypass_id],
           }
         )
@@ -243,7 +243,7 @@ RSpec.describe "PUT /v2/content when the payload is for an already drafted editi
         put "/v2/content/#{content_id}", params: payload.to_json
         access_limit.reload
 
-        expect(access_limit.users).to eq(["new-user"])
+        expect(access_limit.users).to eq(%w[new-user])
         expect(access_limit.auth_bypass_ids).to eq([auth_bypass_id])
       end
     end
@@ -263,7 +263,7 @@ RSpec.describe "PUT /v2/content when the payload is for an already drafted editi
       before do
         payload.merge!(
           access_limited: {
-            users: ["new-user"],
+            users: %w[new-user],
             auth_bypass_ids: [auth_bypass_id],
           }
         )
@@ -275,7 +275,7 @@ RSpec.describe "PUT /v2/content when the payload is for an already drafted editi
         }.to change(AccessLimit, :count).by(1)
 
         access_limit = AccessLimit.find_by!(edition: previously_drafted_item)
-        expect(access_limit.users).to eq(["new-user"])
+        expect(access_limit.users).to eq(%w[new-user])
         expect(access_limit.auth_bypass_ids).to eq([auth_bypass_id])
       end
     end

--- a/spec/integration/put_content/content_with_a_previously_published_edition_spec.rb
+++ b/spec/integration/put_content/content_with_a_previously_published_edition_spec.rb
@@ -26,12 +26,12 @@ RSpec.describe "PUT /v2/content when creating a draft for a previously published
 
   let!(:edition) do
     create(:live_edition,
-      document: document,
-      user_facing_version: 5,
-      first_published_at: first_published_at,
-      publishing_api_first_published_at: publishing_api_first_published_at,
-      base_path: base_path,
-      major_published_at: major_published_at)
+           document: document,
+           user_facing_version: 5,
+           first_published_at: first_published_at,
+           publishing_api_first_published_at: publishing_api_first_published_at,
+           base_path: base_path,
+           major_published_at: major_published_at)
   end
 
   let!(:link) do

--- a/spec/integration/put_content/content_with_a_previously_unpublished_edition_spec.rb
+++ b/spec/integration/put_content/content_with_a_previously_unpublished_edition_spec.rb
@@ -15,10 +15,10 @@ RSpec.describe "PUT /v2/content when creating a draft for a previously unpublish
   before do
     Timecop.freeze(Time.local(2017, 9, 1, 12, 0, 0))
     create(:unpublished_edition,
-      document: create(:document, content_id: content_id, stale_lock_version: 2),
-      user_facing_version: 5,
-      base_path: base_path,
-      publishing_api_first_published_at: publishing_api_first_published_at)
+           document: create(:document, content_id: content_id, stale_lock_version: 2),
+           user_facing_version: 5,
+           base_path: base_path,
+           publishing_api_first_published_at: publishing_api_first_published_at)
   end
 
   it "creates the draft's lock version using the unpublished lock version as a starting point" do

--- a/spec/integration/put_content/path_reservation_spec.rb
+++ b/spec/integration/put_content/path_reservation_spec.rb
@@ -18,8 +18,8 @@ RSpec.describe "Path reservation" do
   context "when the base path has been reserved by another publishing app" do
     before do
       create(:path_reservation,
-        base_path: base_path,
-        publishing_app: "something-else")
+             base_path: base_path,
+             publishing_app: "something-else")
     end
 
     it "responds with an error" do

--- a/spec/integration/put_content/race_conditions_spec.rb
+++ b/spec/integration/put_content/race_conditions_spec.rb
@@ -14,10 +14,10 @@ RSpec.describe Commands::V2::PutContent do
 
     let!(:edition) do
       create(:live_edition,
-        document: document,
-        user_facing_version: 5,
-        first_published_at: 1.year.ago,
-        base_path: base_path)
+             document: document,
+             user_facing_version: 5,
+             first_published_at: 1.year.ago,
+             base_path: base_path)
     end
 
     after do

--- a/spec/integration/reinstating_spec.rb
+++ b/spec/integration/reinstating_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe "Reinstating editions that were previously unpublished" do
       expect(superseded1_item.user_facing_version).to eq(1)
       expect(superseded2_item.user_facing_version).to eq(2)
       expect(published_item.user_facing_version).to eq(1),
-        "The redirect should be regarded as a new piece of content"
+                                                    "The redirect should be regarded as a new piece of content"
     end
 
     describe "after the original edition has been reinstated" do

--- a/spec/integration/unpublish/document_is_already_unpublished_spec.rb
+++ b/spec/integration/unpublish/document_is_already_unpublished_spec.rb
@@ -4,16 +4,16 @@ RSpec.describe "/v2/content/:content_id/unpublish when the document is already u
   let(:content_id) { SecureRandom.uuid }
   let(:document) do
     create(:document,
-      content_id: content_id,
-      locale: "en")
+           content_id: content_id,
+           locale: "en")
   end
 
   let!(:unpublished_edition) do
     create(:unpublished_edition,
-      document: document,
-      base_path: "/vat-rates",
-      explanation: "This explnatin has a typo",
-      alternative_path: "/new-path")
+           document: document,
+           base_path: "/vat-rates",
+           explanation: "This explnatin has a typo",
+           alternative_path: "/new-path")
   end
 
   let(:payload) do
@@ -84,7 +84,7 @@ RSpec.describe "/v2/content/:content_id/unpublish when the document is already u
   context "when the unpublishing type is substitute" do
     let!(:unpublished_edition) do
       create(:substitute_unpublished_edition,
-        document: document)
+             document: document)
     end
 
     it "rejects the request with a 404" do

--- a/spec/lib/events/s3_exporter_spec.rb
+++ b/spec/lib/events/s3_exporter_spec.rb
@@ -11,8 +11,8 @@ RSpec.describe Events::S3Exporter do
   let(:bucket_double) { instance_double("Aws::S3::Bucket", object: object_double) }
   let(:object_double) do
     instance_double("Aws::S3::Object",
-      exists?: object_exists?,
-      put: Aws::S3::Types::PutObjectOutput.new)
+                    exists?: object_exists?,
+                    put: Aws::S3::Types::PutObjectOutput.new)
   end
 
   before do
@@ -79,23 +79,23 @@ RSpec.describe Events::S3Exporter do
       let(:created_before) { theresa_may_appointed }
       let!(:theresa_may_event) do
         create(:event,
-          title: "Theresa May becomes Prime Minister",
-          created_at: theresa_may_appointed)
+               title: "Theresa May becomes Prime Minister",
+               created_at: theresa_may_appointed)
       end
       let!(:david_cameron_event) do
         create(:event,
-          title: "David Cameron becomes Prime Minister",
-          created_at: david_cameron_appointed)
+               title: "David Cameron becomes Prime Minister",
+               created_at: david_cameron_appointed)
       end
       let!(:gordon_brown_event) do
         create(:event,
-          title: "Gordon Brown becomes Prime Minister",
-          created_at: gordon_brown_appointed)
+               title: "Gordon Brown becomes Prime Minister",
+               created_at: gordon_brown_appointed)
       end
       let!(:tony_blair_event) do
         create(:event,
-          title: "Tony Blair becomes Prime Minister",
-          created_at: tony_blair_appointed)
+               title: "Tony Blair becomes Prime Minister",
+               created_at: tony_blair_appointed)
       end
 
       context "and we're wanting events before Theresa May took office" do

--- a/spec/lib/link_expansion_spec.rb
+++ b/spec/lib/link_expansion_spec.rb
@@ -18,8 +18,8 @@ RSpec.describe LinkExpansion do
     context "with a link" do
       let(:link) do
         create(:live_edition,
-          title: "Expanded Link",
-          base_path: "/expanded-link")
+               title: "Expanded Link",
+               base_path: "/expanded-link")
       end
 
       let(:expected) do

--- a/spec/lib/tasks/data_sanitizer_spec.rb
+++ b/spec/lib/tasks/data_sanitizer_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Tasks::DataSanitizer do
 
   let!(:limited_draft) do
     create(:access_limited_draft_edition,
-      base_path: "/limited-draft")
+           base_path: "/limited-draft")
   end
 
   let!(:live_edition) do

--- a/spec/lib/tasks/version_validator_spec.rb
+++ b/spec/lib/tasks/version_validator_spec.rb
@@ -6,12 +6,12 @@ RSpec.describe Tasks::VersionValidator do
 
   before do
     create(:superseded_edition,
-      document: document,
-      user_facing_version: 1)
+           document: document,
+           user_facing_version: 1)
 
     create(:live_edition,
-      document: document,
-      user_facing_version: 2)
+           document: document,
+           user_facing_version: 2)
   end
 
   context "when there are no version sequence problems" do
@@ -40,8 +40,8 @@ RSpec.describe Tasks::VersionValidator do
     before do
       item = Edition.last
       item.document = create(:document,
-        content_id: item.document.content_id,
-        locale: "fr")
+                             content_id: item.document.content_id,
+                             locale: "fr")
       item.user_facing_version = 1
       item.save!(validate: false)
     end

--- a/spec/models/access_limit_spec.rb
+++ b/spec/models/access_limit_spec.rb
@@ -3,9 +3,9 @@ require "rails_helper"
 RSpec.describe AccessLimit do
   subject do
     build(:access_limit,
-      users: users,
-      organisations: organisations,
-      auth_bypass_ids: auth_bypass_ids)
+          users: users,
+          organisations: organisations,
+          auth_bypass_ids: auth_bypass_ids)
   end
 
   let(:users) { [SecureRandom.uuid] }

--- a/spec/models/change_note_spec.rb
+++ b/spec/models/change_note_spec.rb
@@ -7,10 +7,10 @@ RSpec.describe ChangeNote do
   let(:update_type) { "major" }
   let(:edition) do
     create(:edition,
-      update_type: update_type,
-      details: details,
-      public_updated_at: Time.zone.yesterday,
-      change_note: nil)
+           update_type: update_type,
+           details: details,
+           public_updated_at: Time.zone.yesterday,
+           change_note: nil)
   end
 
   describe ".create_from_edition" do

--- a/spec/models/edition_spec.rb
+++ b/spec/models/edition_spec.rb
@@ -159,8 +159,8 @@ RSpec.describe Edition do
       end
       let(:edition) do
         build(:draft_edition,
-          document: existing_edition.document,
-          user_facing_version: 1)
+              document: existing_edition.document,
+              user_facing_version: 1)
       end
 
       it { is_expected.to be_invalid }
@@ -177,8 +177,8 @@ RSpec.describe Edition do
       let(:existing_edition) { create(:draft_edition) }
       let(:edition) do
         build(:draft_edition,
-          document: existing_edition.document,
-          user_facing_version: 1)
+              document: existing_edition.document,
+              user_facing_version: 1)
       end
 
       it { is_expected.to be_invalid }
@@ -191,8 +191,8 @@ RSpec.describe Edition do
       end
       let(:edition) do
         build(:draft_edition,
-          document: existing_edition.document,
-          user_facing_version: 2)
+              document: existing_edition.document,
+              user_facing_version: 2)
       end
 
       it { is_expected.to be_valid }
@@ -205,8 +205,8 @@ RSpec.describe Edition do
       end
       let(:edition) do
         build(:live_edition,
-          document: existing_edition.document,
-          user_facing_version: 2)
+              document: existing_edition.document,
+              user_facing_version: 2)
       end
 
       it { is_expected.to be_invalid }
@@ -219,8 +219,8 @@ RSpec.describe Edition do
       end
       let(:edition) do
         build(:draft_edition,
-          document: existing_edition.document,
-          user_facing_version: 1)
+              document: existing_edition.document,
+              user_facing_version: 1)
       end
 
       it { is_expected.to be_invalid }

--- a/spec/models/expanded_links_spec.rb
+++ b/spec/models/expanded_links_spec.rb
@@ -35,11 +35,11 @@ RSpec.describe ExpandedLinks do
     context "when there is an instance and the payload version of the update is greater" do
       let!(:expanded_links_instance) do
         create(:expanded_links,
-          content_id: content_id,
-          locale: locale,
-          with_drafts: with_drafts,
-          payload_version: 1,
-          expanded_links: {})
+               content_id: content_id,
+               locale: locale,
+               with_drafts: with_drafts,
+               payload_version: 1,
+               expanded_links: {})
       end
 
       it "updates the links" do
@@ -53,11 +53,11 @@ RSpec.describe ExpandedLinks do
     context "when there is an instance and the payload version of the update is lower" do
       let!(:expanded_links_instance) do
         create(:expanded_links,
-          content_id: content_id,
-          locale: locale,
-          with_drafts: with_drafts,
-          payload_version: 5,
-          expanded_links: {})
+               content_id: content_id,
+               locale: locale,
+               with_drafts: with_drafts,
+               payload_version: 5,
+               expanded_links: {})
       end
 
       it "doesn't update" do

--- a/spec/models/link_graph/node_collection_factory_spec.rb
+++ b/spec/models/link_graph/node_collection_factory_spec.rb
@@ -4,10 +4,10 @@ RSpec.describe LinkGraph::NodeCollectionFactory do
   let(:link_reference) { double(:link_reference, valid_link_node?: valid_link_node) }
   let(:link_graph) do
     double(:link_graph,
-      link_reference: link_reference,
-      root_content_id: SecureRandom.uuid,
-      root_locale: :en,
-      with_drafts: false)
+           link_reference: link_reference,
+           root_content_id: SecureRandom.uuid,
+           root_locale: :en,
+           with_drafts: false)
   end
   let(:valid_link_node) { true }
 

--- a/spec/models/path_reservation_spec.rb
+++ b/spec/models/path_reservation_spec.rb
@@ -47,8 +47,8 @@ RSpec.describe PathReservation, type: :model do
     context "when the path reservation already exists" do
       before do
         create(:path_reservation,
-          base_path: "/vat-rates",
-          publishing_app: "something-else")
+               base_path: "/vat-rates",
+               publishing_app: "something-else")
       end
 
       it "raises an error" do

--- a/spec/models/unpublishing_spec.rb
+++ b/spec/models/unpublishing_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe Unpublishing do
       let(:base_path) { "/new-path" }
       let(:edition) do
         create(:edition,
-          base_path: base_path)
+               base_path: base_path)
       end
 
       it "is invalid" do

--- a/spec/pacts/content_store/put_endpoint_spec.rb
+++ b/spec/pacts/content_store/put_endpoint_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe "PUT endpoint pact with the Content Store", pact: true do
 
   let!(:edition) do
     create(:live_edition,
-      document: create(:document, content_id: content_id),
-      base_path: "/vat-rates")
+           document: create(:document, content_id: content_id),
+           base_path: "/vat-rates")
   end
 
   let!(:event) { double(:event, id: 5) }

--- a/spec/presenters/change_history_presenter_spec.rb
+++ b/spec/presenters/change_history_presenter_spec.rb
@@ -4,8 +4,8 @@ RSpec.describe Presenters::ChangeHistoryPresenter do
   let(:document) { create(:document) }
   let(:edition) do
     create(:edition,
-      document: document,
-      details: details.deep_stringify_keys)
+           document: document,
+           details: details.deep_stringify_keys)
   end
   let(:details) { {} }
   subject { described_class.new(edition).change_history }
@@ -52,15 +52,15 @@ RSpec.describe Presenters::ChangeHistoryPresenter do
     context "multiple editions for a single content id" do
       let(:item1) do
         create(:superseded_edition,
-          document: document,
-          details: details,
-          user_facing_version: 1)
+               document: document,
+               details: details,
+               user_facing_version: 1)
       end
       let(:item2) do
         create(:live_edition,
-          document: document,
-          details: details,
-          user_facing_version: 2)
+               document: document,
+               details: details,
+               user_facing_version: 2)
       end
       before do
         ChangeNote.create(edition: item1)

--- a/spec/presenters/debug_presenter_spec.rb
+++ b/spec/presenters/debug_presenter_spec.rb
@@ -5,8 +5,8 @@ RSpec.describe Presenters::DebugPresenter do
 
   let!(:edition) do
     create(:draft_edition,
-                       document: document,
-                       user_facing_version: 3)
+           document: document,
+           user_facing_version: 3)
   end
 
   let!(:link_set) { create(:link_set, content_id: document.content_id) }

--- a/spec/presenters/edition_diff_presenter_spec.rb
+++ b/spec/presenters/edition_diff_presenter_spec.rb
@@ -4,9 +4,9 @@ RSpec.describe Presenters::EditionDiffPresenter do
   let(:content_id) { SecureRandom.uuid }
   let(:edition) do
     create(:edition,
-                        update_type: "major",
-                        links_hash: { "organisations" => [content_id] },
-                        change_note: "a note")
+           update_type: "major",
+           links_hash: { "organisations" => [content_id] },
+           change_note: "a note")
   end
 
   let(:edition_without_links) do
@@ -15,8 +15,8 @@ RSpec.describe Presenters::EditionDiffPresenter do
 
   let(:edition_without_change_note) do
     create(:edition,
-                        update_type: "minor",
-                        links_hash: { "organisations" => [content_id] })
+           update_type: "minor",
+           links_hash: { "organisations" => [content_id] })
   end
 
   EXCLUDED_ATTRIBUTES = %w(

--- a/spec/presenters/edition_presenter_spec.rb
+++ b/spec/presenters/edition_presenter_spec.rb
@@ -29,9 +29,9 @@ RSpec.describe Presenters::EditionPresenter do
     let(:update_type) { "minor" }
     let(:edition) {
       create(:live_edition,
-        update_type: update_type,
-        schema_name: "calendar",
-        document_type: "calendar")
+             update_type: update_type,
+             schema_name: "calendar",
+             document_type: "calendar")
     }
 
     subject(:result) do
@@ -116,8 +116,8 @@ RSpec.describe Presenters::EditionPresenter do
     context "for a live edition" do
       let(:edition) do
         create(:live_edition,
-          base_path: base_path,
-          details: details)
+               base_path: base_path,
+               details: details)
       end
       let!(:link_set) { create(:link_set, content_id: edition.document.content_id) }
 
@@ -133,10 +133,10 @@ RSpec.describe Presenters::EditionPresenter do
     context "for a draft edition" do
       let(:edition) do
         create(:draft_edition,
-          base_path: base_path,
-          details: details,
-          first_published_at: "2014-01-02T03:04:05Z",
-          public_updated_at: "2014-05-14T13:00:06Z")
+               base_path: base_path,
+               details: details,
+               first_published_at: "2014-01-02T03:04:05Z",
+               public_updated_at: "2014-05-14T13:00:06Z")
       end
       let!(:link_set) { create(:link_set, content_id: edition.document.content_id) }
 
@@ -148,8 +148,8 @@ RSpec.describe Presenters::EditionPresenter do
     context "for a withdrawn edition" do
       let!(:edition) do
         create(:withdrawn_unpublished_edition,
-          base_path: base_path,
-          details: details)
+               base_path: base_path,
+               details: details)
       end
       let!(:link_set) { create(:link_set, content_id: edition.document.content_id) }
 
@@ -171,9 +171,9 @@ RSpec.describe Presenters::EditionPresenter do
       context "with an overridden unpublished_at" do
         let!(:edition) do
           create(:withdrawn_unpublished_edition,
-            base_path: base_path,
-            details: details,
-            unpublished_at: Time.new(2016, 9, 10, 4, 5, 6))
+                 base_path: base_path,
+                 details: details,
+                 unpublished_at: Time.new(2016, 9, 10, 4, 5, 6))
         end
 
         it "merges in a withdrawal notice with the withdrawn_at set correctly" do
@@ -237,8 +237,8 @@ RSpec.describe Presenters::EditionPresenter do
     context "for a edition with change notes" do
       let(:edition) do
         create(:draft_edition,
-          base_path: base_path,
-          details: details.slice(:body))
+               base_path: base_path,
+               details: details.slice(:body))
       end
       before do
         ChangeNote.create(change_history.merge(edition: edition))
@@ -313,8 +313,8 @@ RSpec.describe Presenters::EditionPresenter do
 
       let(:edition) do
         create(:live_edition,
-          base_path: base_path,
-          details: details)
+               base_path: base_path,
+               details: details)
       end
 
       it "renders the govspeak as html" do

--- a/spec/presenters/queries/available_translations_spec.rb
+++ b/spec/presenters/queries/available_translations_spec.rb
@@ -18,11 +18,11 @@ RSpec.describe Presenters::Queries::AvailableTranslations do
 
   def create_edition(base_path, state = "published", locale = "en", version = 1)
     create(:edition,
-      document: Document.find_or_create_by(content_id: link_set.content_id, locale: locale),
-      base_path: base_path,
-      state: state,
-      content_store: state == 'draft' ? 'draft' : 'live',
-      user_facing_version: version)
+           document: Document.find_or_create_by(content_id: link_set.content_id, locale: locale),
+           base_path: base_path,
+           state: state,
+           content_store: state == 'draft' ? 'draft' : 'live',
+           user_facing_version: version)
   end
 
   let(:link_set) { create(:link_set) }

--- a/spec/presenters/queries/content_item_presenter_spec.rb
+++ b/spec/presenters/queries/content_item_presenter_spec.rb
@@ -14,10 +14,10 @@ RSpec.describe Presenters::Queries::ContentItemPresenter do
   describe "present" do
     let!(:edition) do
       create(:draft_edition,
-        document: document,
-        base_path: base_path,
-        first_published_at: first_published_at,
-        public_updated_at: public_updated_at)
+             document: document,
+             base_path: base_path,
+             first_published_at: first_published_at,
+             public_updated_at: public_updated_at)
     end
 
     let(:result) { described_class.present(edition) }
@@ -99,11 +99,11 @@ RSpec.describe Presenters::Queries::ContentItemPresenter do
     context "when a change note exists" do
       let!(:edition) do
         create(:draft_edition,
-          document: document,
-          base_path: base_path,
-          update_type: "major",
-          first_published_at: first_published_at,
-          public_updated_at: public_updated_at)
+               document: document,
+               base_path: base_path,
+               update_type: "major",
+               first_published_at: first_published_at,
+               public_updated_at: public_updated_at)
       end
 
       it "presents the item including the change note" do
@@ -187,8 +187,8 @@ RSpec.describe Presenters::Queries::ContentItemPresenter do
 
       let!(:published_item) do
         create(:live_edition,
-          document: document,
-          user_facing_version: 1)
+               document: document,
+               user_facing_version: 1)
       end
 
       it "returns a versioned history of states for the edition" do
@@ -207,9 +207,9 @@ RSpec.describe Presenters::Queries::ContentItemPresenter do
   describe "#get_warnings" do
     before do
       create(:draft_edition,
-        document: document,
-        base_path: base_path,
-        user_facing_version: 2)
+             document: document,
+             base_path: base_path,
+             user_facing_version: 2)
     end
 
     let(:scope) { document.editions }
@@ -238,8 +238,8 @@ RSpec.describe Presenters::Queries::ContentItemPresenter do
       context "with a blocking edition" do
         before do
           @blocking_edition = create(:live_edition,
-            base_path: base_path,
-            user_facing_version: 1)
+                                     base_path: base_path,
+                                     user_facing_version: 1)
         end
 
         it "includes the warning" do

--- a/spec/queries/base_path_for_state_spec.rb
+++ b/spec/queries/base_path_for_state_spec.rb
@@ -98,7 +98,7 @@ RSpec.describe Queries::BasePathForState do
     context "when edition is unpublished with substitute" do
       let!(:conflict_edition) do
         create(:substitute_unpublished_edition,
-          base_path: conflict_base_path)
+               base_path: conflict_base_path)
       end
 
       let(:edition_id) { conflict_edition.id + 1 }
@@ -110,7 +110,7 @@ RSpec.describe Queries::BasePathForState do
     context "when edition is superseded" do
       let!(:conflict_edition) do
         create(:superseded_edition,
-          base_path: conflict_base_path)
+               base_path: conflict_base_path)
       end
 
       let(:edition_id) { conflict_edition.id + 1 }

--- a/spec/queries/get_bulk_links_spec.rb
+++ b/spec/queries/get_bulk_links_spec.rb
@@ -22,23 +22,23 @@ RSpec.describe Queries::GetBulkLinks do
 
   before do
     link_set = create(:link_set,
-      content_id: content_id_with_links,
-      stale_lock_version: 5)
+                      content_id: content_id_with_links,
+                      stale_lock_version: 5)
 
     create(:link,
-      link_set: link_set,
-      link_type: "parent",
-      target_content_id: parent.first)
+           link_set: link_set,
+           link_type: "parent",
+           target_content_id: parent.first)
 
     create(:link,
-      link_set: link_set,
-      link_type: "related",
-      target_content_id: related.first)
+           link_set: link_set,
+           link_type: "related",
+           target_content_id: related.first)
 
     create(:link,
-      link_set: link_set,
-      link_type: "related",
-      target_content_id: related.last)
+           link_set: link_set,
+           link_type: "related",
+           target_content_id: related.last)
   end
 
   describe ".call" do

--- a/spec/queries/get_content_collection_spec.rb
+++ b/spec/queries/get_content_collection_spec.rb
@@ -4,21 +4,21 @@ RSpec.describe Queries::GetContentCollection do
   context "document_type" do
     before do
       create(:draft_edition,
-        base_path: "/a",
-        document_type: "topic",
-        schema_name: "topic")
+             base_path: "/a",
+             document_type: "topic",
+             schema_name: "topic")
       create(:draft_edition,
-        base_path: "/b",
-        document_type: "topic",
-        schema_name: "topic")
+             base_path: "/b",
+             document_type: "topic",
+             schema_name: "topic")
       create(:draft_edition,
-        base_path: "/c",
-        document_type: "mainstream_browse_page",
-        schema_name: "mainstream_browse_page")
+             base_path: "/c",
+             document_type: "mainstream_browse_page",
+             schema_name: "mainstream_browse_page")
       create(:draft_edition,
-        base_path: "/d",
-        document_type: "another_type",
-        schema_name: "another_type")
+             base_path: "/d",
+             document_type: "another_type",
+             schema_name: "another_type")
     end
 
     it "returns the requested fields for all editions" do
@@ -56,13 +56,13 @@ RSpec.describe Queries::GetContentCollection do
 
   it "returns the editions of the given format, and placeholder_format" do
     create(:draft_edition,
-      base_path: "/a",
-      document_type: "topic",
-      schema_name: "topic")
+           base_path: "/a",
+           document_type: "topic",
+           schema_name: "topic")
     create(:draft_edition,
-      base_path: "/b",
-      document_type: "placeholder_topic",
-      schema_name: "placeholder_topic")
+           base_path: "/b",
+           document_type: "placeholder_topic",
+           schema_name: "placeholder_topic")
 
     expect(Queries::GetContentCollection.new(
       document_types: "topic",
@@ -75,13 +75,13 @@ RSpec.describe Queries::GetContentCollection do
 
   it "includes the publishing state of the item" do
     create(:draft_edition,
-      base_path: "/draft",
-      document_type: "topic",
-      schema_name: "topic")
+           base_path: "/draft",
+           document_type: "topic",
+           schema_name: "topic")
     create(:live_edition,
-      base_path: "/live",
-      document_type: "topic",
-      schema_name: "topic")
+           base_path: "/live",
+           document_type: "topic",
+           schema_name: "topic")
 
     expect(Queries::GetContentCollection.new(
       document_types: "topic",
@@ -143,20 +143,20 @@ RSpec.describe Queries::GetContentCollection do
   context "filtering by publishing_app" do
     before do
       create(:draft_edition,
-        base_path: "/a",
-        document_type: "topic",
-        schema_name: "topic",
-        publishing_app: "publisher")
+             base_path: "/a",
+             document_type: "topic",
+             schema_name: "topic",
+             publishing_app: "publisher")
       create(:draft_edition,
-        base_path: "/b",
-        document_type: "topic",
-        schema_name: "topic",
-        publishing_app: "publisher")
+             base_path: "/b",
+             document_type: "topic",
+             schema_name: "topic",
+             publishing_app: "publisher")
       create(:draft_edition,
-        base_path: "/c",
-        document_type: "topic",
-        schema_name: "topic",
-        publishing_app: "whitehall")
+             base_path: "/c",
+             document_type: "topic",
+             schema_name: "topic",
+             publishing_app: "whitehall")
     end
 
     it "returns items corresponding to the publishing_app parameter if present" do
@@ -185,25 +185,25 @@ RSpec.describe Queries::GetContentCollection do
   describe "the locale filter parameter" do
     before do
       create(:draft_edition,
-        document: create(:document, locale: "en"),
-        base_path: "/content.en",
-        document_type: "topic",
-        schema_name: "topic")
+             document: create(:document, locale: "en"),
+             base_path: "/content.en",
+             document_type: "topic",
+             schema_name: "topic")
       create(:draft_edition,
-        document: create(:document, locale: "ar"),
-        base_path: "/content.ar",
-        document_type: "topic",
-        schema_name: "topic")
+             document: create(:document, locale: "ar"),
+             base_path: "/content.ar",
+             document_type: "topic",
+             schema_name: "topic")
       create(:live_edition,
-        document: create(:document, locale: "en"),
-        base_path: "/content.en",
-        document_type: "topic",
-        schema_name: "topic")
+             document: create(:document, locale: "en"),
+             base_path: "/content.en",
+             document_type: "topic",
+             schema_name: "topic")
       create(:live_edition,
-        document: create(:document, locale: "ar"),
-        base_path: "/content.ar",
-        document_type: "topic",
-        schema_name: "topic")
+             document: create(:document, locale: "ar"),
+             base_path: "/content.ar",
+             document_type: "topic",
+             schema_name: "topic")
     end
 
     it "returns the editions filtered by 'en' locale by default" do
@@ -251,17 +251,17 @@ RSpec.describe Queries::GetContentCollection do
       live_1_content_id = SecureRandom.uuid
 
       create(:draft_edition,
-        document: create(:document, content_id: draft_1_content_id),
-        base_path: "/foo",
-        publishing_app: "specialist-publisher")
+             document: create(:document, content_id: draft_1_content_id),
+             base_path: "/foo",
+             publishing_app: "specialist-publisher")
 
       create(:draft_edition,
-        document: create(:document, content_id: draft_2_content_id),
-        base_path: "/bar")
+             document: create(:document, content_id: draft_2_content_id),
+             base_path: "/bar")
 
       create(:live_edition,
-        document: create(:document, content_id: live_1_content_id),
-        base_path: "/baz")
+             document: create(:document, content_id: live_1_content_id),
+             base_path: "/baz")
 
       link_set1 = create(:link_set, content_id: draft_1_content_id)
       link_set2 = create(:link_set, content_id: draft_2_content_id)
@@ -342,17 +342,17 @@ RSpec.describe Queries::GetContentCollection do
   context "when details hash is requested" do
     before do
       create(:draft_edition,
-        base_path: "/z",
-        details: { foo: :bar },
-        document_type: "topic",
-        schema_name: "topic",
-        publishing_app: "publisher")
+             base_path: "/z",
+             details: { foo: :bar },
+             document_type: "topic",
+             schema_name: "topic",
+             publishing_app: "publisher")
       create(:draft_edition,
-        base_path: "/b",
-        details: { baz: :bat },
-        document_type: "placeholder_topic",
-        schema_name: "placeholder_topic",
-        publishing_app: "publisher")
+             base_path: "/b",
+             details: { baz: :bat },
+             document_type: "placeholder_topic",
+             schema_name: "placeholder_topic",
+             publishing_app: "publisher")
     end
     it "returns the details hash" do
       expect(Queries::GetContentCollection.new(
@@ -369,24 +369,24 @@ RSpec.describe Queries::GetContentCollection do
   describe "search_fields" do
     before do
       create(:live_edition,
-        base_path: "/bar/foo",
-        document_type: "topic",
-        schema_name: "topic",
-        title: "Baz",
-        details: {
-          body: "A page about windows.",
-          internal_name: "newtopic"
-        })
+             base_path: "/bar/foo",
+             document_type: "topic",
+             schema_name: "topic",
+             title: "Baz",
+             details: {
+               body: "A page about windows.",
+               internal_name: "newtopic"
+             })
       create(:live_edition,
-        base_path: "/baz",
-        document_type: "topic",
-        schema_name: "topic",
-        title: "zip",
-        description: "foo",
-        details: {
-          body: "A page all about doors.",
-          internal_name: "baz"
-        })
+             base_path: "/baz",
+             document_type: "topic",
+             schema_name: "topic",
+             title: "zip",
+             description: "foo",
+             details: {
+               body: "A page all about doors.",
+               internal_name: "baz"
+             })
     end
 
     let(:search_in) { nil }
@@ -491,19 +491,19 @@ RSpec.describe Queries::GetContentCollection do
           ["/a", "2010-01-06"], ["/b", "2010-01-05"], ["/c", "2010-01-04"], ["/d", "2010-01-03"]
         ].each do |(base_path, public_updated_at)|
           create(:draft_edition,
-            base_path: base_path,
-            document_type: "topic",
-            schema_name: "topic",
-            public_updated_at: public_updated_at)
+                 base_path: base_path,
+                 document_type: "topic",
+                 schema_name: "topic",
+                 public_updated_at: public_updated_at)
         end
         [
           ["/live1", "2010-01-02"], ["/live2", "2010-01-01"]
         ].each do |(base_path, public_updated_at)|
           create(:live_edition,
-            base_path: base_path,
-            document_type: "topic",
-            schema_name: "topic",
-            public_updated_at: public_updated_at)
+                 base_path: base_path,
+                 document_type: "topic",
+                 schema_name: "topic",
+                 public_updated_at: public_updated_at)
         end
       end
 
@@ -594,16 +594,16 @@ RSpec.describe Queries::GetContentCollection do
         document = create(:document)
 
         create(:live_edition,
-          document: document,
-          document_type: "topic",
-          schema_name: "topic",
-          user_facing_version: 1)
+               document: document,
+               document_type: "topic",
+               schema_name: "topic",
+               user_facing_version: 1)
 
         create(:draft_edition,
-          document: document,
-          document_type: "topic",
-          schema_name: "topic",
-          user_facing_version: 2)
+               document: document,
+               document_type: "topic",
+               schema_name: "topic",
+               user_facing_version: 2)
       end
 
       it "returns the latest item only" do

--- a/spec/queries/get_content_spec.rb
+++ b/spec/queries/get_content_spec.rb
@@ -19,9 +19,9 @@ RSpec.describe Queries::GetContent do
 
     before do
       create(:edition,
-        document: document,
-        base_path: "/vat-rates",
-        user_facing_version: 1)
+             document: document,
+             base_path: "/vat-rates",
+             user_facing_version: 1)
     end
 
     it "presents the edition" do
@@ -63,14 +63,14 @@ RSpec.describe Queries::GetContent do
   context "when a draft and a live edition exists for the content_id" do
     before do
       create(:draft_edition,
-        document: document,
-        title: "Draft Title",
-        user_facing_version: 2)
+             document: document,
+             title: "Draft Title",
+             user_facing_version: 2)
 
       create(:live_edition,
-        document: document,
-        title: "Live Title",
-        user_facing_version: 1)
+             document: document,
+             title: "Live Title",
+             user_facing_version: 1)
     end
 
     it "presents the draft edition" do
@@ -82,14 +82,14 @@ RSpec.describe Queries::GetContent do
   context "when editions exist in non-draft, non-live states" do
     before do
       create(:superseded_edition,
-        document: document,
-        user_facing_version: 1,
-        title: "Older Title")
+             document: document,
+             user_facing_version: 1,
+             title: "Older Title")
 
       create(:superseded_edition,
-        document: document,
-        user_facing_version: 2,
-        title: "Newer Title")
+             document: document,
+             user_facing_version: 2,
+             title: "Newer Title")
     end
 
     it "includes these editions" do
@@ -101,14 +101,14 @@ RSpec.describe Queries::GetContent do
   context "when editions exist in multiple locales" do
     before do
       create(:edition,
-        document: fr_document,
-        user_facing_version: 2,
-        title: "French Title")
+             document: fr_document,
+             user_facing_version: 2,
+             title: "French Title")
 
       create(:edition,
-        document: document,
-        user_facing_version: 1,
-        title: "English Title")
+             document: document,
+             user_facing_version: 1,
+             title: "English Title")
     end
 
     it "returns the english edition by default" do
@@ -125,12 +125,12 @@ RSpec.describe Queries::GetContent do
   describe "requesting specific versions" do
     before do
       create(:superseded_edition,
-        document: document,
-        user_facing_version: 1)
+             document: document,
+             user_facing_version: 1)
 
       create(:live_edition,
-        document: document,
-        user_facing_version: 2)
+             document: document,
+             user_facing_version: 2)
     end
 
     it "returns specific versions if provided" do

--- a/spec/queries/get_edition_ids_with_fallbacks_spec.rb
+++ b/spec/queries/get_edition_ids_with_fallbacks_spec.rb
@@ -43,13 +43,13 @@ RSpec.describe Queries::GetEditionIdsWithFallbacks do
       let(:document) { create(:document, content_id: content_ids.first) }
       let!(:draft_edition) do
         create(:draft_edition,
-          document: document,
-          user_facing_version: 2)
+               document: document,
+               user_facing_version: 2)
       end
       let!(:withdrawn_edition) do
         create(:withdrawn_unpublished_edition,
-          document: document,
-          user_facing_version: 1)
+               document: document,
+               user_facing_version: 1)
       end
 
       context "and the state_fallback order is [draft, withdrawn]" do
@@ -67,26 +67,26 @@ RSpec.describe Queries::GetEditionIdsWithFallbacks do
       let(:content_ids) { [SecureRandom.uuid] }
       let(:fr_document) do
         create(:document,
-          content_id: content_ids.first,
-          locale: "fr")
+               content_id: content_ids.first,
+               locale: "fr")
       end
       let(:en_document) do
         create(:document,
-          content_id: content_ids.first,
-          locale: "en")
+               content_id: content_ids.first,
+               locale: "en")
       end
       let!(:fr_draft_edition) do
         create(:draft_edition, document: fr_document)
       end
       let!(:en_draft_edition) do
         create(:draft_edition,
-          document: en_document,
-          user_facing_version: 2)
+               document: en_document,
+               user_facing_version: 2)
       end
       let!(:en_published_edition) do
         create(:live_edition,
-          document: en_document,
-          user_facing_version: 1)
+               document: en_document,
+               user_facing_version: 1)
       end
 
       context "and the locale_fallback_order is [fr]" do
@@ -138,23 +138,23 @@ RSpec.describe Queries::GetEditionIdsWithFallbacks do
       let(:tax_rates_document) { create(:document, content_id: content_ids.last) }
       let!(:vat_draft_edition) do
         create(:draft_edition,
-          document: vat_document,
-          user_facing_version: 2)
+               document: vat_document,
+               user_facing_version: 2)
       end
       let!(:vat_published_edition) do
         create(:live_edition,
-          document: vat_document,
-          user_facing_version: 1)
+               document: vat_document,
+               user_facing_version: 1)
       end
       let!(:tax_rates_draft_edition) do
         create(:draft_edition,
-          document: tax_rates_document,
-          user_facing_version: 2)
+               document: tax_rates_document,
+               user_facing_version: 2)
       end
       let!(:tax_rates_withdrawn_edition) do
         create(:withdrawn_unpublished_edition,
-          document: tax_rates_document,
-          user_facing_version: 1)
+               document: tax_rates_document,
+               user_facing_version: 1)
       end
 
       context "and the state_fallback order is [draft, published]" do
@@ -181,14 +181,14 @@ RSpec.describe Queries::GetEditionIdsWithFallbacks do
       let(:document) { create(:document, content_id: content_ids.first) }
       let!(:draft_edition) do
         create(:draft_edition,
-          document: document,
-          document_type: "gone",
-          user_facing_version: 2)
+               document: document,
+               document_type: "gone",
+               user_facing_version: 2)
       end
       let!(:published_edition) do
         create(:live_edition,
-          document: document,
-          user_facing_version: 1)
+               document: document,
+               user_facing_version: 1)
       end
 
       context "and the state_fallback order is [draft]" do

--- a/spec/queries/get_expanded_links_spec.rb
+++ b/spec/queries/get_expanded_links_spec.rb
@@ -35,11 +35,11 @@ RSpec.describe Queries::GetExpandedLinks do
 
       before do
         create(:expanded_links,
-          content_id: content_id,
-          locale: locale,
-          with_drafts: with_drafts,
-          expanded_links: expanded_links,
-          updated_at: updated_at)
+               content_id: content_id,
+               locale: locale,
+               with_drafts: with_drafts,
+               expanded_links: expanded_links,
+               updated_at: updated_at)
       end
 
       it "returns the data from expanded links" do
@@ -55,9 +55,9 @@ RSpec.describe Queries::GetExpandedLinks do
 
       before do
         create(:link_set,
-          content_id: content_id,
-          links_hash: {},
-          stale_lock_version: link_set_lock_version)
+               content_id: content_id,
+               links_hash: {},
+               stale_lock_version: link_set_lock_version)
       end
 
       it "generates the links" do

--- a/spec/queries/get_link_set_spec.rb
+++ b/spec/queries/get_link_set_spec.rb
@@ -14,19 +14,19 @@ RSpec.describe Queries::GetLinkSet do
 
       before do
         create(:link,
-          link_set: link_set,
-          link_type: "parent",
-          target_content_id: parent.first)
+               link_set: link_set,
+               link_type: "parent",
+               target_content_id: parent.first)
 
         create(:link,
-          link_set: link_set,
-          link_type: "related",
-          target_content_id: related.first)
+               link_set: link_set,
+               link_type: "related",
+               target_content_id: related.first)
 
         create(:link,
-          link_set: link_set,
-          link_type: "related",
-          target_content_id: related.last)
+               link_set: link_set,
+               link_type: "related",
+               target_content_id: related.last)
       end
 
       it "returns the content_id, lock_version and links grouped by link_type" do

--- a/spec/queries/get_linkables.rb
+++ b/spec/queries/get_linkables.rb
@@ -15,11 +15,11 @@ RSpec.describe Queries::GetLinkables do
       let(:title) { "Title" }
       before do
         create(:live_edition,
-          base_path: base_path,
-          details: { internal_name: internal_name },
-          document: create(:document, content_id: content_id),
-          document_type: document_type,
-          title: title)
+               base_path: base_path,
+               details: { internal_name: internal_name },
+               document: create(:document, content_id: content_id),
+               document_type: document_type,
+               title: title)
       end
 
       it "returns an array of linkable presenters" do
@@ -97,8 +97,8 @@ RSpec.describe Queries::GetLinkables do
     context "when the edition is not available in English" do
       before do
         create(:live_edition,
-          document_type: document_type,
-          document: create(:document, locale: "fr"))
+               document_type: document_type,
+               document: create(:document, locale: "fr"))
       end
 
       it { is_expected.to be_empty }
@@ -108,13 +108,13 @@ RSpec.describe Queries::GetLinkables do
       let(:content_id) { SecureRandom.uuid }
       before do
         create(:live_edition,
-          document_type: document_type,
-          title: "Hello",
-          document: create(:document, content_id: content_id))
+               document_type: document_type,
+               title: "Hello",
+               document: create(:document, content_id: content_id))
         create(:live_edition,
-          document_type: document_type,
-          title: "Salut",
-          document: create(:document, content_id: content_id, locale: "fr"))
+               document_type: document_type,
+               title: "Salut",
+               document: create(:document, content_id: content_id, locale: "fr"))
       end
 
       it "has the english title" do
@@ -126,10 +126,10 @@ RSpec.describe Queries::GetLinkables do
       let(:document) { create(:document) }
       let!(:draft_edition) do
         create(:draft_edition,
-          document_type: document_type,
-          title: "Draft",
-          document: document,
-          user_facing_version: 2)
+               document_type: document_type,
+               title: "Draft",
+               document: document,
+               user_facing_version: 2)
       end
 
       it "has the draft edition" do
@@ -139,9 +139,9 @@ RSpec.describe Queries::GetLinkables do
       context "and there is a published edition" do
         let!(:published_edition) do
           create(:live_edition,
-            document_type: document_type,
-            title: "Published",
-            document: document)
+                 document_type: document_type,
+                 title: "Published",
+                 document: document)
         end
 
         it "has the published edition" do

--- a/spec/queries/get_linked_spec.rb
+++ b/spec/queries/get_linked_spec.rb
@@ -35,13 +35,13 @@ RSpec.describe Queries::GetLinked do
     context "when a edition with no draft exists" do
       before do
         create(:live_edition,
-          document: create(:document, content_id: content_id),
-          base_path: "/vat-rules-2020",
-          title: "VAT rules 2020")
+               document: create(:document, content_id: content_id),
+               base_path: "/vat-rules-2020",
+               title: "VAT rules 2020")
 
         create(:live_edition,
-          document: create(:document, content_id: target_content_id),
-          base_path: "/vat-org")
+               document: create(:document, content_id: target_content_id),
+               base_path: "/vat-org")
       end
 
       it "returns no results when no content is linked to it" do
@@ -73,9 +73,9 @@ RSpec.describe Queries::GetLinked do
     context "when a document with draft exists "do
       before do
         create(:live_edition,
-          :with_draft,
-          document: create(:document, content_id: target_content_id),
-          base_path: "/pay-now")
+               :with_draft,
+               document: create(:document, content_id: target_content_id),
+               base_path: "/pay-now")
       end
 
       context "but no edition links to it" do
@@ -105,30 +105,30 @@ RSpec.describe Queries::GetLinked do
       context "editions link to the wanted edition" do
         before do
           create(:live_edition,
-            document: create(:document, content_id: content_id),
-            title: "VAT and VATy things",
-            base_path: "/vat-rates")
+                 document: create(:document, content_id: content_id),
+                 title: "VAT and VATy things",
+                 base_path: "/vat-rates")
           create(:link_set,
-            content_id: content_id,
-            links: [
-              create(:link,
-                link_type: "organisations",
-                target_content_id: target_content_id)
-            ])
+                 content_id: content_id,
+                 links: [
+                   create(:link,
+                          link_type: "organisations",
+                          target_content_id: target_content_id)
+                 ])
 
           edition = create(:live_edition,
-            base_path: '/vatty',
-            title: "Another VATTY thing")
+                           base_path: '/vatty',
+                           title: "Another VATTY thing")
           create(:link_set,
-            content_id: edition.document.content_id,
-            links: [
-              create(:link,
-                link_type: "organisations",
-                target_content_id: target_content_id),
-              create(:link,
-                link_type: "related_links",
-                target_content_id: target_content_id)
-            ])
+                 content_id: edition.document.content_id,
+                 links: [
+                   create(:link,
+                          link_type: "organisations",
+                          target_content_id: target_content_id),
+                   create(:link,
+                          link_type: "related_links",
+                          target_content_id: target_content_id)
+                 ])
         end
 
         context "custom fields have been requested" do
@@ -174,36 +174,36 @@ RSpec.describe Queries::GetLinked do
       context "draft items linking to the wanted draft item" do
         before do
           create(:live_edition,
-            :with_draft,
-            document: create(:document, content_id: another_target_content_id),
-            base_path: "/send-now")
+                 :with_draft,
+                 document: create(:document, content_id: another_target_content_id),
+                 base_path: "/send-now")
 
           create(:draft_edition,
-            document: create(:document, content_id: content_id),
-            title: "HMRC documents")
+                 document: create(:document, content_id: content_id),
+                 title: "HMRC documents")
 
           create(:link_set,
-            content_id: content_id,
-            links: [
-              create(:link,
-                link_type: "organisations",
-                target_content_id: another_target_content_id),
-            ])
+                 content_id: content_id,
+                 links: [
+                   create(:link,
+                          link_type: "organisations",
+                          target_content_id: another_target_content_id),
+                 ])
 
           edition = create(:draft_edition,
-            base_path: '/other-hmrc-document',
-            title: "Another HMRC document")
+                           base_path: '/other-hmrc-document',
+                           title: "Another HMRC document")
 
           create(:link_set,
-            content_id: edition.document.content_id,
-            links: [
-              create(:link,
-                link_type: "organisations",
-                target_content_id: another_target_content_id),
-              create(:link,
-                link_type: "related_links",
-                target_content_id: SecureRandom.uuid)
-            ])
+                 content_id: edition.document.content_id,
+                 links: [
+                   create(:link,
+                          link_type: "organisations",
+                          target_content_id: another_target_content_id),
+                   create(:link,
+                          link_type: "related_links",
+                          target_content_id: SecureRandom.uuid)
+                 ])
         end
 
         it "returns array of hashes, with requested fields" do

--- a/spec/queries/live_edition_blocking_draft_edition_spec.rb
+++ b/spec/queries/live_edition_blocking_draft_edition_spec.rb
@@ -18,10 +18,10 @@ RSpec.describe Queries::LiveEditionBlockingDraftEdition do
     context "with a single edition" do
       before do
         create(:draft_edition,
-          document: document,
-          base_path: base_path,
-          document_type: document_type,
-          user_facing_version: 1)
+               document: document,
+               base_path: base_path,
+               document_type: document_type,
+               user_facing_version: 1)
       end
 
       include_examples "check succeeds"
@@ -30,16 +30,16 @@ RSpec.describe Queries::LiveEditionBlockingDraftEdition do
     context "with two editions of different locales" do
       before do
         create(:draft_edition,
-          document: document,
-          base_path: base_path + ".en",
-          document_type: document_type,
-          user_facing_version: 1)
+               document: document,
+               base_path: base_path + ".en",
+               document_type: document_type,
+               user_facing_version: 1)
 
         create(:draft_edition,
-          document: create(:document, content_id: document.content_id, locale: "es"),
-          base_path: base_path + ".es",
-          document_type: document_type,
-          user_facing_version: 1)
+               document: create(:document, content_id: document.content_id, locale: "es"),
+               base_path: base_path + ".es",
+               document_type: document_type,
+               user_facing_version: 1)
       end
 
       include_examples "check succeeds"
@@ -48,14 +48,14 @@ RSpec.describe Queries::LiveEditionBlockingDraftEdition do
     context "with a unpublished item, of type \"substitute\", and a draft at the same base path" do
       before do
         create(:substitute_unpublished_edition,
-          base_path: base_path,
-          document_type: document_type,
-          user_facing_version: 1)
+               base_path: base_path,
+               document_type: document_type,
+               user_facing_version: 1)
 
         create(:draft_edition,
-          base_path: base_path,
-          document_type: document_type,
-          user_facing_version: 1)
+               base_path: base_path,
+               document_type: document_type,
+               user_facing_version: 1)
       end
 
       include_examples "check succeeds"
@@ -64,15 +64,15 @@ RSpec.describe Queries::LiveEditionBlockingDraftEdition do
     context "with a published item, with a substitutable document_type, and a draft at the same base path" do
       before do
         create(:live_edition,
-          base_path: base_path,
-          document_type: "unpublishing",
-          user_facing_version: 1)
+               base_path: base_path,
+               document_type: "unpublishing",
+               user_facing_version: 1)
 
         create(:draft_edition,
-          document: document,
-          base_path: base_path,
-          document_type: document_type,
-          user_facing_version: 1)
+               document: document,
+               base_path: base_path,
+               document_type: document_type,
+               user_facing_version: 1)
       end
 
       include_examples "check succeeds"
@@ -83,15 +83,15 @@ RSpec.describe Queries::LiveEditionBlockingDraftEdition do
 
       before do
         create(:live_edition,
-          base_path: base_path,
-          document_type: "nonexistent-schema",
-          user_facing_version: 1)
+               base_path: base_path,
+               document_type: "nonexistent-schema",
+               user_facing_version: 1)
 
         create(:draft_edition,
-          document: document,
-          base_path: base_path,
-          document_type: document_type,
-          user_facing_version: 1)
+               document: document,
+               base_path: base_path,
+               document_type: document_type,
+               user_facing_version: 1)
       end
 
       include_examples "check succeeds"
@@ -100,15 +100,15 @@ RSpec.describe Queries::LiveEditionBlockingDraftEdition do
     context "with a unpublished item, and a draft at the same base path" do
       before do
         @blocking_edition = create(:gone_unpublished_edition,
-          base_path: base_path,
-          document_type: document_type,
-          user_facing_version: 1)
+                                   base_path: base_path,
+                                   document_type: document_type,
+                                   user_facing_version: 1)
 
         create(:edition,
-          document: document,
-          base_path: base_path,
-          document_type: document_type,
-          user_facing_version: 1)
+               document: document,
+               base_path: base_path,
+               document_type: document_type,
+               user_facing_version: 1)
       end
 
       it "fails, returning the id of the edition" do
@@ -119,15 +119,15 @@ RSpec.describe Queries::LiveEditionBlockingDraftEdition do
     context "with a published item, and a draft at the same base path" do
       before do
         @blocking_edition = create(:live_edition,
-          base_path: base_path,
-          document_type: document_type,
-          user_facing_version: 1)
+                                   base_path: base_path,
+                                   document_type: document_type,
+                                   user_facing_version: 1)
 
         create(:draft_edition,
-          document: document,
-          base_path: base_path,
-          document_type: document_type,
-          user_facing_version: 1)
+               document: document,
+               base_path: base_path,
+               document_type: document_type,
+               user_facing_version: 1)
       end
 
       it "fails, returning the id of the edition" do
@@ -140,24 +140,24 @@ RSpec.describe Queries::LiveEditionBlockingDraftEdition do
 
       let!(:blocking_edition) do
         create(:live_edition,
-          base_path: base_path,
-          document_type: document_type,
-          user_facing_version: 1)
+               base_path: base_path,
+               document_type: document_type,
+               user_facing_version: 1)
       end
 
       let!(:blocking_edition_2) do
         create(:live_edition,
-          base_path: base_path,
-          document_type: document_type,
-          user_facing_version: 1)
+               base_path: base_path,
+               document_type: document_type,
+               user_facing_version: 1)
       end
 
       let!(:content) do
         create(:draft_edition,
-          document: document,
-          base_path: base_path,
-          document_type: document_type,
-          user_facing_version: 1)
+               document: document,
+               base_path: base_path,
+               document_type: document_type,
+               user_facing_version: 1)
       end
 
       it "doesn't raise any errors" do

--- a/spec/queries/locales_for_editions_spec.rb
+++ b/spec/queries/locales_for_editions_spec.rb
@@ -9,9 +9,9 @@ RSpec.describe Queries::LocalesForEditions do
     base_path_prefix = "vat"
   )
     create(type,
-      document: Document.find_or_create_by(content_id: content_id, locale: locale),
-      base_path: "/#{base_path_prefix}-#{locale}",
-      user_facing_version: user_facing_version)
+           document: Document.find_or_create_by(content_id: content_id, locale: locale),
+           base_path: "/#{base_path_prefix}-#{locale}",
+           user_facing_version: user_facing_version)
   end
 
   describe ".call" do

--- a/spec/requests/content_item_requests/downstream_requests_spec.rb
+++ b/spec/requests/content_item_requests/downstream_requests_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe "Downstream requests", type: :request do
     context "when a link set exists for the edition" do
       let(:link_set) do
         create(:link_set,
-          content_id: v2_content_item[:content_id])
+               content_id: v2_content_item[:content_id])
       end
 
       let(:target_edition) { create(:edition, base_path: "/foo", title: "foo") }
@@ -64,12 +64,12 @@ RSpec.describe "Downstream requests", type: :request do
     context "when only a draft edition exists for the link set" do
       before do
         draft = create(:draft_edition,
-          document: create(:document, content_id: content_id, stale_lock_version: 1),
-          base_path: base_path)
+                       document: create(:document, content_id: content_id, stale_lock_version: 1),
+                       base_path: base_path)
 
         create(:access_limit,
-          users: access_limit_params.fetch(:users),
-          edition: draft)
+               users: access_limit_params.fetch(:users),
+               edition: draft)
       end
 
       it "only sends to the draft content store" do
@@ -87,8 +87,8 @@ RSpec.describe "Downstream requests", type: :request do
     context "when only a live edition exists for the link set" do
       before do
         create(:live_edition,
-          document: create(:document, content_id: content_id),
-          base_path: base_path)
+               document: create(:document, content_id: content_id),
+               base_path: base_path)
       end
 
       it "sends the live item to both content stores" do
@@ -109,17 +109,17 @@ RSpec.describe "Downstream requests", type: :request do
         document = create(:document, content_id: content_id)
 
         draft = create(:draft_edition,
-          document: document,
-          base_path: base_path,
-          user_facing_version: 2)
+                       document: document,
+                       base_path: base_path,
+                       user_facing_version: 2)
 
         create(:access_limit,
-          users: access_limit_params.fetch(:users),
-          edition: draft)
+               users: access_limit_params.fetch(:users),
+               edition: draft)
 
         create(:live_edition,
-          document: document,
-          base_path: base_path)
+               document: document,
+               base_path: base_path)
       end
 
       it "sends to both content stores" do
@@ -196,8 +196,8 @@ RSpec.describe "Downstream requests", type: :request do
     let(:content_id) { SecureRandom.uuid }
     let!(:draft) {
       create(:draft_edition,
-        document: create(:document, content_id: content_id),
-        base_path: base_path)
+             document: create(:document, content_id: content_id),
+             base_path: base_path)
     }
 
     let(:content_item_for_live_content_store) {

--- a/spec/requests/content_item_requests/downstream_timeouts_spec.rb
+++ b/spec/requests/content_item_requests/downstream_timeouts_spec.rb
@@ -31,18 +31,18 @@ RSpec.describe "Downstream timeouts", type: :request do
       document = create(:document, content_id: content_id)
 
       create(:live_edition,
-        v2_content_item
-          .slice(*Edition::TOP_LEVEL_FIELDS)
-          .merge(base_path: base_path, user_facing_version: 1, document: document))
+             v2_content_item
+               .slice(*Edition::TOP_LEVEL_FIELDS)
+               .merge(base_path: base_path, user_facing_version: 1, document: document))
 
       draft = create(:draft_edition,
-        v2_content_item
-          .slice(*Edition::TOP_LEVEL_FIELDS)
-          .merge(base_path: base_path, user_facing_version: 2, document: document))
+                     v2_content_item
+                       .slice(*Edition::TOP_LEVEL_FIELDS)
+                       .merge(base_path: base_path, user_facing_version: 2, document: document))
 
       create(:access_limit,
-        edition: draft,
-        users: access_limit_params.fetch(:users))
+             edition: draft,
+             users: access_limit_params.fetch(:users))
     end
 
     context "draft content store times out" do

--- a/spec/requests/content_item_requests/message_bus_spec.rb
+++ b/spec/requests/content_item_requests/message_bus_spec.rb
@@ -19,8 +19,8 @@ RSpec.describe "Message bus", type: :request do
     context "with a live edition" do
       before do
         create(:live_edition,
-          document: create(:document, content_id: content_id),
-          base_path: base_path)
+               document: create(:document, content_id: content_id),
+               base_path: base_path)
       end
 
       it "sends a message with a 'links' routing key" do
@@ -34,8 +34,8 @@ RSpec.describe "Message bus", type: :request do
     context "with a draft edition" do
       before do
         create(:draft_edition,
-          document: create(:document, content_id: content_id),
-          base_path: base_path)
+               document: create(:document, content_id: content_id),
+               base_path: base_path)
       end
 
       it "doesn't send any messages" do
@@ -52,10 +52,10 @@ RSpec.describe "Message bus", type: :request do
   context "/v2/publish" do
     before do
       create(:draft_edition,
-        document: create(:document, content_id: content_id),
-        document_type: "nonexistent-schema",
-        schema_name: "nonexistent-schema",
-        base_path: base_path)
+             document: create(:document, content_id: content_id),
+             document_type: "nonexistent-schema",
+             schema_name: "nonexistent-schema",
+             base_path: base_path)
     end
 
     it "sends a message with the 'document_type.update_type' routing key" do

--- a/spec/requests/content_item_requests/reallocating_base_path_spec.rb
+++ b/spec/requests/content_item_requests/reallocating_base_path_spec.rb
@@ -10,14 +10,14 @@ RSpec.describe "Reallocating base paths of editions" do
 
   let(:regular_payload) do
     build(:draft_edition,
-      document: create(:document, content_id: content_id)).as_json.deep_symbolize_keys.merge(base_path: base_path)
+          document: create(:document, content_id: content_id)).as_json.deep_symbolize_keys.merge(base_path: base_path)
   end
 
   describe "/v2/content" do
     context "when a base path is occupied by a 'regular' edition" do
       before do
         create(:draft_edition,
-          base_path: base_path)
+               base_path: base_path)
       end
 
       it "cannot be replaced by another 'regular' edition" do
@@ -52,7 +52,7 @@ RSpec.describe "Reallocating base paths of editions" do
 
       it "raises an error" do
         post "/v2/content/#{draft_document.content_id}/publish",
-          params: { update_type: "major", content_id: draft_document.content_id }.to_json
+             params: { update_type: "major", content_id: draft_document.content_id }.to_json
 
         expect(response.status).to eq(422)
       end

--- a/spec/requests/discard_draft_request_spec.rb
+++ b/spec/requests/discard_draft_request_spec.rb
@@ -10,9 +10,9 @@ RSpec.describe "Discard draft requests", type: :request do
     context "when a draft edition exists" do
       let!(:draft_edition) do
         create(:draft_edition,
-          document: document,
-          title: "draft",
-          base_path: base_path)
+               document: document,
+               title: "draft",
+               base_path: base_path)
       end
 
       it "does not send to the live content store" do
@@ -38,9 +38,9 @@ RSpec.describe "Discard draft requests", type: :request do
 
         let!(:french_draft_edition) do
           create(:draft_edition,
-            document: fr_document,
-            title: "draft",
-            base_path: french_base_path)
+                 document: fr_document,
+                 title: "draft",
+                 base_path: french_base_path)
         end
 
         before do

--- a/spec/requests/expanded_links_endpoint_spec.rb
+++ b/spec/requests/expanded_links_endpoint_spec.rb
@@ -14,11 +14,11 @@ RSpec.describe "GET /v2/expanded-links/:id", type: :request do
 
     before do
       create(:expanded_links,
-        content_id: content_id,
-        locale: "en",
-        with_drafts: true,
-        expanded_links: expanded_links,
-        updated_at: updated_at)
+             content_id: content_id,
+             locale: "en",
+             with_drafts: true,
+             expanded_links: expanded_links,
+             updated_at: updated_at)
     end
 
     it "is assumed to be 'en'" do
@@ -41,11 +41,11 @@ RSpec.describe "GET /v2/expanded-links/:id", type: :request do
 
     before do
       create(:expanded_links,
-        content_id: content_id,
-        locale: "de",
-        with_drafts: true,
-        expanded_links: expanded_links,
-        updated_at: updated_at)
+             content_id: content_id,
+             locale: "de",
+             with_drafts: true,
+             expanded_links: expanded_links,
+             updated_at: updated_at)
     end
 
     it "returns the links for that locale" do
@@ -81,11 +81,11 @@ RSpec.describe "GET /v2/expanded-links/:id", type: :request do
 
     before do
       create(:expanded_links,
-        content_id: content_id,
-        locale: "en",
-        with_drafts: false,
-        expanded_links: expanded_links,
-        updated_at: updated_at)
+             content_id: content_id,
+             locale: "en",
+             with_drafts: false,
+             expanded_links: expanded_links,
+             updated_at: updated_at)
     end
 
     it "it returns the links " do
@@ -103,15 +103,15 @@ RSpec.describe "GET /v2/expanded-links/:id", type: :request do
 
     let!(:edition) do
       create(:live_edition,
-        document: create(:document, content_id: content_id),
-        base_path: "/some-path",
-        links_hash: { organisations: [linked_content_id] })
+             document: create(:document, content_id: content_id),
+             base_path: "/some-path",
+             links_hash: { organisations: [linked_content_id] })
     end
 
     let!(:linked_edition) do
       create(:live_edition,
-        document: create(:document, content_id: linked_content_id),
-        base_path: "/another-path")
+             document: create(:document, content_id: linked_content_id),
+             base_path: "/another-path")
     end
 
     let(:expanded_links) do

--- a/spec/requests/index_spec.rb
+++ b/spec/requests/index_spec.rb
@@ -3,19 +3,19 @@ require "rails_helper"
 RSpec.describe "GET /v2/content", type: :request do
   let!(:policy_1) {
     create(:edition,
-      state: "draft",
-      document_type: "policy",
-      schema_name: "policy",
-      title: "Policy 1",
-      base_path: "/cat-rates")
+           state: "draft",
+           document_type: "policy",
+           schema_name: "policy",
+           title: "Policy 1",
+           base_path: "/cat-rates")
   }
 
   let!(:policy_2) {
     create(:edition,
-      state: "published",
-      document_type: "policy",
-      schema_name: "policy",
-      title: "Policy 2")
+           state: "published",
+           document_type: "policy",
+           schema_name: "policy",
+           title: "Policy 2")
   }
 
   it "responds with a list of content items" do

--- a/spec/requests/linkables_spec.rb
+++ b/spec/requests/linkables_spec.rb
@@ -3,21 +3,21 @@ require "rails_helper"
 RSpec.describe "GET /v2/linkables", type: :request do
   let!(:policy_1) {
     create(:edition,
-      state: "draft",
-      document_type: "policy",
-      title: "Policy 1",
-      base_path: "/cat-rates",
-      details: {
-        internal_name: "Cat rates (do not use for actual cats)"
-      })
+           state: "draft",
+           document_type: "policy",
+           title: "Policy 1",
+           base_path: "/cat-rates",
+           details: {
+             internal_name: "Cat rates (do not use for actual cats)"
+           })
   }
 
   let!(:policy_2) {
     create(:edition,
-      state: "published",
-      document_type: "policy",
-      title: "Policy 2",
-      base_path: "/vat-rates")
+           state: "published",
+           document_type: "policy",
+           title: "Policy 2",
+           base_path: "/vat-rates")
   }
 
   around do |example|

--- a/spec/requests/patch_link_set_spec.rb
+++ b/spec/requests/patch_link_set_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "Keeping track of link changes", type: :request do
   scenario "A link is added" do
     make_patch_links_request(
       "2ee935c3-d926-4737-aa23-e8c5edb5c3ca",
-      something: ["1f0b3601-6a1d-4065-adc6-bf6040e2a806"]
+      something: %w[1f0b3601-6a1d-4065-adc6-bf6040e2a806]
     )
 
     expect(LinkChange.count).to eql(1)
@@ -31,12 +31,12 @@ RSpec.describe "Keeping track of link changes", type: :request do
   scenario "A link is changed" do
     make_patch_links_request(
       "2ee935c3-d926-4737-aa23-e8c5edb5c3ca",
-      something: ["1f0b3601-6a1d-4065-adc6-bf6040e2a806"]
+      something: %w[1f0b3601-6a1d-4065-adc6-bf6040e2a806]
     )
 
     make_patch_links_request(
       "2ee935c3-d926-4737-aa23-e8c5edb5c3ca",
-      something: ["0bbd6b21-b6f4-4327-aa40-696bda836000"]
+      something: %w[0bbd6b21-b6f4-4327-aa40-696bda836000]
     )
 
     expect(LinkChange.count).to eql(3)

--- a/spec/requests/unpublishing_spec.rb
+++ b/spec/requests/unpublishing_spec.rb
@@ -12,8 +12,8 @@ RSpec.describe "POST /v2/content/:content_id/unpublish", type: :request do
   let!(:document) { create(:document, content_id: content_id) }
   let!(:edition) do
     create(:live_edition,
-      document: document,
-      base_path: base_path)
+           document: document,
+           base_path: base_path)
   end
 
   describe "withdrawing" do

--- a/spec/service_consumers/pact_helper.rb
+++ b/spec/service_consumers/pact_helper.rb
@@ -35,7 +35,7 @@ Pact.provider_states_for "GDS API Adapters" do
     WebMock.reset!
     DatabaseCleaner.clean_with :truncation
     GDS::SSO.test_user = create(:user,
-      permissions: %w(signin view_all))
+                                permissions: %w(signin view_all))
   end
 
   tear_down do
@@ -75,21 +75,21 @@ Pact.provider_states_for "GDS API Adapters" do
       document = create(:document, content_id: "bed722e6-db68-43e5-9079-063f623335a7")
 
       create(:draft_edition,
-        base_path: "/robots.txt",
-        document: document,
-        title: "Instructions for crawler robots",
-        description: "robots.txt provides rules for which parts of GOV.UK are permitted to be crawled by different bots.",
-        document_type: "special_route",
-        schema_name: "special_route",
-        public_updated_at: "2015-07-30T13:58:11+00:00",
-        publishing_app: "static",
-        rendering_app: "static",
-        routes: [
-          {
-            path: "/robots.txt",
-            type: "exact"
-          },
-        ])
+             base_path: "/robots.txt",
+             document: document,
+             title: "Instructions for crawler robots",
+             description: "robots.txt provides rules for which parts of GOV.UK are permitted to be crawled by different bots.",
+             document_type: "special_route",
+             schema_name: "special_route",
+             public_updated_at: "2015-07-30T13:58:11+00:00",
+             publishing_app: "static",
+             rendering_app: "static",
+             routes: [
+               {
+                 path: "/robots.txt",
+                 type: "exact"
+               },
+             ])
     end
   end
 
@@ -104,22 +104,22 @@ Pact.provider_states_for "GDS API Adapters" do
   provider_state "a draft content item exists with content_id bed722e6-db68-43e5-9079-063f623335a7 with a blocking live item at the same path" do
     set_up do
       create(:live_edition,
-        document: create(:document),
-        base_path: "/blocking_path")
+             document: create(:document),
+             base_path: "/blocking_path")
 
       draft_document = create(:document, content_id: "bed722e6-db68-43e5-9079-063f623335a7")
 
       create(:draft_edition,
-        document: draft_document,
-        base_path: "/blocking_path")
+             document: draft_document,
+             base_path: "/blocking_path")
     end
   end
 
   provider_state "a French content item exists with content_id: bed722e6-db68-43e5-9079-063f623335a7" do
     set_up do
       document = create(:document,
-        content_id: "bed722e6-db68-43e5-9079-063f623335a7",
-        locale: "fr")
+                        content_id: "bed722e6-db68-43e5-9079-063f623335a7",
+                        locale: "fr")
 
       create(:draft_edition, document: document)
     end
@@ -144,8 +144,8 @@ Pact.provider_states_for "GDS API Adapters" do
   provider_state "organisation links exist for content_id bed722e6-db68-43e5-9079-063f623335a7" do
     set_up do
       link_set = create(:link_set,
-        content_id: "bed722e6-db68-43e5-9079-063f623335a7",
-        stale_lock_version: 2)
+                        content_id: "bed722e6-db68-43e5-9079-063f623335a7",
+                        stale_lock_version: 2)
 
       document = create(:document, content_id: "20583132-1619-4c68-af24-77583172c070")
       create(:edition, document: document)
@@ -156,16 +156,16 @@ Pact.provider_states_for "GDS API Adapters" do
   provider_state "empty links exist for content_id bed722e6-db68-43e5-9079-063f623335a7" do
     set_up do
       create(:link_set,
-        content_id: "bed722e6-db68-43e5-9079-063f623335a7",
-        stale_lock_version: 2)
+             content_id: "bed722e6-db68-43e5-9079-063f623335a7",
+             stale_lock_version: 2)
     end
   end
 
   provider_state "taxon links exist for content_id bed722e6-db68-43e5-9079-063f623335a7" do
     set_up do
       link_set = create(:link_set,
-        content_id: "bed722e6-db68-43e5-9079-063f623335a7",
-        stale_lock_version: 2)
+                        content_id: "bed722e6-db68-43e5-9079-063f623335a7",
+                        stale_lock_version: 2)
 
       taxon = create(:document, content_id: "20583132-1619-4c68-af24-77583172c070")
       create(:edition, document: taxon)
@@ -182,8 +182,8 @@ Pact.provider_states_for "GDS API Adapters" do
   provider_state "a draft content item exists with content_id: bed722e6-db68-43e5-9079-063f623335a7 and locale: fr" do
     set_up do
       document = create(:document,
-        content_id: "bed722e6-db68-43e5-9079-063f623335a7",
-        locale: "fr")
+                        content_id: "bed722e6-db68-43e5-9079-063f623335a7",
+                        locale: "fr")
 
       create(:draft_edition, document: document)
     end
@@ -196,25 +196,25 @@ Pact.provider_states_for "GDS API Adapters" do
       ar_doc = create(:document, content_id: "bed722e6-db68-43e5-9079-063f623335a7", locale: "ar")
 
       create(:draft_edition,
-        document: en_doc,
-        document_type: "topic",
-        schema_name: "topic",
-        public_updated_at: "2015-01-03",
-        user_facing_version: 1)
+             document: en_doc,
+             document_type: "topic",
+             schema_name: "topic",
+             public_updated_at: "2015-01-03",
+             user_facing_version: 1)
 
       create(:draft_edition,
-        document: fr_doc,
-        document_type: "topic",
-        schema_name: "topic",
-        public_updated_at: "2015-01-02",
-        user_facing_version: 1)
+             document: fr_doc,
+             document_type: "topic",
+             schema_name: "topic",
+             public_updated_at: "2015-01-02",
+             user_facing_version: 1)
 
       create(:draft_edition,
-        document: ar_doc,
-        document_type: "topic",
-        schema_name: "topic",
-        public_updated_at: "2015-01-01",
-        user_facing_version: 1)
+             document: ar_doc,
+             document_type: "topic",
+             schema_name: "topic",
+             public_updated_at: "2015-01-01",
+             user_facing_version: 1)
     end
   end
 
@@ -223,26 +223,26 @@ Pact.provider_states_for "GDS API Adapters" do
       document = create(:document, content_id: "bed722e6-db68-43e5-9079-063f623335a7")
 
       create(:superseded_edition,
-        document: document,
-        document_type: "topic",
-        schema_name: "topic",
-        public_updated_at: "2015-01-03",
-        user_facing_version: 1)
+             document: document,
+             document_type: "topic",
+             schema_name: "topic",
+             public_updated_at: "2015-01-03",
+             user_facing_version: 1)
 
       create(:live_edition,
-        document: document,
-        document_type: "topic",
-        schema_name: "topic",
-        public_updated_at: "2015-01-03",
-        user_facing_version: 2)
+             document: document,
+             document_type: "topic",
+             schema_name: "topic",
+             public_updated_at: "2015-01-03",
+             user_facing_version: 2)
     end
   end
 
   provider_state "the content item bed722e6-db68-43e5-9079-063f623335a7 is at lock version 3" do
     set_up do
       document = create(:document,
-        content_id: "bed722e6-db68-43e5-9079-063f623335a7",
-        stale_lock_version: 3)
+                        content_id: "bed722e6-db68-43e5-9079-063f623335a7",
+                        stale_lock_version: 3)
 
       create(:draft_edition, document: document)
 
@@ -254,14 +254,14 @@ Pact.provider_states_for "GDS API Adapters" do
   provider_state "the linkset for bed722e6-db68-43e5-9079-063f623335a7 is at lock version 3" do
     set_up do
       document = create(:document,
-        content_id: "bed722e6-db68-43e5-9079-063f623335a7",
-        stale_lock_version: 1)
+                        content_id: "bed722e6-db68-43e5-9079-063f623335a7",
+                        stale_lock_version: 1)
 
       create(:draft_edition, document: document)
 
       create(:link_set,
-        content_id: "bed722e6-db68-43e5-9079-063f623335a7",
-        stale_lock_version: 3)
+             content_id: "bed722e6-db68-43e5-9079-063f623335a7",
+             stale_lock_version: 3)
 
       stub_request(:put, Regexp.new('\A' + Regexp.escape(Plek.find("content-store")) + "/content"))
       stub_request(:put, Regexp.new('\A' + Regexp.escape(Plek.find("draft-content-store")) + "/content"))
@@ -272,11 +272,11 @@ Pact.provider_states_for "GDS API Adapters" do
     set_up do
       (1..4).each do |index|
         create(:live_edition,
-                 title: "title_#{index}",
-                 document: create(:document),
-                 base_path: "/path_#{index}",
-                 document_type: "topic",
-                 public_updated_at: Time.local(2018, 12 - index, 1, 12, 0, 0))
+               title: "title_#{index}",
+               document: create(:document),
+               base_path: "/path_#{index}",
+               document_type: "topic",
+               public_updated_at: Time.local(2018, 12 - index, 1, 12, 0, 0))
       end
     end
   end
@@ -284,29 +284,29 @@ Pact.provider_states_for "GDS API Adapters" do
   provider_state "there is content with document_type 'topic'" do
     set_up do
       document_a = create(:document,
-        content_id: "aaaaaaaa-aaaa-1aaa-aaaa-aaaaaaaaaaaa")
+                          content_id: "aaaaaaaa-aaaa-1aaa-aaaa-aaaaaaaaaaaa")
 
       create(:draft_edition,
-        title: 'Content Item A',
-        document: document_a,
-        base_path: '/a-base-path',
-        document_type: "topic",
-        schema_name: "topic",
-        public_updated_at: '2015-01-02',
-        details: {
-          internal_name: "an internal name",
-        })
+             title: 'Content Item A',
+             document: document_a,
+             base_path: '/a-base-path',
+             document_type: "topic",
+             schema_name: "topic",
+             public_updated_at: '2015-01-02',
+             details: {
+               internal_name: "an internal name",
+             })
 
       document_b = create(:document,
-        content_id: "bbbbbbbb-bbbb-2bbb-bbbb-bbbbbbbbbbbb")
+                          content_id: "bbbbbbbb-bbbb-2bbb-bbbb-bbbbbbbbbbbb")
 
       create(:live_edition,
-        title: 'Content Item B',
-        document: document_b,
-        base_path: '/another-base-path',
-        public_updated_at: '2015-01-01',
-        document_type: "topic",
-        schema_name: "topic")
+             title: 'Content Item B',
+             document: document_b,
+             base_path: '/another-base-path',
+             public_updated_at: '2015-01-01',
+             document_type: "topic",
+             schema_name: "topic")
     end
   end
   provider_state "there are two link changes with a link_type of 'taxons'" do
@@ -321,32 +321,32 @@ Pact.provider_states_for "GDS API Adapters" do
         action2 = create(:action, user_uid: '22222222-2222-2222-2222-222222222222')
 
         create(:edition,
-          title: 'Edition Title A1',
-          base_path: '/base/path/a1',
-          document: document_a1)
+               title: 'Edition Title A1',
+               base_path: '/base/path/a1',
+               document: document_a1)
         create(:edition,
-          title: 'Edition Title A2',
-          base_path: '/base/path/a2',
-          document: document_a2)
+               title: 'Edition Title A2',
+               base_path: '/base/path/a2',
+               document: document_a2)
         create(:edition,
-          title: 'Edition Title B1',
-          base_path: '/base/path/b1',
-          document: document_b1)
+               title: 'Edition Title B1',
+               base_path: '/base/path/b1',
+               document: document_b1)
         create(:edition,
-          title: 'Edition Title B2',
-          base_path: '/base/path/b2',
-          document: document_b2)
+               title: 'Edition Title B2',
+               base_path: '/base/path/b2',
+               document: document_b2)
 
         create(:link_change,
-          source_content_id: document_a1.content_id,
-          target_content_id: document_b1.content_id,
-          action: action1,
-          change: 'add')
+               source_content_id: document_a1.content_id,
+               target_content_id: document_b1.content_id,
+               action: action1,
+               change: 'add')
         create(:link_change,
-          source_content_id: document_a2.content_id,
-          target_content_id: document_b2.content_id,
-          action: action2,
-          change: 'remove')
+               source_content_id: document_a2.content_id,
+               target_content_id: document_b2.content_id,
+               action: action2,
+               change: 'remove')
       end
     end
   end
@@ -357,26 +357,26 @@ Pact.provider_states_for "GDS API Adapters" do
       document_c = create(:document)
 
       create(:draft_edition,
-        document: document_a,
-        title: 'Content Item A',
-        base_path: '/a-base-path',
-        document_type: "topic",
-        schema_name: "topic")
+             document: document_a,
+             title: 'Content Item A',
+             base_path: '/a-base-path',
+             document_type: "topic",
+             schema_name: "topic")
 
       create(:draft_edition,
-        document: document_b,
-        title: 'Content Item B',
-        base_path: '/another-base-path',
-        document_type: "topic",
-        schema_name: "topic")
+             document: document_b,
+             title: 'Content Item B',
+             base_path: '/another-base-path',
+             document_type: "topic",
+             schema_name: "topic")
 
       create(:draft_edition,
-        document: document_c,
-        title: 'Content Item C',
-        base_path: '/yet-another-base-path',
-        document_type: "topic",
-        schema_name: "topic",
-        publishing_app: 'whitehall')
+             document: document_c,
+             title: 'Content Item C',
+             base_path: '/yet-another-base-path',
+             document_type: "topic",
+             schema_name: "topic",
+             publishing_app: 'whitehall')
     end
   end
 
@@ -391,24 +391,24 @@ Pact.provider_states_for "GDS API Adapters" do
       document3 = create(:document, content_id: content_id3)
 
       create(:live_edition,
-        document: document1,
-        user_facing_version: 1)
+             document: document1,
+             user_facing_version: 1)
 
       create(:draft_edition,
-        document: document1,
-        user_facing_version: 2)
+             document: document1,
+             user_facing_version: 2)
 
       create(:live_edition,
-        document: document3,
-        base_path: '/item-b',
-        public_updated_at: '2015-01-02',
-        user_facing_version: 1)
+             document: document3,
+             base_path: '/item-b',
+             public_updated_at: '2015-01-02',
+             user_facing_version: 1)
 
       create(:live_edition,
-        document: document2,
-        base_path: '/item-a',
-        public_updated_at: '2015-01-01',
-        user_facing_version: 1)
+             document: document2,
+             base_path: '/item-a',
+             public_updated_at: '2015-01-01',
+             user_facing_version: 1)
 
       link_set1 = create(:link_set, content_id: content_id3)
       link_set2 = create(:link_set, content_id: content_id2)
@@ -423,18 +423,18 @@ Pact.provider_states_for "GDS API Adapters" do
       document = create(:document, content_id: "bed722e6-db68-43e5-9079-063f623335a7")
 
       create(:draft_edition,
-        document: document,
-        document_type: "topic",
-        schema_name: "topic",
-        details: { foo: :bar })
+             document: document,
+             document_type: "topic",
+             schema_name: "topic",
+             details: { foo: :bar })
     end
   end
 
   provider_state "the content item bed722e6-db68-43e5-9079-063f623335a7 is at version 3" do
     set_up do
       document = create(:document,
-        content_id: "bed722e6-db68-43e5-9079-063f623335a7",
-        stale_lock_version: 3)
+                        content_id: "bed722e6-db68-43e5-9079-063f623335a7",
+                        stale_lock_version: 3)
 
       create(:draft_edition, document: document)
 
@@ -446,8 +446,8 @@ Pact.provider_states_for "GDS API Adapters" do
   provider_state "the published content item bed722e6-db68-43e5-9079-063f623335a7 is at version 3" do
     set_up do
       document = create(:document,
-        content_id: "bed722e6-db68-43e5-9079-063f623335a7",
-        stale_lock_version: 3)
+                        content_id: "bed722e6-db68-43e5-9079-063f623335a7",
+                        stale_lock_version: 3)
 
       create(:live_edition, document: document)
 
@@ -459,14 +459,14 @@ Pact.provider_states_for "GDS API Adapters" do
   provider_state "the linkset for bed722e6-db68-43e5-9079-063f623335a7 is at version 3" do
     set_up do
       document = create(:document,
-        content_id: "bed722e6-db68-43e5-9079-063f623335a7",
-        stale_lock_version: 1)
+                        content_id: "bed722e6-db68-43e5-9079-063f623335a7",
+                        stale_lock_version: 1)
 
       create(:draft_edition, document: document)
 
       create(:link_set,
-        content_id: "bed722e6-db68-43e5-9079-063f623335a7",
-        stale_lock_version: 3)
+             content_id: "bed722e6-db68-43e5-9079-063f623335a7",
+             stale_lock_version: 3)
 
       stub_request(:put, Regexp.new('\A' + Regexp.escape(Plek.find("content-store")) + "/content"))
       stub_request(:put, Regexp.new('\A' + Regexp.escape(Plek.find("draft-content-store")) + "/content"))

--- a/spec/substitution_helper_spec.rb
+++ b/spec/substitution_helper_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe SubstitutionHelper do
 
   let!(:existing_item) {
     create(:draft_edition,
-      document_type: existing_document_type,
-      base_path: existing_base_path)
+           document_type: existing_document_type,
+           base_path: existing_base_path)
   }
 
   before do
@@ -39,8 +39,8 @@ RSpec.describe SubstitutionHelper do
       context "when the existing item is published" do
         let!(:existing_item) {
           create(:live_edition,
-            document_type: existing_document_type,
-            base_path: existing_base_path)
+                 document_type: existing_document_type,
+                 base_path: existing_base_path)
         }
 
         it "does not unpublish the existing published item" do
@@ -76,17 +76,17 @@ RSpec.describe SubstitutionHelper do
 
         it "doesn't unpublish any other items" do
           live_item = create(:live_edition,
-            document_type: existing_document_type,
-            base_path: existing_base_path)
+                             document_type: existing_document_type,
+                             base_path: existing_base_path)
 
           french_item = create(:draft_edition,
-            document: create(:document, locale: "fr"),
-            document_type: existing_document_type,
-            base_path: existing_base_path)
+                               document: create(:document, locale: "fr"),
+                               document_type: existing_document_type,
+                               base_path: existing_base_path)
 
           item_elsewhere = create(:draft_edition,
-            document_type: existing_document_type,
-            base_path: "/somewhere-else")
+                                  document_type: existing_document_type,
+                                  base_path: "/somewhere-else")
 
           expect(live_item.state).not_to eq("unpublished")
           expect(french_item.state).not_to eq("unpublished")
@@ -96,8 +96,8 @@ RSpec.describe SubstitutionHelper do
         context "when the existing item is published" do
           let!(:existing_item) {
             create(:live_edition,
-              document_type: existing_document_type,
-              base_path: existing_base_path)
+                   document_type: existing_document_type,
+                   base_path: existing_base_path)
           }
 
           it "unpublishes the existing published item" do
@@ -115,17 +115,17 @@ RSpec.describe SubstitutionHelper do
 
         it "doesn't unpublish any other items" do
           live_item = create(:live_edition,
-            document_type: existing_document_type,
-            base_path: existing_base_path)
+                             document_type: existing_document_type,
+                             base_path: existing_base_path)
 
           french_item = create(:draft_edition,
-            document: create(:document, locale: "fr"),
-            document_type: existing_document_type,
-            base_path: existing_base_path)
+                               document: create(:document, locale: "fr"),
+                               document_type: existing_document_type,
+                               base_path: existing_base_path)
 
           item_elsewhere = create(:draft_edition,
-            document_type: existing_document_type,
-            base_path: "/somewhere-else")
+                                  document_type: existing_document_type,
+                                  base_path: "/somewhere-else")
 
           expect(live_item.state).not_to eq("unpublished")
           expect(french_item.state).not_to eq("unpublished")
@@ -135,8 +135,8 @@ RSpec.describe SubstitutionHelper do
         context "when the existing item is published" do
           let!(:existing_item) {
             create(:live_edition,
-              document_type: existing_document_type,
-              base_path: existing_base_path)
+                   document_type: existing_document_type,
+                   base_path: existing_base_path)
           }
 
           it "unpublishes the existing published item" do
@@ -153,8 +153,8 @@ RSpec.describe SubstitutionHelper do
         context "when the existing item is published" do
           let!(:existing_item) {
             create(:live_edition,
-              document_type: existing_document_type,
-              base_path: existing_base_path)
+                   document_type: existing_document_type,
+                   base_path: existing_base_path)
           }
 
           it "does not unpublish the existing item" do

--- a/spec/support/dependency_resolution_helper.rb
+++ b/spec/support/dependency_resolution_helper.rb
@@ -1,8 +1,8 @@
 module DependencyResolutionHelper
   def create_link_set(content_id = nil, links_hash: {})
     link_set = create(:link_set,
-      content_id: content_id || SecureRandom.uuid,
-      links_hash: links_hash)
+                      content_id: content_id || SecureRandom.uuid,
+                      links_hash: links_hash)
     link_set.content_id
   end
 
@@ -15,19 +15,19 @@ module DependencyResolutionHelper
     version: 1
   )
     create(factory,
-      document: Document.find_or_create_by(content_id: content_id, locale: locale),
-      base_path: base_path,
-      user_facing_version: version,
-      links_hash: links_hash)
+           document: Document.find_or_create_by(content_id: content_id, locale: locale),
+           base_path: base_path,
+           user_facing_version: version,
+           links_hash: links_hash)
   end
 
   def create_link(from, to, link_type, link_position = 0)
     link_set = LinkSet.find_or_create_by(content_id: from)
 
     create(:link,
-      link_set: link_set,
-      target_content_id: to,
-      link_type: link_type,
-      position: link_position)
+           link_set: link_set,
+           target_content_id: to,
+           link_type: link_type,
+           position: link_position)
   end
 end

--- a/spec/support/matchers/a_gzipped_file.rb
+++ b/spec/support/matchers/a_gzipped_file.rb
@@ -8,6 +8,7 @@ RSpec::Matchers.define :a_gzipped_file do
     begin
       @file = Zlib::GzipReader.open(actual)
       return true unless @expected_contents
+
       values_match?(@expected_contents, @file.read)
     rescue Zlib::GzipFile::Error
       false

--- a/spec/support/request_helpers/mocks.rb
+++ b/spec/support/request_helpers/mocks.rb
@@ -46,9 +46,9 @@ module RequestHelpers
 
     def access_limit_params
       {
-        users: [
-          "bf3e4b4f-f02d-4658-95a7-df7c74cd0f50",
-          "74c7d700-5b4a-0131-7a8e-005056030037",
+        users: %w[
+          bf3e4b4f-f02d-4658-95a7-df7c74cd0f50
+          74c7d700-5b4a-0131-7a8e-005056030037
         ],
         auth_bypass_ids: [],
       }
@@ -58,7 +58,7 @@ module RequestHelpers
       {
         content_id: content_id,
         links: {
-          organisations: ["30986e26-f504-4e14-a93f-a9593c34a8d9"]
+          organisations: %w[30986e26-f504-4e14-a93f-a9593c34a8d9]
         }
       }
     end

--- a/spec/support/transactional_command.rb
+++ b/spec/support/transactional_command.rb
@@ -28,10 +28,10 @@ RSpec.shared_examples_for TransactionalCommand do
       new_count = Edition.count
 
       expect(new_count).to eq(previous_count),
-        "The transaction should have been rolled back"
+                           "The transaction should have been rolled back"
 
       expect(Event.count).to be_zero,
-        "The command should not have logged an event"
+                             "The command should not have logged an event"
     end
   end
 end

--- a/spec/validators/base_path_for_state_validator_spec.rb
+++ b/spec/validators/base_path_for_state_validator_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe BasePathForStateValidator do
 
   let(:edition) do
     build(:edition,
-      state: state_name,
-      base_path: base_path)
+          state: state_name,
+          base_path: base_path)
   end
 
   describe ".validate" do
@@ -31,16 +31,16 @@ RSpec.describe BasePathForStateValidator do
 
       let(:conflict_document) do
         create(:document,
-          content_id: conflict_content_id,
-          locale: conflict_locale)
+               content_id: conflict_content_id,
+               locale: conflict_locale)
       end
 
       let!(:conflict_edition) do
         create(:edition,
-          document: conflict_document,
-          state: conflict_state_name,
-          base_path: conflict_base_path,
-          user_facing_version: 2)
+               document: conflict_document,
+               state: conflict_state_name,
+               base_path: conflict_base_path,
+               user_facing_version: 2)
       end
 
       before { edition.base_path = conflict_base_path }

--- a/spec/validators/state_for_document_validator_spec.rb
+++ b/spec/validators/state_for_document_validator_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe StateForDocumentValidator do
 
   let(:edition) do
     build(:edition,
-      state: state_name,
-      document: document)
+          state: state_name,
+          document: document)
   end
 
   describe "#validate" do
@@ -33,7 +33,7 @@ RSpec.describe StateForDocumentValidator do
         context "when #{hash[:scenario]}" do
           let!(:conflict_edition) {
             create(hash[:factory],
-              document: document)
+                   document: document)
           }
           let(:state_name) { hash[:state] }
           let(:expected_error) do

--- a/spec/validators/version_for_document_validator_spec.rb
+++ b/spec/validators/version_for_document_validator_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe VersionForDocumentValidator do
 
   let(:edition) do
     build(:edition,
-      document: document,
-      user_facing_version: version)
+          document: document,
+          user_facing_version: version)
   end
 
   describe "#validate" do
@@ -30,8 +30,8 @@ RSpec.describe VersionForDocumentValidator do
     context "when version and document are the same" do
       let!(:conflict_edition) {
         create(:edition,
-          document: document,
-          user_facing_version: version)
+               document: document,
+               user_facing_version: version)
       }
       let(:expected_error) do
         "user_facing_version=#{version} and document=#{document.id} " +

--- a/spec/workers/dependency_resolution_worker_spec.rb
+++ b/spec/workers/dependency_resolution_worker_spec.rb
@@ -51,8 +51,8 @@ RSpec.describe DependencyResolutionWorker, :perform do
   context "with a draft version available" do
     let!(:draft_edition) do
       create(:draft_edition,
-        document: document,
-        user_facing_version: 2)
+             document: document,
+             user_facing_version: 2)
     end
 
     it "doesn't send draft content to the live content store" do

--- a/spec/workers/downstream_discard_draft_worker_spec.rb
+++ b/spec/workers/downstream_discard_draft_worker_spec.rb
@@ -5,8 +5,8 @@ RSpec.describe DownstreamDiscardDraftWorker do
 
   let(:edition) do
     create(:draft_edition,
-      base_path: base_path,
-      title: "Draft")
+           base_path: base_path,
+           title: "Draft")
   end
 
   let(:content_id) { edition.content_id }
@@ -68,9 +68,9 @@ RSpec.describe DownstreamDiscardDraftWorker do
   context "has a live edition with same base_path" do
     let!(:live_edition) do
       create(:live_edition,
-        base_path: base_path,
-        document: edition.document,
-        title: "live")
+             base_path: base_path,
+             document: edition.document,
+             title: "live")
     end
     let(:live_content_item_arguments) do
       arguments.merge("live_content_item_id" => live_edition.id)
@@ -91,9 +91,9 @@ RSpec.describe DownstreamDiscardDraftWorker do
   context "has a live edition with a different base_path" do
     let(:live_edition) do
       create(:live_edition,
-        base_path: "/bar",
-        document: edition.document,
-        title: "Live")
+             base_path: "/bar",
+             document: edition.document,
+             title: "Live")
     end
     let(:live_content_item_arguments) do
       arguments.merge("live_content_item_id" => live_edition.id)
@@ -141,9 +141,9 @@ RSpec.describe DownstreamDiscardDraftWorker do
 
     it "wont send to content store without a base_path" do
       pathless = create(:draft_edition,
-        base_path: nil,
-        document_type: "contact",
-        schema_name: "contact")
+                        base_path: nil,
+                        document_type: "contact",
+                        schema_name: "contact")
       expect(Adapters::DraftContentStore).to_not receive(:delete_content_item)
       subject.perform(
         arguments.merge("content_id" => pathless.document.content_id, "base_path" => nil)

--- a/spec/workers/downstream_draft_worker_spec.rb
+++ b/spec/workers/downstream_draft_worker_spec.rb
@@ -55,9 +55,9 @@ RSpec.describe DownstreamDraftWorker do
     context "edition has a nil base path" do
       it "doesn't send the item to the draft content store" do
         pathless = create(:draft_edition,
-          base_path: nil,
-          document_type: "contact",
-          schema_name: "contact")
+                          base_path: nil,
+                          document_type: "contact",
+                          schema_name: "contact")
 
         expect(Adapters::DraftContentStore).to_not receive(:put_content_item)
         subject.perform(arguments.merge("content_id" => pathless.document.content_id))

--- a/spec/workers/downstream_live_worker_spec.rb
+++ b/spec/workers/downstream_live_worker_spec.rb
@@ -81,9 +81,9 @@ RSpec.describe DownstreamLiveWorker do
 
     it "wont send to content store without a base_path" do
       pathless = create(:live_edition,
-        base_path: nil,
-        document_type: "contact",
-        schema_name: "contact")
+                        base_path: nil,
+                        document_type: "contact",
+                        schema_name: "contact")
       expect(Adapters::ContentStore).to_not receive(:put_content_item)
       subject.perform(arguments.merge("content_id" => pathless.document.content_id))
     end


### PR DESCRIPTION
This autofixes linting issues in this project, disables diff linting so any new PRs will be linted against the whole project rather than just the changed, and updates rubocop to the latest version.