### PR TITLE
Better facilitate changing the locale of published content

### DIFF
--- a/app/commands/v2/publish.rb
+++ b/app/commands/v2/publish.rb
@@ -18,6 +18,7 @@ module Commands
         unless edition.pathless?
           redirect_old_base_path
           clear_published_items_of_same_locale_and_base_path
+          clear_published_item_of_different_locale_but_matching_base_path
         end
 
         set_publishing_request_id
@@ -150,6 +151,28 @@ module Commands
           callbacks: callbacks,
           nested: true,
         )
+      end
+
+      def clear_published_item_of_different_locale_but_matching_base_path
+        return unless edition.base_path
+
+        published_edition_for_different_locale = Edition.with_document.where(
+          documents: {
+            content_id: document.content_id,
+          },
+          state: :published,
+          base_path: edition.base_path,
+        ).where.not(
+          documents: {
+            locale: document.locale,
+          },
+        ).first
+
+        return unless published_edition_for_different_locale
+
+        # This enables changing the locale of some content where a
+        # published edition for the previous locale still exists.
+        published_edition_for_different_locale.substitute
       end
 
       def set_timestamps

--- a/spec/commands/v2/publish_spec.rb
+++ b/spec/commands/v2/publish_spec.rb
@@ -320,6 +320,32 @@ RSpec.describe Commands::V2::Publish do
       end
     end
 
+    context "that has a different locale" do
+      let!(:live_edition) do
+        create(
+          :live_edition,
+          document: document,
+          base_path: draft_item.base_path,
+        )
+      end
+
+      let!(:cy_document) do
+        create(:document, content_id: draft_item.document.content_id, locale: "cy")
+      end
+
+      it "replaces the old draft with the new one" do
+        draft_item.update!(document: cy_document)
+
+        expect {
+          described_class.call(
+            { content_id: cy_document.content_id, locale: "cy" },
+          )
+        }.not_to raise_error
+
+        expect(Edition.find(live_edition.id).state).to eq("unpublished")
+      end
+    end
+
     context "with a 'previous_version' which does not match the current lock version of the draft item" do
       before do
         payload.merge!(previous_version: 1)


### PR DESCRIPTION
Similar to 8471eba4553564a489f074b1b87fb39534003486, this commit aims
to make it possible to take some content, and change it's
locale. Because the locale is part of the document in the Publishing
API, this it turns out was rather difficult.

With this commit, it should be possible to publish a draft, where it
has a different locale to some content which shares the content id and
base path.

This is motivated by some changes in Publisher to allow changing the
locale, but should help other publishing apps as well.

:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/publishing-api), after merging.
