### PR TITLE
Add chief_scientific_advisor_role

### DIFF
--- a/lib/expansion_rules.rb
+++ b/lib/expansion_rules.rb
@@ -97,6 +97,7 @@ module ExpansionRules
       ambassador_role
       board_member_role
       chief_professional_officer_role
+      chief_scientific_advisor_role
       chief_scientific_officer_role
       deputy_head_of_mission_role
       governor_role

--- a/spec/lib/expansion_rules_spec.rb
+++ b/spec/lib/expansion_rules_spec.rb
@@ -88,6 +88,7 @@ RSpec.describe ExpansionRules do
     specify { expect(rules.expansion_fields(:ambassador_role)).to eq(role_fields) }
     specify { expect(rules.expansion_fields(:board_member_role)).to eq(role_fields) }
     specify { expect(rules.expansion_fields(:chief_professional_officer_role)).to eq(role_fields) }
+    specify { expect(rules.expansion_fields(:chief_scientific_advisor_role)).to eq(role_fields) }
     specify { expect(rules.expansion_fields(:chief_scientific_officer_role)).to eq(role_fields) }
     specify { expect(rules.expansion_fields(:deputy_head_of_mission_role)).to eq(role_fields) }
     specify { expect(rules.expansion_fields(:governor_role)).to eq(role_fields) }


### PR DESCRIPTION
This is a type of role in Whitehall which was originally missed off.

[Trello Card](https://trello.com/c/1V8xiZUl/1529-add-chief-scientific-advisor-role-2)