### PR TITLE
Use editions auth bypass

### DIFF
--- a/app/commands/v2/put_content.rb
+++ b/app/commands/v2/put_content.rb
@@ -104,7 +104,6 @@ module Commands
             access_limit.update_attributes!(
               users: (payload[:access_limited][:users] || []),
               organisations: (payload[:access_limited][:organisations] || []),
-              auth_bypass_ids: (payload[:access_limited][:auth_bypass_ids] || []),
             )
           end
         else

--- a/app/models/access_limit.rb
+++ b/app/models/access_limit.rb
@@ -1,17 +1,11 @@
 class AccessLimit < ApplicationRecord
   belongs_to :edition
 
-  after_save :copy_auth_bypass_ids_to_edition
-
   validate :user_uids_are_strings
   validate :auth_bypass_ids_are_uuids
   validate :user_organisations_are_uuids
 
 private
-
-  def copy_auth_bypass_ids_to_edition
-    edition.update!(auth_bypass_ids: auth_bypass_ids)
-  end
 
   def user_uids_are_strings
     unless users.all? { |id| id.is_a?(String) }

--- a/app/models/access_limit.rb
+++ b/app/models/access_limit.rb
@@ -2,7 +2,6 @@ class AccessLimit < ApplicationRecord
   belongs_to :edition
 
   validate :user_uids_are_strings
-  validate :auth_bypass_ids_are_uuids
   validate :user_organisations_are_uuids
 
 private
@@ -10,12 +9,6 @@ private
   def user_uids_are_strings
     unless users.all? { |id| id.is_a?(String) }
       errors.add(:users, ["contains non-string user UIDs"])
-    end
-  end
-
-  def auth_bypass_ids_are_uuids
-    unless auth_bypass_ids.all? { |id| UuidValidator.valid?(id) }
-      errors.add(:auth_bypass_ids, ["contains invalid UUIDs"])
     end
   end
 

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -78,8 +78,6 @@ class Edition < ApplicationRecord
   delegate :content_id, :locale, to: :document
 
   def auth_bypass_ids_are_uuids
-    return if !auth_bypass_ids
-
     unless auth_bypass_ids.all? { |id| UuidValidator.valid?(id) }
       errors.add(:auth_bypass_ids, ["contains invalid UUIDs"])
     end

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -10,6 +10,7 @@ class Edition < ApplicationRecord
 
   TOP_LEVEL_FIELDS = %i[
     analytics_identifier
+    auth_bypass_ids
     base_path
     content_store
     description

--- a/app/presenters/queries/content_item_presenter.rb
+++ b/app/presenters/queries/content_item_presenter.rb
@@ -228,6 +228,8 @@ module Presenters
           results.each do |result|
             json_columns.each { |c| parse_json_column(result, c) }
             int_columns.each { |c| parse_int_column(result, c) }
+            parse_auth_bypass_ids_column(result, "auth_bypass_ids")
+
             parse_state_history(result)
             parse_links(result, "links")
 
@@ -252,6 +254,12 @@ module Presenters
         return unless result.key?(column)
 
         result[column] = result[column].to_i
+      end
+
+      def parse_auth_bypass_ids_column(result, column)
+        return unless result.key?(column)
+
+        result[column] = result[column].delete("{}").split(",")
       end
 
       def parse_links(result, column)

--- a/spec/commands/v2/put_content_spec.rb
+++ b/spec/commands/v2/put_content_spec.rb
@@ -183,7 +183,6 @@ RSpec.describe Commands::V2::PutContent do
           payload.merge!(access_limited: {
             users: %w[new-user],
             organisations: [organisation_id],
-            auth_bypass_ids: [auth_bypass_id],
           })
         end
 
@@ -195,7 +194,6 @@ RSpec.describe Commands::V2::PutContent do
           access_limit = AccessLimit.last
           expect(access_limit.users).to eq(%w[new-user])
           expect(access_limit.organisations).to eq([organisation_id])
-          expect(access_limit.auth_bypass_ids).to eq([auth_bypass_id])
           expect(access_limit.edition).to eq(Edition.last)
         end
       end
@@ -248,7 +246,6 @@ RSpec.describe Commands::V2::PutContent do
           payload.merge!(access_limited: {
             users: %w[new-user],
             organisations: [organisation_id],
-            auth_bypass_ids: [auth_bypass_id],
           })
         end
 
@@ -260,7 +257,6 @@ RSpec.describe Commands::V2::PutContent do
           access_limit = AccessLimit.last
           expect(access_limit.users).to eq(%w[new-user])
           expect(access_limit.organisations).to eq([organisation_id])
-          expect(access_limit.auth_bypass_ids).to eq([auth_bypass_id])
           expect(access_limit.edition).to eq(edition)
         end
       end
@@ -292,7 +288,6 @@ RSpec.describe Commands::V2::PutContent do
             payload.merge!(access_limited: {
               users: %w[new-user],
               organisations: [organisation_id],
-              auth_bypass_ids: [auth_bypass_id],
             })
           end
 
@@ -302,7 +297,6 @@ RSpec.describe Commands::V2::PutContent do
             access_limit.reload
             expect(access_limit.users).to eq(%w[new-user])
             expect(access_limit.organisations).to eq([organisation_id])
-            expect(access_limit.auth_bypass_ids).to eq([auth_bypass_id])
           end
         end
       end

--- a/spec/commands/v2/put_content_spec.rb
+++ b/spec/commands/v2/put_content_spec.rb
@@ -124,6 +124,33 @@ RSpec.describe Commands::V2::PutContent do
       end
     end
 
+    context "when the payload includes auth_bypass_ids" do
+      it "updates edition with access_limits auth_bypass_ids" do
+        auth_bypass_id = SecureRandom.uuid
+        payload.merge!(access_limited: { auth_bypass_ids: [auth_bypass_id] })
+
+        expect { described_class.call(payload) }.to_not change(AccessLimit, :count)
+        expect(Edition.last.auth_bypass_ids).to eq([auth_bypass_id])
+      end
+
+      it "updates edition with root auth_bypass_ids" do
+        payload.merge!(auth_bypass_ids: [SecureRandom.uuid])
+
+        described_class.call(payload)
+        expect(Edition.last.auth_bypass_ids).to eq(payload[:auth_bypass_ids])
+      end
+
+      it "updates edition with root auth_bypass_ids over access_limits" do
+        payload.merge!(
+          auth_bypass_ids: [SecureRandom.uuid],
+          access_limited: { auth_bypass_ids: [SecureRandom.uuid] },
+        )
+
+        described_class.call(payload)
+        expect(Edition.last.auth_bypass_ids).to eq(payload[:auth_bypass_ids])
+      end
+    end
+
     it_behaves_like TransactionalCommand
 
     context "when the draft does not exist" do

--- a/spec/factories/edition.rb
+++ b/spec/factories/edition.rb
@@ -30,7 +30,6 @@ FactoryBot.define do
     content_store { "draft" }
     sequence(:base_path) { |n| "/vat-rates-#{n}" }
     user_facing_version { 1 }
-    auth_bypass_ids { [SecureRandom.uuid] }
 
     transient do
       change_note { "note" }

--- a/spec/integration/put_content/content_with_a_previous_draft_spec.rb
+++ b/spec/integration/put_content/content_with_a_previous_draft_spec.rb
@@ -234,7 +234,6 @@ RSpec.describe "PUT /v2/content when the payload is for an already drafted editi
         payload.merge!(
           access_limited: {
             users: %w[new-user],
-            auth_bypass_ids: [auth_bypass_id],
           },
         )
       end
@@ -244,7 +243,6 @@ RSpec.describe "PUT /v2/content when the payload is for an already drafted editi
         access_limit.reload
 
         expect(access_limit.users).to eq(%w[new-user])
-        expect(access_limit.auth_bypass_ids).to eq([auth_bypass_id])
       end
     end
 
@@ -268,12 +266,10 @@ RSpec.describe "PUT /v2/content when the payload is for an already drafted editi
 
   context "when the previously drafted item does not have an access limit" do
     context "when the params includes an access limit" do
-      let(:auth_bypass_id) { SecureRandom.uuid }
       before do
         payload.merge!(
           access_limited: {
             users: %w[new-user],
-            auth_bypass_ids: [auth_bypass_id],
           },
         )
       end
@@ -285,7 +281,6 @@ RSpec.describe "PUT /v2/content when the payload is for an already drafted editi
 
         access_limit = AccessLimit.find_by!(edition: previously_drafted_item)
         expect(access_limit.users).to eq(%w[new-user])
-        expect(access_limit.auth_bypass_ids).to eq([auth_bypass_id])
       end
     end
   end

--- a/spec/integration/put_content/content_with_a_previous_draft_spec.rb
+++ b/spec/integration/put_content/content_with_a_previous_draft_spec.rb
@@ -257,6 +257,15 @@ RSpec.describe "PUT /v2/content when the payload is for an already drafted editi
     end
   end
 
+  context "when the auth_bypass_ids has been updated" do
+    it "updates the edition with auth_bypass_ids params" do
+      payload.merge!(auth_bypass_ids: [SecureRandom.uuid])
+
+      put "/v2/content/#{content_id}", params: payload.to_json
+      expect(Edition.last.auth_bypass_ids).to eq(payload[:auth_bypass_ids])
+    end
+  end
+
   context "when the previously drafted item does not have an access limit" do
     context "when the params includes an access limit" do
       let(:auth_bypass_id) { SecureRandom.uuid }

--- a/spec/models/access_limit_spec.rb
+++ b/spec/models/access_limit_spec.rb
@@ -43,14 +43,6 @@ RSpec.describe AccessLimit do
     end
   end
 
-  context "copys auth_bypass_ids to the edition" do
-    it "when auth_bypass_ids are present" do
-      auth_bypass_ids = [SecureRandom.uuid, SecureRandom.uuid]
-      access_limit = create(:access_limit, auth_bypass_ids: auth_bypass_ids)
-      expect(access_limit.edition.auth_bypass_ids).to eq(auth_bypass_ids)
-    end
-  end
-
   describe "validates organisation_ids" do
     context "where organisation_ids has an array with a uuids" do
       let(:organisations) { [SecureRandom.uuid, SecureRandom.uuid] }

--- a/spec/models/access_limit_spec.rb
+++ b/spec/models/access_limit_spec.rb
@@ -4,13 +4,11 @@ RSpec.describe AccessLimit do
   subject do
     build(:access_limit,
           users: users,
-          organisations: organisations,
-          auth_bypass_ids: auth_bypass_ids)
+          organisations: organisations)
   end
 
   let(:users) { [SecureRandom.uuid] }
   let(:organisations) { [] }
-  let(:auth_bypass_ids) { [] }
 
   it { is_expected.to be_valid }
 
@@ -22,23 +20,6 @@ RSpec.describe AccessLimit do
 
     context "where users has an array with an integer" do
       let(:users) { [123] }
-      it { is_expected.to be_invalid }
-    end
-  end
-
-  describe "validates auth_bypass_ids" do
-    context "where auth_bypass_ids has an array with a uuids" do
-      let(:auth_bypass_ids) { [SecureRandom.uuid, SecureRandom.uuid] }
-      it { is_expected.to be_valid }
-    end
-
-    context "where auth_bypass_ids has an array with non uuids" do
-      let(:auth_bypass_ids) { ["not-a-uuid"] }
-      it { is_expected.to be_invalid }
-    end
-
-    context "where users has an array with an integer" do
-      let(:auth_bypass_ids) { [123] }
       it { is_expected.to be_invalid }
     end
   end

--- a/spec/presenters/queries/content_item_presenter_spec.rb
+++ b/spec/presenters/queries/content_item_presenter_spec.rb
@@ -17,7 +17,8 @@ RSpec.describe Presenters::Queries::ContentItemPresenter do
              document: document,
              base_path: base_path,
              first_published_at: first_published_at,
-             public_updated_at: public_updated_at)
+             public_updated_at: public_updated_at,
+             auth_bypass_ids: [SecureRandom.uuid])
     end
 
     let(:result) { described_class.present(edition) }
@@ -25,6 +26,7 @@ RSpec.describe Presenters::Queries::ContentItemPresenter do
     let(:expected_output) do
       {
         "analytics_identifier" => "GDS01",
+        "auth_bypass_ids" => edition.auth_bypass_ids,
         "base_path" => base_path,
         "content_id" => content_id,
         "content_store" => "draft",


### PR DESCRIPTION
Publishing API stores auth_bypass_ids inside access limit models. They should instead be stored distinctly on an edition. This makes it easier for us to share auth_bypass_id via link expansion and helps reduce an area of frequent confusion in the code base.

Tested in integration using content-publisher (sending root auth_bypass_ids and nested access_limited auth_bypass_ids). In all variations, the code worked as expected.

More information on the implementation in the commits: ->

Trello:
https://trello.com/c/DnYanQdY/132-separate-auth-bypassing-from-access-limiting-in-publishing-api