### PR TITLE
Add rake task to clean up invalid About page drafts for World Orgs

### DIFF
--- a/lib/tasks/data_hygiene.rake
+++ b/lib/tasks/data_hygiene.rake
@@ -37,4 +37,23 @@ namespace :data_hygiene do
       puts "rake 'represent_downstream:content_id[#{args[:content_id]}]'"
     end
   end
+
+  desc "Removes invalid about page drafts from world organisations that can prevent editing"
+  task remove_invalid_worldorg_drafts: :environment do
+    about_pages = Edition
+     .where(document_type: "about", state: "draft")
+     .select { |edition| edition.base_path =~ /\A\/world\/organisations\/[^\/]+\z/ }
+     .map { |edition| [edition.document.content_id, edition.document.locale] }
+
+    puts "Found #{about_pages.size} invalid draft Worldwide Organisation editions to remove"
+    about_pages.each do |content_id, locale|
+      puts "Removing draft edition #{content_id}"
+      Commands::V2::DiscardDraft.call(
+        {
+          content_id: content_id,
+          locale: locale,
+        },
+      )
+    end
+  end
 end


### PR DESCRIPTION
Issues in how Whitehall and Publishing API communicate can leave invalid
draft pages in the P-API that prevents editing of the valid pages. This
rake task can be run to clean up the invalid pages, allowing edits again
until a more permanent fix is implemented.

Further information:
The original implementation, since removed: https://github.com/alphagov/whitehall/pull/4756
Trello: https://trello.com/c/ONpclO4S/2064-5-fix-gdsapi-error-gdsapihttpunprocessableentity-adminworldwideofficescontroller
Trello 2: https://trello.com/c/w2Zew6It/922-investigate-redirecting-about-pages-for-worldwide-organisations-in-whitehall

