### PR TITLE
Add seniority to role link expansion rules

### DIFF
--- a/lib/expansion_rules.rb
+++ b/lib/expansion_rules.rb
@@ -83,6 +83,7 @@ module_function
   TAXON_FIELDS = (DEFAULT_FIELDS + %i[description details phase]).freeze
   NEED_FIELDS = (DEFAULT_FIELDS + details_fields(:role, :goal, :benefit, :met_when, :justifications)).freeze
   FINDER_FIELDS = (DEFAULT_FIELDS + details_fields(:facets)).freeze
+  MINISTERIAL_ROLE_FIELDS = (DEFAULT_FIELDS + details_fields(:body, :role_payment_type, :seniority)).freeze
   PERSON_FIELDS = (DEFAULT_FIELDS + details_fields(:body, :image)).freeze
   PERSON_FIELDS_WITH_IMAGE = (DEFAULT_FIELDS + details_fields(:image)).freeze
   ROLE_FIELDS = (DEFAULT_FIELDS + details_fields(:body, :role_payment_type)).freeze
@@ -116,7 +117,6 @@ module_function
       governor_role
       high_commissioner_role
       military_role
-      ministerial_role
       special_representative_role
       traffic_commissioner_role
       worldwide_office_staff_role
@@ -173,6 +173,8 @@ module_function
         fields: GOVERNMENT_FIELDS },
       { document_type: :coronavirus_landing_page,
         fields: DEFAULT_FIELDS_AND_DESCRIPTION },
+      { document_type: :ministerial_role,
+        fields: MINISTERIAL_ROLE_FIELDS },
     ] +
     CUSTOM_EXPANSION_FIELDS_FOR_ROLES +
     CUSTOM_EXPANSION_FIELDS_FOR_PEOPLE

--- a/spec/lib/expansion_rules_spec.rb
+++ b/spec/lib/expansion_rules_spec.rb
@@ -47,6 +47,7 @@ RSpec.describe ExpansionRules do
     let(:mainstream_browser_page_fields) { default_fields + %i[description] }
     let(:need_fields) { default_fields + [%i[details role], %i[details goal], %i[details benefit], %i[details met_when], %i[details justifications]] }
     let(:finder_fields) { default_fields + [%i[details facets]] }
+    let(:ministerial_role_fields) { role_fields + [%i[details seniority]] }
     let(:person_fields) { default_fields + [%i[details body], %i[details image]] }
     let(:person_with_image_fields) { default_fields + [%i[details image]] }
     let(:role_fields) { default_fields + [%i[details body], %i[details role_payment_type]] }
@@ -81,6 +82,8 @@ RSpec.describe ExpansionRules do
     specify { expect(rules.expansion_fields(:person, link_type: :ordered_chief_professional_officers)).to eq(person_with_image_fields) }
     specify { expect(rules.expansion_fields(:person, link_type: :ordered_special_representatives)).to eq(person_with_image_fields) }
 
+    specify { expect(rules.expansion_fields(:ministerial_role)).to eq(ministerial_role_fields) }
+
     specify { expect(rules.expansion_fields(:ambassador_role)).to eq(role_fields) }
     specify { expect(rules.expansion_fields(:board_member_role)).to eq(role_fields) }
     specify { expect(rules.expansion_fields(:chief_professional_officer_role)).to eq(role_fields) }
@@ -90,7 +93,6 @@ RSpec.describe ExpansionRules do
     specify { expect(rules.expansion_fields(:governor_role)).to eq(role_fields) }
     specify { expect(rules.expansion_fields(:high_commissioner_role)).to eq(role_fields) }
     specify { expect(rules.expansion_fields(:military_role)).to eq(role_fields) }
-    specify { expect(rules.expansion_fields(:ministerial_role)).to eq(role_fields) }
     specify { expect(rules.expansion_fields(:special_representative_role)).to eq(role_fields) }
     specify { expect(rules.expansion_fields(:traffic_commissioner_role)).to eq(role_fields) }
     specify { expect(rules.expansion_fields(:worldwide_office_staff_role)).to eq(role_fields) }


### PR DESCRIPTION
Part of the work to migrate rendering of the government/ministers page
from whitehall to collections. This change is necessary so collections
can order the list of ministers correctly based on `seniority`.

More info here: https://trello.com/c/T6u4LjxS/2062-3-add-sorting-information-to-ministers-content-item

And here: https://trello.com/c/loAlkIp7/1715-8-migrate-government-ministers-to-collections

:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/publishing-api), after merging.
