### PR TITLE
Retire USE_LOCAL_PACT in favour of PACT_URI

### DIFF
--- a/docs/pact_testing.md
+++ b/docs/pact_testing.md
@@ -16,7 +16,6 @@ What this means is:
 - the build of publishing api will use this pactfile to test the publishing-api
   service
 
-
 ## How it works
 
 The gds-api-adapters gem, as the consumer of the pact, includes in its test
@@ -29,7 +28,6 @@ When the tests suite is successfully run, a JSON file is output that contains
 the details of these requests and their expected results. This can then be
 replayed against the real Publishing API application to test that it behaves as
 expected.
-
 
 ## How the tests run in CI
 
@@ -45,20 +43,18 @@ the pact against that branch using the `pact:verify:branch` rake task.
 In publishing-api itself, the Jenkins job runs the `pact:verify` rake task to
 verify the current branch against the master branch.
 
-
 ## Running the pacts in development
 
 You can use `pact:verify` locally to run the current branch against the master
 branch of pacts stored in Pact Broker. If you need to run them against a local
 version of gds-api-adapters, run the tests in that directory
-and then set the `USE_LOCAL_PACT` env variable:
+and then set the `PACT_URI` env variable:
 
-    USE_LOCAL_PACT=1 bundle exec rake pact:verify
+```
+PACT_URI="../gds-api-adapters/spec/pacts/gds_api_adapters-publishing_api.json" bundle exec rake pact:verify
+```
 
-This will cause pact to look for the pactfile in
-`../gds-api-adapters/spec/pacts/gds_api_adapters-publishing_api.json`. You can
-additionally override this location by setting the `GDS_API_PACT_PATH` variable.
-
+This will cause pact to look for the pactfile in gds-api-adapters.
 
 ## Making breaking changes
 
@@ -70,7 +66,6 @@ specified branch of publishing-api, by manually running the branch build and
 entering the relevant branch name as the `PUBLISHING_API_BRANCH` parameter.
 This will allow Jenkins to report a successful test run and let the branch be
 merged.
-
 
 [pact]: https://github.com/realestate-com-au/pact
 [gds-api-adapters-publishing-api-tests]: https://github.com/alphagov/gds-api-adapters/blob/master/test/publishing_api_test.rb

--- a/spec/service_consumers/pact_helper.rb
+++ b/spec/service_consumers/pact_helper.rb
@@ -18,8 +18,8 @@ end
 
 Pact.service_provider "Publishing API" do
   honours_pact_with "GDS API Adapters" do
-    if ENV["USE_LOCAL_PACT"]
-      pact_uri ENV.fetch("GDS_API_PACT_PATH", "../gds-api-adapters/spec/pacts/gds_api_adapters-publishing_api.json")
+    if ENV["PACT_URI"]
+      pact_uri(ENV["PACT_URI"])
     else
       base_url = ENV.fetch("PACT_BROKER_BASE_URL", "https://pact-broker.cloudapps.digital")
       url = "#{base_url}/pacts/provider/#{url_encode(name)}/consumer/#{url_encode(consumer_name)}"


### PR DESCRIPTION
This is much easier to configure, is local by implication, and
is how we do things in other repos now.

Trello: https://trello.com/c/rnfUFP5o/2453-experiment-with-common-configuration-for-pact-tests-timebox-2-days