### PR TITLE
Clarify example in rake task

### DIFF
--- a/lib/tasks/represent_downstream.rake
+++ b/lib/tasks/represent_downstream.rake
@@ -95,7 +95,7 @@ namespace :represent_downstream do
     Represent documents by document type(s) downstream on the high_priority sidekiq
     queue
     Usage
-    rake 'represent_downstream:high_priority:document_type[organisation]'
+    rake 'represent_downstream:high_priority:document_type[NewsArticle]'
     "
     task :document_type, [:document_types] => :environment do |_t, args|
       document_types = args[:document_types].split(" ")


### PR DESCRIPTION
The example usage of the rake task 
`represent_downstream:high_priority:document_type` is slightly unclear. 
By using the document type `organisation` it may seem as if it is a task 
for redownstreaming documents for one organisation. 

Changing it to `NewsArticle` may make this clearer.