### PR TITLE
Add temporary Rake task to update pa-ur locales to pa-pk

### DIFF
--- a/lib/tasks/data_hygiene.rake
+++ b/lib/tasks/data_hygiene.rake
@@ -56,4 +56,10 @@ namespace :data_hygiene do
       )
     end
   end
+
+  desc "Temporary task to update incorrect locale"
+  task update_pa_ur_to_pa_pk_locale: :environment do
+    docs = Document.where(locale: "pa-ur")
+    docs.update_all(locale: "pa-pk")
+  end
 end


### PR DESCRIPTION
The pa-ur locale was incorrectly added and is being replaced by
pa-pk. A small number of documents were published in this locale.

Republishing from the publishing application creates new
translations, but does not remove the incorrect ones from the
publishing-api or downstream.

This Rake task will update the incorrect translations so that
republishing will not create new translations, but instead correct
the existing documents and represent downstream.

[trello](https://trello.com/c/devOCero/2369-3-change-punjabi-pakistan-language-tag)