### PR TITLE
Remove support for pa-ur locale

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -80,7 +80,6 @@ module PublishingAPI
       no
       pa
       pa-pk
-      pa-ur
       pl
       ps
       pt


### PR DESCRIPTION
Removes support for pa-ur which was superseded by pa-pk

[trello](https://trello.com/c/devOCero/2369-3-change-punjabi-pakistan-language-tag)