### PR TITLE
[WIP][DO NOT MERGE]Add rake task to backfill temp columns

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,7 @@
 
 library("govuk")
 
-node("postgresql-9.3") {
+node("postgresql-9.6") {
 
   govuk.buildProject(
     extraParameters: [

--- a/app/models/access_limit.rb
+++ b/app/models/access_limit.rb
@@ -4,6 +4,8 @@ class AccessLimit < ApplicationRecord
   validate :user_uids_are_strings
   validate :user_organisations_are_uuids
 
+  before_save :save_to_temp_columns
+
 private
 
   def user_uids_are_strings
@@ -16,5 +18,10 @@ private
     unless organisations.all? { |id| UuidValidator.valid?(id) }
       errors.add(:organisations, ["contains invalid UUIDs"])
     end
+  end
+
+  def save_to_temp_columns
+    self.temp_users = users
+    self.temp_organisations = organisations
   end
 end

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -77,6 +77,8 @@ class Edition < ApplicationRecord
 
   delegate :content_id, :locale, to: :document
 
+  before_save :save_to_temp_columns
+
   def auth_bypass_ids_are_uuids
     unless auth_bypass_ids.all? { |id| UuidValidator.valid?(id) }
       errors.add(:auth_bypass_ids, ["contains invalid UUIDs"])
@@ -248,5 +250,11 @@ private
 
   def requires_rendering_app?
     renderable_content? && NO_RENDERING_APP_FORMATS.exclude?(document_type)
+  end
+
+  def save_to_temp_columns
+    self.temp_details = details
+    self.temp_routes = routes
+    self.temp_redirects = redirects
   end
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,11 +1,17 @@
 class Event < ApplicationRecord
   include SymbolizeJSON
 
+  before_save :save_to_temp_columns
+
   def as_csv
     attributes.merge("payload" => payload.to_json)
   end
 
   def self.maximum_id
     Event.maximum(:id) || 0
+  end
+
+  def save_to_temp_columns
+    self.temp_payload = payload
   end
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -4,7 +4,7 @@ class Event < ApplicationRecord
   before_save :save_to_temp_columns
 
   def as_csv
-    attributes.merge("payload" => payload.to_json)
+    attributes.merge("payload" => payload.to_json).delete_if { |k, _| k == "temp_payload" }
   end
 
   def self.maximum_id

--- a/app/models/expanded_links.rb
+++ b/app/models/expanded_links.rb
@@ -1,6 +1,8 @@
 class ExpandedLinks < ApplicationRecord
   include FindOrCreateLocked
 
+  before_save :save_to_temp_columns
+
   def self.locked_update(
     content_id:,
     locale:,
@@ -22,5 +24,9 @@ class ExpandedLinks < ApplicationRecord
         expanded_links: expanded_links,
       )
     end
+  end
+
+  def save_to_temp_columns
+    self.temp_expanded_links = expanded_links
   end
 end

--- a/app/models/unpublishing.rb
+++ b/app/models/unpublishing.rb
@@ -3,6 +3,8 @@ class Unpublishing < ApplicationRecord
 
   self.inheritance_column = nil
 
+  before_save :save_to_temp_columns
+
   belongs_to :edition
 
   VALID_TYPES = %w(
@@ -41,5 +43,9 @@ class Unpublishing < ApplicationRecord
 
   def self.is_substitute?(edition)
     where(edition: edition).pluck(:type).first == "substitute"
+  end
+
+  def save_to_temp_columns
+    self.temp_redirects = redirects
   end
 end

--- a/app/presenters/edition_presenter.rb
+++ b/app/presenters/edition_presenter.rb
@@ -17,6 +17,9 @@ module Presenters
       publishing_api_first_published_at
       publishing_api_last_edited_at
       state
+      temp_details
+      temp_redirects
+      temp_routes
       unpublishing_type
       updated_at
       user_facing_version

--- a/db/migrate/20200306102404_add_jsonb_columns.rb
+++ b/db/migrate/20200306102404_add_jsonb_columns.rb
@@ -1,0 +1,15 @@
+class AddJsonbColumns < ActiveRecord::Migration[5.2]
+  def change
+    change_table :access_limits, bulk: true do |t|
+      t.jsonb :temp_users, :temp_organisations
+    end
+
+    change_table :editions, bulk: true do |t|
+      t.jsonb :temp_details, :temp_routes, :temp_redirects
+    end
+
+    add_column :events, :temp_payload, :jsonb
+    add_column :expanded_links, :temp_expanded_links, :jsonb
+    add_column :unpublishings, :temp_redirects, :jsonb
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_10_14_160219) do
+ActiveRecord::Schema.define(version: 2020_03_06_102404) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -21,6 +21,8 @@ ActiveRecord::Schema.define(version: 2019_10_14_160219) do
     t.datetime "updated_at", null: false
     t.integer "edition_id"
     t.json "organisations", default: [], null: false
+    t.jsonb "temp_users"
+    t.jsonb "temp_organisations"
     t.index ["edition_id"], name: "index_access_limits_on_edition_id"
   end
 
@@ -85,6 +87,9 @@ ActiveRecord::Schema.define(version: 2019_10_14_160219) do
     t.datetime "publishing_api_first_published_at"
     t.datetime "publishing_api_last_edited_at"
     t.string "auth_bypass_ids", default: [], null: false, array: true
+    t.jsonb "temp_details"
+    t.jsonb "temp_routes"
+    t.jsonb "temp_redirects"
     t.index ["base_path", "content_store"], name: "index_editions_on_base_path_and_content_store", unique: true
     t.index ["document_id", "content_store"], name: "index_editions_on_document_id_and_content_store", unique: true
     t.index ["document_id", "state"], name: "index_editions_on_document_id_and_state"
@@ -107,6 +112,7 @@ ActiveRecord::Schema.define(version: 2019_10_14_160219) do
     t.datetime "updated_at"
     t.string "request_id"
     t.uuid "content_id"
+    t.jsonb "temp_payload"
   end
 
   create_table "expanded_links", force: :cascade do |t|
@@ -117,6 +123,7 @@ ActiveRecord::Schema.define(version: 2019_10_14_160219) do
     t.bigint "payload_version", default: 0, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.jsonb "temp_expanded_links"
     t.index ["content_id", "locale", "with_drafts"], name: "expanded_links_content_id_locale_with_drafts_index", unique: true
   end
 
@@ -171,6 +178,7 @@ ActiveRecord::Schema.define(version: 2019_10_14_160219) do
     t.datetime "updated_at"
     t.datetime "unpublished_at"
     t.json "redirects"
+    t.jsonb "temp_redirects"
     t.index ["edition_id", "type"], name: "index_unpublishings_on_edition_id_and_type"
     t.index ["edition_id"], name: "index_unpublishings_on_edition_id"
   end

--- a/lib/tasks/backfill_new_jsonb_columns.rake
+++ b/lib/tasks/backfill_new_jsonb_columns.rake
@@ -1,0 +1,30 @@
+desc "Backfill new temp jsonb columns with data from original json colums"
+task backfill_new_jsonb_columns: :environment do
+  AccessLimit.find_each.with_index do |access_limit, index|
+    access_limit.update(temp_users: access_limit.users,
+                        temp_organisations: access_limit.organisations)
+    puts "Updated #{(index + 1)} temp_users and temp_organisations"
+  end
+
+  Edition.find_each.with_index do |edition, index|
+    edition.update(temp_details: edition.details.delete("\u0000"),
+                   temp_routes: edition.routes.delete("\u0000"),
+                   temp_redirects: edition.redirects.delete("\u0000"))
+    puts "Updated #{(index + 1)} temp_details, temp_routes and temp_redirects"
+  end
+
+  Event.find_each.with_index do |event, index|
+    event.update(temp_payload: event.payload.delete("\u0000"))
+    puts "Updated #{(index + 1)} temp_payload"
+  end
+
+  ExpandedLinks.find_each.with_index do |expanded_links, index|
+    expanded_links.update(temp_expanded_links: expanded_links.expanded_links.delete("\u0000"))
+    puts "Updated #{(index + 1)} temp_expanded_links"
+  end
+
+  Unpublishing.find_each.with_index do |unpublishing, index|
+    unpublishing.update(temp_redirects: unpublishing.redirects.delete("\u0000"))
+    puts "Updated #{(index + 1)} temp_redirects"
+  end
+end

--- a/spec/lib/events/s3_importer_spec.rb
+++ b/spec/lib/events/s3_importer_spec.rb
@@ -16,9 +16,9 @@ RSpec.describe Events::S3Importer do
   let(:file) { gzipped_file(file_contents) }
   let(:file_contents) do
     <<-CSV.strip_heredoc
-      id,action,payload,user_uid,created_at,updated_at,request_id,content_id
-      10,Publish,"{""content_id"":""2cc503f1-5fef-4fac-8381-63f6689cd6a2""}",,2015-11-11 09:55:00 UTC,2015-11-11 09:55:00 UTC,,2cc503f1-5fef-4fac-8381-63f6689cd6a2
-      11,Publish,"{""content_id"":""8bc0c1dd-4842-4283-a123-5671a34b67eb""}",e676cb22-0c0c-4534-9514-a65ebcc7a9e2,2015-11-11 14:00:00 UTC,2015-11-11 14:00:00 UTC,2027-1477408502.282-80.194.77.100-1361,8bc0c1dd-4842-4283-a123-5671a34b67eb
+      id,action,temp_payload,payload,user_uid,created_at,updated_at,request_id,content_id
+      10,Publish,"{""content_id"":""2cc503f1-5fef-4fac-8381-63f6689cd6a2""}","{""content_id"":""2cc503f1-5fef-4fac-8381-63f6689cd6a2""}",,2015-11-11 09:55:00 UTC,2015-11-11 09:55:00 UTC,,2cc503f1-5fef-4fac-8381-63f6689cd6a2
+      11,Publish,"{""content_id"":""8bc0c1dd-4842-4283-a123-5671a34b67eb""}","{""content_id"":""8bc0c1dd-4842-4283-a123-5671a34b67eb""}",e676cb22-0c0c-4534-9514-a65ebcc7a9e2,2015-11-11 14:00:00 UTC,2015-11-11 14:00:00 UTC,2027-1477408502.282-80.194.77.100-1361,8bc0c1dd-4842-4283-a123-5671a34b67eb
     CSV
   end
   let(:event_10_attributes) do
@@ -31,6 +31,7 @@ RSpec.describe Events::S3Importer do
       updated_at: Time.zone.local(2015, 11, 11, 9, 55),
       request_id: nil,
       content_id: "2cc503f1-5fef-4fac-8381-63f6689cd6a2",
+      temp_payload: { "content_id" => "2cc503f1-5fef-4fac-8381-63f6689cd6a2" },
     }
   end
   let(:event_11_attributes) do
@@ -43,6 +44,7 @@ RSpec.describe Events::S3Importer do
       updated_at: Time.utc(2015, 11, 11, 14),
       request_id: "2027-1477408502.282-80.194.77.100-1361",
       content_id: "8bc0c1dd-4842-4283-a123-5671a34b67eb",
+      temp_payload: { "content_id" => "8bc0c1dd-4842-4283-a123-5671a34b67eb" },
     }
   end
 


### PR DESCRIPTION
This adds a rake task to backfill the new temporary jsonb columns with
data from the original json colums.

This is part of the multistep no downtime database change to use the new
jsonb data type.

After the migration to the new data type has finished, this can be
deleted.

Trello card: https://trello.com/c/IJ6dRZyw/1829-pub-api-jsonb-migration-pt-ii-backfill-new-columns