### PR TITLE
Remove auth_bypass_ids from access_limits

### DIFF
--- a/app/models/access_limit.rb
+++ b/app/models/access_limit.rb
@@ -4,6 +4,8 @@ class AccessLimit < ApplicationRecord
   validate :user_uids_are_strings
   validate :user_organisations_are_uuids
 
+  self.ignored_columns = %w(auth_bypass_ids)
+
 private
 
   def user_uids_are_strings

--- a/db/migrate/20191014160219_remove_auth_bypass_ids_from_access_limits.rb
+++ b/db/migrate/20191014160219_remove_auth_bypass_ids_from_access_limits.rb
@@ -1,0 +1,5 @@
+class RemoveAuthBypassIdsFromAccessLimits < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :access_limits, :auth_bypass_ids, :json
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_10_10_161856) do
+ActiveRecord::Schema.define(version: 2019_10_14_160219) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -20,7 +20,6 @@ ActiveRecord::Schema.define(version: 2019_10_10_161856) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "edition_id"
-    t.json "auth_bypass_ids", default: [], null: false
     t.json "organisations", default: [], null: false
     t.index ["edition_id"], name: "index_access_limits_on_edition_id"
   end


### PR DESCRIPTION
This is the final peice of work for
https://trello.com/c/DnYanQdY/132-separate-auth-bypassing-from-access-limiting-in-publishing-api
which removes the unused auth_bypass_ids column from access_limits.

Relies on:
https://github.com/alphagov/publishing-api/pull/1625

Related Trello's:
https://trello.com/c/DnYanQdY/132-separate-auth-bypassing-from-access-limiting-in-publishing-api

https://trello.com/c/AhyYCLZy/142-separate-authbypassids-from-access-limiting-in-content-store