### PR TITLE
Bugfix: Enable exporting events twice in a week

### DIFF
--- a/lib/tasks/events.rake
+++ b/lib/tasks/events.rake
@@ -1,7 +1,7 @@
 namespace :events do
   desc "Export events to S3. Defaults to the beginning of week 2 months ago, otherwise dates can be specified in a form that Date.parse understands."
   task :export_to_s3, %i[created_before created_on_or_after] => :environment do |_, args|
-    created_before = args[:created_before] ? Time.zone.parse(args[:created_before]) : 1.month.ago.beginning_of_week(:sunday)
+    created_before = args[:created_before] ? Time.zone.parse(args[:created_before]) : 30.days.ago
     created_on_or_after = args[:created_on_or_after] ? Time.zone.parse(args[:created_on_or_after]) : nil
     exported, s3_key = Events::S3Exporter.new(created_before, created_on_or_after).export
     puts "Exported #{exported} event#{exported == 1 ? '' : 's'} successfully to #{s3_key} 🎉"


### PR DESCRIPTION
We have a cron job set up to run the rake task
events:export_to_s3 every 7 days.

The task was run on 28 March 2021 and 04 April 2021.

The second run failed with the error:
Events::S3Exporter::EventsExportExistsError: S3 already
has an export for events/2021-02-28T00:00:00+00:00.csv.gz

This is because the default time to fetch events before is
`1.month.ago.beginning_of_week(:sunday)`, which produces the
same date on both March 28 and April 04:

```ruby
(DateTime.new(2021, 03, 28, 04, 38) - 1.month).beginning_of_week(:sunday)
(DateTime.new(2021, 04, 04, 04, 38) - 1.month).beginning_of_week(:sunday)
```

Both of the above commands give the same date: Feb 28 2021.

Changing the period to 30.days (without specifying the
weekday to start from) fixes the issue by ensuring that
running the same command on any day will give a unique
date.

This allows us to run the task multiple times per calendar week.