### PR TITLE
Include .nhs.uk as an acceptable government redirect destination

### DIFF
--- a/app/validators/routes_and_redirects_validator.rb
+++ b/app/validators/routes_and_redirects_validator.rb
@@ -166,7 +166,7 @@ private
     end
 
     def government_domain?(host)
-      host.end_with?(".gov.uk", ".judiciary.uk", "etl.beis.gov.uk")
+      host.end_with?(".gov.uk", ".judiciary.uk", "etl.beis.gov.uk", ".nhs.uk")
     end
 
     def invalid_destination?(destination)
@@ -189,7 +189,7 @@ private
         return
       end
 
-      errors << "external redirects only accepted within the gov.uk, judiciary.uk or etl.beis.gov.uk domains" unless
+      errors << "external redirects only accepted within the gov.uk, judiciary.uk, etl.beis.gov.uk or nhs.uk domains" unless
         government_domain?(uri.host)
 
       errors << "internal redirect should not be specified with full url" if

--- a/app/validators/routes_and_redirects_validator.rb
+++ b/app/validators/routes_and_redirects_validator.rb
@@ -166,7 +166,7 @@ private
     end
 
     def government_domain?(host)
-      host.end_with?(".gov.uk", ".judiciary.uk", "etl.beis.gov.uk", ".nhs.uk")
+      host.end_with?(".gov.uk", ".judiciary.uk", ".nhs.uk")
     end
 
     def invalid_destination?(destination)
@@ -189,7 +189,7 @@ private
         return
       end
 
-      errors << "external redirects only accepted within the gov.uk, judiciary.uk, etl.beis.gov.uk or nhs.uk domains" unless
+      errors << "external redirects only accepted within the gov.uk, judiciary.uk or nhs.uk domains" unless
         government_domain?(uri.host)
 
       errors << "internal redirect should not be specified with full url" if

--- a/spec/support/routes_and_redirects_validator.rb
+++ b/spec/support/routes_and_redirects_validator.rb
@@ -209,6 +209,7 @@ RSpec.shared_examples_for RoutesAndRedirectsValidator do
           https://new-vat-rates.campaign.gov.uk/path/to/your/new/vat-rates?q=123&&a=23344
           https://www.judiciary.uk/
           https://etl.beis.gov.uk/
+          https://www.nhs.uk/
         ].each do |destination|
           edition.redirects = [{ path: "#{subject.base_path}/new", type: "exact", destination: destination }]
 


### PR DESCRIPTION
Trello: https://trello.com/c/vXyz6gg7/301-tt-migration-to-nhsuk-redirect-https-wwwgovuk-getting-tested-for-coronavirus

GOV.UK are intended to set-up a number of redirects to www.nhs.uk in the
coming weeks as the canonical source of a number of documents are moving
to www.nhs.uk, the previous mainstream GOV.UK pages will then be
replaced with www.nhs.uk redirects.

I've also removed etl.beis.gov.uk as this host is covered by the `ends_with?(".gov.uk")` clause.