### PR TITLE
Include description with coronavirus links

### DIFF
--- a/lib/expansion_rules.rb
+++ b/lib/expansion_rules.rb
@@ -171,6 +171,8 @@ module_function
         fields: WORLD_LOCATION_FIELDS },
       { document_type: :government,
         fields: GOVERNMENT_FIELDS },
+      { document_type: :coronavirus_landing_page,
+        fields: DEFAULT_FIELDS_AND_DESCRIPTION },
     ] +
     CUSTOM_EXPANSION_FIELDS_FOR_ROLES +
     CUSTOM_EXPANSION_FIELDS_FOR_PEOPLE


### PR DESCRIPTION
We use this in subtitles for links from /coronavirus to its child pages.

https://trello.com/c/rBSB0bIQ/281-automatically-add-the-hub-page-metadescription-below-hub-links-in-the-accordion