### PR TITLE
Remove old role appointment link paths

### DIFF
--- a/lib/expansion_rules.rb
+++ b/lib/expansion_rules.rb
@@ -30,10 +30,6 @@ module ExpansionRules
     [:ordered_related_items_overrides, :taxons],
     [:facets, :facet_values, :facet_group],
     [:facet_group, :facets, :facet_values],
-    [:ordered_current_appointments, :role, :ordered_parent_organisations],
-    [:ordered_current_appointments, :person],
-    [:ordered_previous_appointments, :role, :ordered_parent_organisations],
-    [:ordered_previous_appointments, :person],
     [:role_appointments, :person],
     [:role_appointments, :role, :ordered_parent_organisations],
   ].freeze

--- a/spec/presenters/queries/expanded_link_set_spec.rb
+++ b/spec/presenters/queries/expanded_link_set_spec.rb
@@ -42,13 +42,10 @@ RSpec.describe Presenters::Queries::ExpandedLinkSet do
     let(:c) { create_link_set }
 
     before do
-      create_link(a, b, "ordered_current_appointments")
-      create_edition(a, "/a")
-      create_edition(b, "/b", document_type: "role_appointment")
-      create_link(b, c, "role")
+      create_edition(a, "/a", document_type: "person")
       create_edition(
-        c,
-        "/c",
+        b,
+        "/b",
         document_type: "ministerial_role",
         details: {
           body: [
@@ -59,10 +56,14 @@ RSpec.describe Presenters::Queries::ExpandedLinkSet do
           ],
         },
       )
+      create_edition(c, "/c", document_type: "role_appointment")
+
+      create_link(c, a, "person")
+      create_link(c, b, "role")
     end
 
     it "recursively calls the details presenter and renders govspeak inside expanded links" do
-      b = expanded_links[:ordered_current_appointments].first
+      b = expanded_links[:role_appointments].first
       c = b[:links][:role].first
       expect(c[:details][:body]).to match([
         {


### PR DESCRIPTION
All the people and roles have been republished from Whitehall now so the links no longer exist. Instead we can use the reverse links put in my the Publishing API.

See https://github.com/alphagov/publishing-api/pull/1645 for more information.

[Trello Card](https://trello.com/c/roHfuPUV/1549-8-use-reverse-links-for-role-appointments)