### PR TITLE
Allow judiciary.uk redirects

### DIFF
--- a/app/validators/routes_and_redirects_validator.rb
+++ b/app/validators/routes_and_redirects_validator.rb
@@ -165,6 +165,10 @@ private
       destination.starts_with?("/")
     end
 
+    def government_domain?(host)
+      host.end_with?(".gov.uk") || host.end_with?(".judiciary.uk")
+    end
+
     def invalid_destination?(destination)
       uri = URI.parse(destination)
       !url_constructed_as_expected?(destination, uri)
@@ -185,8 +189,8 @@ private
         return
       end
 
-      errors << "external redirects only accepted within the gov.uk domain" unless
-        uri.host.end_with?(".gov.uk")
+      errors << "external redirects only accepted within the gov.uk or judiciary.uk domain" unless
+        government_domain?(uri.host)
 
       errors << "internal redirect should not be specified with full url" if
         %w[gov.uk www.gov.uk].include? uri.host

--- a/spec/support/routes_and_redirects_validator.rb
+++ b/spec/support/routes_and_redirects_validator.rb
@@ -207,6 +207,7 @@ RSpec.shared_examples_for RoutesAndRedirectsValidator do
           https://new-vat-rates.campaign.gov.uk/
           https://new-vat-rates.campaign.gov.uk/path/to/your/new/vat-rates
           https://new-vat-rates.campaign.gov.uk/path/to/your/new/vat-rates?q=123&&a=23344
+          https://www.judiciary.uk/
         ].each do |destination|
           edition.redirects = [{ path: "#{subject.base_path}/new", type: "exact", destination: destination }]
 


### PR DESCRIPTION
It's been approved by policy and engagement that documents can be redirected to a domain under `judiciary.uk`.

See https://govuk.zendesk.com/agent/tickets/4440152 for the background. A user wanted to unpublish some guidance and have it redirect to appropriate replacements hosted on `judiciary.uk`.