### PR TITLE
Migrate all publisher MHCLG docs to DLUHC

### DIFF
--- a/lib/tasks/tmp_migrate_publisher_mhclg_docs_to_dluhc.rake
+++ b/lib/tasks/tmp_migrate_publisher_mhclg_docs_to_dluhc.rake
@@ -1,0 +1,26 @@
+desc "Migrate mainstream publisher docs from MHCLG to DLUHC"
+task migrate_publisher_mhclg_docs_to_dluhc: :environment do
+  mhclg_content_id = "2e7868a8-38f5-4ff6-b62f-9a15d1c22d28"
+  dluhc_content_id = "c45c316a-a4f5-42c7-b94d-d7f1821be18e"
+
+  mhclg_content_ids = Edition
+    .distinct
+    .where(publishing_app: "publisher", state: %w[draft published])
+    .joins(:document)
+    .joins("INNER JOIN link_sets ON documents.content_id = link_sets.content_id")
+    .joins("INNER JOIN links ON link_sets.id = links.link_set_id")
+    .where(links: { target_content_id: mhclg_content_id, link_type: "organisations" })
+    .pluck("documents.content_id")
+    .uniq
+
+  puts "#{mhclg_content_ids.count} MHCLG documents to be migrated to DLUHC\n"
+
+  mhclg_content_ids.each do |content_id|
+    Commands::V2::PatchLinkSet.call(
+      content_id: content_id,
+      links: { organisations: [dluhc_content_id] },
+    )
+
+    puts "Migrated document with content_id: #{content_id}"
+  end
+end


### PR DESCRIPTION
A Zendesk ticket [1] has come in requesting all MHCLG documents be
migrated to DLUHC. This only applies to documents created in Publisher
[2].

The normal place to do this sort of migration would be from the app
itself, however as the organisation is never persisted for documents in
Publisher (only set and fetched from Publishing API), then it wouldn't
be possible to decipher MHCLG documents without querying links
(`get_links`) for every single document in the publishing app.

Successful rake task run: https://deploy.blue.staging.govuk.digital/job/run-rake-task/189026/console

## Before
<img width="1576" alt="Screenshot 2021-10-07 at 17 35 11" src="https://user-images.githubusercontent.com/24479188/136427076-bfb3ad3b-2eb7-41ca-937f-09f03ec6e30d.png">

## After
<img width="1477" alt="Screenshot 2021-10-07 at 17 35 19" src="https://user-images.githubusercontent.com/24479188/136427099-e9c92173-ca69-4e6b-a3b6-e372bdd3d724.png">


[1]: https://govuk.zendesk.com/agent/tickets/4734281
[2]: https://github.com/alphagov/publisher/