### PR TITLE
Render Govspeak inside expanded links

### DIFF
--- a/app/presenters/details_presenter.rb
+++ b/app/presenters/details_presenter.rb
@@ -47,7 +47,7 @@ module Presenters
     end
 
     def change_history
-      @change_history ||= change_history_presenter.change_history
+      @change_history ||= change_history_presenter&.change_history
     end
 
     def render_govspeak(value)

--- a/app/presenters/queries/expanded_link_set.rb
+++ b/app/presenters/queries/expanded_link_set.rb
@@ -45,7 +45,17 @@ module Presenters
       end
 
       def expanded_links
-        link_expansion.links_with_content
+        link_expansion.links_with_content.each_with_object({}) do |(link_type, links), memo|
+          memo[link_type] = links.map { |link_hash| present_expanded_link(link_hash) }
+        end
+      end
+
+      def present_expanded_link(link_hash)
+        link_hash.tap do |hash|
+          if hash[:details]
+            hash[:details] = Presenters::DetailsPresenter.new(hash[:details], nil).details
+          end
+        end
       end
 
       def available_translations

--- a/spec/presenters/details_presenter_spec.rb
+++ b/spec/presenters/details_presenter_spec.rb
@@ -5,12 +5,24 @@ RSpec.describe Presenters::DetailsPresenter do
     let(:change_history_presenter) do
       instance_double(Presenters::ChangeHistoryPresenter, change_history: [])
     end
+
     subject do
       described_class.new(edition_details, change_history_presenter).details
     end
 
     context "when we're passed details without a body" do
       let(:edition_details) { {} }
+
+      it "matches original details" do
+        is_expected.to match(edition_details)
+      end
+    end
+
+    context "without a change history presenter" do
+      let(:change_history_presenter) { nil }
+      let(:edition_details) do
+        { body: "Without change history" }
+      end
 
       it "matches original details" do
         is_expected.to match(edition_details)

--- a/spec/presenters/queries/expanded_link_set_spec.rb
+++ b/spec/presenters/queries/expanded_link_set_spec.rb
@@ -7,17 +7,17 @@ RSpec.describe Presenters::Queries::ExpandedLinkSet do
   let(:b) { create_link_set }
 
   let(:locale) { "en" }
+  let(:with_drafts) { false }
 
   subject(:expanded_links) {
     described_class.by_content_id(
       a,
       locale: locale,
-      with_drafts: present_drafts,
+      with_drafts: with_drafts,
     ).links
   }
 
   describe "multiple translations" do
-    let(:present_drafts) { false }
     let(:locale_fallback_order) { %w(ar en) }
 
     before do
@@ -35,6 +35,39 @@ RSpec.describe Presenters::Queries::ExpandedLinkSet do
           a_hash_including(base_path: "/a.fr"),
         ])
       end
+    end
+  end
+
+  describe "details" do
+    before do
+      create_link(a, b, "role")
+      create_edition(a, "/a")
+      create_edition(
+        b,
+        "/b",
+        document_type: "ministerial_role",
+        details: {
+          body: [
+            {
+              content_type: "text/govspeak",
+              content: "Body",
+            },
+          ],
+        },
+      )
+    end
+
+    it "calls the details presenter and renders govspeak inside expanded links" do
+      expect(expanded_links[:role].first[:details][:body]).to match([
+        {
+          content_type: "text/govspeak",
+          content: "Body",
+        },
+        {
+          content_type: "text/html",
+          content: "<p>Body</p>\n",
+        },
+      ])
     end
   end
 end

--- a/spec/support/dependency_resolution_helper.rb
+++ b/spec/support/dependency_resolution_helper.rb
@@ -12,13 +12,15 @@ module DependencyResolutionHelper
     factory: :live_edition,
     locale: "en",
     links_hash: {},
-    version: 1
+    version: 1,
+    **kwargs
   )
     create(factory,
            document: Document.find_or_create_by(content_id: content_id, locale: locale),
            base_path: base_path,
            user_facing_version: version,
-           links_hash: links_hash)
+           links_hash: links_hash,
+           **kwargs)
   end
 
   def create_link(from, to, link_type, link_position = 0)


### PR DESCRIPTION
This changes the expanded link set presenter to render Govspeak inside the `details` hash of an expanded link using the `DetailsPresenter`.

The reason for this is so that links to a document have the same structure as the presented document itself (albeit perhaps with a fewer number of presented fields).

A good example of this is related to people and roles:

If you take a look at the expanded links in this Content Item for the roles:

https://www.gov.uk/api/content/government/people/boris-johnson

We can see that only the Govspeak is available:

```
"body": [
{
"content_type": "text/govspeak",
"content": "The Prime Minister is the leader of Her Majesty's Government and is ultimately responsible for the policy and decisions of the government.\r\n\r\nAs leader of the UK government the Prime Minister also:\r\n\r\n* oversees the [operation of the Civil Service](https://www.gov.uk/government/ministers/minister-for-the-civil-service) and government agencies\r\n* appoints members of the government\r\n* is the principal government figure in the House of Commons\r\n"
}
]
```

Whereas if we go directly to the Content Item for the role itself (https://www.gov.uk/api/content/government/ministers/prime-minister), we see that the Govspeak has been rendered into HTML:

```
"details": {
"body": "<p>The Prime Minister is the leader of Her Majesty's Government and is ultimately responsible for the policy and decisions of the government.</p>\n\n<p>As leader of the UK government the Prime Minister also:</p>\n\n<ul>\n  <li>oversees the <a href=\"https://www.gov.uk/government/ministers/minister-for-the-civil-service\">operation of the Civil Service</a> and government agencies</li>\n  <li>appoints members of the government</li>\n  <li>is the principal government figure in the House of Commons</li>\n</ul>\n",
...
}
```

Note that this is showing just the HTML [because Content Store extracts the HTML content rather than showing both the HTML and the Govspeak version](https://github.com/alphagov/content-store/blob/88614ec8e249af9bb374c673f32a90f083278638/app/presenters/content_item_presenter.rb#L36).

[Trello Card](https://trello.com/c/evPuXJDW/1525-render-govspeak-in-person-and-roles-content-items-3)