### PR TITLE
Upgrade to Ruby 2.7.1

### DIFF
--- a/app/commands/v2/discard_draft.rb
+++ b/app/commands/v2/discard_draft.rb
@@ -14,7 +14,7 @@ module Commands
         after_transaction_commit { downstream_discard_draft }
 
         Action.create_discard_draft_action(draft, locale, event)
-        Success.new(content_id: content_id)
+        Success.new({ content_id: content_id })
       end
 
     private

--- a/app/commands/v2/import.rb
+++ b/app/commands/v2/import.rb
@@ -60,7 +60,7 @@ module Commands
           )
         end
 
-        Success.new(content_id: payload[:content_id])
+        Success.new({ content_id: payload[:content_id] })
       end
 
     private
@@ -95,7 +95,7 @@ module Commands
           case state[:name]
           when "unpublished"
             content_item.unpublish(
-              state.slice(
+              **state.slice(
                 :type, :explanation, :alternative_path, :unpublished_at
               ),
             )

--- a/app/commands/v2/post_action.rb
+++ b/app/commands/v2/post_action.rb
@@ -37,7 +37,7 @@ module Commands
 
         unless edition
           message = "Could not find an edition to associate this action with"
-          raise_command_error(404, message, fields: {})
+          raise_command_error(404, message, { fields: {} })
         end
 
         edition

--- a/app/commands/v2/publish.rb
+++ b/app/commands/v2/publish.rb
@@ -6,7 +6,7 @@ module Commands
         publish_edition
         after_transaction_commit { send_downstream }
 
-        Success.new(content_id: content_id)
+        Success.new({ content_id: content_id })
       end
 
     private
@@ -81,10 +81,10 @@ module Commands
       def no_draft_item_exists
         if already_published?
           message = "Cannot publish an already published edition"
-          raise_command_error(409, message, fields: {})
+          raise_command_error(409, message, { fields: {}})
         else
           message = "Item with content_id #{content_id} and locale #{locale} does not exist"
-          raise_command_error(404, message, fields: {})
+          raise_command_error(404, message, { fields: {}})
         end
       end
 
@@ -93,16 +93,20 @@ module Commands
           raise_command_error(
             422,
             "update_type is required",
-            fields: {
-              update_type: ["is invalid"],
+            {
+              fields: {
+                update_type: ["is invalid"],
+              },
             },
           )
         elsif !valid_update_types.include?(update_type)
           raise_command_error(
             422,
             "An update_type of '#{update_type}' is invalid",
-            fields: {
-              update_type: ["must be one of #{valid_update_types.inspect}"],
+            {
+              fields: {
+                update_type: ["must be one of #{valid_update_types.inspect}"],
+              },
             },
           )
         end

--- a/app/commands/v2/republish.rb
+++ b/app/commands/v2/republish.rb
@@ -8,7 +8,7 @@ module Commands
         republish_edition
         after_transaction_commit { send_downstream } if downstream
 
-        Success.new(content_id: content_id)
+        Success.new({ content_id: content_id })
       end
 
     private
@@ -32,7 +32,7 @@ module Commands
 
       def no_republishable_item_exists
         message = "A live item with content_id #{content_id} and locale #{locale} does not exist"
-        raise_command_error(404, message, fields: {})
+        raise_command_error(404, message, { fields: {}})
       end
 
       def republish_edition

--- a/app/commands/v2/unpublish.rb
+++ b/app/commands/v2/unpublish.rb
@@ -19,7 +19,7 @@ module Commands
           event,
         )
 
-        Success.new(content_id: document.content_id)
+        Success.new({ content_id: document.content_id })
       end
 
     private
@@ -44,7 +44,7 @@ module Commands
 
       def raise_invalid_unpublishing_type
         message = "#{unpublishing_type} is not a valid unpublishing type"
-        raise_command_error(422, message, fields: {})
+        raise_command_error(422, message, { fields: {}})
       end
 
       def edition
@@ -54,14 +54,14 @@ module Commands
       def validate_allow_discard_draft
         if payload[:allow_draft] && payload[:discard_drafts]
           message = "allow_draft and discard_drafts cannot be used together"
-          raise_command_error(422, message, fields: {})
+          raise_command_error(422, message, { fields: {}})
         end
       end
 
       def validate_edition_presence
         if edition.blank?
           message = "Could not find an edition to unpublish"
-          raise_command_error(404, message, fields: {})
+          raise_command_error(404, message, { fields: {}})
         end
       end
 
@@ -79,7 +79,7 @@ module Commands
             )
           else
             message = "Cannot unpublish with a draft present"
-            raise_command_error(422, message, fields: {})
+            raise_command_error(422, message, { fields: {}})
           end
         end
       end
@@ -97,12 +97,12 @@ module Commands
         end
 
         edition.unpublish(
-          payload
+          **payload
             .slice(:type, :explanation, :alternative_path, :unpublished_at)
             .merge(redirects: redirects),
         )
       rescue ActiveRecord::RecordInvalid => e
-        raise_command_error(422, e.message, fields: {})
+        raise_command_error(422, e.message, { fields: {}})
       end
 
       def redirects

--- a/app/controllers/publish_intents_controller.rb
+++ b/app/controllers/publish_intents_controller.rb
@@ -9,7 +9,7 @@ class PublishIntentsController < ApplicationController
   end
 
   def destroy
-    response = Commands::DeletePublishIntent.call(base_path: base_path)
+    response = Commands::DeletePublishIntent.call({ base_path: base_path })
     render status: response.code, json: response
   end
 

--- a/lib/data_hygiene/change_note_remover.rb
+++ b/lib/data_hygiene/change_note_remover.rb
@@ -20,8 +20,8 @@ module DataHygiene
       change_note
     end
 
-    def self.call(*args)
-      new(*args).call
+    def self.call(*args, **kwargs)
+      new(*args, **kwargs).call
     end
 
     private_class_method :new

--- a/lib/whitehall_eu_exit_report.rb
+++ b/lib/whitehall_eu_exit_report.rb
@@ -2,8 +2,8 @@ require "fileutils"
 require "ostruct"
 
 class WhitehallEuExitReport
-  def self.call(*args)
-    new(*args).call
+  def self.call(**args)
+    new(**args).call
   end
 
   def initialize(path:)

--- a/spec/commands/base_command_spec.rb
+++ b/spec/commands/base_command_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe Commands::BaseCommand do
         expect(sample_rate).to eq 1
       end
 
-      expect(Commands::SlowCommand.call(foo: "bar")).to eq :foo
+      expect(Commands::SlowCommand.call({ foo: "bar" })).to eq :foo
     end
   end
 end

--- a/spec/commands/reserve_path_spec.rb
+++ b/spec/commands/reserve_path_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Commands::ReservePath do
     context "with an invalid payload" do
       it "returns a CommandError" do
         expect {
-          described_class.call(base_path: "///")
+          described_class.call({ base_path: "///" })
         }.to raise_error CommandError
       end
     end

--- a/spec/commands/v2/patch_link_set_spec.rb
+++ b/spec/commands/v2/patch_link_set_spec.rb
@@ -66,8 +66,10 @@ RSpec.describe Commands::V2::PatchLinkSet do
       )
 
       described_class.call(
-        content_id: link_set.content_id,
-        links: {},
+        {
+          content_id: link_set.content_id,
+          links: {},
+        },
       )
 
       expect(link_set.links.count).to eql(1)

--- a/spec/commands/v2/republish_spec.rb
+++ b/spec/commands/v2/republish_spec.rb
@@ -67,14 +67,14 @@ RSpec.describe Commands::V2::Republish do
       let(:edition) { create(:unpublished_edition) }
 
       it "sets the edition state to published" do
-        expect { described_class.call(content_id: edition.content_id) }
+        expect { described_class.call({ content_id: edition.content_id }) }
           .to change { edition.reload.state }
           .from("unpublished")
           .to("published")
       end
 
       it "deletes the unpublishing" do
-        expect { described_class.call(content_id: edition.content_id) }
+        expect { described_class.call({ content_id: edition.content_id }) }
           .to change { edition.reload.unpublishing }
           .to(nil)
       end
@@ -96,7 +96,7 @@ RSpec.describe Commands::V2::Republish do
       let(:edition) { create(:draft_edition) }
 
       it "raises an error" do
-        expect { described_class.call(content_id: edition.content_id) }
+        expect { described_class.call({ content_id: edition.content_id }) }
           .to raise_error(CommandError, /does not exist/)
       end
     end
@@ -111,7 +111,7 @@ RSpec.describe Commands::V2::Republish do
 
       it "doesn't call the DownstreamDraftWorker" do
         expect(DownstreamDraftWorker).not_to receive(:perform_async_in_queue)
-        described_class.call(content_id: document.content_id)
+        described_class.call({ content_id: document.content_id })
       end
     end
 

--- a/spec/integration/put_content/race_conditions_spec.rb
+++ b/spec/integration/put_content/race_conditions_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Commands::V2::PutContent do
 
     it "copes with race conditions" do
       described_class.call(payload)
-      Commands::V2::Publish.call(content_id: content_id, update_type: "minor")
+      Commands::V2::Publish.call({ content_id: content_id, update_type: "minor" })
 
       thread1 = Thread.new { described_class.call(payload) }
       thread2 = Thread.new { described_class.call(payload) }

--- a/spec/models/expanded_links_spec.rb
+++ b/spec/models/expanded_links_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe ExpandedLinks do
       }
     end
 
-    subject(:run_method) { described_class.locked_update(attributes) }
+    subject(:run_method) { described_class.locked_update(**attributes) }
 
     context "when there isn't an instance" do
       it "creates one" do

--- a/spec/queries/get_edition_ids_with_fallbacks_spec.rb
+++ b/spec/queries/get_edition_ids_with_fallbacks_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Queries::GetEditionIdsWithFallbacks do
         locale_fallback_order: locale_fallback_order,
       }
     end
-    subject { described_class.call(content_ids, options) }
+    subject { described_class.call(content_ids, **options) }
 
     it { is_expected.to be_a(Array) }
 


### PR DESCRIPTION
These are the necessary changes for Ruby 2.7.1

Since there is a script that changes all the apps' Ruby versions at once, I've left the version at 2.6.6

Still getting this warning `validators/uuid_validator.rb:33: warning: deprecated Object#=~ is called on Integer; it always returns nil`, but is fine since an integer value should always return nil in this case.


:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/publishing-api), after merging.
