### PR TITLE
Add ministers page to ministerial role pages reverse links

### DIFF
--- a/lib/expansion_rules.rb
+++ b/lib/expansion_rules.rb
@@ -45,6 +45,7 @@ module ExpansionRules
     pages_secondary_to_step_nav: :secondary_to_step_navs,
     person: :role_appointments,
     role: :role_appointments,
+    ministerial: :ministers,
   }.freeze
 
   # These fields are required by the frontend_links definition in the


### PR DESCRIPTION
This is PR is part of moving the rendering of pages from Whitehall-frontend to Collections.

Currently `ministerial` role pages have a link to the `ministers` page provided by the Whitehall database. We are moving this link instead to the content item for minister roles pages.

### Individual minister content items
Before republishing:
<img width="424" alt="Screenshot 2020-04-24 at 10 43 18" src="https://user-images.githubusercontent.com/13475227/80204621-1e61f380-8621-11ea-905e-3eca009056b9.png">

After republishing:
<img width="885" alt="Screenshot 2020-04-24 at 10 45 52" src="https://user-images.githubusercontent.com/13475227/80204652-2a4db580-8621-11ea-9f47-49c604426362.png">

### ministers index page
<img width="1306" alt="Screenshot 2020-04-28 at 12 20 09" src="https://user-images.githubusercontent.com/13475227/80481633-bf66ec00-894a-11ea-9f19-45a0462f0256.png">

Dependent PRs:
https://github.com/alphagov/govuk-content-schemas/pull/979
https://github.com/alphagov/govuk-content-schemas/pull/982
https://github.com/alphagov/whitehall/pull/5554

[Trello](https://trello.com/c/i1ffrXiZ/1913-5-link-ministers-to-the-government-ministers-content-item) 