### PR TITLE
Dont send auth_bypass_ids as part of access_limited

### DIFF
--- a/app/presenters/edition_presenter.rb
+++ b/app/presenters/edition_presenter.rb
@@ -84,7 +84,7 @@ module Presenters
     end
 
     def access_limited
-      return {} unless access_limit || edition.auth_bypass_ids.present?
+      return {} unless access_limit
 
       if edition.state != "draft"
         GovukError.notify(
@@ -96,9 +96,8 @@ module Presenters
       else
         {
           access_limited: {
-            users: access_limit&.users || [],
-            organisations: access_limit&.organisations || [],
-            auth_bypass_ids: edition.auth_bypass_ids,
+            users: access_limit.users,
+            organisations: access_limit.organisations,
           },
         }
       end

--- a/spec/presenters/edition_presenter_spec.rb
+++ b/spec/presenters/edition_presenter_spec.rb
@@ -152,10 +152,6 @@ RSpec.describe Presenters::EditionPresenter do
         expected.merge!(auth_bypass_ids: edition.auth_bypass_ids)
         expect(result).to match(a_hash_including(expected))
       end
-
-      it "presents auth_bypass_ids in access limit and root" do
-        expect(result[:auth_bypass_ids]).to eq(result[:access_limited][:auth_bypass_ids])
-      end
     end
 
     context "for a withdrawn edition" do
@@ -294,7 +290,6 @@ RSpec.describe Presenters::EditionPresenter do
         it "populates the access_limited hash" do
           expect(result[:access_limited][:users].length).to eq(1)
           expect(result[:access_limited][:organisations].length).to eq(1)
-          expect(result[:access_limited][:auth_bypass_ids].length).to eq(0)
         end
       end
 


### PR DESCRIPTION
Now content-store can handle auth_bypass_ids being sent via the root
here - https://github.com/alphagov/content-store/pull/634, we should
remove them being sent as part of access_limited.