### PR TITLE
[WIP][DO NOT MERGE] Remove JSON columns

### DIFF
--- a/app/models/access_limit.rb
+++ b/app/models/access_limit.rb
@@ -4,8 +4,6 @@ class AccessLimit < ApplicationRecord
   validate :user_uids_are_strings
   validate :user_organisations_are_uuids
 
-  before_save :save_to_temp_columns
-
 private
 
   def user_uids_are_strings
@@ -18,10 +16,5 @@ private
     unless organisations.all? { |id| UuidValidator.valid?(id) }
       errors.add(:organisations, ["contains invalid UUIDs"])
     end
-  end
-
-  def save_to_temp_columns
-    self.temp_users = users
-    self.temp_organisations = organisations
   end
 end

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -77,8 +77,6 @@ class Edition < ApplicationRecord
 
   delegate :content_id, :locale, to: :document
 
-  before_save :save_to_temp_columns
-
   def auth_bypass_ids_are_uuids
     unless auth_bypass_ids.all? { |id| UuidValidator.valid?(id) }
       errors.add(:auth_bypass_ids, ["contains invalid UUIDs"])
@@ -250,11 +248,5 @@ private
 
   def requires_rendering_app?
     renderable_content? && NO_RENDERING_APP_FORMATS.exclude?(document_type)
-  end
-
-  def save_to_temp_columns
-    self.temp_details = details
-    self.temp_routes = routes
-    self.temp_redirects = redirects
   end
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,17 +1,11 @@
 class Event < ApplicationRecord
   include SymbolizeJSON
 
-  before_save :save_to_temp_columns
-
   def as_csv
     attributes.merge("payload" => payload.to_json).delete_if { |k, _| k == "temp_payload" }
   end
 
   def self.maximum_id
     Event.maximum(:id) || 0
-  end
-
-  def save_to_temp_columns
-    self.temp_payload = payload
   end
 end

--- a/app/models/expanded_links.rb
+++ b/app/models/expanded_links.rb
@@ -1,8 +1,6 @@
 class ExpandedLinks < ApplicationRecord
   include FindOrCreateLocked
 
-  before_save :save_to_temp_columns
-
   def self.locked_update(
     content_id:,
     locale:,
@@ -24,9 +22,5 @@ class ExpandedLinks < ApplicationRecord
         expanded_links: expanded_links,
       )
     end
-  end
-
-  def save_to_temp_columns
-    self.temp_expanded_links = expanded_links
   end
 end

--- a/app/models/unpublishing.rb
+++ b/app/models/unpublishing.rb
@@ -3,8 +3,6 @@ class Unpublishing < ApplicationRecord
 
   self.inheritance_column = nil
 
-  before_save :save_to_temp_columns
-
   belongs_to :edition
 
   VALID_TYPES = %w(
@@ -43,9 +41,5 @@ class Unpublishing < ApplicationRecord
 
   def self.is_substitute?(edition)
     where(edition: edition).pluck(:type).first == "substitute"
-  end
-
-  def save_to_temp_columns
-    self.temp_redirects = redirects
   end
 end

--- a/db/migrate/20200403124645_remove_old_json_columns_rename_new_jsonb_columns.rb
+++ b/db/migrate/20200403124645_remove_old_json_columns_rename_new_jsonb_columns.rb
@@ -1,0 +1,56 @@
+class RemoveOldJsonColumnsRenameNewJsonbColumns < ActiveRecord::Migration[5.2]
+  def up
+    # Remove json columns
+    change_table :access_limits, bulk: true do |t|
+      t.remove :users, :organisations
+    end
+
+    change_table :editions, bulk: true do |t|
+      t.remove :details, :routes, :redirects
+    end
+
+    remove_column :events, :payload, :json
+    remove_column :expanded_links, :expanded_links, :json
+    remove_column :unpublishings, :redirects, :json
+  end
+
+  def down; end
+
+  def change
+    # Add defaults and constraints to new jsonb columns
+    change_table :access_limits, bulk: true do |t|
+      t.change_default :temp_users, from: nil, to: []
+      t.change_default :temp_organisations, from: nil, to: []
+    end
+
+    change_column_null :access_limits, :temp_users, false
+    change_column_null :access_limits, :temp_organisations, false
+
+    change_table :editions, bulk: true do |t|
+      t.change_default :temp_details, from: nil, to: {}
+      t.change_default :temp_routes, from: nil, to: []
+      t.change_default :temp_redirects, from: nil, to: []
+    end
+
+    change_column_default(:events, :temp_payload, from: nil, to: {})
+
+    change_column_default(:expanded_links, :temp_expanded_links, from: nil, to: {})
+    change_column_null :expanded_links, :temp_expanded_links, false, {}
+
+    # Rename new jsonb columns
+    change_table :access_limits, bulk: true do |t|
+      t.rename :temp_users, :users
+      t.rename :temp_organisations, :organisations
+    end
+
+    change_table :editions, bulk: true do |t|
+      t.rename :temp_details, :details
+      t.rename :temp_routes, :routes
+      t.rename :temp_redirects, :redirects
+    end
+
+    rename_column :events, :temp_payload, :payload
+    rename_column :expanded_links, :temp_expanded_links, :expanded_links
+    rename_column :unpublishings, :temp_redirects, :redirects
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,19 +10,17 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_03_25_115319) do
+ActiveRecord::Schema.define(version: 2020_04_03_124645) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "access_limits", id: :serial, force: :cascade do |t|
-    t.json "users", default: [], null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "edition_id"
-    t.json "organisations", default: [], null: false
-    t.jsonb "temp_users"
-    t.jsonb "temp_organisations"
+    t.jsonb "users", default: [], null: false
+    t.jsonb "organisations", default: [], null: false
     t.index ["edition_id"], name: "index_access_limits_on_edition_id"
   end
 
@@ -61,9 +59,6 @@ ActiveRecord::Schema.define(version: 2020_03_25_115319) do
   create_table "editions", id: :serial, force: :cascade do |t|
     t.string "title"
     t.datetime "public_updated_at"
-    t.json "details", default: {}
-    t.json "routes", default: []
-    t.json "redirects", default: []
     t.string "publishing_app"
     t.string "rendering_app"
     t.string "update_type"
@@ -87,9 +82,9 @@ ActiveRecord::Schema.define(version: 2020_03_25_115319) do
     t.datetime "publishing_api_first_published_at"
     t.datetime "publishing_api_last_edited_at"
     t.string "auth_bypass_ids", default: [], null: false, array: true
-    t.jsonb "temp_details"
-    t.jsonb "temp_routes"
-    t.jsonb "temp_redirects"
+    t.jsonb "details", default: {}
+    t.jsonb "routes", default: []
+    t.jsonb "redirects", default: []
     t.index ["base_path", "content_store"], name: "index_editions_on_base_path_and_content_store", unique: true
     t.index ["document_id", "content_store"], name: "index_editions_on_document_id_and_content_store", unique: true
     t.index ["document_id", "state"], name: "index_editions_on_document_id_and_state"
@@ -106,24 +101,22 @@ ActiveRecord::Schema.define(version: 2020_03_25_115319) do
 
   create_table "events", id: :serial, force: :cascade do |t|
     t.string "action", null: false
-    t.json "payload", default: {}
     t.string "user_uid"
     t.datetime "created_at"
     t.datetime "updated_at"
     t.string "request_id"
     t.uuid "content_id"
-    t.jsonb "temp_payload"
+    t.jsonb "payload", default: {}
   end
 
   create_table "expanded_links", force: :cascade do |t|
     t.uuid "content_id", null: false
     t.string "locale", null: false
     t.boolean "with_drafts", null: false
-    t.json "expanded_links", default: {}, null: false
     t.bigint "payload_version", default: 0, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.jsonb "temp_expanded_links"
+    t.jsonb "expanded_links", default: {}, null: false
     t.index ["content_id", "locale", "with_drafts"], name: "expanded_links_content_id_locale_with_drafts_index", unique: true
   end
 
@@ -177,8 +170,7 @@ ActiveRecord::Schema.define(version: 2020_03_25_115319) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.datetime "unpublished_at"
-    t.json "redirects"
-    t.jsonb "temp_redirects"
+    t.jsonb "redirects"
     t.index ["edition_id", "type"], name: "index_unpublishings_on_edition_id_and_type"
     t.index ["edition_id"], name: "index_unpublishings_on_edition_id", unique: true
   end


### PR DESCRIPTION
Following the addition and backfilling of new JSONB columns, this PR creates a migration to add default values and constraints to them before removing the old JSON columns and renaming the new columns. This PR also removes callbacks to save to new columns.

[Trello](https://trello.com/c/S7iyCLbj/1830-3-pub-api-jsonb-migration-pt-iii-switch-to-new-columns)