### PR TITLE
Present updated_at downstream

### DIFF
--- a/app/presenters/edition_presenter.rb
+++ b/app/presenters/edition_presenter.rb
@@ -17,7 +17,6 @@ module Presenters
       publishing_api_last_edited_at
       state
       unpublishing_type
-      updated_at
       user_facing_version
       web_url
       withdrawn


### PR DESCRIPTION
This is so we can use this field in search-api when generating
sitemaps.

---

[Trello card](https://trello.com/c/fVDwVHnm/1001-use-updateddate-in-sitemapxml)