### PR TITLE
Tune link expansion for governments

### DIFF
--- a/lib/expansion_rules.rb
+++ b/lib/expansion_rules.rb
@@ -66,6 +66,7 @@ module ExpansionRules
   DEFAULT_FIELDS_AND_DESCRIPTION = (DEFAULT_FIELDS + [:description]).freeze
 
   CONTACT_FIELDS = (DEFAULT_FIELDS + details_fields(:description, :title, :contact_form_links, :post_addresses, :email_addresses, :phone_numbers)).freeze
+  GOVERNMENT_FIELDS = (%i[content_id title api_path base_path document_type] + details_fields(:start_date, :end_date, :current)).freeze
   ORGANISATION_FIELDS = (DEFAULT_FIELDS - [:public_updated_at] + details_fields(:logo, :brand, :default_news_image)).freeze
   TAXON_FIELDS = (DEFAULT_FIELDS + %i[description details phase]).freeze
   NEED_FIELDS = (DEFAULT_FIELDS + details_fields(:role, :goal, :benefit, :met_when, :justifications)).freeze
@@ -159,6 +160,8 @@ module ExpansionRules
         fields: FACET_FIELDS },
       { document_type: :facet_value,
         fields: FACET_VALUE_FIELDS },
+      { document_type: :government,
+        fields: GOVERNMENT_FIELDS },
     ] +
     CUSTOM_EXPANSION_FIELDS_FOR_ROLES
   ).freeze


### PR DESCRIPTION
Content can be linked to a government, which is used by frontend apps
to display when content was published by a previous government.

To do this, some fields in the details are required. These changes
tune the fields included when linking to governments to include
everything required, and not include things that don't look
useful (like analytics_identifier, locale and schema_name).