### PR TITLE
Add Description to link expansion rules for Take Part pages

### DIFF
--- a/lib/expansion_rules.rb
+++ b/lib/expansion_rules.rb
@@ -90,7 +90,7 @@ module_function
   ROLE_APPOINTMENT_FIELDS = (DEFAULT_FIELDS + details_fields(:started_on, :ended_on, :current, :person_appointment_order)).freeze
   STEP_BY_STEP_FIELDS = (DEFAULT_FIELDS + [%i[details step_by_step_nav title], %i[details step_by_step_nav steps]]).freeze
   STEP_BY_STEP_AUTH_BYPASS_FIELDS = (STEP_BY_STEP_FIELDS + %i[auth_bypass_ids]).freeze
-  TAKE_PART_PAGE_FIELDS = (DEFAULT_FIELDS + %i[details])
+  TAKE_PART_PAGE_FIELDS = (DEFAULT_FIELDS + %i[description details]).freeze
   TRAVEL_ADVICE_FIELDS = (DEFAULT_FIELDS + details_fields(:country, :change_description)).freeze
   WORLD_LOCATION_FIELDS = %i[content_id title schema_name locale analytics_identifier].freeze
 


### PR DESCRIPTION
We were missing the description when the Take Part pages were linked
into the Get Involved page. This commit solves the problem.

Related to Get Involved migration work: https://trello.com/c/7BjH9PyC/2083-8-migrate-government-get-involved-to-government-frontend