### PR TITLE
Add link expansion rules for Take Part pages

### DIFF
--- a/lib/expansion_rules.rb
+++ b/lib/expansion_rules.rb
@@ -90,6 +90,7 @@ module_function
   ROLE_APPOINTMENT_FIELDS = (DEFAULT_FIELDS + details_fields(:started_on, :ended_on, :current, :person_appointment_order)).freeze
   STEP_BY_STEP_FIELDS = (DEFAULT_FIELDS + [%i[details step_by_step_nav title], %i[details step_by_step_nav steps]]).freeze
   STEP_BY_STEP_AUTH_BYPASS_FIELDS = (STEP_BY_STEP_FIELDS + %i[auth_bypass_ids]).freeze
+  TAKE_PART_PAGE_FIELDS = (DEFAULT_FIELDS + %i[details])
   TRAVEL_ADVICE_FIELDS = (DEFAULT_FIELDS + details_fields(:country, :change_description)).freeze
   WORLD_LOCATION_FIELDS = %i[content_id title schema_name locale analytics_identifier].freeze
 
@@ -165,6 +166,8 @@ module_function
         fields: STEP_BY_STEP_AUTH_BYPASS_FIELDS },
       { document_type: :step_by_step_nav,
         fields: STEP_BY_STEP_FIELDS },
+      { document_type: :take_part,
+        fields: TAKE_PART_PAGE_FIELDS },
       { document_type: :travel_advice,
         fields: TRAVEL_ADVICE_FIELDS },
       { document_type: :world_location,


### PR DESCRIPTION
Adding the rules so that we can see all the details for the take part
pages when using link expansion for the Get Involved page once it is
published through Government Frontend.

Related Trello card: https://trello.com/c/7BjH9PyC/2083-8-migrate-government-get-involved-to-government-frontend
Related Schema change pull request: https://github.com/alphagov/govuk-content-schemas/pull/1069