### PR TITLE
Replace fork with official sidekiq-unique-jobs gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,10 +19,7 @@ gem "hashdiff"
 gem "json-schema", require: false
 gem "pg"
 gem "plek"
-# We can't use v5 of this because it requires redis 3 and we use 2.8
-# We use our own fork because the latest 4.x release has a bug with
-# removing jobs from the uniquejobs hash in redis
-gem "sidekiq-unique-jobs", git: "https://github.com/alphagov/sidekiq-unique-jobs", branch: "fix-for-upstream-195-backported-to-4-x-branch", require: false
+gem "sidekiq-unique-jobs"
 gem "whenever", require: false
 gem "with_advisory_lock"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,3 @@
-GIT
-  remote: https://github.com/alphagov/sidekiq-unique-jobs
-  revision: 6c03e39c3ad6ba1468d567c22bb99908f6fdb317
-  branch: fix-for-upstream-195-backported-to-4-x-branch
-  specs:
-    sidekiq-unique-jobs (4.0.18)
-      sidekiq (>= 2.6)
-      thor
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -998,6 +989,9 @@ GEM
       aws-eventstream (~> 1, >= 1.0.2)
     bindex (0.8.1)
     brakeman (5.0.4)
+    brpoplpush-redis_script (0.1.2)
+      concurrent-ruby (~> 1.0, >= 1.0.5)
+      redis (>= 1.0, <= 5.0)
     builder (3.2.4)
     bunny (2.16.1)
       amq-protocol (~> 2.3, >= 2.3.1)
@@ -1345,6 +1339,11 @@ GEM
     sidekiq-statsd (2.1.0)
       activesupport
       sidekiq (>= 3.3.1)
+    sidekiq-unique-jobs (7.1.5)
+      brpoplpush-redis_script (> 0.1.1, <= 2.0.0)
+      concurrent-ruby (~> 1.0, >= 1.0.5)
+      sidekiq (>= 5.0, < 7.0)
+      thor (>= 0.20, < 2.0)
     simplecov (0.18.5)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
@@ -1445,7 +1444,7 @@ DEPENDENCIES
   rspec
   rspec-rails
   rubocop-govuk
-  sidekiq-unique-jobs!
+  sidekiq-unique-jobs
   simplecov
   spring
   spring-commands-rspec
@@ -1457,4 +1456,4 @@ DEPENDENCIES
   with_advisory_lock
 
 BUNDLED WITH
-   2.1.4
+   2.2.24

--- a/app/workers/downstream_draft_worker.rb
+++ b/app/workers/downstream_draft_worker.rb
@@ -6,7 +6,7 @@ class DownstreamDraftWorker
   include PerformAsyncInQueue
 
   sidekiq_options queue: HIGH_QUEUE,
-                  unique: :until_executing,
+                  lock: :until_executing,
                   unique_args: :uniq_args
 
   def self.uniq_args(args)

--- a/app/workers/downstream_live_worker.rb
+++ b/app/workers/downstream_live_worker.rb
@@ -6,7 +6,7 @@ class DownstreamLiveWorker
   include PerformAsyncInQueue
 
   sidekiq_options queue: HIGH_QUEUE,
-                  unique: :until_executing,
+                  lock: :until_executing,
                   unique_args: :uniq_args
 
   def self.uniq_args(args)

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,5 +1,7 @@
 Sidekiq.configure_client do |config|
   config.client_middleware do |chain|
     chain.add SidekiqLoggerMiddleware
+    # See https://github.com/mhenrixon/sidekiq-unique-jobs/blob/921aaa4efc998b102790d1f4ecce2ebac609e464/README.md#add-the-middleware
+    chain.add SidekiqUniqueJobs::Middleware::Client
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -37,7 +37,7 @@ Dir[Rails.root.join("spec/support/**/*.rb")].sort.each { |f| require f }
 require "sidekiq-unique-jobs"
 Sidekiq.configure_client do |config|
   config.client_middleware do |chain|
-    chain.remove SidekiqUniqueJobs::Client::Middleware
+    chain.remove SidekiqUniqueJobs::Middleware::Client
   end
 end
 


### PR DESCRIPTION
We have maintained a fork of the gem mhenrixon/sidekiq-unique-jobs at alphagov/sidekiq-unique-jobs.

The motivation for the fork was that we were running version 2 of Redis that is incompatible with version 5+ of the sidekiq-unique-jobs gem.

We needed a fork rather than pinning the gem version, since we backported an upstream fix from version 5 of the gem to our fork of version 4.

This enabled us to stay on a version of the gem which supported an older version of Redis, and use a bugfix only available in later unavailable versions.

For more details see https://github.com/alphagov/link-checker-api/commit/7627af9c0d703ee0f1958c514390dff75b3fc26f

Since we are now running Redis version 3 in production, we no longer need to maintain a fork of the gem.

Publishing API is the last app to use the fork rather than the upstream gem. All other apps such as link-checker-api are now using the upstream gem.

This will enable us to archive our fork.

### Tests

* I deployed this branch to integration and tested that I can manually publish a document from Publisher
* I ssh'd to publishing-api integration and tested uniqueness is still enforced.
    ```
    irb(main):001:0> [DownstreamDraftWorker.perform_async(1,300), DownstreamDraftWorker.perform_async(1,300)]
    Enqueuing DownstreamDraftWorker to queue: downstream_high with job id: 855ae61596380463307b77bc and arguments: 1
    Enqueuing DownstreamDraftWorker to queue: downstream_high with job id: 333cba52a4bc4c49bd345b02 and arguments: 1
    2021-08-16T10:24:14.354Z 11918 TID-1pd2 uniquejobs-client DIG-uniquejobs:aa7e0430809794ada0a7bcb63428eedb INFO: Skipping job with id (333cba52a4bc4c49bd345b02) because lock_digest: (uniquejobs:aa7e0430809794ada0a7bcb63428eedb) already exists
    => ["855ae61596380463307b77bc", nil]
    ```

https://trello.com/c/ft2pX8p2/603-redis-cluster-upgrade