### PR TITLE
Remove none null and default

### DIFF
--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -77,6 +77,8 @@ class Edition < ApplicationRecord
   delegate :content_id, :locale, to: :document
 
   def auth_bypass_ids_are_uuids
+    return if !auth_bypass_ids
+
     unless auth_bypass_ids.all? { |id| UuidValidator.valid?(id) }
       errors.add(:auth_bypass_ids, ["contains invalid UUIDs"])
     end

--- a/db/migrate/20191007162200_add_auth_bypass_ids_to_editions.rb
+++ b/db/migrate/20191007162200_add_auth_bypass_ids_to_editions.rb
@@ -1,5 +1,5 @@
 class AddAuthBypassIdsToEditions < ActiveRecord::Migration[5.2]
   def change
-    add_column :editions, :auth_bypass_ids, :string, array: true, null: false, default: []
+    add_column :editions, :auth_bypass_ids, :string, array: true
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -85,7 +85,7 @@ ActiveRecord::Schema.define(version: 2019_10_07_162200) do
     t.datetime "published_at"
     t.datetime "publishing_api_first_published_at"
     t.datetime "publishing_api_last_edited_at"
-    t.string "auth_bypass_ids", default: [], null: false, array: true
+    t.string "auth_bypass_ids", array: true
     t.index ["base_path", "content_store"], name: "index_editions_on_base_path_and_content_store", unique: true
     t.index ["document_id", "content_store"], name: "index_editions_on_document_id_and_content_store", unique: true
     t.index ["document_id", "state"], name: "index_editions_on_document_id_and_state"


### PR DESCRIPTION
These extra options were causing the DB to lock for an extended period
of time, removing them should reduce downtime significantly during the
migration.