### PR TITLE
Add missing PR template for this repo

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,7 @@
+:warning: This application is Continuously Deployed: :warning:
+
+- Merged changes are automatically deployed to staging and production.
+
+- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.
+
+- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/publishing-api), after merging.


### PR DESCRIPTION
https://trello.com/c/9HyK1pht/174-consolidate-cd-retro-outcomes-into-cards-or-the-draft-rfc

Somehow this got missed when enabling CD for this app.

## Template preview

:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/publishing-api), after merging.