### PR TITLE
Include role_payment_type in link expansion

### DIFF
--- a/lib/expansion_rules.rb
+++ b/lib/expansion_rules.rb
@@ -80,7 +80,7 @@ module ExpansionRules
   FINDER_FIELDS = (DEFAULT_FIELDS + details_fields(:facets)).freeze
   PERSON_FIELDS = (DEFAULT_FIELDS + details_fields(:body, :image)).freeze
   PERSON_FIELDS_WITH_IMAGE = (DEFAULT_FIELDS + details_fields(:image)).freeze
-  ROLE_FIELDS = (DEFAULT_FIELDS + details_fields(:body)).freeze
+  ROLE_FIELDS = (DEFAULT_FIELDS + details_fields(:body, :role_payment_type)).freeze
   ROLE_APPOINTMENT_FIELDS = (DEFAULT_FIELDS + details_fields(:started_on, :ended_on, :current, :person_appointment_order)).freeze
   STEP_BY_STEP_FIELDS = (DEFAULT_FIELDS + [%i[details step_by_step_nav title], %i[details step_by_step_nav steps]]).freeze
   STEP_BY_STEP_AUTH_BYPASS_FIELDS = (STEP_BY_STEP_FIELDS + %i[auth_bypass_ids]).freeze

--- a/spec/lib/expansion_rules_spec.rb
+++ b/spec/lib/expansion_rules_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe ExpansionRules do
     let(:finder_fields) { default_fields + [%i(details facets)] }
     let(:person_fields) { default_fields + [%i(details body), %i(details image)] }
     let(:person_with_image_fields) { default_fields + [%i(details image)] }
-    let(:role_fields) { default_fields + [%i(details body)] }
+    let(:role_fields) { default_fields + [%i(details body), %i(details role_payment_type)] }
     let(:role_appointment_fields) { default_fields + [%i(details started_on), %i(details ended_on), %i(details current), %i(details person_appointment_order)] }
     let(:service_manual_topic_fields) { default_fields + %i(description) }
     let(:step_by_step_fields) { default_fields + [%i(details step_by_step_nav title), %i(details step_by_step_nav steps)] }


### PR DESCRIPTION
We need this to render the organisation pages from the expanded links: 

https://github.com/alphagov/collections/blob/2aa433770a7473143d780c68c8bb499cf8d9aa44/app/presenters/organisations/people_presenter.rb#L103

[Trello Card](https://trello.com/c/NRhnejWA/1942-5-send-links-to-people-instead-of-details-hash-in-the-organisations-in-whitehall)