### PR TITLE
Include person body in role appointment links

### DIFF
--- a/lib/expansion_rules.rb
+++ b/lib/expansion_rules.rb
@@ -71,6 +71,7 @@ module ExpansionRules
   TAXON_FIELDS = (DEFAULT_FIELDS + %i[description details phase]).freeze
   NEED_FIELDS = (DEFAULT_FIELDS + details_fields(:role, :goal, :benefit, :met_when, :justifications)).freeze
   FINDER_FIELDS = (DEFAULT_FIELDS + details_fields(:facets)).freeze
+  PERSON_FIELDS = (DEFAULT_FIELDS + details_fields(:body)).freeze
   ROLE_FIELDS = (DEFAULT_FIELDS + details_fields(:body)).freeze
   ROLE_APPOINTMENT_FIELDS = (DEFAULT_FIELDS + details_fields(:started_on, :ended_on, :current, :person_appointment_order)).freeze
   STEP_BY_STEP_FIELDS = (DEFAULT_FIELDS + [%i[details step_by_step_nav title], %i[details step_by_step_nav steps]]).freeze
@@ -138,6 +139,9 @@ module ExpansionRules
         fields: FINDER_FIELDS },
       { document_type: :mainstream_browse_page,
         fields: DEFAULT_FIELDS_AND_DESCRIPTION },
+      { document_type: :person,
+        link_type: :person,
+        fields: PERSON_FIELDS },
       { document_type: :role_appointment,
         fields: ROLE_APPOINTMENT_FIELDS },
       { document_type: :service_manual_topic,

--- a/spec/lib/expansion_rules_spec.rb
+++ b/spec/lib/expansion_rules_spec.rb
@@ -47,6 +47,7 @@ RSpec.describe ExpansionRules do
     let(:mainstream_browser_page_fields) { default_fields + %i(description) }
     let(:need_fields) { default_fields + [%i(details role), %i(details goal), %i(details benefit), %i(details met_when), %i(details justifications)] }
     let(:finder_fields) { default_fields + [%i(details facets)] }
+    let(:person_fields) { default_fields + [%i(details body)] }
     let(:role_fields) { default_fields + [%i(details body)] }
     let(:role_appointment_fields) { default_fields + [%i(details started_on), %i(details ended_on), %i(details current), %i(details person_appointment_order)] }
     let(:service_manual_topic_fields) { default_fields + %i(description) }
@@ -82,6 +83,8 @@ RSpec.describe ExpansionRules do
     specify { expect(rules.expansion_fields(:organisation)).to eq(organisation_fields) }
     specify { expect(rules.expansion_fields(:placeholder_organisation)).to eq(organisation_fields) }
     specify { expect(rules.expansion_fields(:placeholder_topical_event)).to eq(default_fields) }
+    specify { expect(rules.expansion_fields(:person, link_type: :people)).to eq(default_fields) }
+    specify { expect(rules.expansion_fields(:person, link_type: :person)).to eq(person_fields) }
     specify { expect(rules.expansion_fields(:role_appointment)).to eq(role_appointment_fields) }
     specify { expect(rules.expansion_fields(:service_manual_topic)).to eq(service_manual_topic_fields) }
     specify { expect(rules.expansion_fields(:topical_event)).to eq(default_fields) }


### PR DESCRIPTION
We need these to render the current role holder on the role pages.

I've limited it to the `person` link type to avoid expanding this field when a person is linked to under the `people` link type.

[Trello Card](https://trello.com/c/02C3OKnk/1559-2add-current-role-holder-to-role-pages)