### PR TITLE
Copy auth_bypass_ids from AccessLimit to Edition

### DIFF
--- a/db/migrate/20191010161856_copy_auth_bypass_ids_to_editions.rb
+++ b/db/migrate/20191010161856_copy_auth_bypass_ids_to_editions.rb
@@ -1,0 +1,9 @@
+class CopyAuthBypassIdsToEditions < ActiveRecord::Migration[5.2]
+  disable_ddl_transaction!
+
+  def up
+    AccessLimit.includes(:edition).find_each do |access_limit|
+      access_limit.edition.update!(auth_bypass_ids: access_limit.auth_bypass_ids)
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_10_10_131917) do
+ActiveRecord::Schema.define(version: 2019_10_10_161856) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
This migration copies over all the auth_bypass_ids records from the
access_limits table to it's corresponding edition.

Relies on:
https://github.com/alphagov/publishing-api/pull/1620

Trello:
https://trello.com/c/DnYanQdY/132-separate-auth-bypassing-from-access-limiting-in-publishing-api