### PR TITLE
Bump govuk_document_types from 0.9.3 to 1.0.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,7 +39,6 @@ group :development, :test do
   gem "database_cleaner"
   gem "factory_bot_rails"
   gem "faker"
-  gem "govuk-content-schema-test-helpers"
   gem "govuk_test"
   gem "pact"
   gem "pact_broker-client"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1073,8 +1073,6 @@ GEM
       nokogumbo (~> 2)
       rinku (~> 2.0)
       sanitize (>= 5.2.1, < 6)
-    govuk-content-schema-test-helpers (1.6.1)
-      json-schema (~> 2.8.0)
     govuk_app_config (2.10.0)
       logstasher (>= 1.2.2, < 2.2.0)
       sentry-raven (~> 3.1.1)
@@ -1419,7 +1417,6 @@ DEPENDENCIES
   gds-api-adapters
   gds-sso
   govspeak
-  govuk-content-schema-test-helpers
   govuk_app_config
   govuk_document_types
   govuk_schemas

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1080,7 +1080,7 @@ GEM
       sentry-raven (~> 3.1.1)
       statsd-ruby (~> 1.5.0)
       unicorn (>= 5.4, < 5.9)
-    govuk_document_types (0.9.3)
+    govuk_document_types (1.0.0)
     govuk_publishing_components (24.4.0)
       govuk_app_config
       kramdown

--- a/spec/presenters/edition_presenter_spec.rb
+++ b/spec/presenters/edition_presenter_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe Presenters::EditionPresenter do
     end
 
     it "matches the notification schema" do
-      expect(subject).to be_valid_against_schema("calendar")
+      expect(subject).to be_valid_against_notification_schema("calendar")
     end
 
     it "doesnt include auth_bypass_ids in message queue" do

--- a/spec/presenters/gone_presenter_spec.rb
+++ b/spec/presenters/gone_presenter_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe GonePresenter do
     end
 
     it "matches the notification schema" do
-      expect(subject).to be_valid_against_schema("gone")
+      expect(subject).to be_valid_against_notification_schema("gone")
     end
 
     context "with a nil base_path" do
@@ -21,7 +21,7 @@ RSpec.describe GonePresenter do
       end
 
       it "matches the notification schema" do
-        expect(subject).to be_valid_against_schema("gone")
+        expect(subject).to be_valid_against_notification_schema("gone")
       end
     end
   end

--- a/spec/presenters/redirect_presenter_spec.rb
+++ b/spec/presenters/redirect_presenter_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe RedirectPresenter do
     end
 
     it "matches the notification schema" do
-      expect(subject).to be_valid_against_schema("redirect")
+      expect(subject).to be_valid_against_notification_schema("redirect")
     end
   end
 end

--- a/spec/presenters/vanish_presenter_spec.rb
+++ b/spec/presenters/vanish_presenter_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe VanishPresenter do
     end
 
     it "matches the notification schema" do
-      expect(subject).to be_valid_against_schema("vanish")
+      expect(subject).to be_valid_against_notification_schema("vanish")
     end
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -18,7 +18,6 @@ Sidekiq::Logging.logger = nil
 Sidekiq::Testing.server_middleware do |chain|
   chain.add GovukSidekiq::APIHeaders::ServerMiddleware
 end
-require "govuk-content-schema-test-helpers"
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are
@@ -86,9 +85,4 @@ RSpec.configure do |config|
       login_as_stub_user
     end
   end
-end
-
-GovukContentSchemaTestHelpers.configure do |config|
-  config.schema_type = "notification"
-  config.project_root = Rails.root
 end

--- a/spec/support/govuk_content_schemas.rb
+++ b/spec/support/govuk_content_schemas.rb
@@ -1,2 +1,2 @@
-require "govuk-content-schema-test-helpers/rspec_matchers"
-RSpec.configuration.include GovukContentSchemaTestHelpers::RSpecMatchers
+require "govuk_schemas/rspec_matchers"
+RSpec.configuration.include GovukSchemas::RSpecMatchers


### PR DESCRIPTION
One of the specs broke, and I noticed that we are still using govuk-content-schema-test-helpers, so I updated things to use govuk_schemas instead.

Bumps [govuk_document_types](https://github.com/alphagov/govuk_document_types) from 0.9.3 to 1.0.0.
<details>
<summary>Changelog</summary>
<p><em>Sourced from <a href="https://github.com/alphagov/govuk_document_types/blob/master/CHANGELOG.md">govuk_document_types's changelog</a>.</em></p>
<blockquote>
<h1>1.0.0</h1>
<ul>
<li>Remove deprecated supertypes</li>
<li>Add Flood &amp; Coastal Erosion Risk Management Report (FCERM) Research Report to research supergroup</li>
</ul>
</blockquote>
</details>
<details>
<summary>Commits</summary>
<ul>
<li><a href="https://github.com/alphagov/govuk_document_types/commit/05f21ec7803bb28789a7b2e2ce1ad521ae660378"><code>05f21ec</code></a> Merge pull request <a href="https://github-redirect.dependabot.com/alphagov/govuk_document_types/issues/73">#73</a> from alphagov/remove-deprecated-supertypes</li>
<li><a href="https://github.com/alphagov/govuk_document_types/commit/507ceb37013a55110cb0aeaf52d426c72925ad3c"><code>507ceb3</code></a> Release version 1.0.0</li>
<li><a href="https://github.com/alphagov/govuk_document_types/commit/c796efc4a5d1de87080d9f5d1704ff5d38b3a969"><code>c796efc</code></a> Merge pull request <a href="https://github-redirect.dependabot.com/alphagov/govuk_document_types/issues/72">#72</a> from alphagov/add-fcerm-report</li>
<li><a href="https://github.com/alphagov/govuk_document_types/commit/b2efb036bcf6a69763ea3fbb67e132d1729b43e3"><code>b2efb03</code></a> Add FCERM Research Report to research supergroup</li>
<li><a href="https://github.com/alphagov/govuk_document_types/commit/98a3dd070323a69eb2eccfee1f3fe8b40065c0f9"><code>98a3dd0</code></a> Merge pull request <a href="https://github-redirect.dependabot.com/alphagov/govuk_document_types/issues/71">#71</a> from alphagov/remove-deprecated-supertypes</li>
<li><a href="https://github.com/alphagov/govuk_document_types/commit/1f3a7a957ac8aca21d391ba407298021a8120a18"><code>1f3a7a9</code></a> Remove deprecated supertypes</li>
<li>See full diff in <a href="https://github.com/alphagov/govuk_document_types/compare/v0.9.3...v1.0.0">compare view</a></li>
</ul>
</details>
<br />

</details>