### PR TITLE
Specify the default branch as main

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,10 +1,10 @@
 #!/usr/bin/env groovy
 
-library("govuk")
+library("govuk@default-branch")
 
 node("postgresql-9.6") {
-
   govuk.buildProject(
+    defaultBranch: "main",
     extraParameters: [
       stringParam(
         name: "CONTENT_STORE_BRANCH",


### PR DESCRIPTION
I'm going to rename the default branch from master to main. We need to temporarily use a branch of govuk-jenkinslib, but once we're happy everything works there we'll merge that into the main branch.