### PR TITLE
Expand ordered previous appointments

### DIFF
--- a/lib/expansion_rules.rb
+++ b/lib/expansion_rules.rb
@@ -30,10 +30,8 @@ module ExpansionRules
     [:ordered_related_items_overrides, :taxons],
     [:facets, :facet_values, :facet_group],
     [:facet_group, :facets, :facet_values],
-    [:ordered_current_appointments, :role],
     [:ordered_current_appointments, :role, :ordered_parent_organisations],
     [:ordered_current_appointments, :person],
-    [:ordered_previous_appointments, :role],
     [:ordered_previous_appointments, :role, :ordered_parent_organisations],
     [:ordered_previous_appointments, :person],
   ].freeze

--- a/lib/expansion_rules.rb
+++ b/lib/expansion_rules.rb
@@ -33,6 +33,9 @@ module ExpansionRules
     [:ordered_current_appointments, :role],
     [:ordered_current_appointments, :role, :ordered_parent_organisations],
     [:ordered_current_appointments, :person],
+    [:ordered_previous_appointments, :role],
+    [:ordered_previous_appointments, :role, :ordered_parent_organisations],
+    [:ordered_previous_appointments, :person],
   ].freeze
 
   REVERSE_LINKS = {


### PR DESCRIPTION
We need this information to render the people pages from the content store.

[Trello Card](https://trello.com/c/6nmFOv1K/1499-expand-ordered-previous-appointments)