### PR TITLE
Add rake task to allow updating of country names in specialist documents

### DIFF
--- a/lib/tasks/update_specialist_publisher_countries.rake
+++ b/lib/tasks/update_specialist_publisher_countries.rake
@@ -1,0 +1,35 @@
+namespace :content do
+  #See git commit log on this comment for details
+  desc "Updates a country name for specialist publications"
+  task :update_specialist_publication_countries, %i[old_country new_country] => :environment do |_, args|
+    if args.old_country.blank? || args.new_country.blank?
+      raise ArgumentError, "This task takes two arguments: the current country name and the new country name."
+    end
+
+    health = Edition.where(document_type: 'export_health_certificate')
+    puts "Attempting to update type: export_health_certificate"
+    filt_health = health.select { |h| h.details[:metadata][:destination_country].present? && h.details[:metadata][:destination_country].include?(args.old_country) }
+    filt_health.each do |doc|
+      puts "Processing #{doc.title}"
+      details = doc.details
+      met = details[:metadata]
+      met[:destination_country].map! { |c| c == args.old_country ? args.new_country : c }
+      details[:metadata] = met
+      doc.details = details
+      doc.save
+    end
+
+    interdevfund = Edition.where(document_type: 'international_development_fund')
+    puts "Attempting to update type: international_development_fund"
+    filt_fund = interdevfund.select { |h| h.details[:metadata][:location].present? && h.details[:metadata][:location].include?(args.old_country) }
+    filt_fund.each do |doc|
+      puts "Processing #{doc.title}"
+      details = doc.details
+      met = details[:metadata]
+      met[:location].map! { |c| c == args.old_country ? args.new_country : c }
+      details[:metadata] = met
+      doc.details = details
+      doc.save
+    end
+  end
+end


### PR DESCRIPTION
Turns out when the work was put in to allow updating of country names in
our database, we left a large blindspot in specialist publications. This
was found when it was reported that North Macedonia had not been set as
the correct name for the country for more than two years after the name
change.

This rake task allows the relevant documents to be updated when needed,
and should be done after changes made to relevant files in
govuk-content-schemas and specialist-publisher as seen in these two
pull requests:

https://github.com/alphagov/govuk-content-schemas/pull/1011
https://github.com/alphagov/specialist-publisher/pull/1714

:warning: This application is Continuously Deployed: :warning:

- Merged changes are automatically deployed to staging and production.

- Make sure you follow [the guidance for deployments](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) **before** you merge.

- Check your branch is being deployed in the [Release app](https://release.publishing.service.gov.uk/applications/publishing-api), after merging.
