### PR TITLE
Expand roles for other people link types

### DIFF
--- a/lib/expansion_rules.rb
+++ b/lib/expansion_rules.rb
@@ -32,7 +32,12 @@ module ExpansionRules
     %i[role_appointments role],
     %i[role_appointments role ordered_parent_organisations],
     %i[ministers role_appointments person],
+    %i[ordered_board_members role_appointments role],
+    %i[ordered_chief_professional_officers role_appointments role],
+    %i[ordered_military_personnel role_appointments role],
     %i[ordered_ministers role_appointments role],
+    %i[ordered_special_representatives role_appointments role],
+    %i[ordered_traffic_commissioners role_appointments role],
   ].freeze
 
   REVERSE_LINKS = {


### PR DESCRIPTION
I originally thought we only needed the role information for ministers, but it turns out that we also need it for the other people link types.

[Trello Card](https://trello.com/c/NRhnejWA/1942-5-send-links-to-people-instead-of-details-hash-in-the-organisations-in-whitehall)