### PR TITLE
Match JSON and JSONB

### DIFF
--- a/app/models/symbolize_json.rb
+++ b/app/models/symbolize_json.rb
@@ -1,7 +1,7 @@
 module SymbolizeJSON
   def self.included(model)
     model.columns.each do |column|
-      next unless column.sql_type == "json"
+      next unless column.sql_type.match(/^jsonb?$/i)
 
       model.class_eval do
         define_method(column.name) do

--- a/lib/events/s3_importer.rb
+++ b/lib/events/s3_importer.rb
@@ -35,7 +35,7 @@ module Events
     end
 
     def attributes(row)
-      json_fields = Event.columns.select { |e| e.type == :json }.map(&:name)
+      json_fields = Event.columns.select { |e| e.type.match(/^jsonb?$/i) }.map(&:name)
       json = row.each_with_object({}) do |(field, value), memo|
         memo[field] = Oj.load(value) if json_fields.include?(field)
       end


### PR DESCRIPTION
In a couple of places, the app checks if the column type is `json`, this needs to be changed to accept both `json` and `jsonb` before we switch to using the new columns.

[Trello](https://trello.com/c/S7iyCLbj/1830-3-pub-api-jsonb-migration-pt-iii-switch-to-new-columns)