### PR TITLE
Add pa-ur locale (Punjabi Shahmukhi - Urdu script)

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -79,6 +79,7 @@ module PublishingAPI
       nl
       no
       pa
+      pa-ur
       pl
       ps
       pt

--- a/config/application.rb
+++ b/config/application.rb
@@ -40,7 +40,6 @@ module PublishingAPI
     config.eager_load_paths << "#{config.root}/lib"
 
     config.i18n.available_locales = %i[
-      en
       ar
       az
       be
@@ -52,6 +51,7 @@ module PublishingAPI
       de
       dr
       el
+      en
       es
       es-419
       et


### PR DESCRIPTION
We already support `pa`, Punjabi Gurmukhi, a language used in Punjab,
India. This is to add `pa-ur`, Punjabi Shahmukhi, a language used in
Punjab, Pakistan, that uses the Urdu script.

More information on the two languages can be found on this Wikipedia
page: https://en.wikipedia.org/wiki/Punjabi_language

The reason `pa-ur` was chosen as locale code is that `pa` is the
language code for Punjabi and `ur` is the script subtag for Urdu. More
information on this can be found on this Mozilla developer docs page:
https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/lang#Language_tag_syntax

Docs followed: https://docs.publishing.service.gov.uk/manual/add-translation-whitehall.html

Zendesk ticket: https://govuk.zendesk.com/agent/tickets/4371686

Related PRs:
- https://github.com/alphagov/whitehall/pull/5915
- https://github.com/alphagov/government-frontend/pull/1942
- https://github.com/alphagov/govuk-content-schemas/pull/1034
- https://github.com/alphagov/content-store/pull/791
- https://github.com/alphagov/publishing-api/pull/1883
