### PR TITLE
Avoid updating dependencies if links haven't changed

### DIFF
--- a/app/models/link_set.rb
+++ b/app/models/link_set.rb
@@ -2,4 +2,28 @@ class LinkSet < ApplicationRecord
   include FindOrCreateLocked
 
   has_many :links, -> { order(link_type: :asc, position: :asc) }, dependent: :destroy
+
+  # We could define the `==` method on `Link` to perform this check but that
+  # breaks the strict definition of a model instance being a representation of
+  # a specific row in the database as it would allow two different rows to
+  # equate.
+  ComparableLink = Struct.new(:link) do
+    delegate :target_content_id, :link_type, :position, to: :link
+
+    def hash
+      [target_content_id, link_type, position].hash
+    end
+
+    def eql?(other)
+      target_content_id == other.target_content_id &&
+        link_type == other.link_type &&
+        position == other.position
+    end
+  end
+
+  def links_changed?(other_links)
+    links_set = links.map { |link| ComparableLink.new(link) }.to_set
+    other_links_set = other_links.map { |link| ComparableLink.new(link) }.to_set
+    links_set != other_links_set
+  end
 end

--- a/spec/commands/v2/patch_link_set_spec.rb
+++ b/spec/commands/v2/patch_link_set_spec.rb
@@ -312,11 +312,7 @@ RSpec.describe Commands::V2::PatchLinkSet do
           expect(DownstreamLiveWorker).to receive(:perform_async_in_queue)
             .with(
               "downstream_high",
-              content_id: content_id,
-              locale: locale,
-              message_queue_event_type: "links",
-              orphaned_content_ids: [],
-              source_command: "patch_link_set",
+              a_hash_including(content_id: content_id, locale: locale),
             )
         end
 

--- a/spec/models/link_set_spec.rb
+++ b/spec/models/link_set_spec.rb
@@ -1,0 +1,72 @@
+require "rails_helper"
+
+RSpec.describe LinkSet do
+  subject(:link_set) { create(:link_set) }
+
+  describe "links_changed?" do
+    let(:other_links) { [] }
+    subject(:links_changed?) { link_set.links_changed?(other_links) }
+
+    context "with no links" do
+      it { is_expected.to be false }
+    end
+
+    context "with only saved links" do
+      before { create(:link, link_set: link_set) }
+
+      it { is_expected.to be true }
+    end
+
+    context "with only other links" do
+      let(:other_links) { [build(:link, link_set: link_set)] }
+
+      it { is_expected.to be true }
+    end
+
+    context "with the same other links" do
+      let(:link) { create(:link, link_set: link_set) }
+      let(:other_links) { [build(:link, link_set: link_set, target_content_id: link.target_content_id)] }
+
+      it { is_expected.to be false }
+    end
+
+    context "with different other links" do
+      let(:target_content_id) { SecureRandom.uuid }
+      let(:link_type) { "link_type" }
+      let(:position) { 0 }
+
+      let(:link) do
+        create(
+          :link, link_set: link_set, target_content_id: target_content_id,
+          link_type: link_type, position: position
+        )
+      end
+      let(:other_link) { nil }
+      let(:other_links) { [other_link] }
+
+      context "different target_content_id" do
+        let(:other_link) do
+          build(:link, target_content_id: SecureRandom.uuid, link_type: link_type, position: position)
+        end
+
+        it { is_expected.to be true }
+      end
+
+      context "different link_type" do
+        let(:other_link) do
+          build(:link, target_content_id: target_content_id, link_type: "link_type2", position: position)
+        end
+
+        it { is_expected.to be true }
+      end
+
+      context "different position" do
+        let(:other_link) do
+          build(:link, target_content_id: target_content_id, link_type: link_type, position: 1)
+        end
+
+        it { is_expected.to be true }
+      end
+    end
+  end
+end


### PR DESCRIPTION
If the links given to the patch link set command aren't any different to the current links, we don't need to update any dependencies because the expanded links won't have changed.

A few of our publishing applications (notably [hmrc-manuals-api](https://github.com/alphagov/hmrc-manuals-api/blob/69cc927ebe786ef4bcb6ae1edb6d2bcdc09ca963/app/notifiers/publishing_api_notifier.rb#L6-L11) and whitehall) will always call patch link set when publishing a piece of content, often with the same links as before. This can lead to high numbers of items on the downstream low queue.

[Trello Card](https://trello.com/c/uhuMk5bI/1200-patch-link-set-should-check-whether-dependency-resolution-is-necessary)