### PR TITLE
Add migration to remove "ministers" links

### DIFF
--- a/db/migrate/20200428134322_remove_ministers_links.rb
+++ b/db/migrate/20200428134322_remove_ministers_links.rb
@@ -1,0 +1,5 @@
+class RemoveMinistersLinks < ActiveRecord::Migration[6.0]
+  def up
+    Link.where(link_type: "ministers").destroy_all
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -2,15 +2,15 @@
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
 #
-# Note that this schema.rb definition is the authoritative source for your
-# database schema. If you need to create the application database on another
-# system, you should be using db:schema:load, not running all the migrations
-# from scratch. The latter is a flawed and unsustainable approach (the more migrations
-# you'll amass, the slower it'll run and the greater likelihood for issues).
+# This file is the source Rails uses to define your schema when running `rails
+# db:schema:load`. When creating a new database, `rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_06_120740) do
+ActiveRecord::Schema.define(version: 2020_04_28_134322) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
This link type has been deprecated since 2018, is unused, and
whitehall doesn't publish it any more.