### PR TITLE
Remove support for facet groups

### DIFF
--- a/lib/expansion_rules.rb
+++ b/lib/expansion_rules.rb
@@ -28,8 +28,6 @@ module ExpansionRules
     [:taxons, :parent_taxons.recurring, :root_taxon],
     [:ordered_related_items, :mainstream_browse_pages, :parent.recurring],
     %i[ordered_related_items_overrides taxons],
-    %i[facets facet_values facet_group],
-    %i[facet_group facets facet_values],
     %i[role_appointments person],
     %i[role_appointments role ordered_parent_organisations],
   ].freeze
@@ -83,22 +81,6 @@ module ExpansionRules
   STEP_BY_STEP_AUTH_BYPASS_FIELDS = (STEP_BY_STEP_FIELDS + %i[auth_bypass_ids]).freeze
   TRAVEL_ADVICE_FIELDS = (DEFAULT_FIELDS + details_fields(:country, :change_description)).freeze
   WORLD_LOCATION_FIELDS = %i[content_id title schema_name locale analytics_identifier].freeze
-  FACET_GROUP_FIELDS = (MANDATORY_FIELDS + %i[schema_name] + details_fields(:name, :description)).freeze
-  FACET_FIELDS = (
-    MANDATORY_FIELDS + %i[schema_name] + details_fields(
-      :combine_mode,
-      :display_as_result_metadata,
-      :filterable,
-      :filter_key,
-      :key,
-      :name,
-      :preposition,
-      :short_name,
-      :type,
-    )
-  ).freeze
-  FACET_VALUE_FIELDS = (MANDATORY_FIELDS + %i[schema_name] + details_fields(:label, :value)).freeze
-
   CUSTOM_EXPANSION_FIELDS_FOR_ROLES = (
     %i(
       ambassador_role
@@ -163,12 +145,6 @@ module ExpansionRules
         fields: TRAVEL_ADVICE_FIELDS },
       { document_type: :world_location,
         fields: WORLD_LOCATION_FIELDS },
-      { document_type: :facet_group,
-        fields: FACET_GROUP_FIELDS },
-      { document_type: :facet,
-        fields: FACET_FIELDS },
-      { document_type: :facet_value,
-        fields: FACET_VALUE_FIELDS },
       { document_type: :government,
         fields: GOVERNMENT_FIELDS },
     ] +

--- a/spec/lib/expansion_rules_spec.rb
+++ b/spec/lib/expansion_rules_spec.rb
@@ -55,22 +55,6 @@ RSpec.describe ExpansionRules do
     let(:step_by_step_auth_bypass_fields) { step_by_step_fields + %i(auth_bypass_ids) }
     let(:travel_advice_fields) { default_fields + [%i(details country), %i(details change_description)] }
     let(:world_location_fields) { %i(content_id title schema_name locale analytics_identifier) }
-    let(:facet_group_fields) { %i(content_id title locale schema_name) + [%i(details name), %i(details description)] }
-    let(:facet_fields) { %i(content_id title locale schema_name) + facet_details_fields }
-    let(:facet_value_fields) { %i(content_id title locale schema_name) + [%i(details label), %i(details value)] }
-    let(:facet_details_fields) do
-      %i[
-        combine_mode
-        display_as_result_metadata
-        filterable
-        filter_key
-        key
-        name
-        preposition
-        short_name
-        type
-      ].map { |key| [:details, key] }
-    end
 
     specify { expect(rules.expansion_fields(:redirect)).to eq([]) }
     specify { expect(rules.expansion_fields(:gone)).to eq([]) }
@@ -116,10 +100,6 @@ RSpec.describe ExpansionRules do
 
     specify { expect(rules.expansion_fields(:finder, link_type: :finder)).to eq(finder_fields) }
     specify { expect(rules.expansion_fields(:parent, link_type: :finder)).to eq(default_fields) }
-
-    specify { expect(rules.expansion_fields(:facet_group)).to eq(facet_group_fields) }
-    specify { expect(rules.expansion_fields(:facet)).to eq(facet_fields) }
-    specify { expect(rules.expansion_fields(:facet_value)).to eq(facet_value_fields) }
   end
 
   describe ".expansion_fields_for_document_type" do


### PR DESCRIPTION
We removed the business readiness finder and facet groups so these
expansion rules can be removed too.

Trello: https://trello.com/c/mSsEMP7M/524-remove-support-for-facet-groups-from-publishing-api