### PR TITLE
Add temporary rake task to fix 'value_of_funding' values

### DIFF
--- a/lib/tasks/tmp_international_development_funds.rake
+++ b/lib/tasks/tmp_international_development_funds.rake
@@ -2,11 +2,13 @@ namespace :international_development_funds do
   desc "Republishes international development funds with new 'value_of_funding' values"
   task update_value_of_funding: :environment do
     Edition.where(document_type: "international_development_fund").each do |edition|
-      next unless edition.details.dig(:metadata, :value_of_funding) == %w[up-to-100000]
+      value_of_funding = edition.details.dig(:metadata, :value_of_funding) || []
+      next unless value_of_funding.include?("up-to-100000")
 
+      other_values = value_of_funding.reject { |val| val == "up-to-100000" }
       edition.details = edition.details.deep_merge({
         metadata: {
-          value_of_funding: %w[10001-to-100000],
+          value_of_funding: other_values.unshift("10001-to-100000"),
         },
       })
       edition.save!

--- a/lib/tasks/tmp_international_development_funds.rake
+++ b/lib/tasks/tmp_international_development_funds.rake
@@ -1,0 +1,15 @@
+namespace :international_development_funds do
+  desc "Republishes international development funds with new 'value_of_funding' values"
+  task update_value_of_funding: :environment do
+    Edition.where(document_type: "international_development_fund").each do |edition|
+      next unless edition.details.dig(:metadata, :value_of_funding) == %w[up-to-100000]
+
+      edition.details = edition.details.deep_merge({
+        metadata: {
+          value_of_funding: %w[10001-to-100000],
+        },
+      })
+      edition.save!
+    end
+  end
+end

--- a/spec/lib/tasks/tmp_international_development_funds_spec.rb
+++ b/spec/lib/tasks/tmp_international_development_funds_spec.rb
@@ -19,6 +19,21 @@ RSpec.describe "rake international_development_funds:update_value_of_funding", r
     expect(edition.reload.details[:metadata][:value_of_funding]).to eq(%w[10001-to-100000])
   end
 
+  it "preserves any other value_of_funding choices" do
+    edition = create(
+      :edition,
+      document_type: "international_development_fund",
+      details: { metadata: { value_of_funding: %w[up-to-100000 100001-500000] } },
+    )
+
+    task.invoke
+
+    expect(edition.reload.details[:metadata][:value_of_funding]).to eq(%w[
+      10001-to-100000
+      100001-500000
+    ])
+  end
+
   it "does not change the value_of_funding for the values that are unchanged" do
     unchanged_values = %w[
       up-to-10000
@@ -76,5 +91,15 @@ RSpec.describe "rake international_development_funds:update_value_of_funding", r
       },
       bar: "baz",
     })
+  end
+
+  it "doesn't crash if `value_of_funding` is not defined" do
+    create(
+      :edition,
+      document_type: "international_development_fund",
+      details: { metadata: { foo: "bar" } },
+    )
+
+    expect { task.invoke }.to_not raise_error
   end
 end

--- a/spec/lib/tasks/tmp_international_development_funds_spec.rb
+++ b/spec/lib/tasks/tmp_international_development_funds_spec.rb
@@ -1,0 +1,80 @@
+require "rails_helper"
+
+RSpec.describe "rake international_development_funds:update_value_of_funding", rake_task: true do
+  let(:task) { Rake::Task["international_development_funds:update_value_of_funding"] }
+
+  before :each do
+    task.reenable # without this, calling `invoke` does nothing after first test
+  end
+
+  it "changes the value_of_funding for existing editions where appropriate" do
+    edition = create(
+      :edition,
+      document_type: "international_development_fund",
+      details: { metadata: { value_of_funding: %w[up-to-100000] } },
+    )
+
+    task.invoke
+
+    expect(edition.reload.details[:metadata][:value_of_funding]).to eq(%w[10001-to-100000])
+  end
+
+  it "does not change the value_of_funding for the values that are unchanged" do
+    unchanged_values = %w[
+      up-to-10000
+      10001-to-100000
+      100001-500000
+      500001-to-1000000
+      more-than-1000000
+    ]
+    editions = unchanged_values.map do |val|
+      create(
+        :edition,
+        document_type: "international_development_fund",
+        details: { metadata: { value_of_funding: [val] } },
+      )
+    end
+
+    task.invoke
+
+    unchanged_values.each_with_index do |val, index|
+      expect(editions[index].reload.details[:metadata][:value_of_funding]).to eq([val])
+    end
+  end
+
+  it "does not change the value_of_funding for editions if they are not of type international_development_fund" do
+    edition = create(
+      :edition,
+      document_type: "services_and_information",
+      details: { metadata: { value_of_funding: %w[up-to-100000] } },
+    )
+
+    task.invoke
+
+    expect(edition.reload.details[:metadata][:value_of_funding]).to eq(%w[up-to-100000])
+  end
+
+  it "does not lose other metadata that exist in the 'details'" do
+    edition = create(
+      :edition,
+      document_type: "international_development_fund",
+      details: {
+        metadata: {
+          value_of_funding: %w[up-to-100000],
+          foo: "bar",
+        },
+        bar: "baz",
+      },
+    )
+
+    task.invoke
+
+    expect(edition.reload.details).to eq({
+      metadata: {
+        value_of_funding: %w[10001-to-100000],
+        foo: "bar",
+      },
+      bar: "baz",
+    })
+  end
+end


### PR DESCRIPTION
Dependent on https://github.com/alphagov/govuk-content-schemas/pull/1043

The previous "Up to £100,000" value will now become "£10,001 to
£100,000", in preparation for a new category "Up to £10,000". The
department have confirmed that no current international development
funds are below £10,001, so "10001-to-100000" should be the new
value for these.

Once the Rake task has been executed, we can revert this commit
as the code will no longer be needed.

Trello: https://trello.com/c/eDFwuCFY/2356-5-changes-to-international-development-funding-finder