### PR TITLE
Add descriptions to link expansion of taxons

### DIFF
--- a/lib/expansion_rules.rb
+++ b/lib/expansion_rules.rb
@@ -61,7 +61,7 @@ module ExpansionRules
 
   CONTACT_FIELDS = (DEFAULT_FIELDS + details_fields(:description, :title, :contact_form_links, :post_addresses, :email_addresses, :phone_numbers)).freeze
   ORGANISATION_FIELDS = (DEFAULT_FIELDS - [:public_updated_at] + details_fields(:logo, :brand, :default_news_image)).freeze
-  TAXON_FIELDS = (DEFAULT_FIELDS + [:details, :phase]).freeze
+  TAXON_FIELDS = (DEFAULT_FIELDS + %i(description details phase)).freeze
   NEED_FIELDS = (DEFAULT_FIELDS + details_fields(:role, :goal, :benefit, :met_when, :justifications)).freeze
   FINDER_FIELDS = (DEFAULT_FIELDS + details_fields(:facets)).freeze
   ROLE_APPOINTMENT_FIELDS = (DEFAULT_FIELDS + details_fields(:started_on, :ended_on)).freeze

--- a/spec/lib/expansion_rules_spec.rb
+++ b/spec/lib/expansion_rules_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe ExpansionRules do
     let(:default_fields) { rules::DEFAULT_FIELDS }
     let(:contact_fields) { default_fields + [%i(details description), %i(details title), %i(details contact_form_links), %i(details post_addresses), %i(details email_addresses), %i(details phone_numbers)] }
     let(:organisation_fields) { default_fields - [:public_updated_at] + [%i(details logo), %i(details brand), %i(details default_news_image)] }
-    let(:taxon_fields) { default_fields + %i(details phase) }
+    let(:taxon_fields) { default_fields + %i(description details phase) }
     let(:mainstream_browser_page_fields) { default_fields + %i(description) }
     let(:need_fields) { default_fields + [%i(details role), %i(details goal), %i(details benefit), %i(details met_when), %i(details justifications)] }
     let(:finder_fields) { default_fields + [%i(details facets)] }


### PR DESCRIPTION
This is necessary for world location taxon pages.

For example: https://www.gov.uk/world/eswatini vs https://www.gov.uk/world/france