### PR TITLE
Fix time formatting in Content Items Presenter

### DIFF
--- a/app/presenters/queries/content_item_presenter.rb
+++ b/app/presenters/queries/content_item_presenter.rb
@@ -125,6 +125,8 @@ module Presenters
           "to_char(publishing_api_last_edited_at, '#{ISO8601_SQL}') as publishing_api_last_edited_at"
         when :publishing_api_first_published_at
           "to_char(publishing_api_first_published_at, '#{ISO8601_SQL}') as publishing_api_first_published_at"
+        when :updated_at
+          "to_char(editions.updated_at, '#{ISO8601_SQL}') as updated_at"
         when :unpublishing
           "#{UNPUBLISHING_SQL} AS unpublishing"
         when :change_note

--- a/app/presenters/queries/content_item_presenter.rb
+++ b/app/presenters/queries/content_item_presenter.rb
@@ -191,6 +191,8 @@ module Presenters
         scope
       end
 
+      ISO8601_SQL = "YYYY-MM-DD\"T\"HH24:MI:SS\"Z\"".freeze
+
       # Creating a JSON object with specified keys in PostgreSQL 9.3
       # is a little awkward, but is possible through the use of column
       # aliases
@@ -206,7 +208,7 @@ module Presenters
               unpublishings.explanation,
               unpublishings.alternative_path,
               unpublishings.redirects,
-              unpublishings.unpublished_at
+              to_char(unpublishings.unpublished_at, '#{ISO8601_SQL}')
             )
           )
           AS
@@ -219,8 +221,6 @@ module Presenters
           )
         )
       SQL
-
-      ISO8601_SQL = "YYYY-MM-DD\"T\"HH24:MI:SS\"Z\"".freeze
 
       def parse_results(results)
         json_columns = %w(details routes redirects state_history unpublishing links)

--- a/spec/controllers/v2/content_items_controller_spec.rb
+++ b/spec/controllers/v2/content_items_controller_spec.rb
@@ -216,8 +216,8 @@ RSpec.describe V2::ContentItemsController do
           results = parsed_response["results"]
 
           expect(results).to eq([
-            { "updated_at" => "2016-01-01 00:00:00" },
-            { "updated_at" => "2016-02-02 00:00:00" },
+            { "updated_at" => "2016-01-01T00:00:00Z" },
+            { "updated_at" => "2016-02-02T00:00:00Z" },
           ])
         end
       end
@@ -230,8 +230,8 @@ RSpec.describe V2::ContentItemsController do
           results = parsed_response["results"]
 
           expect(results).to eq([
-            { "updated_at" => "2016-02-02 00:00:00" },
-            { "updated_at" => "2016-01-01 00:00:00" },
+            { "updated_at" => "2016-02-02T00:00:00Z" },
+            { "updated_at" => "2016-01-01T00:00:00Z" },
           ])
         end
       end

--- a/spec/presenters/queries/content_item_presenter_spec.rb
+++ b/spec/presenters/queries/content_item_presenter_spec.rb
@@ -75,12 +75,25 @@ RSpec.describe Presenters::Queries::ContentItemPresenter do
     end
 
     context "for a published edition" do
-      before do
-        edition.update!(state: "published")
+      let(:unpublished_edition) { create(:unpublished_edition) }
+
+      it "has a publication state of unpublished" do
+        result = described_class.present(unpublished_edition)
+        expect(result.fetch("publication_state")).to eq("unpublished")
       end
 
-      it "has a publication state of published" do
-        expect(result.fetch("publication_state")).to eq("published")
+      it "includes unpublishing details" do
+        unpublishing = unpublished_edition.unpublishing
+        result = described_class.present(unpublished_edition)
+        expect(result["unpublishing"])
+          .to match(
+            a_hash_including(
+              "type" => unpublishing.type,
+              "explanation" => unpublishing.explanation,
+              "alternative_path" => unpublishing.alternative_path,
+              "unpublished_at" => unpublishing.unpublished_at.rfc3339,
+            ),
+          )
       end
     end
 

--- a/spec/presenters/queries/content_item_presenter_spec.rb
+++ b/spec/presenters/queries/content_item_presenter_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe Presenters::Queries::ContentItemPresenter do
         "state_history" => { 1 => "draft" },
         "title" => "VAT rates",
         "update_type" => "minor",
-        "updated_at" => "2016-01-01 00:00:00",
+        "updated_at" => "2016-01-01T00:00:00Z",
         "user_facing_version" => 1,
       }
     end


### PR DESCRIPTION
Trello: https://trello.com/c/e8zIJIoy/1526-expand-integrity-checks-to-cover-withdrawing-and-removing

This fixes the presentation of two sets of timestamps from the Presenters::Queries::ContentItemPresenter that were not being specified with their timezone like the other ones in the class were. The need for this change does underline how fragile the current time presentation system is in this class.

This does potentially a risk a backwards compatibility issue, however I think this is risk is low as these times were in unusual formats that weren't documented. I'm therefore considering this be just a basic bug fix.