### PR TITLE
Persist unpublished_at for all unpublishings 

### DIFF
--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -170,8 +170,6 @@ class Edition < ApplicationRecord
     content_store = type == "substitute" ? nil : "live"
     update!(state: "unpublished", content_store: content_store)
 
-    unpublished_at = nil unless type == "withdrawal"
-
     if unpublishing.present?
       unpublishing.update(
         type: type,

--- a/app/presenters/gone_presenter.rb
+++ b/app/presenters/gone_presenter.rb
@@ -1,8 +1,9 @@
 class GonePresenter
-  def initialize(base_path:, content_id:, publishing_app:, alternative_path:, explanation:, locale:)
+  def initialize(base_path:, content_id:, publishing_app:, public_updated_at:, alternative_path:, explanation:, locale:)
     @base_path = base_path
     @content_id = content_id
     @publishing_app = publishing_app
+    @public_updated_at = public_updated_at
     @alternative_path = alternative_path
     @explanation = explanation
     @locale = locale
@@ -13,6 +14,7 @@ class GonePresenter
       base_path: edition.base_path,
       content_id: edition.content_id,
       publishing_app: edition.publishing_app,
+      public_updated_at: edition.unpublishing.unpublished_at || edition.unpublishing.created_at,
       alternative_path: edition.unpublishing.alternative_path,
       explanation: edition.unpublishing.explanation,
       locale: edition.locale,
@@ -33,7 +35,7 @@ class GonePresenter
 
 private
 
-  attr_reader :base_path, :content_id, :publishing_app, :alternative_path, :explanation, :locale
+  attr_reader :base_path, :content_id, :publishing_app, :public_updated_at, :alternative_path, :explanation, :locale
 
   def present
     {
@@ -42,6 +44,7 @@ private
       base_path: base_path,
       locale: locale,
       publishing_app: publishing_app,
+      public_updated_at: public_updated_at&.iso8601,
       details: {
         explanation: explanation,
         alternative_path: alternative_path,

--- a/app/presenters/redirect_presenter.rb
+++ b/app/presenters/redirect_presenter.rb
@@ -13,7 +13,7 @@ class RedirectPresenter
       base_path: edition.base_path,
       content_id: edition.content_id,
       publishing_app: edition.publishing_app,
-      public_updated_at: edition.unpublishing.created_at,
+      public_updated_at: edition.unpublishing.unpublished_at || edition.unpublishing.created_at,
       redirects: edition.unpublishing.redirects,
       locale: edition.locale,
     )

--- a/doc/api.md
+++ b/doc/api.md
@@ -304,11 +304,9 @@ type. Uses [optimistic-locking][optimistic-locking].
 - `unpublished_at` *(optional)*
   - An [RFC 3339][rfc-3339] formatted timestamp should be provided, although
     [other formats][to-time-docs] may be accepted.
-  - Specifies when this edition was withdrawn. Ignored for unpublishing
-    types other than `withdrawn`.
-  - If omitted, the `withdrawn_at` time will be taken to be the time this call
-    was made.
-
+  - Specifies a publisher provided time of when this content was removed/withdrawn.
+  - Used to override the `withdrawn_at` time provided to content store, for
+    withdrawn documents content.
 
 ### State changes
 

--- a/spec/commands/v2/unpublish_spec.rb
+++ b/spec/commands/v2/unpublish_spec.rb
@@ -163,6 +163,7 @@ RSpec.describe Commands::V2::Unpublish do
         expect(unpublishing.type).to eq("gone")
         expect(unpublishing.explanation).to eq("Removed for testing porpoises")
         expect(unpublishing.alternative_path).to eq("/new-path")
+        expect(unpublishing.unpublished_at).to be_nil
       end
 
       it "sends an unpublishing downstream" do
@@ -207,30 +208,11 @@ RSpec.describe Commands::V2::Unpublish do
           }
         end
 
-        it "ignores the provided unpublished_at" do
+        it "persists the provided unpublished_at" do
           described_class.call(payload)
 
           unpublishing = Unpublishing.find_by(edition: live_edition)
-          expect(unpublishing.unpublished_at).to be_nil
-        end
-
-        context "for a withdrawal" do
-          let(:payload) do
-            {
-              content_id: content_id,
-              type: "withdrawal",
-              explanation: "Removed for testing porpoises",
-              alternative_path: "/new-path",
-              unpublished_at: Time.zone.local(2016, 8, 1, 10, 10, 10).rfc3339,
-            }
-          end
-
-          it "persists the provided unpublished_at" do
-            described_class.call(payload)
-
-            unpublishing = Unpublishing.find_by(edition: live_edition)
-            expect(unpublishing.unpublished_at).to eq Time.zone.local(2016, 8, 1, 10, 10, 10)
-          end
+          expect(unpublishing.unpublished_at).to eq Time.zone.local(2016, 8, 1, 1, 1, 1)
         end
       end
     end

--- a/spec/factories/unpublished_edition.rb
+++ b/spec/factories/unpublished_edition.rb
@@ -8,7 +8,7 @@ FactoryBot.define do
       unpublishing_type { "gone" }
       explanation { "Removed for testing reasons" }
       alternative_path { "/new-path" }
-      unpublished_at { nil }
+      unpublished_at { "2014-01-02T03:04:05Z" }
     end
 
     after(:create) do |edition, evaluator|

--- a/spec/requests/unpublishing_spec.rb
+++ b/spec/requests/unpublishing_spec.rb
@@ -212,6 +212,7 @@ RSpec.describe "POST /v2/content/:content_id/unpublish", type: :request do
             },
           ],
           payload_version: anything,
+          public_updated_at: anything,
         },
       }
     }


### PR DESCRIPTION
It seemed a strange anomaly that we omit this field in all types of
unpublishing other than withdrawn. This caught the Publishing Workflow
team out who found out they were sending this as part of migration for
it not to be persisted.

Even though this has no effect on public facing aspects it still seems
to make more sense to store it if provided than just ignore it.