### PR TITLE
Expand person image for certain links

### DIFF
--- a/lib/expansion_rules.rb
+++ b/lib/expansion_rules.rb
@@ -77,12 +77,27 @@ module ExpansionRules
   NEED_FIELDS = (DEFAULT_FIELDS + details_fields(:role, :goal, :benefit, :met_when, :justifications)).freeze
   FINDER_FIELDS = (DEFAULT_FIELDS + details_fields(:facets)).freeze
   PERSON_FIELDS_WITH_BODY = (DEFAULT_FIELDS + details_fields(:body)).freeze
+  PERSON_FIELDS_WITH_IMAGE = (DEFAULT_FIELDS + details_fields(:image)).freeze
   ROLE_FIELDS = (DEFAULT_FIELDS + details_fields(:body)).freeze
   ROLE_APPOINTMENT_FIELDS = (DEFAULT_FIELDS + details_fields(:started_on, :ended_on, :current, :person_appointment_order)).freeze
   STEP_BY_STEP_FIELDS = (DEFAULT_FIELDS + [%i[details step_by_step_nav title], %i[details step_by_step_nav steps]]).freeze
   STEP_BY_STEP_AUTH_BYPASS_FIELDS = (STEP_BY_STEP_FIELDS + %i[auth_bypass_ids]).freeze
   TRAVEL_ADVICE_FIELDS = (DEFAULT_FIELDS + details_fields(:country, :change_description)).freeze
   WORLD_LOCATION_FIELDS = %i[content_id title schema_name locale analytics_identifier].freeze
+
+  CUSTOM_EXPANSION_FIELDS_FOR_PEOPLE = (
+    %i(
+      ordered_ministers
+      ordered_board_members
+      ordered_military_personnel
+      ordered_traffic_commissioners
+      ordered_chief_professional_officers
+      ordered_special_representatives
+    ).map do |link_type|
+      { document_type: :person, link_type: link_type, fields: PERSON_FIELDS_WITH_IMAGE }
+    end
+  ).freeze
+
   CUSTOM_EXPANSION_FIELDS_FOR_ROLES = (
     %i(
       ambassador_role
@@ -150,7 +165,8 @@ module ExpansionRules
       { document_type: :government,
         fields: GOVERNMENT_FIELDS },
     ] +
-    CUSTOM_EXPANSION_FIELDS_FOR_ROLES
+    CUSTOM_EXPANSION_FIELDS_FOR_ROLES +
+    CUSTOM_EXPANSION_FIELDS_FOR_PEOPLE
   ).freeze
 
   POSSIBLE_FIELDS_FOR_LINK_EXPANSION = DEFAULT_FIELDS +

--- a/lib/expansion_rules.rb
+++ b/lib/expansion_rules.rb
@@ -76,7 +76,7 @@ module ExpansionRules
   TAXON_FIELDS = (DEFAULT_FIELDS + %i[description details phase]).freeze
   NEED_FIELDS = (DEFAULT_FIELDS + details_fields(:role, :goal, :benefit, :met_when, :justifications)).freeze
   FINDER_FIELDS = (DEFAULT_FIELDS + details_fields(:facets)).freeze
-  PERSON_FIELDS = (DEFAULT_FIELDS + details_fields(:body)).freeze
+  PERSON_FIELDS_WITH_BODY = (DEFAULT_FIELDS + details_fields(:body)).freeze
   ROLE_FIELDS = (DEFAULT_FIELDS + details_fields(:body)).freeze
   ROLE_APPOINTMENT_FIELDS = (DEFAULT_FIELDS + details_fields(:started_on, :ended_on, :current, :person_appointment_order)).freeze
   STEP_BY_STEP_FIELDS = (DEFAULT_FIELDS + [%i[details step_by_step_nav title], %i[details step_by_step_nav steps]]).freeze
@@ -130,7 +130,7 @@ module ExpansionRules
         fields: DEFAULT_FIELDS_AND_DESCRIPTION },
       { document_type: :person,
         link_type: :person,
-        fields: PERSON_FIELDS },
+        fields: PERSON_FIELDS_WITH_BODY },
       { document_type: :role_appointment,
         fields: ROLE_APPOINTMENT_FIELDS },
       { document_type: :service_manual_topic,

--- a/lib/expansion_rules.rb
+++ b/lib/expansion_rules.rb
@@ -76,7 +76,7 @@ module ExpansionRules
   TAXON_FIELDS = (DEFAULT_FIELDS + %i[description details phase]).freeze
   NEED_FIELDS = (DEFAULT_FIELDS + details_fields(:role, :goal, :benefit, :met_when, :justifications)).freeze
   FINDER_FIELDS = (DEFAULT_FIELDS + details_fields(:facets)).freeze
-  PERSON_FIELDS_WITH_BODY = (DEFAULT_FIELDS + details_fields(:body)).freeze
+  PERSON_FIELDS = (DEFAULT_FIELDS + details_fields(:body, :image)).freeze
   PERSON_FIELDS_WITH_IMAGE = (DEFAULT_FIELDS + details_fields(:image)).freeze
   ROLE_FIELDS = (DEFAULT_FIELDS + details_fields(:body)).freeze
   ROLE_APPOINTMENT_FIELDS = (DEFAULT_FIELDS + details_fields(:started_on, :ended_on, :current, :person_appointment_order)).freeze
@@ -145,7 +145,7 @@ module ExpansionRules
         fields: DEFAULT_FIELDS_AND_DESCRIPTION },
       { document_type: :person,
         link_type: :person,
-        fields: PERSON_FIELDS_WITH_BODY },
+        fields: PERSON_FIELDS },
       { document_type: :role_appointment,
         fields: ROLE_APPOINTMENT_FIELDS },
       { document_type: :service_manual_topic,

--- a/spec/lib/expansion_rules_spec.rb
+++ b/spec/lib/expansion_rules_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe ExpansionRules do
     let(:mainstream_browser_page_fields) { default_fields + %i(description) }
     let(:need_fields) { default_fields + [%i(details role), %i(details goal), %i(details benefit), %i(details met_when), %i(details justifications)] }
     let(:finder_fields) { default_fields + [%i(details facets)] }
-    let(:person_fields) { default_fields + [%i(details body)] }
+    let(:person_with_body_fields) { default_fields + [%i(details body)] }
     let(:role_fields) { default_fields + [%i(details body)] }
     let(:role_appointment_fields) { default_fields + [%i(details started_on), %i(details ended_on), %i(details current), %i(details person_appointment_order)] }
     let(:service_manual_topic_fields) { default_fields + %i(description) }
@@ -68,7 +68,7 @@ RSpec.describe ExpansionRules do
     specify { expect(rules.expansion_fields(:placeholder_organisation)).to eq(organisation_fields) }
     specify { expect(rules.expansion_fields(:placeholder_topical_event)).to eq(default_fields) }
     specify { expect(rules.expansion_fields(:person, link_type: :people)).to eq(default_fields) }
-    specify { expect(rules.expansion_fields(:person, link_type: :person)).to eq(person_fields) }
+    specify { expect(rules.expansion_fields(:person, link_type: :person)).to eq(person_with_body_fields) }
     specify { expect(rules.expansion_fields(:role_appointment)).to eq(role_appointment_fields) }
     specify { expect(rules.expansion_fields(:service_manual_topic)).to eq(service_manual_topic_fields) }
     specify { expect(rules.expansion_fields(:topical_event)).to eq(default_fields) }

--- a/spec/lib/expansion_rules_spec.rb
+++ b/spec/lib/expansion_rules_spec.rb
@@ -48,6 +48,7 @@ RSpec.describe ExpansionRules do
     let(:need_fields) { default_fields + [%i(details role), %i(details goal), %i(details benefit), %i(details met_when), %i(details justifications)] }
     let(:finder_fields) { default_fields + [%i(details facets)] }
     let(:person_with_body_fields) { default_fields + [%i(details body)] }
+    let(:person_with_image_fields) { default_fields + [%i(details image)] }
     let(:role_fields) { default_fields + [%i(details body)] }
     let(:role_appointment_fields) { default_fields + [%i(details started_on), %i(details ended_on), %i(details current), %i(details person_appointment_order)] }
     let(:service_manual_topic_fields) { default_fields + %i(description) }
@@ -72,6 +73,13 @@ RSpec.describe ExpansionRules do
     specify { expect(rules.expansion_fields(:role_appointment)).to eq(role_appointment_fields) }
     specify { expect(rules.expansion_fields(:service_manual_topic)).to eq(service_manual_topic_fields) }
     specify { expect(rules.expansion_fields(:topical_event)).to eq(default_fields) }
+
+    specify { expect(rules.expansion_fields(:person, link_type: :ordered_ministers)).to eq(person_with_image_fields) }
+    specify { expect(rules.expansion_fields(:person, link_type: :ordered_board_members)).to eq(person_with_image_fields) }
+    specify { expect(rules.expansion_fields(:person, link_type: :ordered_military_personnel)).to eq(person_with_image_fields) }
+    specify { expect(rules.expansion_fields(:person, link_type: :ordered_traffic_commissioners)).to eq(person_with_image_fields) }
+    specify { expect(rules.expansion_fields(:person, link_type: :ordered_chief_professional_officers)).to eq(person_with_image_fields) }
+    specify { expect(rules.expansion_fields(:person, link_type: :ordered_special_representatives)).to eq(person_with_image_fields) }
 
     specify { expect(rules.expansion_fields(:ambassador_role)).to eq(role_fields) }
     specify { expect(rules.expansion_fields(:board_member_role)).to eq(role_fields) }

--- a/spec/lib/expansion_rules_spec.rb
+++ b/spec/lib/expansion_rules_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe ExpansionRules do
     let(:mainstream_browser_page_fields) { default_fields + %i(description) }
     let(:need_fields) { default_fields + [%i(details role), %i(details goal), %i(details benefit), %i(details met_when), %i(details justifications)] }
     let(:finder_fields) { default_fields + [%i(details facets)] }
-    let(:person_with_body_fields) { default_fields + [%i(details body)] }
+    let(:person_fields) { default_fields + [%i(details body), %i(details image)] }
     let(:person_with_image_fields) { default_fields + [%i(details image)] }
     let(:role_fields) { default_fields + [%i(details body)] }
     let(:role_appointment_fields) { default_fields + [%i(details started_on), %i(details ended_on), %i(details current), %i(details person_appointment_order)] }
@@ -69,7 +69,7 @@ RSpec.describe ExpansionRules do
     specify { expect(rules.expansion_fields(:placeholder_organisation)).to eq(organisation_fields) }
     specify { expect(rules.expansion_fields(:placeholder_topical_event)).to eq(default_fields) }
     specify { expect(rules.expansion_fields(:person, link_type: :people)).to eq(default_fields) }
-    specify { expect(rules.expansion_fields(:person, link_type: :person)).to eq(person_with_body_fields) }
+    specify { expect(rules.expansion_fields(:person, link_type: :person)).to eq(person_fields) }
     specify { expect(rules.expansion_fields(:role_appointment)).to eq(role_appointment_fields) }
     specify { expect(rules.expansion_fields(:service_manual_topic)).to eq(service_manual_topic_fields) }
     specify { expect(rules.expansion_fields(:topical_event)).to eq(default_fields) }


### PR DESCRIPTION
These links are used in organisation pages and they will sometimes need to render the image of the person.

Related to https://github.com/alphagov/govuk-content-schemas/pull/983.

[Trello Card](https://trello.com/c/NRhnejWA/1942-5-send-links-to-people-instead-of-details-hash-in-the-organisations-in-whitehall)