### PR TITLE
Use Postgres 13 on Continuous Integration server

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,9 @@
 
 library("govuk")
 
-node("postgresql-9.6") {
+node {
+  // Run against the Postgres 13 Docker instance on GOV.UK CI
+  govuk.setEnvar("TEST_DATABASE_URL", "postgresql://postgres@127.0.0.1:54313/publishing-api-test")
 
   govuk.buildProject(
     extraParameters: [

--- a/config/database.yml
+++ b/config/database.yml
@@ -12,7 +12,7 @@ development:
 test:
   <<: *default
   database: publishing_api_test
-  url: <%= ENV["DATABASE_URL"].try(:sub, /([-_]development)?$/, '_test')%>
+  url: <%= ENV["TEST_DATABASE_URL"] %>
 
 production:
   <<: *default


### PR DESCRIPTION
This changes the Jenkins CI configuration to use Postgres 13.

Postgres 13 is [available at port `54313`][1] on the CI server. By explicitly setting the `TEST_DATABASE_URL`, we're telling Rails to use that Postgres server.

Previously, Rails implicitly used the default Postgres port `5432` which is a Postgres 9.6 server.

Trello ticket: https://trello.com/c/zVdVJqFM

[1]: https://docs.publishing.service.gov.uk/manual/test-and-build-a-project-on-jenkins-ci.html#specifying-which-database-to-use