### PR TITLE
Present expanded links details recursively

### DIFF
--- a/app/presenters/queries/expanded_link_set.rb
+++ b/app/presenters/queries/expanded_link_set.rb
@@ -45,13 +45,21 @@ module Presenters
       end
 
       def expanded_links
-        link_expansion.links_with_content.each_with_object({}) do |(link_type, links), memo|
-          memo[link_type] = links.map { |link_hash| present_expanded_link(link_hash) }
+        present_expanded_links(link_expansion.links_with_content)
+      end
+
+      def present_expanded_links(links)
+        links.each_with_object({}) do |(link_type, link_hashes), hash|
+          hash[link_type] = link_hashes.map { |link_hash| present_expanded_link(link_hash) }
         end
       end
 
       def present_expanded_link(link_hash)
         link_hash.tap do |hash|
+          if hash[:links]
+            hash[:links] = present_expanded_links(hash[:links])
+          end
+
           if hash[:details]
             hash[:details] = Presenters::DetailsPresenter.new(hash[:details], nil).details
           end

--- a/spec/presenters/queries/expanded_link_set_spec.rb
+++ b/spec/presenters/queries/expanded_link_set_spec.rb
@@ -39,12 +39,16 @@ RSpec.describe Presenters::Queries::ExpandedLinkSet do
   end
 
   describe "details" do
+    let(:c) { create_link_set }
+
     before do
-      create_link(a, b, "role")
+      create_link(a, b, "ordered_current_appointments")
       create_edition(a, "/a")
+      create_edition(b, "/b", document_type: "role_appointment")
+      create_link(b, c, "role")
       create_edition(
-        b,
-        "/b",
+        c,
+        "/c",
         document_type: "ministerial_role",
         details: {
           body: [
@@ -57,8 +61,10 @@ RSpec.describe Presenters::Queries::ExpandedLinkSet do
       )
     end
 
-    it "calls the details presenter and renders govspeak inside expanded links" do
-      expect(expanded_links[:role].first[:details][:body]).to match([
+    it "recursively calls the details presenter and renders govspeak inside expanded links" do
+      b = expanded_links[:ordered_current_appointments].first
+      c = b[:links][:role].first
+      expect(c[:details][:body]).to match([
         {
           content_type: "text/govspeak",
           content: "Body",


### PR DESCRIPTION
In 29616ce67ab4480334fa0615f2db09d396d74064 the expanded set presenter was changed to present the details hash of an expanded link. Unfortunately this only worked one level down in the links, whereas instead we want all levels of links to be presented correctly.