### PR TITLE
Only send orphaned content_ids downstream 4 locale

### DIFF
--- a/app/workers/dependency_resolution_worker.rb
+++ b/app/workers/dependency_resolution_worker.rb
@@ -13,7 +13,12 @@ class DependencyResolutionWorker
       send_downstream(content_id, locale)
     end
 
-    orphaned_content_ids.each { |content_id| send_downstream(content_id, locale) }
+    orphaned_content_ids_for_locale = Document.where(
+      content_id: orphaned_content_ids,
+      locale: locale,
+    ).pluck(:content_id)
+
+    orphaned_content_ids_for_locale.each { |content_id| send_downstream(content_id, locale) }
   end
 
 private


### PR DESCRIPTION
This change updates the behaviour of sending orphaned links downstream
depending on the locales of both the source link change and the
resulting dependency resolution link changes.

Originally, when a patch links request was made then if any links were
removed / replaced [1] then they would be added to the orphaned links
array and subsequently represented downstream [2]. This worked fine as
long as the orphaned link edition had the same locale as the original
link change edition [3] but if these were different then we would end up
trying to represent orphaned links (editions) in locales that they never
supported resulting in a `AbortWorkerError` [4].

This bug was exacerbated by a scheduled job which replaced a load of
suggested links for content every two weeks [5] which resulted in
thousands of errors periodically.

We now check in Publishing API that the dependency editions being
represented downstream are available in the given locale before
attempting to represent them.

Orphaned content ids can get potentially generated from actions such as
patch_links, put_content, unpublish and publish. As this is a generic
update in the dependency worker this change will apply across these
requests which will prevent these from raising unnecessary errors.

Tested in staging.

Trello:
https://trello.com/c/SeUUIIVK/2259-5-investigate-and-fix-abortworkererror-sidekiq-downstreamworker

[1]: https://github.com/alphagov/publishing-api/blob/43aaeddc918c560a0998e3e567cf446ba5e59757/app/commands/v2/patch_link_set.rb#L28-L29
[2]: https://github.com/alphagov/publishing-api/blob/master/app/workers/dependency_resolution_worker.rb#L16
[3]: https://github.com/alphagov/publishing-api/blob/43aaeddc918c560a0998e3e567cf446ba5e59757/app/commands/v2/patch_link_set.rb#L80-L88
[4]: https://github.com/alphagov/publishing-api/blob/43aaeddc918c560a0998e3e567cf446ba5e59757/app/workers/downstream_live_worker.rb#L26-L28
[5]: https://github.com/alphagov/govuk-related-links-recommender/blob/35e495c0d4e13e61abf15d98d86fa6781e1c8499/concourse.yml#L32-L37