### PR TITLE
Remove misleading noise from RSpec test

### DIFF
--- a/spec/requests/lookups_spec.rb
+++ b/spec/requests/lookups_spec.rb
@@ -7,8 +7,6 @@ RSpec.describe "POST /lookup-by-base-path", type: :request do
 
       post "/lookup-by-base-path"
 
-      print parsed_response
-
       expect(parsed_response).to eql(expected_error_response)
     end
   end


### PR DESCRIPTION
One of the RSpec tests printed an error message directly to the console. This was misleading behaviour because it made it look like there was an error occuring within the tests – despite RSpec reporting 0 failures at the end of the run.

It turns out the printed error message was actually expected as part of the test. The `print` statement was probably added to help with debugging during development, and then was never removed.