### PR TITLE
Use correct date field names for governments

### DIFF
--- a/lib/expansion_rules.rb
+++ b/lib/expansion_rules.rb
@@ -66,7 +66,7 @@ module ExpansionRules
   DEFAULT_FIELDS_AND_DESCRIPTION = (DEFAULT_FIELDS + [:description]).freeze
 
   CONTACT_FIELDS = (DEFAULT_FIELDS + details_fields(:description, :title, :contact_form_links, :post_addresses, :email_addresses, :phone_numbers)).freeze
-  GOVERNMENT_FIELDS = (%i[content_id title api_path base_path document_type] + details_fields(:start_date, :end_date, :current)).freeze
+  GOVERNMENT_FIELDS = (%i[content_id title api_path base_path document_type] + details_fields(:started_on, :ended_on, :current)).freeze
   ORGANISATION_FIELDS = (DEFAULT_FIELDS - [:public_updated_at] + details_fields(:logo, :brand, :default_news_image)).freeze
   TAXON_FIELDS = (DEFAULT_FIELDS + %i[description details phase]).freeze
   NEED_FIELDS = (DEFAULT_FIELDS + details_fields(:role, :goal, :benefit, :met_when, :justifications)).freeze


### PR DESCRIPTION
The publishing API refers to start_date and end_date fields, but these should be started_on and ended_on, according to the database.