### PR TITLE
Add none null constraint to auth_bypass_ids

### DIFF
--- a/db/migrate/20191010161433_add_none_null_constraint_to_auth_bypass_ids.rb
+++ b/db/migrate/20191010161433_add_none_null_constraint_to_auth_bypass_ids.rb
@@ -1,0 +1,5 @@
+class AddNoneNullConstraintToAuthBypassIds < ActiveRecord::Migration[5.2]
+  def change
+    change_column_null :editions, :auth_bypass_ids, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -85,7 +85,7 @@ ActiveRecord::Schema.define(version: 2019_10_10_161856) do
     t.datetime "published_at"
     t.datetime "publishing_api_first_published_at"
     t.datetime "publishing_api_last_edited_at"
-    t.string "auth_bypass_ids", default: [], array: true
+    t.string "auth_bypass_ids", default: [], null: false, array: true
     t.index ["base_path", "content_store"], name: "index_editions_on_base_path_and_content_store", unique: true
     t.index ["document_id", "content_store"], name: "index_editions_on_document_id_and_content_store", unique: true
     t.index ["document_id", "state"], name: "index_editions_on_document_id_and_state"


### PR DESCRIPTION
Relies on: https://github.com/alphagov/publishing-api/pull/1621

Trello:
https://trello.com/c/DnYanQdY/132-separate-auth-bypassing-from-access-limiting-in-publishing-api