### PR TITLE
Expand role information for ordered ministers

### DIFF
--- a/lib/expansion_rules.rb
+++ b/lib/expansion_rules.rb
@@ -32,6 +32,7 @@ module ExpansionRules
     %i[role_appointments role],
     %i[role_appointments role ordered_parent_organisations],
     %i[ministers role_appointments person],
+    %i[ordered_ministers role_appointments role],
   ].freeze
 
   REVERSE_LINKS = {


### PR DESCRIPTION
We need the role information to render the ministers section of organisation pages.

[Trello Card](https://trello.com/c/NRhnejWA/1942-5-send-links-to-people-instead-of-details-hash-in-the-organisations-in-whitehall)