### PR TITLE
Only present auth_bypass_ids of draft editions

### DIFF
--- a/app/presenters/edition_presenter.rb
+++ b/app/presenters/edition_presenter.rb
@@ -67,7 +67,7 @@ module Presenters
     attr_reader :draft, :edition
 
     def auth_bypass_ids
-      return {} unless draft
+      return {} if edition.state != "draft"
 
       { auth_bypass_ids: edition.auth_bypass_ids || [] }
     end

--- a/spec/presenters/edition_presenter_spec.rb
+++ b/spec/presenters/edition_presenter_spec.rb
@@ -128,6 +128,7 @@ RSpec.describe Presenters::EditionPresenter do
           :live_edition,
           base_path: base_path,
           details: details,
+          auth_bypass_ids: [SecureRandom.uuid],
         )
       end
       let!(:link_set) { create(:link_set, content_id: edition.document.content_id) }
@@ -138,6 +139,13 @@ RSpec.describe Presenters::EditionPresenter do
 
       it "adds the supertypes" do
         expect(result["user_journey_document_supertype"]).to be_present
+      end
+
+      it "doesn't include auth_bypass_ids when presenting to draft content store" do
+        presented = described_class.new(edition, draft: true)
+                                   .for_content_store(payload_version)
+
+        expect(presented).not_to include(:auth_bypass_ids)
       end
     end
 


### PR DESCRIPTION
Trello: https://trello.com/c/IQ26eiaW/240-make-content-publisher-use-changing-auth-bypass-tokens

This changes the approach used for presenting editions to the draft
content store to only share auth_bypass_ids of editions that are in a
draft state. This is a change from the approach where live editions
share auth_bypass_ids to the draft content store.

This change has been introduced following an incident where Leicester
City Council tweeted out a link to draft content with an auth_bypass_id,
even though that content was published people could still view that
content on the draft stack and were surprised. Arguably this would have
likely been resolved much quicker if that link instead took people to a
login screen and thus appeared broken for everyone.

There was previous value to keeping the auth_bypass_ids available on a
live edition as this allowed any fact checkers to continue to have
working links even after the content was published (in a scenario where
the content was published pending a review).

In hinsight of the incident I've concluded that the risks of a leaked
link situation trump the hypothetical needs of slow fact checking and
have made this change.