### PR TITLE
Run rubocop, spec and verify:pact as default task

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,12 +20,13 @@ node("postgresql-9.6") {
     beforeTest: {
       setExtraEnvVars(govuk);
     },
+
     publishingE2ETests: true,
     afterTest: {
       publishCoverage(govuk);
 
       lock("publishing-api-$NODE_NAME-test") {
-        runPublishingApiPactTests(govuk);
+        publishPublishingApiPactTests(govuk);
 
         runContentStorePactTests(govuk);
       }
@@ -55,11 +56,7 @@ def publishCoverage(_govuk) {
   }
 }
 
-def runPublishingApiPactTests(_govuk) {
-  stage("Verify pact") {
-    sh "bundle exec rake pact:verify"
-  }
-
+def publishPublishingApiPactTests(_govuk) {
   stage("Publish pacts") {
     withCredentials([[$class: "UsernamePasswordMultiBinding", credentialsId: "pact-broker-ci-dev",
       usernameVariable: "PACT_BROKER_USERNAME", passwordVariable: "PACT_BROKER_PASSWORD"]]) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,17 +23,15 @@ node("postgresql-9.6") {
     publishingE2ETests: true,
     afterTest: {
       lock("publishing-api-$NODE_NAME-test") {
-        publishPublishingApiPactTests(govuk);
-
+        publishPublishingApiPactTests();
         runContentStorePactTests(govuk);
       }
     },
     brakeman: true,
-    rubyLintDiff: false,
   )
 }
 
-def publishPublishingApiPactTests(_govuk) {
+def publishPublishingApiPactTests() {
   stage("Publish pacts") {
     withCredentials([[$class: "UsernamePasswordMultiBinding", credentialsId: "pact-broker-ci-dev",
       usernameVariable: "PACT_BROKER_USERNAME", passwordVariable: "PACT_BROKER_PASSWORD"]]) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,13 +18,10 @@ node("postgresql-9.6") {
       )
     ],
     beforeTest: {
-      setExtraEnvVars(govuk);
+      govuk.setEnvar("PACT_BROKER_BASE_URL", "https://pact-broker.cloudapps.digital")
     },
-
     publishingE2ETests: true,
     afterTest: {
-      publishCoverage(govuk);
-
       lock("publishing-api-$NODE_NAME-test") {
         publishPublishingApiPactTests(govuk);
 
@@ -34,26 +31,6 @@ node("postgresql-9.6") {
     brakeman: true,
     rubyLintDiff: false,
   )
-}
-
-def setExtraEnvVars(govuk) {
-  // enable coverage reporting in tests
-  govuk.setEnvar("RCOV", "1")
-  // setup pact broker url for pact tests
-  govuk.setEnvar("PACT_BROKER_BASE_URL", "https://pact-broker.cloudapps.digital")
-}
-
-def publishCoverage(_govuk) {
-  stage("Publish coverage") {
-    publishHTML(target: [
-      allowMissing: false,
-      alwaysLinkToLastBuild: false,
-      keepAll: true,
-      reportDir: "coverage",
-      reportFiles: "index.html",
-      reportName: "Coverage Report"
-    ])
-  }
 }
 
 def publishPublishingApiPactTests(_govuk) {

--- a/Rakefile
+++ b/Rakefile
@@ -4,3 +4,13 @@
 require File.expand_path("config/application", __dir__)
 
 Rails.application.load_tasks
+
+begin
+  require "rubocop/rake_task"
+  RuboCop::RakeTask.new
+rescue LoadError
+  # Rubocop isn't available in all environments
+end
+
+Rake::Task[:default].clear if Rake::Task.task_defined?(:default)
+task default: %i[rubocop spec pact:verify]

--- a/app/commands/v2/publish.rb
+++ b/app/commands/v2/publish.rb
@@ -82,10 +82,10 @@ module Commands
       def no_draft_item_exists
         if already_published?
           message = "Cannot publish an already published edition"
-          raise_command_error(409, message, { fields: {}})
+          raise_command_error(409, message, { fields: {} })
         else
           message = "Item with content_id #{content_id} and locale #{locale} does not exist"
-          raise_command_error(404, message, { fields: {}})
+          raise_command_error(404, message, { fields: {} })
         end
       end
 

--- a/app/commands/v2/put_content.rb
+++ b/app/commands/v2/put_content.rb
@@ -182,7 +182,7 @@ module Commands
         ).where.not(
           documents: {
             locale: document.locale,
-          }
+          },
         ).first
 
         return unless draft_edition_for_different_locale

--- a/app/commands/v2/republish.rb
+++ b/app/commands/v2/republish.rb
@@ -32,7 +32,7 @@ module Commands
 
       def no_republishable_item_exists
         message = "A live item with content_id #{content_id} and locale #{locale} does not exist"
-        raise_command_error(404, message, { fields: {}})
+        raise_command_error(404, message, { fields: {} })
       end
 
       def republish_edition

--- a/app/commands/v2/unpublish.rb
+++ b/app/commands/v2/unpublish.rb
@@ -44,7 +44,7 @@ module Commands
 
       def raise_invalid_unpublishing_type
         message = "#{unpublishing_type} is not a valid unpublishing type"
-        raise_command_error(422, message, { fields: {}})
+        raise_command_error(422, message, { fields: {} })
       end
 
       def edition
@@ -54,14 +54,14 @@ module Commands
       def validate_allow_discard_draft
         if payload[:allow_draft] && payload[:discard_drafts]
           message = "allow_draft and discard_drafts cannot be used together"
-          raise_command_error(422, message, { fields: {}})
+          raise_command_error(422, message, { fields: {} })
         end
       end
 
       def validate_edition_presence
         if edition.blank?
           message = "Could not find an edition to unpublish"
-          raise_command_error(404, message, { fields: {}})
+          raise_command_error(404, message, { fields: {} })
         end
       end
 
@@ -79,7 +79,7 @@ module Commands
             )
           else
             message = "Cannot unpublish with a draft present"
-            raise_command_error(422, message, { fields: {}})
+            raise_command_error(422, message, { fields: {} })
           end
         end
       end
@@ -102,7 +102,7 @@ module Commands
             .merge(redirects: redirects),
         )
       rescue ActiveRecord::RecordInvalid => e
-        raise_command_error(422, e.message, { fields: {}})
+        raise_command_error(422, e.message, { fields: {} })
       end
 
       def redirects


### PR DESCRIPTION
Trello: https://trello.com/c/5Gob6WUL/147-for-everyone-ensure-that-rubocop-runs-as-part-of-bundle-exec-rake-as-one-of-the-default-tasks

This task is used by CI to build the app. To reflect this I've removed
the pact verify stage from the Jenkins stages.

This turns on linting that had accidentally been switched off following https://github.com/alphagov/govuk-jenkinslib/pull/74 it also includes some other minor clean ups of files related to Jenkins and Rake. See commits for more details