### PR TITLE
Expand links for all types of roles

### DIFF
--- a/lib/expansion_rules.rb
+++ b/lib/expansion_rules.rb
@@ -91,55 +91,75 @@ module ExpansionRules
   ).freeze
   FACET_VALUE_FIELDS = (%i[content_id title locale schema_name] + details_fields(:label, :value)).freeze
 
-  CUSTOM_EXPANSION_FIELDS = [
-    { document_type: :redirect,
-      fields: [] },
-    { document_type: :gone,
-      fields: [] },
-    { document_type: :contact,
-      fields: CONTACT_FIELDS },
-    { document_type: :topical_event,
-      fields: DEFAULT_FIELDS },
-    { document_type: :placeholder_topical_event,
-      fields: DEFAULT_FIELDS },
-    { document_type: :organisation,
-      fields: ORGANISATION_FIELDS },
-    { document_type: :placeholder_organisation,
-      fields: ORGANISATION_FIELDS },
-    { document_type: :taxon,
-      fields: TAXON_FIELDS },
-    { document_type: :need,
-      fields: NEED_FIELDS },
-    { document_type: :finder,
-      link_type: :finder,
-      fields: FINDER_FIELDS },
-    { document_type: :mainstream_browse_page,
-      fields: DEFAULT_FIELDS_AND_DESCRIPTION },
-    { document_type: :role,
-      fields: ROLE_FIELDS },
-    { document_type: :role_appointment,
-      fields: ROLE_APPOINTMENT_FIELDS },
-    { document_type: :service_manual_topic,
-      fields: DEFAULT_FIELDS_AND_DESCRIPTION },
-    { document_type: :step_by_step_nav,
-      link_type: :part_of_step_navs,
-      fields: STEP_BY_STEP_AUTH_BYPASS_FIELDS },
-    { document_type: :step_by_step_nav,
-      link_type: :related_to_step_navs,
-      fields: STEP_BY_STEP_AUTH_BYPASS_FIELDS },
-    { document_type: :step_by_step_nav,
-      fields: STEP_BY_STEP_FIELDS },
-    { document_type: :travel_advice,
-      fields: TRAVEL_ADVICE_FIELDS },
-    { document_type: :world_location,
-      fields: WORLD_LOCATION_FIELDS },
-    { document_type: :facet_group,
-      fields: FACET_GROUP_FIELDS },
-    { document_type: :facet,
-      fields: FACET_FIELDS },
-    { document_type: :facet_value,
-      fields: FACET_VALUE_FIELDS },
-  ].freeze
+  CUSTOM_EXPANSION_FIELDS_FOR_ROLES = (
+    %i(
+      ambassador_role
+      board_member_role
+      chief_professional_officer_role
+      chief_scientific_officer_role
+      deputy_head_of_mission_role
+      governor_role
+      high_commissioner_role
+      military_role
+      ministerial_role
+      special_representative_role
+      traffic_commissioner_role
+      worldwide_office_staff_role
+    ).map do |document_type|
+      { document_type: document_type, fields: ROLE_FIELDS }
+    end
+  ).freeze
+
+  CUSTOM_EXPANSION_FIELDS = (
+    [
+      { document_type: :redirect,
+        fields: [] },
+      { document_type: :gone,
+        fields: [] },
+      { document_type: :contact,
+        fields: CONTACT_FIELDS },
+      { document_type: :topical_event,
+        fields: DEFAULT_FIELDS },
+      { document_type: :placeholder_topical_event,
+        fields: DEFAULT_FIELDS },
+      { document_type: :organisation,
+        fields: ORGANISATION_FIELDS },
+      { document_type: :placeholder_organisation,
+        fields: ORGANISATION_FIELDS },
+      { document_type: :taxon,
+        fields: TAXON_FIELDS },
+      { document_type: :need,
+        fields: NEED_FIELDS },
+      { document_type: :finder,
+        link_type: :finder,
+        fields: FINDER_FIELDS },
+      { document_type: :mainstream_browse_page,
+        fields: DEFAULT_FIELDS_AND_DESCRIPTION },
+      { document_type: :role_appointment,
+        fields: ROLE_APPOINTMENT_FIELDS },
+      { document_type: :service_manual_topic,
+        fields: DEFAULT_FIELDS_AND_DESCRIPTION },
+      { document_type: :step_by_step_nav,
+        link_type: :part_of_step_navs,
+        fields: STEP_BY_STEP_AUTH_BYPASS_FIELDS },
+      { document_type: :step_by_step_nav,
+        link_type: :related_to_step_navs,
+        fields: STEP_BY_STEP_AUTH_BYPASS_FIELDS },
+      { document_type: :step_by_step_nav,
+        fields: STEP_BY_STEP_FIELDS },
+      { document_type: :travel_advice,
+        fields: TRAVEL_ADVICE_FIELDS },
+      { document_type: :world_location,
+        fields: WORLD_LOCATION_FIELDS },
+      { document_type: :facet_group,
+        fields: FACET_GROUP_FIELDS },
+      { document_type: :facet,
+        fields: FACET_FIELDS },
+      { document_type: :facet_value,
+        fields: FACET_VALUE_FIELDS },
+    ] +
+    CUSTOM_EXPANSION_FIELDS_FOR_ROLES
+  ).freeze
 
   POSSIBLE_FIELDS_FOR_LINK_EXPANSION = DEFAULT_FIELDS +
     %i[details] +

--- a/spec/lib/expansion_rules_spec.rb
+++ b/spec/lib/expansion_rules_spec.rb
@@ -81,10 +81,22 @@ RSpec.describe ExpansionRules do
     specify { expect(rules.expansion_fields(:organisation)).to eq(organisation_fields) }
     specify { expect(rules.expansion_fields(:placeholder_organisation)).to eq(organisation_fields) }
     specify { expect(rules.expansion_fields(:placeholder_topical_event)).to eq(default_fields) }
-    specify { expect(rules.expansion_fields(:role)).to eq(role_fields) }
     specify { expect(rules.expansion_fields(:role_appointment)).to eq(role_appointment_fields) }
     specify { expect(rules.expansion_fields(:service_manual_topic)).to eq(service_manual_topic_fields) }
     specify { expect(rules.expansion_fields(:topical_event)).to eq(default_fields) }
+
+    specify { expect(rules.expansion_fields(:ambassador_role)).to eq(role_fields) }
+    specify { expect(rules.expansion_fields(:board_member_role)).to eq(role_fields) }
+    specify { expect(rules.expansion_fields(:chief_professional_officer_role)).to eq(role_fields) }
+    specify { expect(rules.expansion_fields(:chief_scientific_officer_role)).to eq(role_fields) }
+    specify { expect(rules.expansion_fields(:deputy_head_of_mission_role)).to eq(role_fields) }
+    specify { expect(rules.expansion_fields(:governor_role)).to eq(role_fields) }
+    specify { expect(rules.expansion_fields(:high_commissioner_role)).to eq(role_fields) }
+    specify { expect(rules.expansion_fields(:military_role)).to eq(role_fields) }
+    specify { expect(rules.expansion_fields(:ministerial_role)).to eq(role_fields) }
+    specify { expect(rules.expansion_fields(:special_representative_role)).to eq(role_fields) }
+    specify { expect(rules.expansion_fields(:traffic_commissioner_role)).to eq(role_fields) }
+    specify { expect(rules.expansion_fields(:worldwide_office_staff_role)).to eq(role_fields) }
 
     specify { expect(rules.expansion_fields(:step_by_step_nav, link_type: :part_of_step_navs)).to eq(step_by_step_auth_bypass_fields) }
     specify { expect(rules.expansion_fields(:step_by_step_nav, link_type: :part_of_step_navs, draft: false)).to eq(step_by_step_fields) }


### PR DESCRIPTION
This follows on from 4e1a73fb98120ee66db2c31eaac933b618977f78 which incorrectly added link expansion for a `role` document_type which doesn't actually exist. Instead there are [many different kinds of role document_types](https://github.com/alphagov/govuk-content-schemas/blob/d63686ddb0ecb356231b61c2bd034f34f9c00c28/formats/role.jsonnet#L2-L15).