### PR TITLE
Remove `lint` Rake task

### DIFF
--- a/lib/tasks/lint.rake
+++ b/lib/tasks/lint.rake
@@ -1,4 +1,0 @@
-desc "Run govuk-lint with similar params to CI"
-task lint: :environment do
-  sh "bundle exec rubocop --format clang app config Gemfile lib spec"
-end


### PR DESCRIPTION
- This `lint` task is not very useful as it hides the directories that
  it operates on, and we're trying to move away from wrappers.
- Instead, I think we can leave people to run `bundle exec rubocop` on
  their own - it's less typing than `bundle exec rake lint` and
  `rubocop --help` works for options.

https://trello.com/c/IEUuFOVa/129-remove-the-lint-rake-task-from-apps-that-have-it
as part of the developer tooling group.