### PR TITLE
Disable ddl transaction for this migration

### DIFF
--- a/db/migrate/20191007162200_add_auth_bypass_ids_to_editions.rb
+++ b/db/migrate/20191007162200_add_auth_bypass_ids_to_editions.rb
@@ -1,4 +1,6 @@
 class AddAuthBypassIdsToEditions < ActiveRecord::Migration[5.2]
+  disable_ddl_transaction!
+
   def change
     add_column :editions, :auth_bypass_ids, :string, array: true, null: false, default: []
   end


### PR DESCRIPTION
This migration would lock the whole of the editions table and as it
takes a while to run as updating every edition we need to disable the
transaction.