### PR TITLE
Increase downstream high healthcheck thresholds

### DIFF
--- a/app/models/healthcheck/queue_latency.rb
+++ b/app/models/healthcheck/queue_latency.rb
@@ -1,8 +1,8 @@
 class Healthcheck::QueueLatency < GovukHealthcheck::SidekiqQueueLatencyCheck
   QUEUES = {
     'downstream_high' => {
-      warning: 20, # seconds
-      critical: 60 # seconds
+      warning: 45, # seconds
+      critical: 90 # seconds
     }
   }.freeze
 


### PR DESCRIPTION
This alert was triggered this morning but no action was required as it was within a normal range, so we can increase the threshold here.