### PR TITLE
Change the RedirectHelper not to consider previous drafts

### DIFF
--- a/app/commands/v2/put_content.rb
+++ b/app/commands/v2/put_content.rb
@@ -87,8 +87,8 @@ module Commands
         return unless payload[:base_path]
 
         RedirectHelper::Redirect.new(previously_published_edition,
-                                     @previous_edition,
-                                     payload, callbacks).create
+                                     payload,
+                                     callbacks).create
       end
 
       def present_response(edition)

--- a/app/helpers/redirect_helper.rb
+++ b/app/helpers/redirect_helper.rb
@@ -1,59 +1,37 @@
 module RedirectHelper
   class Redirect
-    attr_reader :previously_published_item, :previously_drafted_item, :payload, :callbacks
+    attr_reader :previously_published_item, :payload, :callbacks
 
-    def initialize(previously_published_item, previously_drafted_item, payload, callbacks)
+    def initialize(previously_published_item, payload, callbacks)
       @previously_published_item = previously_published_item
-      @previously_drafted_item = previously_drafted_item
       @payload = payload
       @callbacks = callbacks
     end
 
     def create
-      return unless path_has_changed?
+      return unless previously_published_item.path_has_changed?
 
       redirect_payload = RedirectPresenter.new(
-        base_path: previous_base_path,
-        content_id: previous_content_id,
-        locale: owning_document.locale,
-        redirects: redirects_for(previous_routes, previous_base_path, payload[:base_path]),
+        base_path: previously_published_item.previous_base_path,
+        content_id: previously_published_item.content_id,
+        locale: previously_published_item.document.locale,
+        redirects: redirects_for(
+          previously_published_item.routes,
+          previously_published_item.previous_base_path,
+          payload[:base_path],
+        ),
         publishing_app: payload[:publishing_app],
       ).for_redirect_helper(SecureRandom.uuid)
 
-      Commands::V2::PutContent.call(redirect_payload,
-                                    callbacks: callbacks,
-                                    nested: true,
-                                    owning_document_id: owning_document.id)
+      Commands::V2::PutContent.call(
+        redirect_payload,
+        callbacks: callbacks,
+        nested: true,
+        owning_document_id: previously_published_item.document.id,
+      )
     end
 
   private
-
-
-    def path_has_changed?
-      previously_published_item.path_has_changed? ||
-        previously_drafted_item_base_path_changed?
-    end
-
-    def previously_drafted_item_base_path_changed?
-      return false unless previously_drafted_item
-
-      previously_drafted_item.base_path != payload[:base_path]
-    end
-
-    def previous_routes
-      previously_published_item.routes ||
-        previously_drafted_item.routes
-    end
-
-    def previous_base_path
-      previously_published_item.previous_base_path ||
-        previously_drafted_item.base_path
-    end
-
-    def previous_content_id
-      previously_published_item.content_id ||
-        previously_drafted_item.content_id
-    end
 
     def redirects_for(routes, old_base_path, new_base_path)
       routes.map do |route|
@@ -63,11 +41,6 @@ module RedirectHelper
           destination: route[:path].gsub(old_base_path, new_base_path),
         }
       end
-    end
-
-    def owning_document
-      previously_published_item.try(:document) ||
-        previously_drafted_item.document
     end
   end
 end

--- a/spec/integration/put_content/content_with_a_previous_draft_spec.rb
+++ b/spec/integration/put_content/content_with_a_previous_draft_spec.rb
@@ -113,38 +113,6 @@ RSpec.describe "PUT /v2/content when the payload is for an already drafted editi
       expect(previously_drafted_item.base_path).to eq("/vat-rates")
     end
 
-    it "creates a redirect" do
-      put "/v2/content/#{content_id}", params: payload.to_json
-
-      redirect = Edition.find_by(
-        base_path: "/old-path",
-        state: "draft",
-      )
-
-      expect(redirect).to be_present
-      expect(redirect.schema_name).to eq("redirect")
-      expect(redirect.publishing_app).to eq("publisher")
-
-      expect(redirect.redirects).to eq([
-        {
-          path: "/old-path",
-          type: "exact",
-          destination: base_path,
-        }, {
-          path: "/old-path.atom",
-          type: "exact",
-          destination: "#{base_path}.atom",
-        }
-      ])
-      expect(redirect.document.owning_document).to eq(previously_drafted_item.document)
-    end
-
-    it "sends a create request to the draft content store for the redirect" do
-      expect(DownstreamDraftWorker).to receive(:perform_async_in_queue).twice
-
-      put "/v2/content/#{content_id}", params: payload.to_json
-    end
-
     context "when the locale differs from the existing draft edition" do
       before do
         payload.merge!(locale: "fr", title: "French Title")


### PR DESCRIPTION
Previously it was trying to setup redirects for drafts, so I'm
guessing if you had /a as published, a draft for /b, and then updated
the draft to be /c, a redirect would be drafted for /b to /c as well
as /a to /b.

While not being optimal, and just redirecting from /a to /c, this also
broke if you moved the draft from /b to /c and then back to /b, as the
created redirect would be circular.

This commit changes the RedirectHelper to not even consider the
previous draft (if one exists), as I think the correct behaviour can
be defined in terms of the payload, and the previously published item.