### PR TITLE
Fix deprecation warning about raw SQL

### DIFF
--- a/app/queries/get_linkables.rb
+++ b/app/queries/get_linkables.rb
@@ -33,13 +33,13 @@ module Queries
           "documents.locale": "en",
         )
         .order("documents.content_id ASC")
-        .order("CASE editions.state WHEN 'published' THEN 0 ELSE 1 END")
+        .order(Arel.sql("CASE editions.state WHEN 'published' THEN 0 ELSE 1 END"))
         .pluck(
-          "DISTINCT ON (documents.content_id) documents.content_id",
+          Arel.sql("DISTINCT ON (documents.content_id) documents.content_id"),
           :title,
           :state,
           :base_path,
-          "COALESCE(details->>'internal_name', title)",
+          Arel.sql("COALESCE(details->>'internal_name', title)"),
         )
     end
   end


### PR DESCRIPTION
https://trello.com/c/jiqKv1lg/1299-audit-dependabot-for-publishing-api

Followed this article: https://medium.com/@mitsun.chieh/activerecord-relation-with-raw-sql-argument-returns-a-warning-exception-raising-8999f1b9898a