### PR TITLE
Track the sources of dependency resolution

### DIFF
--- a/app/commands/v2/discard_draft.rb
+++ b/app/commands/v2/discard_draft.rb
@@ -6,6 +6,7 @@ module Commands
 
         check_version_and_raise_if_conflicting(document, payload[:previous_version])
 
+        save_document_type
         delete_supporting_objects(document.draft)
         delete_draft_from_database
         increment_lock_version
@@ -47,6 +48,7 @@ module Commands
           locale: locale,
           update_dependencies: true,
           source_command: "discard_draft",
+          source_document_type: @document_type,
         )
       end
 
@@ -64,6 +66,15 @@ module Commands
           content_id: payload[:content_id],
           locale: payload.fetch(:locale, Edition::DEFAULT_LOCALE),
         )
+      end
+
+      # We pass the document type into the `DownstreamDiscardDraftWorker` which
+      # passes it down to the `DependencyResolutionWorker`. The reason we do
+      # this here and not in the discard draft worker is because the edition
+      # may have already been destroyed by the time the worker runs, and it
+      # wouldn't be able to access the destroyed edition's document type.
+      def save_document_type
+        @document_type = document.draft.document_type
       end
     end
   end

--- a/app/commands/v2/discard_draft.rb
+++ b/app/commands/v2/discard_draft.rb
@@ -46,6 +46,7 @@ module Commands
           content_id: content_id,
           locale: locale,
           update_dependencies: true,
+          source_command: "discard_draft",
         )
       end
 

--- a/app/commands/v2/patch_link_set.rb
+++ b/app/commands/v2/patch_link_set.rb
@@ -94,6 +94,7 @@ module Commands
           content_id: content_id,
           locale: locale,
           orphaned_content_ids: orphaned_content_ids,
+          source_command: "patch_link_set",
         )
       end
 
@@ -105,6 +106,7 @@ module Commands
           locale: locale,
           message_queue_event_type: "links",
           orphaned_content_ids: orphaned_content_ids,
+          source_command: "patch_link_set",
         )
       end
 

--- a/app/commands/v2/publish.rb
+++ b/app/commands/v2/publish.rb
@@ -229,7 +229,7 @@ module Commands
           content_id: content_id,
           locale: locale,
           update_dependencies: update_dependencies?,
-          source_command: "publish"
+          source_command: "publish",
         }
       end
     end

--- a/app/commands/v2/publish.rb
+++ b/app/commands/v2/publish.rb
@@ -195,10 +195,8 @@ module Commands
         end
       end
 
-      def update_dependencies?
-        @update_dependencies ||= LinkExpansion::EditionDiff.new(
-          edition, previous_edition: previous_edition
-        ).present?
+      def edition_diff
+        @edition_diff ||= LinkExpansion::EditionDiff.new(edition, previous_edition: previous_edition)
       end
 
       def send_downstream_live
@@ -228,8 +226,9 @@ module Commands
         {
           content_id: content_id,
           locale: locale,
-          update_dependencies: update_dependencies?,
+          update_dependencies: edition_diff.present?,
           source_command: "publish",
+          source_fields: edition_diff.fields,
         }
       end
     end

--- a/app/commands/v2/publish.rb
+++ b/app/commands/v2/publish.rb
@@ -198,7 +198,7 @@ module Commands
       def update_dependencies?
         @update_dependencies ||= LinkExpansion::EditionDiff.new(
           edition, previous_edition: previous_edition
-        ).should_update_dependencies?
+        ).present?
       end
 
       def send_downstream_live

--- a/app/commands/v2/publish.rb
+++ b/app/commands/v2/publish.rb
@@ -229,6 +229,7 @@ module Commands
           content_id: content_id,
           locale: locale,
           update_dependencies: update_dependencies?,
+          source_command: "publish"
         }
       end
     end

--- a/app/commands/v2/put_content.rb
+++ b/app/commands/v2/put_content.rb
@@ -151,7 +151,7 @@ module Commands
       end
 
       def update_dependencies?(edition)
-        LinkExpansion::EditionDiff.new(edition, previous_edition: @previous_edition).should_update_dependencies?
+        LinkExpansion::EditionDiff.new(edition, previous_edition: @previous_edition).present?
       end
 
       def send_downstream(content_id, locale, edition, orphaned_links)

--- a/app/commands/v2/put_content.rb
+++ b/app/commands/v2/put_content.rb
@@ -21,7 +21,7 @@ module Commands
           send_downstream(
             document.content_id,
             document.locale,
-            update_dependencies?(edition),
+            edition,
             orphaned_links
           )
         end
@@ -154,7 +154,7 @@ module Commands
         LinkExpansion::EditionDiff.new(edition, previous_edition: @previous_edition).should_update_dependencies?
       end
 
-      def send_downstream(content_id, locale, update_dependencies, orphaned_links)
+      def send_downstream(content_id, locale, edition, orphaned_links)
         return unless downstream
 
         queue = bulk_publishing? ? DownstreamDraftWorker::LOW_QUEUE : DownstreamDraftWorker::HIGH_QUEUE
@@ -163,7 +163,7 @@ module Commands
           queue,
           content_id: content_id,
           locale: locale,
-          update_dependencies: update_dependencies,
+          update_dependencies: update_dependencies?(edition),
           orphaned_content_ids: orphaned_links,
           source_command: "put_content",
         )

--- a/app/commands/v2/put_content.rb
+++ b/app/commands/v2/put_content.rb
@@ -165,6 +165,7 @@ module Commands
           locale: locale,
           update_dependencies: update_dependencies,
           orphaned_content_ids: orphaned_links,
+          source_command: "put_content",
         )
       end
     end

--- a/app/commands/v2/represent_downstream.rb
+++ b/app/commands/v2/represent_downstream.rb
@@ -30,6 +30,7 @@ module Commands
             content_id: content_id,
             locale: locale,
             update_dependencies: false,
+            source_command: "represent_downstream",
           )
         end
       end
@@ -48,6 +49,7 @@ module Commands
             locale: locale,
             message_queue_event_type: "links",
             update_dependencies: false,
+            source_command: "represent_downstream",
           )
         end
       end

--- a/app/commands/v2/republish.rb
+++ b/app/commands/v2/republish.rb
@@ -59,6 +59,7 @@ module Commands
             content_id: content_id,
             locale: locale,
             update_dependencies: true,
+            source_command: "republish",
           )
         end
 
@@ -68,6 +69,7 @@ module Commands
           locale: locale,
           message_queue_event_type: "republish",
           update_dependencies: true,
+          source_command: "republish",
         )
       end
     end

--- a/app/commands/v2/unpublish.rb
+++ b/app/commands/v2/unpublish.rb
@@ -116,6 +116,7 @@ module Commands
           content_id: document.content_id,
           locale: document.locale,
           update_dependencies: true,
+          source_command: "unpublish",
         )
 
         DownstreamLiveWorker.perform_async_in_queue(
@@ -125,6 +126,7 @@ module Commands
           update_dependencies: true,
           orphaned_content_ids: orphaned_content_ids,
           message_queue_event_type: "unpublish",
+          source_command: "unpublish",
         )
       end
 

--- a/app/workers/dependency_resolution_worker.rb
+++ b/app/workers/dependency_resolution_worker.rb
@@ -70,6 +70,7 @@ private
       update_dependencies: false,
       dependency_resolution_source_content_id: content_id,
       source_command: source_command,
+      source_fields: source_fields,
     )
   end
 
@@ -84,6 +85,7 @@ private
       update_dependencies: false,
       dependency_resolution_source_content_id: content_id,
       source_command: source_command,
+      source_fields: source_fields,
     )
   end
 end

--- a/app/workers/dependency_resolution_worker.rb
+++ b/app/workers/dependency_resolution_worker.rb
@@ -69,6 +69,7 @@ private
       locale: locale,
       update_dependencies: false,
       dependency_resolution_source_content_id: content_id,
+      source_command: source_command,
     )
   end
 
@@ -82,6 +83,7 @@ private
       message_queue_event_type: "links",
       update_dependencies: false,
       dependency_resolution_source_content_id: content_id,
+      source_command: source_command,
     )
   end
 end

--- a/app/workers/downstream_discard_draft_worker.rb
+++ b/app/workers/downstream_discard_draft_worker.rb
@@ -29,7 +29,8 @@ class DownstreamDiscardDraftWorker
 private
 
   attr_reader :base_path, :content_id, :locale, :edition,
-              :payload_version, :update_dependencies
+              :payload_version, :update_dependencies,
+              :source_command
 
   def assign_attributes(attributes)
     @base_path = attributes.fetch(:base_path)
@@ -38,6 +39,7 @@ private
     @payload_version = Event.maximum_id
     @edition = Queries::GetEditionForContentStore.(content_id, locale, true)
     @update_dependencies = attributes.fetch(:update_dependencies, true)
+    @source_command = attributes[:source_command]
   end
 
   def enqueue_dependencies
@@ -45,6 +47,7 @@ private
       content_store: Adapters::DraftContentStore,
       content_id: content_id,
       locale: locale,
+      source_command: source_command,
     )
   end
 

--- a/app/workers/downstream_discard_draft_worker.rb
+++ b/app/workers/downstream_discard_draft_worker.rb
@@ -30,7 +30,7 @@ private
 
   attr_reader :base_path, :content_id, :locale, :edition,
               :payload_version, :update_dependencies,
-              :source_command
+              :source_command, :source_document_type
 
   def assign_attributes(attributes)
     @base_path = attributes.fetch(:base_path)
@@ -40,6 +40,7 @@ private
     @edition = Queries::GetEditionForContentStore.(content_id, locale, true)
     @update_dependencies = attributes.fetch(:update_dependencies, true)
     @source_command = attributes[:source_command]
+    @source_document_type = attributes[:source_document_type]
   end
 
   def enqueue_dependencies
@@ -48,6 +49,7 @@ private
       content_id: content_id,
       locale: locale,
       source_command: source_command,
+      source_document_type: edition&.document_type || source_document_type,
     )
   end
 

--- a/app/workers/downstream_draft_worker.rb
+++ b/app/workers/downstream_draft_worker.rb
@@ -48,7 +48,8 @@ class DownstreamDraftWorker
 private
 
   attr_reader :content_id, :locale, :edition, :payload_version,
-              :update_dependencies, :dependency_resolution_source_content_id, :orphaned_content_ids
+              :update_dependencies, :dependency_resolution_source_content_id, :orphaned_content_ids,
+              :source_command
 
   def assign_attributes(attributes)
     @content_id = attributes.fetch(:content_id)
@@ -61,6 +62,7 @@ private
       :dependency_resolution_source_content_id,
       nil
     )
+    @source_command = attributes[:source_command]
   end
 
   def enqueue_dependencies
@@ -69,6 +71,7 @@ private
       content_id: content_id,
       locale: locale,
       orphaned_content_ids: orphaned_content_ids,
+      source_command: source_command,
     )
   end
 

--- a/app/workers/downstream_draft_worker.rb
+++ b/app/workers/downstream_draft_worker.rb
@@ -72,6 +72,7 @@ private
       locale: locale,
       orphaned_content_ids: orphaned_content_ids,
       source_command: source_command,
+      source_document_type: edition.document_type,
     )
   end
 

--- a/app/workers/downstream_draft_worker.rb
+++ b/app/workers/downstream_draft_worker.rb
@@ -49,7 +49,7 @@ private
 
   attr_reader :content_id, :locale, :edition, :payload_version,
               :update_dependencies, :dependency_resolution_source_content_id, :orphaned_content_ids,
-              :source_command
+              :source_command, :source_fields
 
   def assign_attributes(attributes)
     @content_id = attributes.fetch(:content_id)
@@ -63,6 +63,7 @@ private
       nil
     )
     @source_command = attributes[:source_command]
+    @source_fields = attributes.fetch(:source_fields, [])
   end
 
   def enqueue_dependencies
@@ -73,6 +74,7 @@ private
       orphaned_content_ids: orphaned_content_ids,
       source_command: source_command,
       source_document_type: edition.document_type,
+      source_fields: source_fields,
     )
   end
 

--- a/app/workers/downstream_live_worker.rb
+++ b/app/workers/downstream_live_worker.rb
@@ -77,6 +77,7 @@ private
       locale: locale,
       orphaned_content_ids: orphaned_content_ids,
       source_command: source_command,
+      source_document_type: edition.document_type,
     )
   end
 

--- a/app/workers/downstream_live_worker.rb
+++ b/app/workers/downstream_live_worker.rb
@@ -53,7 +53,7 @@ private
   attr_reader :content_id, :locale, :edition, :payload_version,
               :message_queue_event_type, :update_dependencies,
               :dependency_resolution_source_content_id, :orphaned_content_ids,
-              :source_command
+              :source_command, :source_fields
 
   def assign_attributes(attributes)
     @content_id = attributes.fetch(:content_id)
@@ -68,6 +68,7 @@ private
       nil
     )
     @source_command = attributes[:source_command]
+    @source_fields = attributes.fetch(:source_fields, [])
   end
 
   def enqueue_dependencies
@@ -78,6 +79,7 @@ private
       orphaned_content_ids: orphaned_content_ids,
       source_command: source_command,
       source_document_type: edition.document_type,
+      source_fields: source_fields,
     )
   end
 

--- a/app/workers/downstream_live_worker.rb
+++ b/app/workers/downstream_live_worker.rb
@@ -52,7 +52,8 @@ private
 
   attr_reader :content_id, :locale, :edition, :payload_version,
               :message_queue_event_type, :update_dependencies,
-              :dependency_resolution_source_content_id, :orphaned_content_ids
+              :dependency_resolution_source_content_id, :orphaned_content_ids,
+              :source_command
 
   def assign_attributes(attributes)
     @content_id = attributes.fetch(:content_id)
@@ -66,6 +67,7 @@ private
       :dependency_resolution_source_content_id,
       nil
     )
+    @source_command = attributes[:source_command]
   end
 
   def enqueue_dependencies
@@ -74,6 +76,7 @@ private
       content_id: content_id,
       locale: locale,
       orphaned_content_ids: orphaned_content_ids,
+      source_command: source_command,
     )
   end
 

--- a/lib/link_expansion/edition_diff.rb
+++ b/lib/link_expansion/edition_diff.rb
@@ -11,10 +11,14 @@ class LinkExpansion::EditionDiff
     diff.present?
   end
 
+  def fields
+    diff.map(&:first)
+  end
+
 private
 
   def diff
-    hash_diff(
+    @diff ||= hash_diff(
       previous_edition_expanded,
       current_edition_expanded
     )

--- a/lib/link_expansion/edition_diff.rb
+++ b/lib/link_expansion/edition_diff.rb
@@ -7,7 +7,7 @@ class LinkExpansion::EditionDiff
     @version = version
   end
 
-  def should_update_dependencies?
+  def present?
     diff.present?
   end
 

--- a/spec/commands/v2/discard_draft_spec.rb
+++ b/spec/commands/v2/discard_draft_spec.rb
@@ -68,6 +68,7 @@ RSpec.describe Commands::V2::DiscardDraft do
               content_id: document.content_id,
               locale: document.locale,
               source_command: "discard_draft",
+              source_document_type: "services_and_information",
             ),
           )
 
@@ -120,6 +121,7 @@ RSpec.describe Commands::V2::DiscardDraft do
                 content_id: document.content_id,
                 locale: document.locale,
                 source_command: "discard_draft",
+                source_document_type: "services_and_information",
               ),
             )
           described_class.call(payload)
@@ -156,6 +158,7 @@ RSpec.describe Commands::V2::DiscardDraft do
                 content_id: document.content_id,
                 locale: document.locale,
                 source_command: "discard_draft",
+                source_document_type: "services_and_information",
               ),
             )
           described_class.call(payload)
@@ -179,6 +182,7 @@ RSpec.describe Commands::V2::DiscardDraft do
                 content_id: document.content_id,
                 locale: document.locale,
                 source_command: "discard_draft",
+                source_document_type: "services_and_information",
               ),
             )
           described_class.call(payload)

--- a/spec/commands/v2/discard_draft_spec.rb
+++ b/spec/commands/v2/discard_draft_spec.rb
@@ -67,6 +67,7 @@ RSpec.describe Commands::V2::DiscardDraft do
               base_path: base_path,
               content_id: document.content_id,
               locale: document.locale,
+              source_command: "discard_draft",
             ),
           )
 
@@ -118,6 +119,7 @@ RSpec.describe Commands::V2::DiscardDraft do
                 base_path: base_path,
                 content_id: document.content_id,
                 locale: document.locale,
+                source_command: "discard_draft",
               ),
             )
           described_class.call(payload)
@@ -153,6 +155,7 @@ RSpec.describe Commands::V2::DiscardDraft do
                 base_path: base_path,
                 content_id: document.content_id,
                 locale: document.locale,
+                source_command: "discard_draft",
               ),
             )
           described_class.call(payload)
@@ -175,6 +178,7 @@ RSpec.describe Commands::V2::DiscardDraft do
                 base_path: base_path,
                 content_id: document.content_id,
                 locale: document.locale,
+                source_command: "discard_draft",
               ),
             )
           described_class.call(payload)

--- a/spec/commands/v2/patch_link_set_spec.rb
+++ b/spec/commands/v2/patch_link_set_spec.rb
@@ -316,7 +316,7 @@ RSpec.describe Commands::V2::PatchLinkSet do
               locale: locale,
               message_queue_event_type: "links",
               orphaned_content_ids: [],
-              source_command: "patch_link_set"
+              source_command: "patch_link_set",
             )
         end
 

--- a/spec/commands/v2/patch_link_set_spec.rb
+++ b/spec/commands/v2/patch_link_set_spec.rb
@@ -316,6 +316,7 @@ RSpec.describe Commands::V2::PatchLinkSet do
               locale: locale,
               message_queue_event_type: "links",
               orphaned_content_ids: [],
+              source_command: "patch_link_set"
             )
         end
 

--- a/spec/commands/v2/publish_spec.rb
+++ b/spec/commands/v2/publish_spec.rb
@@ -49,6 +49,13 @@ RSpec.describe Commands::V2::Publish do
       }
     end
 
+    it "sets the source_command to publish" do
+      expect(DownstreamLiveWorker).to receive(:perform_async_in_queue)
+        .with("downstream_high", hash_including(source_command: "publish"))
+
+      described_class.call(payload)
+    end
+
     context "with no update_type" do
       before do
         payload.delete(:update_type)

--- a/spec/commands/v2/publish_spec.rb
+++ b/spec/commands/v2/publish_spec.rb
@@ -56,6 +56,22 @@ RSpec.describe Commands::V2::Publish do
       described_class.call(payload)
     end
 
+    it "sets the source_fields to the correct value" do
+      expect(DownstreamLiveWorker)
+        .to receive(:perform_async_in_queue)
+        .with(
+          "downstream_high",
+          hash_including(
+            source_fields: %i(
+              analytics_identifier api_path base_path content_id document_type
+              locale public_updated_at schema_name title withdrawn
+            )
+          )
+        )
+
+      described_class.call(payload)
+    end
+
     context "with no update_type" do
       before do
         payload.delete(:update_type)
@@ -174,6 +190,13 @@ RSpec.describe Commands::V2::Publish do
         expect(DownstreamLiveWorker)
           .to receive(:perform_async_in_queue)
           .with("downstream_high", a_hash_including(update_dependencies: true))
+
+        described_class.call(payload)
+      end
+
+      it "sets the source_fields to the correct value" do
+        expect(DownstreamLiveWorker).to receive(:perform_async_in_queue)
+          .with("downstream_high", hash_including(source_fields: %i(public_updated_at title)))
 
         described_class.call(payload)
       end

--- a/spec/commands/v2/put_content_spec.rb
+++ b/spec/commands/v2/put_content_spec.rb
@@ -70,6 +70,10 @@ RSpec.describe Commands::V2::PutContent do
             :content_id, :locale,
             update_dependencies: true,
             source_command: "put_content",
+            source_fields: %i(
+              analytics_identifier api_path base_path content_id document_type
+              locale public_updated_at schema_name title withdrawn
+            ),
           ),
         )
 

--- a/spec/commands/v2/put_content_spec.rb
+++ b/spec/commands/v2/put_content_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe Commands::V2::PutContent do
       expect(DownstreamDraftWorker).to receive(:perform_async_in_queue)
         .with(
           "downstream_high",
-          a_hash_including(:content_id, :locale, update_dependencies: true),
+          a_hash_including(:content_id, :locale, update_dependencies: true, source_command: "put_content"),
         )
 
       described_class.call(payload)

--- a/spec/commands/v2/put_content_spec.rb
+++ b/spec/commands/v2/put_content_spec.rb
@@ -66,7 +66,11 @@ RSpec.describe Commands::V2::PutContent do
       expect(DownstreamDraftWorker).to receive(:perform_async_in_queue)
         .with(
           "downstream_high",
-          a_hash_including(:content_id, :locale, update_dependencies: true, source_command: "put_content"),
+          a_hash_including(
+            :content_id, :locale,
+            update_dependencies: true,
+            source_command: "put_content",
+          ),
         )
 
       described_class.call(payload)

--- a/spec/commands/v2/represent_downstream_spec.rb
+++ b/spec/commands/v2/represent_downstream_spec.rb
@@ -54,6 +54,13 @@ RSpec.describe Commands::V2::RepresentDownstream do
           .exactly(1).times
         subject.call(Document.pluck(:content_id), with_drafts: false)
       end
+
+      it "has a source_command of 'represent_downstream'" do
+        expect(DownstreamLiveWorker).to receive(:perform_async_in_queue)
+          .with(anything, a_hash_including(source_command: "represent_downstream"))
+          .at_least(1).times
+        subject.call(Document.pluck(:content_id), with_drafts: false)
+      end
     end
 
     context "scope" do

--- a/spec/commands/v2/republish_spec.rb
+++ b/spec/commands/v2/republish_spec.rb
@@ -43,6 +43,7 @@ RSpec.describe Commands::V2::Republish do
           locale: published_edition.locale,
           message_queue_event_type: "republish",
           update_dependencies: true,
+          source_command: "republish",
         )
 
       described_class.call(payload)
@@ -56,6 +57,7 @@ RSpec.describe Commands::V2::Republish do
           content_id: published_edition.content_id,
           locale: published_edition.locale,
           update_dependencies: true,
+          source_command: "republish",
         )
 
       described_class.call(payload)

--- a/spec/commands/v2/unpublish_spec.rb
+++ b/spec/commands/v2/unpublish_spec.rb
@@ -169,12 +169,12 @@ RSpec.describe Commands::V2::Unpublish do
         expect(DownstreamDraftWorker).to receive(:perform_async_in_queue)
           .with(
             "downstream_high",
-            a_hash_including(content_id: content_id, locale: locale)
+            a_hash_including(content_id: content_id, locale: locale, source_command: "unpublish")
           )
         expect(DownstreamLiveWorker).to receive(:perform_async_in_queue)
           .with(
             "downstream_high",
-            a_hash_including(content_id: content_id, locale: locale)
+            a_hash_including(content_id: content_id, locale: locale, source_command: "unpublish")
           )
 
         described_class.call(payload)

--- a/spec/lib/link_expansion/edition_diff_spec.rb
+++ b/spec/lib/link_expansion/edition_diff_spec.rb
@@ -45,6 +45,10 @@ RSpec.describe LinkExpansion::EditionDiff do
 
   context "diff in title" do
     include_examples "should update dependencies"
+
+    it "should have the correct changed fields" do
+      expect(subject.fields).to eq(%i(title))
+    end
   end
 
   context "diff in title, document_type and base_path" do
@@ -60,6 +64,10 @@ RSpec.describe LinkExpansion::EditionDiff do
     end
 
     include_examples "should update dependencies"
+
+    it "should have the correct changed fields" do
+      expect(subject.fields).to match_array(%i(api_path base_path document_type title))
+    end
   end
 
   context "diff in details when a finder" do
@@ -75,6 +83,10 @@ RSpec.describe LinkExpansion::EditionDiff do
     end
 
     include_examples "should update dependencies"
+
+    it "should have the correct changed fields" do
+      expect(subject.fields).to match_array(%i(details document_type title))
+    end
   end
 
   context "diff inside details hash" do
@@ -101,6 +113,10 @@ RSpec.describe LinkExpansion::EditionDiff do
       end
 
       include_examples "should update dependencies"
+
+      it "should have the correct changed fields" do
+        expect(subject.fields).to eq(%i(details))
+      end
     end
 
     context "with a field that doesn't matter" do

--- a/spec/lib/link_expansion/edition_diff_spec.rb
+++ b/spec/lib/link_expansion/edition_diff_spec.rb
@@ -31,20 +31,20 @@ RSpec.describe LinkExpansion::EditionDiff do
 
   subject { described_class.new(current_edition) }
 
-  shared_examples "should update dependencies" do
-    it "should update dependencies" do
-      expect(subject.should_update_dependencies?).to eq(true)
+  shared_examples "should have changes" do
+    it "should have changes" do
+      expect(subject.present?).to eq(true)
     end
   end
 
-  shared_examples "shouldn't update dependencies" do
-    it "shouldn't update dependencies" do
-      expect(subject.should_update_dependencies?).to eq(false)
+  shared_examples "shouldn't have changes" do
+    it "shouldn't have changes" do
+      expect(subject.present?).to eq(false)
     end
   end
 
   context "diff in title" do
-    include_examples "should update dependencies"
+    include_examples "should have changes"
 
     it "should have the correct changed fields" do
       expect(subject.fields).to eq(%i(title))
@@ -63,7 +63,7 @@ RSpec.describe LinkExpansion::EditionDiff do
       )
     end
 
-    include_examples "should update dependencies"
+    include_examples "should have changes"
 
     it "should have the correct changed fields" do
       expect(subject.fields).to match_array(%i(api_path base_path document_type title))
@@ -82,7 +82,7 @@ RSpec.describe LinkExpansion::EditionDiff do
       )
     end
 
-    include_examples "should update dependencies"
+    include_examples "should have changes"
 
     it "should have the correct changed fields" do
       expect(subject.fields).to match_array(%i(details document_type title))
@@ -112,7 +112,7 @@ RSpec.describe LinkExpansion::EditionDiff do
         )
       end
 
-      include_examples "should update dependencies"
+      include_examples "should have changes"
 
       it "should have the correct changed fields" do
         expect(subject.fields).to eq(%i(details))
@@ -131,31 +131,31 @@ RSpec.describe LinkExpansion::EditionDiff do
         )
       end
 
-      include_examples "shouldn't update dependencies"
+      include_examples "shouldn't have changes"
     end
   end
 
   context "multiple versions" do
     before { current_edition.supersede }
     subject { described_class.new(new_draft_edition) }
-    include_examples "shouldn't update dependencies"
+    include_examples "shouldn't have changes"
   end
 
   context "no previous item" do
     let!(:previous_edition) { nil }
-    include_examples "should update dependencies"
+    include_examples "should have changes"
   end
 
   context "provide the edition to compare" do
     context "given an empty hash" do
       subject { described_class.new(new_draft_edition, previous_edition: {}) }
-      include_examples "should update dependencies"
+      include_examples "should have changes"
     end
 
     context "given an edition" do
       let(:presented_item) { new_draft_edition.to_h.deep_stringify_keys }
       subject { described_class.new(new_draft_edition, previous_edition: presented_item) }
-      include_examples "shouldn't update dependencies"
+      include_examples "shouldn't have changes"
     end
   end
 end

--- a/spec/workers/dependency_resolution_worker_spec.rb
+++ b/spec/workers/dependency_resolution_worker_spec.rb
@@ -150,4 +150,31 @@ RSpec.describe DependencyResolutionWorker, :perform do
       end
     end
   end
+
+  context "with source information" do
+    after do
+      described_class.new.perform(
+        content_id: content_id,
+        content_store: "Adapters::ContentStore",
+        locale: "en",
+        source_command: "patch_link_set",
+        source_document_type: "answer",
+        source_fields: %w(description details.body)
+      )
+    end
+
+    it "sends source stats to statsd" do
+      expect(GovukStatsd).to receive(:increment)
+        .with("dependency_resolution.source.command.patch_link_set")
+
+      expect(GovukStatsd).to receive(:increment)
+        .with("dependency_resolution.source.document_type.answer")
+
+      expect(GovukStatsd).to receive(:increment)
+        .with("dependency_resolution.source.field.description")
+
+      expect(GovukStatsd).to receive(:increment)
+        .with("dependency_resolution.source.field.details.body")
+    end
+  end
 end

--- a/spec/workers/downstream_discard_draft_worker_spec.rb
+++ b/spec/workers/downstream_discard_draft_worker_spec.rb
@@ -169,6 +169,12 @@ RSpec.describe DownstreamDiscardDraftWorker do
           .with(a_hash_including(source_command: "command"))
         subject.perform(arguments)
       end
+
+      it "sends the document type to the worker" do
+        expect(DependencyResolutionWorker).to receive(:perform_async)
+          .with(a_hash_including(source_document_type: "document_type"))
+        subject.perform(arguments.merge("source_document_type" => "document_type"))
+      end
     end
 
     context "can not update dependencies" do

--- a/spec/workers/downstream_draft_worker_spec.rb
+++ b/spec/workers/downstream_draft_worker_spec.rb
@@ -114,6 +114,12 @@ RSpec.describe DownstreamDraftWorker do
           .with(a_hash_including(source_document_type: "services_and_information"))
         subject.perform(arguments)
       end
+
+      it "sends the dependency resolution fields to the worker" do
+        expect(DependencyResolutionWorker).to receive(:perform_async)
+          .with(a_hash_including(source_fields: %i(field)))
+        subject.perform(arguments.merge("source_fields" => %i(field)))
+      end
     end
 
     context "can not update dependencies" do

--- a/spec/workers/downstream_draft_worker_spec.rb
+++ b/spec/workers/downstream_draft_worker_spec.rb
@@ -94,9 +94,18 @@ RSpec.describe DownstreamDraftWorker do
 
   describe "update dependencies" do
     context "can update dependencies" do
-      let(:arguments) { base_arguments.merge("update_dependencies" => true) }
+      let(:arguments) do
+        base_arguments.merge("update_dependencies" => true, "source_command" => "command")
+      end
+
       it "enqueues dependencies" do
         expect(DependencyResolutionWorker).to receive(:perform_async)
+        subject.perform(arguments)
+      end
+
+      it "sends the source command to the worker" do
+        expect(DependencyResolutionWorker).to receive(:perform_async)
+          .with(a_hash_including(source_command: "command"))
         subject.perform(arguments)
       end
     end

--- a/spec/workers/downstream_draft_worker_spec.rb
+++ b/spec/workers/downstream_draft_worker_spec.rb
@@ -108,6 +108,12 @@ RSpec.describe DownstreamDraftWorker do
           .with(a_hash_including(source_command: "command"))
         subject.perform(arguments)
       end
+
+      it "sends the document type to the worker" do
+        expect(DependencyResolutionWorker).to receive(:perform_async)
+          .with(a_hash_including(source_document_type: "services_and_information"))
+        subject.perform(arguments)
+      end
     end
 
     context "can not update dependencies" do

--- a/spec/workers/downstream_live_worker_spec.rb
+++ b/spec/workers/downstream_live_worker_spec.rb
@@ -141,6 +141,12 @@ RSpec.describe DownstreamLiveWorker do
           .with(a_hash_including(source_document_type: "services_and_information"))
         subject.perform(arguments)
       end
+
+      it "sends the dependency resolution fields to the worker" do
+        expect(DependencyResolutionWorker).to receive(:perform_async)
+          .with(a_hash_including(source_fields: %i(field)))
+        subject.perform(arguments.merge("source_fields" => %i(field)))
+      end
     end
 
     context "can not update dependencies" do

--- a/spec/workers/downstream_live_worker_spec.rb
+++ b/spec/workers/downstream_live_worker_spec.rb
@@ -121,9 +121,19 @@ RSpec.describe DownstreamLiveWorker do
 
   describe "update dependencies" do
     context "can update dependencies" do
+      let(:arguments) do
+        base_arguments.merge("update_dependencies" => true, "source_command" => "command")
+      end
+
       it "enqueues dependencies" do
         expect(DependencyResolutionWorker).to receive(:perform_async)
-        subject.perform(arguments.merge("update_dependencies" => true))
+        subject.perform(arguments)
+      end
+
+      it "sends the source command to the worker" do
+        expect(DependencyResolutionWorker).to receive(:perform_async)
+          .with(a_hash_including(source_command: "command"))
+        subject.perform(arguments)
       end
     end
 

--- a/spec/workers/downstream_live_worker_spec.rb
+++ b/spec/workers/downstream_live_worker_spec.rb
@@ -135,6 +135,12 @@ RSpec.describe DownstreamLiveWorker do
           .with(a_hash_including(source_command: "command"))
         subject.perform(arguments)
       end
+
+      it "sends the document type to the worker" do
+        expect(DependencyResolutionWorker).to receive(:perform_async)
+          .with(a_hash_including(source_document_type: "services_and_information"))
+        subject.perform(arguments)
+      end
     end
 
     context "can not update dependencies" do


### PR DESCRIPTION
This adds tracking on three sources of dependency resolution (command, document type and changed fields) so that we can gather a better picture about what is triggered dependency resolution. This should help us in the quest to reduce the latency of the downstream low queue by building a dashboard telling us where to focus our efforts.

The tracking works by sending the data to Graphite via Statsd which we will use to build a Grafana dashboard in the future.

[Trello Card](https://trello.com/c/7SfWSbLs/1189-improve-tracking-of-what-triggers-dependency-resolution)