### PR TITLE
Support dependency resolution with the same link type

### DIFF
--- a/lib/expansion_rules.rb
+++ b/lib/expansion_rules.rb
@@ -199,7 +199,10 @@ module ExpansionRules
   def reverse_link_types_hash(link_types)
     link_types.each_with_object({}) do |(link_type, content_ids), memo|
       reversed = reverse_link_type(link_type)
-      memo[reversed] = content_ids if reversed
+      if reversed
+        memo[reversed] ||= []
+        memo[reversed] += content_ids
+      end
     end
   end
 

--- a/spec/integration/dependency_resolution_spec.rb
+++ b/spec/integration/dependency_resolution_spec.rb
@@ -244,4 +244,17 @@ RSpec.describe "Dependency Resolution" do
       expect(dependency_resolution).to match_array([link_content_id])
     end
   end
+
+  context "where there are role_appointments links" do
+    let(:person) { SecureRandom.uuid }
+    let(:role) { SecureRandom.uuid }
+
+    before do
+      create_link_set(content_id, links_hash: { person: [person], role: [role] })
+    end
+
+    it "has a dependency to all items" do
+      expect(dependency_resolution).to match_array([person, role])
+    end
+  end
 end


### PR DESCRIPTION
This continues from the work done in https://github.com/alphagov/publishing-api/pull/1647 to allow the Publishing API to support reverse links with the same link type.

Currently because of the way we do `memo[reversed] = content_ids` this means that if the `reversed` type is the same as one previously (as is the case for `role_appointments` from both `person` and `role`) the previous `content_ids` get overwritten.

[Trello Card](https://trello.com/c/roHfuPUV/1549-8-use-reverse-links-for-role-appointments)