### PR TITLE
Revert "Add temporary Rake task to update pa-ur locales to pa-pk"

### DIFF
--- a/lib/tasks/data_hygiene.rake
+++ b/lib/tasks/data_hygiene.rake
@@ -56,10 +56,4 @@ namespace :data_hygiene do
       )
     end
   end
-
-  desc "Temporary task to update incorrect locale"
-  task update_pa_ur_to_pa_pk_locale: :environment do
-    docs = Document.where(locale: "pa-ur")
-    docs.update_all(locale: "pa-pk")
-  end
 end


### PR DESCRIPTION
This was a temporary Rake task that has now been run in Production
This reverts commit 326998739e544bfb12f6ddfa759202374be7d09b.