### PR TITLE
Remove pact branch verify rake task

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1097,7 +1097,7 @@ GEM
       sidekiq (>= 5, < 6)
       sidekiq-logging-json (~> 0.0)
       sidekiq-statsd (>= 2.1)
-    govuk_test (2.0.0)
+    govuk_test (2.1.0)
       brakeman (~> 4.6)
       capybara
       puma

--- a/lib/tasks/pact.rake
+++ b/lib/tasks/pact.rake
@@ -4,19 +4,6 @@ require "pact/tasks"
 require "pact_broker/client/tasks"
 require "pact/tasks/task_helper"
 
-desc "Verify the API contract for a specific branch"
-task "pact:verify:branch", [:branch_name] => :environment do |t, args|
-  abort "Please provide a branch name. eg rake #{t.name}[my_feature_branch]" unless args[:branch_name]
-
-  pact_version = args[:branch_name] == "master" ? args[:branch_name] : "branch-#{args[:branch_name]}"
-
-  ClimateControl.modify(GDS_API_ADAPTERS_PACT_VERSION: pact_version) do
-    Pact::TaskHelper.handle_verification_failure do
-      Pact::TaskHelper.execute_pact_verify
-    end
-  end
-end
-
 PactBroker::Client::PublicationTask.new("branch") do |task|
   task.consumer_version = ENV.fetch("PACT_TARGET_BRANCH")
   task.pact_broker_base_url = ENV.fetch("PACT_BROKER_BASE_URL")


### PR DESCRIPTION
In https://github.com/alphagov/govuk_test/pull/34, we added this rake task to the `govuk_test` gem. We can now remove it from the application as it is now in the gem.

Trello card: https://trello.com/c/rnfUFP5o