### PR TITLE
Better support publishing apps changing edition locales

### DIFF
--- a/spec/commands/v2/put_content_spec.rb
+++ b/spec/commands/v2/put_content_spec.rb
@@ -340,6 +340,23 @@ RSpec.describe Commands::V2::PutContent do
       end
     end
 
+    context "when a draft does exist with a different locale" do
+      let(:en_document) { create(:document, content_id: content_id) }
+      let!(:en_edition) do
+        create(:draft_edition, base_path: base_path, document: en_document)
+      end
+
+      it "replaces the old draft with the new one" do
+        expect {
+          described_class.call(payload.merge(locale: "cy"))
+        }.not_to raise_error
+
+        expect {
+          Edition.find(en_edition.id)
+        }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+
     context "field doesn't change between drafts" do
       it "doesn't update the dependencies" do
         expect(DownstreamDraftWorker).to receive(:perform_async_in_queue)


### PR DESCRIPTION
Previously, if an English draft existed, and a publishing app sent a
Welsh draft for the same content_id/base_path, the Publishing API
would reject this as it conflicts with the existing English draft.

I think the intent is unambiguous here, the new draft should replace
the old one. This change makes that happen.

I'm looking at this in particular, as some content in Publisher has
the wrong locale, and this change to the Publishing API will make
fixing the locale for this affected content easier.

:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/publishing-api), after merging.
