### PR TITLE
Remove `pact:verify:branch[BRANCH_NAME]` rake task

### DIFF
--- a/lib/tasks/pact.rake
+++ b/lib/tasks/pact.rake
@@ -1,21 +1,6 @@
 return if Rails.env.production?
 
-require "pact/tasks"
 require "pact_broker/client/tasks"
-require "pact/tasks/task_helper"
-
-desc "Verify the API contract for a specific branch"
-task "pact:verify:branch", [:branch_name] => :environment do |t, args|
-  abort "Please provide a branch name. eg rake #{t.name}[my_feature_branch]" unless args[:branch_name]
-
-  pact_version = args[:branch_name] == "master" ? args[:branch_name] : "branch-#{args[:branch_name]}"
-
-  ClimateControl.modify(GDS_API_ADAPTERS_PACT_VERSION: pact_version) do
-    Pact::TaskHelper.handle_verification_failure do
-      Pact::TaskHelper.execute_pact_verify
-    end
-  end
-end
 
 PactBroker::Client::PublicationTask.new("branch") do |task|
   task.consumer_version = ENV.fetch("PACT_TARGET_BRANCH")

--- a/spec/service_consumers/pact_helper.rb
+++ b/spec/service_consumers/pact_helper.rb
@@ -24,7 +24,7 @@ Pact.service_provider "Publishing API" do
       base_url = ENV.fetch("PACT_BROKER_BASE_URL", "https://pact-broker.cloudapps.digital")
       url = "#{base_url}/pacts/provider/#{url_encode(name)}/consumer/#{url_encode(consumer_name)}"
 
-      pact_uri "#{url}/versions/#{url_encode(ENV.fetch('GDS_API_ADAPTERS_PACT_VERSION', 'master'))}"
+      pact_uri "#{url}/versions/#{url_encode(ENV.fetch('PACT_CONSUMER_VERSION', 'master'))}"
     end
   end
 end


### PR DESCRIPTION
The same can be achieved with the default `pact:verify` task by:

```
govuk-docker-run env GDS_API_ADAPTERS_PACT_VERSION=foo bundle exec rake pact:verify
```

We don't need to expose an additional task to test against a
branch of the consumer.

This also renames 'GDS_API_ADAPTERS_PACT_VERSION' =>
'PACT_CONSUMER_VERSION', as implemented in https://github.com/alphagov/gds-api-adapters/pull/1049.

This is more generic and allows us to standardise our Pact setup
regardless of what the Consumer and Provider is. Most of our Pact
tests have GDS Api Adapters as the Consumer, but we also have
tests between Content Store and Publishing API, where Publishing
API is the Consumer.
So rather than defining two different ENV variables and having
to account for the difference, the hope is that one common ENV
will allow us to consolidate as much behaviour as possible,
perhaps in somewhere like govuk_test.

Trello: https://trello.com/c/rnfUFP5o/2453-experiment-with-common-configuration-for-pact-tests-timebox-2-days