### PR TITLE
Automatically discard path reservations for unused drafts

### DIFF
--- a/app/commands/v2/discard_draft.rb
+++ b/app/commands/v2/discard_draft.rb
@@ -49,8 +49,8 @@ module Commands
       end
 
       def delete_supporting_objects
-        AccessLimit.find_by(edition: draft).try(:destroy)
-        ChangeNote.where(edition: draft).destroy_all
+        AccessLimit.where(edition: draft).delete_all
+        ChangeNote.where(edition: draft).delete_all
       end
 
       def increment_lock_version

--- a/app/commands/v2/discard_draft.rb
+++ b/app/commands/v2/discard_draft.rb
@@ -7,26 +7,22 @@ module Commands
         check_version_and_raise_if_conflicting(document, payload[:previous_version])
 
         save_document_type
-        delete_supporting_objects(document.draft)
+        delete_supporting_objects
         delete_draft_from_database
         increment_lock_version
 
-        after_transaction_commit do
-          downstream_discard_draft(
-            document.draft.base_path,
-            document.content_id,
-            document.locale,
-          )
-        end
+        after_transaction_commit { downstream_discard_draft }
 
-        Action.create_discard_draft_action(document.draft, document.locale, event)
-        Success.new(content_id: document.content_id)
+        Action.create_discard_draft_action(draft, locale, event)
+        Success.new(content_id: content_id)
       end
 
     private
 
+      delegate :draft, :content_id, :locale, to: :document
+
       def raise_error_if_missing_draft!
-        return if document.draft.present?
+        return if draft.present?
 
         code = document.published_or_unpublished.present? ? 422 : 404
         message = "There is not a draft edition of this document to discard"
@@ -35,15 +31,15 @@ module Commands
       end
 
       def delete_draft_from_database
-        document.draft.destroy
+        draft.destroy
       end
 
-      def downstream_discard_draft(path_used, content_id, locale)
+      def downstream_discard_draft
         return unless downstream
 
         DownstreamDiscardDraftWorker.perform_async_in_queue(
           DownstreamDiscardDraftWorker::HIGH_QUEUE,
-          base_path: path_used,
+          base_path: draft.base_path,
           content_id: content_id,
           locale: locale,
           update_dependencies: true,
@@ -52,9 +48,9 @@ module Commands
         )
       end
 
-      def delete_supporting_objects(edition)
-        AccessLimit.find_by(edition: edition).try(:destroy)
-        ChangeNote.where(edition: edition).destroy_all
+      def delete_supporting_objects
+        AccessLimit.find_by(edition: draft).try(:destroy)
+        ChangeNote.where(edition: draft).destroy_all
       end
 
       def increment_lock_version
@@ -74,7 +70,7 @@ module Commands
       # may have already been destroyed by the time the worker runs, and it
       # wouldn't be able to access the destroyed edition's document type.
       def save_document_type
-        @document_type = document.draft.document_type
+        @document_type = draft.document_type
       end
     end
   end

--- a/app/commands/v2/discard_draft.rb
+++ b/app/commands/v2/discard_draft.rb
@@ -51,6 +51,18 @@ module Commands
       def delete_supporting_objects
         AccessLimit.where(edition: draft).delete_all
         ChangeNote.where(edition: draft).delete_all
+        delete_path_reservation
+      end
+
+      def delete_path_reservation
+        return unless draft.base_path
+        return if Edition.exists?(base_path: draft.base_path,
+                                  content_store: :live,
+                                  publishing_app: draft.publishing_app)
+
+        PathReservation
+          .where(base_path: draft.base_path, publishing_app: draft.publishing_app)
+          .delete_all
       end
 
       def increment_lock_version

--- a/docs/api.md
+++ b/docs/api.md
@@ -164,6 +164,8 @@ presented edition and [warnings](#warnings).
 
 - If a `base_path` is provided it is reserved for use of the given
   `publishing_app`.
+- If this is changing the `base_path` of a draft edition the previous
+  `base_path` reserved will be discarded.
 - Any draft editions for different documents that have a matching `base_path`
   and have a document_type of "coming soon", "gone", "redirect" or
   "unpublishing" will be deleted.

--- a/docs/api.md
+++ b/docs/api.md
@@ -353,6 +353,7 @@ the draft content store with the published item, if one exists. Uses
 ### State changes
 
 - The draft edition will be deleted from the Publishing API.
+- Any reserved paths unique to the draft edition will also be discarded.
 - The draft edition will be removed from the draft content store.
 - If a published edition exists it will be added to the draft content store.
 


### PR DESCRIPTION
This introduces the automatic removal of PathReservation models when drafts are either discarded or have their base_path changed. This has been introduced to replace a manual process where developers need to remove PathReservation models manually when a publisher tries to create a draft of a document in Content Publisher that they previously discarded in Whitehall.

The approach taken here is to assume that editing the base_path of a draft edition or discarding a draft edition is an implicit giving up of a path reservation when it is not also used for a live edition. This is to reflect that almost all path reservations are created implicitly as part of a put content rather than explicitly via a call to a specific endpoint.

The motivation for adding this code to Publishing API was because I didn't want to create similar code in a number of publishing applications. We currently have [code to manage this](https://github.com/alphagov/content-publisher/blob/d41fabb5ce00f137ed6b409c130c51c499f91b9f/app/services/discard_draft_edition_service.rb#L14) in Content Publisher and would need similar in Whitehall, which I [initially coded](https://github.com/alphagov/whitehall/tree/delete-path-reservations-on-discard-draft) before deciding it would be better placed in Publishing API.

## The good

- Support should no longer receive tickets being unable to move working on content from Whitehall to Content Publisher (and vice-versa)
- Can remove code from Content Publisher
- Handling this in Publishing API can be done simpler than publishing apps as it can be done implicitly in existing requests whereas publishing apps need new requests for this
- We'll stop building up such a big pile of URLs that are reserved and never going to be used (currently have 35,000 reserved without a corresponding edition)

## The bad

- This complicates the path reservation system further. The system itself is confusing because it can be populated both implicitly (through put content) or explicitly (through path reservation endpoint) without distinguishing between them. This change thus makes an implicit assumption that discarding means no longer wanting a path which could be surprising if you're using path reservations explicitly.

## The ugly

- The tweaking the command classes and their tests was pretty hairy, it's all rather fragmented. I did what I could without wanting to do any wider rewriting.

More info in the commits.