### PR TITLE
Add expansion rules for roles without organisations

### DIFF
--- a/lib/expansion_rules.rb
+++ b/lib/expansion_rules.rb
@@ -31,6 +31,7 @@ module ExpansionRules
     %i[facets facet_values facet_group],
     %i[facet_group facets facet_values],
     %i[role_appointments person],
+    %i[role_appointments role],
     %i[role_appointments role ordered_parent_organisations],
   ].freeze
 

--- a/spec/integration/dependency_resolution_spec.rb
+++ b/spec/integration/dependency_resolution_spec.rb
@@ -257,4 +257,18 @@ RSpec.describe "Dependency Resolution" do
       expect(dependency_resolution).to match_array([person, role])
     end
   end
+
+  context "from the context of a role when there are role_appointments" do
+    let(:role) { content_id }
+    let(:person) { SecureRandom.uuid }
+    let(:role_appointment) { SecureRandom.uuid }
+
+    before do
+      create_link_set(role_appointment, links_hash: { person: [person], role: [role] })
+    end
+
+    it "has a dependency to all items" do
+      expect(dependency_resolution).to match_array([role_appointment, person, role])
+    end
+  end
 end


### PR DESCRIPTION
In https://github.com/alphagov/publishing-api/pull/1645 I added the expansion rules for role appointments, roles and people. I was under the impression that any subsets of those rules would be captured, but it turns out you have to be explicit with the paths.

Previously, the rule `[:role_appointments, :role, :ordered_parent_organisations]` meant that dependency resolution was only triggered on roles which were tagged to an organisation (which isn't always necessarily the case). By adding the explicit rule `[:role_appointments, :role]` it means we also get dependency resolution for roles not tagged to an organisation.

I've added a test case for this situation which is a bit unusual because the role itself ends up being a dependency for the role. Although this is something we could neaten up I think it's fine for now. The reason this happens is because the links go `role` -> `role_appointment` -> `role`.

[Trello Card](https://trello.com/c/EawMaLeZ/1726-updating-a-base-path-less-role-doesnt-update-the-people-appointed-to-it)