### PR TITLE
Rename `GDS_API_PACT_VERSION` => `GDS_API_ADAPTERS_PACT_VERSION`

### DIFF
--- a/lib/tasks/pact.rake
+++ b/lib/tasks/pact.rake
@@ -10,7 +10,7 @@ task "pact:verify:branch", [:branch_name] => :environment do |t, args|
 
   pact_version = args[:branch_name] == "master" ? args[:branch_name] : "branch-#{args[:branch_name]}"
 
-  ClimateControl.modify(GDS_API_PACT_VERSION: pact_version) do
+  ClimateControl.modify(GDS_API_ADAPTERS_PACT_VERSION: pact_version) do
     Pact::TaskHelper.handle_verification_failure do
       Pact::TaskHelper.execute_pact_verify
     end

--- a/spec/service_consumers/pact_helper.rb
+++ b/spec/service_consumers/pact_helper.rb
@@ -24,7 +24,7 @@ Pact.service_provider "Publishing API" do
       base_url = ENV.fetch("PACT_BROKER_BASE_URL", "https://pact-broker.cloudapps.digital")
       url = "#{base_url}/pacts/provider/#{url_encode(name)}/consumer/#{url_encode(consumer_name)}"
 
-      pact_uri "#{url}/versions/#{url_encode(ENV.fetch('GDS_API_PACT_VERSION', 'master'))}"
+      pact_uri "#{url}/versions/#{url_encode(ENV.fetch('GDS_API_ADAPTERS_PACT_VERSION', 'master'))}"
     end
   end
 end


### PR DESCRIPTION
This is a more expressive name, first coined when adding Pact tests to Collections:
https://github.com/alphagov/collections/pull/2281#discussion_r576018574

It's also been applied to Frontend:
https://github.com/alphagov/frontend/pull/2644