### PR TITLE
Add rake task to republish documents by document type

### DIFF
--- a/lib/tasks/represent_downstream.rake
+++ b/lib/tasks/represent_downstream.rake
@@ -99,5 +99,19 @@ namespace :represent_downstream do
         queue: DownstreamQueue::HIGH_QUEUE,
       )
     end
+
+    desc "
+    Represent documents by document type(s) downstream on the high_priority sidekiq
+    queue
+    Usage
+    rake 'represent_downstream:high_priority:document_type[organisation]'
+    "
+    task :document_type, [:document_types] => :environment do |_t, args|
+      document_types = args[:document_types].split(" ")
+      represent_downstream(
+        current_documents.where(editions: { document_type: document_types }),
+        queue: DownstreamQueue::HIGH_QUEUE,
+      )
+    end
   end
 end


### PR DESCRIPTION
We would like to prioritise republishing organisation pages if there
is a delay due to a large publishing queue.

This rake task gives us the flexibilty to pass any document type(s)
and republish all affected editions using the `high_priority`
sidekiq queue.

Trello card: https://trello.com/c/uzKUr4WT/1613-3-make-sure-organisation-pages-show-people-changes-quickly-during-reshuffle