### PR TITLE
Allow redirects to etl.beis.gov.uk

### DIFF
--- a/app/validators/routes_and_redirects_validator.rb
+++ b/app/validators/routes_and_redirects_validator.rb
@@ -166,7 +166,7 @@ private
     end
 
     def government_domain?(host)
-      host.end_with?(".gov.uk") || host.end_with?(".judiciary.uk")
+      host.end_with?(".gov.uk", ".judiciary.uk", "etl.beis.gov.uk")
     end
 
     def invalid_destination?(destination)
@@ -189,7 +189,7 @@ private
         return
       end
 
-      errors << "external redirects only accepted within the gov.uk or judiciary.uk domain" unless
+      errors << "external redirects only accepted within the gov.uk, judiciary.uk or etl.beis.gov.uk domains" unless
         government_domain?(uri.host)
 
       errors << "internal redirect should not be specified with full url" if

--- a/spec/support/routes_and_redirects_validator.rb
+++ b/spec/support/routes_and_redirects_validator.rb
@@ -208,6 +208,7 @@ RSpec.shared_examples_for RoutesAndRedirectsValidator do
           https://new-vat-rates.campaign.gov.uk/path/to/your/new/vat-rates
           https://new-vat-rates.campaign.gov.uk/path/to/your/new/vat-rates?q=123&&a=23344
           https://www.judiciary.uk/
+          https://etl.beis.gov.uk/
         ].each do |destination|
           edition.redirects = [{ path: "#{subject.base_path}/new", type: "exact", destination: destination }]
 


### PR DESCRIPTION
Allows withdrawn documents to redirect to `etl.beis.gov.uk`.  This has been approved as a domain we are permitted to redirect documents to.

Trello card: https://trello.com/c/138P3vIk