### PR TITLE
Remove deprecation of change history field

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -101,11 +101,9 @@ presented edition and [warnings](#warnings).
   - A description of the content that can be displayed publicly.
 - `details` *(conditionally required, default: {})*
   - JSON object representing data specific to the `document_type`.
-  - **Deprecated**: If there is no top-level `change_note` attribute,
-    and this is a "major" `update_type`, then the Publishing API may
-    extract the `change_note` from the details hash. This behaviour is
-    for backwards compatibility, the top-level `change_note` attribute
-    should be used instead.
+  - If there is no top-level `change_note` attribute, and this is a "major"
+    `update_type`, then the Publishing API may extract the `change_note` from
+    the details hash.
 	- If `details` has a member named `change_note`, that is used.
 	- Otherwise, if `details` contains a member named
       `change_history`, then the `note` with the latest corresponding


### PR DESCRIPTION
Trello: https://trello.com/c/GrVzLvnd/1468-document-the-change-note-decisions-in-content-publisher-adr-and-publishing-api-documentation

This field is still in active use and meets a number of use cases that
replacement field, change_note, cannot meet.

Further context for this is included in the Content Publisher ADR:
https://github.com/alphagov/content-publisher/pull/1933