### PR TITLE
Remove `ignore_columns`

### DIFF
--- a/app/models/access_limit.rb
+++ b/app/models/access_limit.rb
@@ -4,8 +4,6 @@ class AccessLimit < ApplicationRecord
   validate :user_uids_are_strings
   validate :user_organisations_are_uuids
 
-  self.ignored_columns = %w(auth_bypass_ids)
-
 private
 
   def user_uids_are_strings


### PR DESCRIPTION
Trello: https://trello.com/c/sUjBwDG0

Reverts change added here: https://github.com/alphagov/publishing-api/pull/1626/commits/ae79f85defc0a0619cc0969b0921411c0ab1f562

`auth_bypass_ids` where added to ignored columns to allow them to be removed.
Now that the migration has been run to remove the column, this code is no longer required.