### PR TITLE
Add RFC 141 healthcheck endpoints

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -67,6 +67,12 @@ Rails.application.routes.draw do
         Healthcheck::QueueLatency,
       )
 
+  get "/healthcheck/live", to: proc { [200, {}, %w[OK]] }
+  get "/healthcheck/ready", to: GovukHealthcheck.rack_response(
+    GovukHealthcheck::ActiveRecord,
+    GovukHealthcheck::SidekiqRedis,
+  )
+
   if Rails.env.development?
     require "sidekiq/web"
     mount Sidekiq::Web => "/sidekiq"


### PR DESCRIPTION
The sidekiq latency healthcheck will be defined in puppet directly.

Once govuk-puppet has been updated, the old endpoint can be removed.

See the RFC for more details.

---

[Trello card](https://trello.com/c/tl6RV1el/723-improve-govuk-healthchecks)