### PR TITLE
Support reverse links with the same link type

### DIFF
--- a/lib/link_expansion.rb
+++ b/lib/link_expansion.rb
@@ -83,11 +83,14 @@ private
     edition_hash = content_cache.find(content_id)
     return {} if !edition_hash || !should_link?(node.link_type, edition_hash)
 
-    reverse_to_direct_link_type = rules.reverse_to_direct_link_type(node.link_types_path.first)
-    expanded = rules.expand_fields(edition_hash,
-                                   link_type: reverse_to_direct_link_type,
-                                   draft: with_drafts)
-    { reverse_to_direct_link_type => [expanded.merge(links: {})] }
+    rules
+      .reverse_to_direct_link_type(node.link_types_path.first)
+      .each_with_object({}) do |reverse_to_direct_link_type, memo|
+        expanded = rules.expand_fields(edition_hash,
+                                       link_type: reverse_to_direct_link_type,
+                                       draft: with_drafts)
+        memo[reverse_to_direct_link_type] = [expanded.merge(links: {})]
+      end
   end
 
   def should_link?(link_type, edition_hash)


### PR DESCRIPTION
We want reverse links for `role_appointments` to come from direct links of both a `person` and `role` type. Currently reverse links can only be associated with one type of direct link.

The reverse links with the same type were added in: https://github.com/alphagov/publishing-api/pull/1645

The current behaviour means that we only see the `role_appointments` links in a person content item, and not in the role. The reason for this is through the use of `REVERSE_LINKS.key` which only returns the key for the first occurrence of a value, and not all the keys associated with a value. Person happens to be above role in the `REVERSE_LINKS` hash so the Publishing API thinks that only people need to get the reverse links for role appointments.

[Trello Card](https://trello.com/c/roHfuPUV/1549-8-use-reverse-links-for-role-appointments)