### PR TITLE
Only record dependency resolution fields if not a new document

### DIFF
--- a/app/commands/v2/publish.rb
+++ b/app/commands/v2/publish.rb
@@ -228,7 +228,7 @@ module Commands
           locale: locale,
           update_dependencies: edition_diff.present?,
           source_command: "publish",
-          source_fields: edition_diff.fields,
+          source_fields: edition_diff.has_previous_edition? ? edition_diff.fields : [],
         }
       end
     end

--- a/app/commands/v2/put_content.rb
+++ b/app/commands/v2/put_content.rb
@@ -165,7 +165,7 @@ module Commands
           update_dependencies: edition_diff.present?,
           orphaned_content_ids: orphaned_links,
           source_command: "put_content",
-          source_fields: edition_diff.fields,
+          source_fields: edition_diff.has_previous_edition? ? edition_diff.fields : [],
         )
       end
     end

--- a/lib/link_expansion/edition_diff.rb
+++ b/lib/link_expansion/edition_diff.rb
@@ -15,6 +15,10 @@ class LinkExpansion::EditionDiff
     diff.map(&:first)
   end
 
+  def has_previous_edition?
+    previous_edition.present?
+  end
+
 private
 
   def diff
@@ -29,7 +33,7 @@ private
   end
 
   def previous_edition_expanded
-    return {} if previous_edition.blank?
+    return {} unless has_previous_edition?
 
     ExpansionRules.expand_fields(previous_edition.to_h.deep_symbolize_keys, nil)
   end

--- a/spec/commands/v2/publish_spec.rb
+++ b/spec/commands/v2/publish_spec.rb
@@ -62,10 +62,7 @@ RSpec.describe Commands::V2::Publish do
         .with(
           "downstream_high",
           hash_including(
-            source_fields: %i(
-              analytics_identifier api_path base_path content_id document_type
-              locale public_updated_at schema_name title withdrawn
-            )
+            source_fields: []
           )
         )
 


### PR DESCRIPTION
Currently we record the fields as a source of dependency resolution if the document is new. This means we always get fields such as `content_id`, `document_type`, etc showing as a source of dependency resolution. This is not useful to us because really we only want to know which fields of a document are changing that causes dependency resolution (because publishing a new document will always trigger dependency resolution and there's nothing for us to improve there).

[Trello Card](https://trello.com/c/7SfWSbLs/1189-improve-tracking-of-what-triggers-dependency-resolution)