### PR TITLE
Add person to ministers links

### DIFF
--- a/lib/expansion_rules.rb
+++ b/lib/expansion_rules.rb
@@ -31,6 +31,7 @@ module ExpansionRules
     %i[role_appointments person],
     %i[role_appointments role],
     %i[role_appointments role ordered_parent_organisations],
+    %i[ministers role_appointments person],
   ].freeze
 
   REVERSE_LINKS = {


### PR DESCRIPTION
This expands the role appointments so we get the details of the person without needing to make a separate request to the content store for each role.  The downside is that the content item becomes massive: 3MB.  It includes the current *and past* appointments!

In the future we might want to investigate making the current role appointment and previous role appointments different link types somehow.

We get this sort of thing:

```
      "ministers" : [
         {
            "web_url" : "https://www.integration.publishing.service.gov.uk/government/ministers/prime-minister",
            "public_updated_at" : "2018-11-05T08:52:39Z",
            "title" : "Prime Minister",
            "withdrawn" : false,
            "locale" : "en",
            "api_url" : "https://www.integration.publishing.service.gov.uk/api/content/government/ministers/prime-minister",
            "details" : {
               "body" : "<p>The Prime Minister is the leader of Her Majesty’s Government and is ultimately responsible for the policy and decisions of the government.</p>\n\n<p>As leader of the UK government the Prime Minister also:</p>\n\n<ul>\n  <li>oversees the <a href
            },
            "links" : {
               "role_appointments" : [
                  {
                     "locale" : "en",
                     "title" : "The Rt Hon David Cameron - Prime Minister",
                     "withdrawn" : false,
                     "public_updated_at" : "2019-11-07T15:02:24Z",
                     "schema_name" : "role_appointment",
                     "document_type" : "role_appointment",
                     "content_id" : "614abfd2-a26b-4df9-af6c-179e0fe1d99d",
                     "links" : {
                        "person" : [
                           {
                              "public_updated_at" : "2019-11-07T15:02:24Z",
                              "web_url" : "https://www.integration.publishing.service.gov.uk/government/people/david-cameron",
                              "api_url" : "https://www.integration.publishing.service.gov.uk/api/content/government/people/david-cameron",
                              "locale" : "en",
                              "title" : "The Rt Hon David Cameron",
                              "withdrawn" : false,
                              "schema_name" : "person",
                              "document_type" : "person",
                              "content_id" : "8529186b-c0f1-11e4-8223-005056011aef",
                              "links" : {},
                              "details" : {
                                 "body" : "<p>David Cameron was Prime Minister from May 2010 until July 2016. David led a Conservative and Liberal Democrat coalition government from 2010 until 2015 and continued as Prime Minister from May 2015 leading a Conservative gover
                              },
                              "base_path" : "/government/people/david-cameron",
                              "api_path" : "/api/content/government/people/david-cameron"
                           }
                        ]
                     },
                     "details" : {
                        "person_appointment_order" : 1,
                        "ended_on" : "2016-07-13T00:00:00+01:00",
                        "started_on" : "2010-05-12T00:00:00+01:00",
                        "current" : false
                     }
                  },
```

---

[Trello card](https://trello.com/c/i1ffrXiZ/1913-5-link-ministers-to-the-government-ministers-content-item)