### PR TITLE
Add reverse links for appointments

### DIFF
--- a/lib/expansion_rules.rb
+++ b/lib/expansion_rules.rb
@@ -34,6 +34,8 @@ module ExpansionRules
     [:ordered_current_appointments, :person],
     [:ordered_previous_appointments, :role, :ordered_parent_organisations],
     [:ordered_previous_appointments, :person],
+    [:role_appointments, :person],
+    [:role_appointments, :role, :ordered_parent_organisations],
   ].freeze
 
   REVERSE_LINKS = {
@@ -46,6 +48,8 @@ module ExpansionRules
     pages_related_to_step_nav: :related_to_step_navs,
     legacy_taxons: :topic_taxonomy_taxons,
     pages_secondary_to_step_nav: :secondary_to_step_navs,
+    person: :role_appointments,
+    role: :role_appointments,
   }.freeze
 
   DEFAULT_FIELDS = [


### PR DESCRIPTION
This means that when you link to a person or a role from a role appointment, the person and the role will automatically get a link back to the appointment.

This is useful because it means we don't need to maintain four links for each appointment (person -> appointment, appointment -> person, role -> appointment, appointment -> role) rather than two links (appointment -> role, appointment -> person). Having four links means that it's possible for the links to become out of sync.

In practice this means that Whitehall needs to republish people and roles whenever an appointment changes using `after_save` hooks without relying entirely on the Publishing API for this kind of dependency resolution.

I've left the expansion rules for the old `ordered_current_appointments` style links, but once the frontend has been converted to read the data from the new `appointments` link, we can remove those rules.

This will end up merging the two `ordered_current_appointments` and `ordered_previous_appointments` into one link (`appointments`) which means the frontends will have to parse the appointments to work out if they are current or not. This pushes more logic into frontends, but it means there is less duplicate state to manage in the publishing apps (we don't need to patch links when an appointment transitions from previous to current).

I've chosen the name `appointed_person` and `appointed_role` for the explicit links because we already have links to `person` and `role` for attaching documents to a particular person and I didn't want them to get a reverse link.

I've chosen the name `appointments` for the reverse link since it's the same as `ordered_current_appointments` except that I don't believe we can make any guarantees on the ordering any more and because it will include both the current and the previous appointments.

[Trello Card](https://trello.com/c/roHfuPUV/1362-use-reverse-links-for-role-appointments)