### PR TITLE
Fix government links schema issues

### DIFF
--- a/lib/expansion_rules.rb
+++ b/lib/expansion_rules.rb
@@ -48,16 +48,21 @@ module ExpansionRules
     role: :role_appointments,
   }.freeze
 
-  DEFAULT_FIELDS = [
+  # These fields are required by the frontend_links definition in the
+  # govuk-content-schemas
+  MANDATORY_FIELDS = [
+    :content_id,
+    :title,
+    :locale,
+  ].freeze
+
+  DEFAULT_FIELDS = MANDATORY_FIELDS + [
     :analytics_identifier,
     :api_path,
     :base_path,
-    :content_id,
     :document_type,
-    :locale,
     :public_updated_at,
     :schema_name,
-    :title,
     :withdrawn,
   ].freeze
 

--- a/lib/expansion_rules.rb
+++ b/lib/expansion_rules.rb
@@ -83,9 +83,9 @@ module ExpansionRules
   STEP_BY_STEP_AUTH_BYPASS_FIELDS = (STEP_BY_STEP_FIELDS + %i[auth_bypass_ids]).freeze
   TRAVEL_ADVICE_FIELDS = (DEFAULT_FIELDS + details_fields(:country, :change_description)).freeze
   WORLD_LOCATION_FIELDS = [:content_id, :title, :schema_name, :locale, :analytics_identifier].freeze
-  FACET_GROUP_FIELDS = (%i[content_id title locale schema_name] + details_fields(:name, :description)).freeze
+  FACET_GROUP_FIELDS = (MANDATORY_FIELDS + %i[schema_name] + details_fields(:name, :description)).freeze
   FACET_FIELDS = (
-    %i[content_id title locale schema_name] + details_fields(
+    MANDATORY_FIELDS + %i[schema_name] + details_fields(
       :combine_mode,
       :display_as_result_metadata,
       :filterable,
@@ -97,7 +97,7 @@ module ExpansionRules
       :type,
     )
   ).freeze
-  FACET_VALUE_FIELDS = (%i[content_id title locale schema_name] + details_fields(:label, :value)).freeze
+  FACET_VALUE_FIELDS = (MANDATORY_FIELDS + %i[schema_name] + details_fields(:label, :value)).freeze
 
   CUSTOM_EXPANSION_FIELDS_FOR_ROLES = (
     %i(

--- a/lib/expansion_rules.rb
+++ b/lib/expansion_rules.rb
@@ -71,7 +71,7 @@ module ExpansionRules
   DEFAULT_FIELDS_AND_DESCRIPTION = (DEFAULT_FIELDS + [:description]).freeze
 
   CONTACT_FIELDS = (DEFAULT_FIELDS + details_fields(:description, :title, :contact_form_links, :post_addresses, :email_addresses, :phone_numbers)).freeze
-  GOVERNMENT_FIELDS = (%i[content_id title api_path base_path document_type] + details_fields(:started_on, :ended_on, :current)).freeze
+  GOVERNMENT_FIELDS = (MANDATORY_FIELDS + %i[api_path base_path document_type] + details_fields(:started_on, :ended_on, :current)).freeze
   ORGANISATION_FIELDS = (DEFAULT_FIELDS - [:public_updated_at] + details_fields(:logo, :brand, :default_news_image)).freeze
   TAXON_FIELDS = (DEFAULT_FIELDS + %i[description details phase]).freeze
   NEED_FIELDS = (DEFAULT_FIELDS + details_fields(:role, :goal, :benefit, :met_when, :justifications)).freeze

--- a/spec/commands/v2/publish_spec.rb
+++ b/spec/commands/v2/publish_spec.rb
@@ -192,8 +192,15 @@ RSpec.describe Commands::V2::Publish do
       end
 
       it "sets the source_fields to the correct value" do
-        expect(DownstreamLiveWorker).to receive(:perform_async_in_queue)
-          .with("downstream_high", hash_including(source_fields: %i(public_updated_at title)))
+        expect(DownstreamLiveWorker).to(
+          receive(:perform_async_in_queue)
+            .with(
+              "downstream_high",
+              hash_including(
+                source_fields: contain_exactly(:public_updated_at, :title),
+              ),
+            ),
+        )
 
         described_class.call(payload)
       end

--- a/spec/lib/link_expansion/edition_hash_spec.rb
+++ b/spec/lib/link_expansion/edition_hash_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe LinkExpansion::EditionHash do
     end
     it "accepts an array argument" do
       expect(described_class.from(%w[123])).to include(
-        analytics_identifier: "123",
+        ExpansionRules::POSSIBLE_FIELDS_FOR_LINK_EXPANSION[0] => "123",
       )
     end
     it "accepts a Hash argument" do


### PR DESCRIPTION
This fixes the omission of locale. I was thinking that locale wasn't
necessary, but after fighting the govuk-content-schemas for a bit, I
think it's worth including.

If in the future the government pages are translated, then some pages
may include a non-en locale representation of the government, and
being explicit about that would be useful.