### PR TITLE
Add multi-level link path expansion for roles

### DIFF
--- a/lib/expansion_rules.rb
+++ b/lib/expansion_rules.rb
@@ -30,6 +30,9 @@ module ExpansionRules
     [:ordered_related_items_overrides, :taxons],
     [:facets, :facet_values, :facet_group],
     [:facet_group, :facets, :facet_values],
+    [:ordered_current_appointments, :role],
+    [:ordered_current_appointments, :role, :ordered_parent_organisations],
+    [:ordered_current_appointments, :person],
   ].freeze
 
   REVERSE_LINKS = {
@@ -64,6 +67,7 @@ module ExpansionRules
   TAXON_FIELDS = (DEFAULT_FIELDS + %i(description details phase)).freeze
   NEED_FIELDS = (DEFAULT_FIELDS + details_fields(:role, :goal, :benefit, :met_when, :justifications)).freeze
   FINDER_FIELDS = (DEFAULT_FIELDS + details_fields(:facets)).freeze
+  ROLE_FIELDS = (DEFAULT_FIELDS + details_fields(:body)).freeze
   ROLE_APPOINTMENT_FIELDS = (DEFAULT_FIELDS + details_fields(:started_on, :ended_on)).freeze
   STEP_BY_STEP_FIELDS = (DEFAULT_FIELDS + [%i(details step_by_step_nav title), %i(details step_by_step_nav steps)]).freeze
   TRAVEL_ADVICE_FIELDS = (DEFAULT_FIELDS + details_fields(:country, :change_description)).freeze
@@ -96,6 +100,7 @@ module ExpansionRules
     { document_type: :need,                       fields: NEED_FIELDS },
     { document_type: :finder, link_type: :finder, fields: FINDER_FIELDS },
     { document_type: :mainstream_browse_page,     fields: DEFAULT_FIELDS_AND_DESCRIPTION },
+    { document_type: :role,                       fields: ROLE_FIELDS },
     { document_type: :role_appointment,           fields: ROLE_APPOINTMENT_FIELDS },
     { document_type: :service_manual_topic,       fields: DEFAULT_FIELDS_AND_DESCRIPTION },
     { document_type: :step_by_step_nav,           fields: STEP_BY_STEP_FIELDS },

--- a/spec/lib/expansion_rules_spec.rb
+++ b/spec/lib/expansion_rules_spec.rb
@@ -46,6 +46,7 @@ RSpec.describe ExpansionRules do
     let(:mainstream_browser_page_fields) { default_fields + %i(description) }
     let(:need_fields) { default_fields + [%i(details role), %i(details goal), %i(details benefit), %i(details met_when), %i(details justifications)] }
     let(:finder_fields) { default_fields + [%i(details facets)] }
+    let(:role_fields) { default_fields + [%i(details body)] }
     let(:role_appointment_fields) { default_fields + [%i(details started_on), %i(details ended_on)] }
     let(:service_manual_topic_fields) { default_fields + %i(description) }
     let(:step_by_step_fields) { default_fields + [%i(details step_by_step_nav title), %i(details step_by_step_nav steps)] }
@@ -79,6 +80,7 @@ RSpec.describe ExpansionRules do
     specify { expect(rules.expansion_fields(:organisation)).to eq(organisation_fields) }
     specify { expect(rules.expansion_fields(:placeholder_organisation)).to eq(organisation_fields) }
     specify { expect(rules.expansion_fields(:placeholder_topical_event)).to eq(default_fields) }
+    specify { expect(rules.expansion_fields(:role)).to eq(role_fields) }
     specify { expect(rules.expansion_fields(:role_appointment)).to eq(role_appointment_fields) }
     specify { expect(rules.expansion_fields(:service_manual_topic)).to eq(service_manual_topic_fields) }
     specify { expect(rules.expansion_fields(:step_by_step_nav)).to eq(step_by_step_fields) }


### PR DESCRIPTION
This should make it easier to migrate these formats away from Whitehall.

This change should make it possible to render, for example https://www.gov.uk/api/content/government/people/boris-johnson, using the data that is just contained in the content item itself.

This is a continuation of https://github.com/alphagov/publishing-api/pull/1347 which is quite old now.