### PR TITLE
Delete auth_bypass_ids when content goes live

### DIFF
--- a/app/commands/v2/publish.rb
+++ b/app/commands/v2/publish.rb
@@ -31,7 +31,7 @@ module Commands
         set_update_type
         set_timestamps
         edition.publish
-        remove_access_limit
+        remove_draft_access
         create_publish_action
         create_change_note if payload[:update_type].present?
       end
@@ -56,7 +56,8 @@ module Commands
         @access_limit ||= AccessLimit.find_by(edition: edition)
       end
 
-      def remove_access_limit
+      def remove_draft_access
+        edition.update!(auth_bypass_ids: []) if edition.auth_bypass_ids.any?
         access_limit.try(:destroy)
       end
 

--- a/app/commands/v2/publish.rb
+++ b/app/commands/v2/publish.rb
@@ -45,13 +45,9 @@ module Commands
         ChangeNote.create_from_edition(payload, edition)
       end
 
-      def access_limit
-        @access_limit ||= AccessLimit.find_by(edition: edition)
-      end
-
       def remove_draft_access
         edition.update!(auth_bypass_ids: []) if edition.auth_bypass_ids.any?
-        access_limit.try(:destroy)
+        AccessLimit.where(edition: edition).delete_all
       end
 
       def validate

--- a/app/commands/v2/unpublish.rb
+++ b/app/commands/v2/unpublish.rb
@@ -31,7 +31,7 @@ module Commands
 
       def reset_draft_access
         edition.update!(auth_bypass_ids: []) if edition.auth_bypass_ids.any?
-        AccessLimit.find_by(edition: edition).try(:destroy)
+        AccessLimit.where(edition: edition).delete_all
       end
 
       def valid_unpublishing_type?

--- a/app/commands/v2/unpublish.rb
+++ b/app/commands/v2/unpublish.rb
@@ -6,7 +6,7 @@ module Commands
 
         previous.supersede if previous_edition_should_be_superseded?
         transition_state
-        AccessLimit.find_by(edition: edition).try(:destroy)
+        reset_draft_access
 
         after_transaction_commit do
           send_downstream
@@ -27,6 +27,11 @@ module Commands
       def transition_state
         raise_invalid_unpublishing_type unless valid_unpublishing_type?
         unpublish
+      end
+
+      def reset_draft_access
+        edition.update!(auth_bypass_ids: []) if edition.auth_bypass_ids.any?
+        AccessLimit.find_by(edition: edition).try(:destroy)
       end
 
       def valid_unpublishing_type?

--- a/app/presenters/edition_presenter.rb
+++ b/app/presenters/edition_presenter.rb
@@ -67,7 +67,7 @@ module Presenters
     attr_reader :draft, :edition
 
     def auth_bypass_ids
-      return {} if edition.state != "draft"
+      return {} unless draft
 
       { auth_bypass_ids: edition.auth_bypass_ids || [] }
     end

--- a/spec/commands/v2/publish_spec.rb
+++ b/spec/commands/v2/publish_spec.rb
@@ -549,6 +549,18 @@ RSpec.describe Commands::V2::Publish do
       end
     end
 
+    context "when the draft edition has auth_bypass_ids" do
+      before do
+        draft_item.update!(auth_bypass_ids: [SecureRandom.uuid])
+      end
+
+      it "resets the auth_bypass_ids" do
+        expect { described_class.call(payload) }
+          .to change { draft_item.reload.auth_bypass_ids }
+          .to([])
+      end
+    end
+
     context "when given an invalid update_type" do
       before do
         payload[:update_type] = "invalid"

--- a/spec/commands/v2/publish_spec.rb
+++ b/spec/commands/v2/publish_spec.rb
@@ -133,6 +133,9 @@ RSpec.describe Commands::V2::Publish do
       end
 
       it "updates the dependencies" do
+        expect(DownstreamDraftWorker)
+          .to receive(:perform_async_in_queue)
+          .with("downstream_high", a_hash_including(update_dependencies: true))
         expect(DownstreamLiveWorker)
           .to receive(:perform_async_in_queue)
           .with("downstream_high", a_hash_including(update_dependencies: true))
@@ -194,6 +197,10 @@ RSpec.describe Commands::V2::Publish do
       end
 
       it "updates the dependencies" do
+        expect(DownstreamDraftWorker)
+          .to receive(:perform_async_in_queue)
+          .with("downstream_high", a_hash_including(update_dependencies: true))
+
         expect(DownstreamLiveWorker)
           .to receive(:perform_async_in_queue)
           .with("downstream_high", a_hash_including(update_dependencies: true))
@@ -233,24 +240,15 @@ RSpec.describe Commands::V2::Publish do
       end
 
       it "doesn't updates the dependencies" do
+        expect(DownstreamDraftWorker)
+          .to receive(:perform_async_in_queue)
+          .with("downstream_high", a_hash_including(update_dependencies: false))
+
         expect(DownstreamLiveWorker)
           .to receive(:perform_async_in_queue)
           .with("downstream_high", a_hash_including(update_dependencies: false))
 
         described_class.call(payload)
-      end
-
-      context "with an access limit" do
-        before do
-          create(:access_limit, edition: draft_item)
-        end
-
-        it "sends to the draft downstream without updating dependencies" do
-          expect(DownstreamDraftWorker).to receive(:perform_async_in_queue)
-            .with("downstream_high", a_hash_including(update_dependencies: false))
-
-          described_class.call(payload)
-        end
       end
     end
 

--- a/spec/commands/v2/unpublish_spec.rb
+++ b/spec/commands/v2/unpublish_spec.rb
@@ -289,6 +289,18 @@ RSpec.describe Commands::V2::Unpublish do
           end
         end
 
+        context "where there is auth_bypass_ids on the draft edition" do
+          before do
+            draft_edition.update!(auth_bypass_ids: [SecureRandom.uuid])
+          end
+
+          it "removes the auth_bypass_ids" do
+            expect { described_class.call(payload_with_allow_draft) }
+              .to change { draft_edition.reload.auth_bypass_ids }
+              .to([])
+          end
+        end
+
         it "sends an unpublishing to the live content store" do
           expect(DownstreamLiveWorker).to receive(:perform_async_in_queue)
             .with(

--- a/spec/presenters/edition_presenter_spec.rb
+++ b/spec/presenters/edition_presenter_spec.rb
@@ -128,7 +128,6 @@ RSpec.describe Presenters::EditionPresenter do
           :live_edition,
           base_path: base_path,
           details: details,
-          auth_bypass_ids: [SecureRandom.uuid],
         )
       end
       let!(:link_set) { create(:link_set, content_id: edition.document.content_id) }
@@ -139,13 +138,6 @@ RSpec.describe Presenters::EditionPresenter do
 
       it "adds the supertypes" do
         expect(result["user_journey_document_supertype"]).to be_present
-      end
-
-      it "doesn't include auth_bypass_ids when presenting to draft content store" do
-        presented = described_class.new(edition, draft: true)
-                                   .for_content_store(payload_version)
-
-        expect(presented).not_to include(:auth_bypass_ids)
       end
     end
 


### PR DESCRIPTION
Trello: https://trello.com/c/IQ26eiaW/240-make-content-publisher-use-changing-auth-bypass-tokens

This is a follow up to https://github.com/alphagov/publishing-api/pull/1825 which wasn't sufficient to achieve the aim of removing auth_bypass_ids when content is published live. This didn't work for 2 reasons: 1) the draft content store wasn't updated on a publish and 2) if it was sent, because content store uses an upsert, the absence of a field doesn't delete it.

To resolve this the auth_bypass_ids follows the same pattern as access limiting by removing the data at the point of going live and then always updating the draft content store - which is something we should be doing anyway to set the correct timestamps.