### PR TITLE
Use text for long varchar database fields

### DIFF
--- a/db/migrate/20220105221134_use_text_for_long_change_notes.rb
+++ b/db/migrate/20220105221134_use_text_for_long_change_notes.rb
@@ -1,0 +1,9 @@
+class UseTextForLongChangeNotes < ActiveRecord::Migration[6.1]
+  def up
+    change_column :change_notes, :note, :text
+  end
+
+  def down
+    change_column :change_notes, :note, :string
+  end
+end

--- a/db/migrate/20220105221906_use_text_for_long_path_reservations.rb
+++ b/db/migrate/20220105221906_use_text_for_long_path_reservations.rb
@@ -1,0 +1,9 @@
+class UseTextForLongPathReservations < ActiveRecord::Migration[6.1]
+  def up
+    change_column :path_reservations, :base_path, :text
+  end
+
+  def down
+    change_column :path_reservations, :base_path, :string
+  end
+end

--- a/db/migrate/20220105222241_use_text_for_long_edition_columns.rb
+++ b/db/migrate/20220105222241_use_text_for_long_edition_columns.rb
@@ -1,0 +1,17 @@
+class UseTextForLongEditionColumns < ActiveRecord::Migration[6.1]
+  def up
+    change_table :editions, bulk: true do |t|
+      t.change :base_path, :text
+      t.change :description, :text
+      t.change :title, :text
+    end
+  end
+
+  def down
+    change_table :editions, bulk: true do |t|
+      t.change :base_path, :string
+      t.change :description, :string
+      t.change :title, :string
+    end
+  end
+end

--- a/db/migrate/20220105222552_use_text_for_long_unpublishings_columns.rb
+++ b/db/migrate/20220105222552_use_text_for_long_unpublishings_columns.rb
@@ -1,0 +1,15 @@
+class UseTextForLongUnpublishingsColumns < ActiveRecord::Migration[6.1]
+  def up
+    change_table :unpublishings, bulk: true do |t|
+      t.change :alternative_path, :text
+      t.change :explanation, :text
+    end
+  end
+
+  def down
+    change_table :unpublishings, bulk: true do |t|
+      t.change :alternative_path, :string
+      t.change :explanation, :string
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -2,15 +2,15 @@
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
 #
-# This file is the source Rails uses to define your schema when running `rails
-# db:schema:load`. When creating a new database, `rails db:schema:load` tends to
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
 # be faster and is potentially less error prone than running all of your
 # migrations from scratch. Old migrations may fail to apply correctly if those
 # migrations use external dependencies or application code.
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_06_153224) do
+ActiveRecord::Schema.define(version: 2022_01_05_222552) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -37,7 +37,7 @@ ActiveRecord::Schema.define(version: 2020_05_06_153224) do
   end
 
   create_table "change_notes", id: :serial, force: :cascade do |t|
-    t.string "note", default: ""
+    t.text "note", default: ""
     t.datetime "public_timestamp"
     t.integer "edition_id", null: false
     t.datetime "created_at"
@@ -57,7 +57,7 @@ ActiveRecord::Schema.define(version: 2020_05_06_153224) do
   end
 
   create_table "editions", id: :serial, force: :cascade do |t|
-    t.string "title"
+    t.text "title"
     t.datetime "public_updated_at"
     t.string "publishing_app"
     t.string "rendering_app"
@@ -72,10 +72,10 @@ ActiveRecord::Schema.define(version: 2020_05_06_153224) do
     t.datetime "last_edited_at"
     t.string "state", null: false
     t.integer "user_facing_version", default: 1, null: false
-    t.string "base_path"
+    t.text "base_path"
     t.string "content_store"
     t.integer "document_id", null: false
-    t.string "description"
+    t.text "description"
     t.string "publishing_request_id"
     t.datetime "major_published_at"
     t.datetime "published_at"
@@ -155,7 +155,7 @@ ActiveRecord::Schema.define(version: 2020_05_06_153224) do
   end
 
   create_table "path_reservations", id: :serial, force: :cascade do |t|
-    t.string "base_path", null: false
+    t.text "base_path", null: false
     t.string "publishing_app", null: false
     t.datetime "created_at"
     t.datetime "updated_at"
@@ -165,8 +165,8 @@ ActiveRecord::Schema.define(version: 2020_05_06_153224) do
   create_table "unpublishings", id: :serial, force: :cascade do |t|
     t.integer "edition_id", null: false
     t.string "type", null: false
-    t.string "explanation"
-    t.string "alternative_path"
+    t.text "explanation"
+    t.text "alternative_path"
     t.datetime "created_at"
     t.datetime "updated_at"
     t.datetime "unpublished_at"


### PR DESCRIPTION
Trello: https://trello.com/c/tRtDucM6/64-plan-production-upgrade-for-publishing-api-postgresql-database

This change has been made to resolve a problem experienced when using
this application with AWS Database Migration Service. We found issues
where DMS truncates some long strings and can have false positives for
DMS validation. These are resolved by using TEXT instead.

Aside from the above this change has very little impact on the
application, behind the scenes PostgreSQL represents VARCHAR and TEXT
very similarly 1. Arguably TEXT is a more semantic choice for these long
values.

I was a bit worried that this might be a slow migration due to some of
these columns being indexed but my test on integration was very fast,
which seems to indicate indexes aren't rebuilt with this change.

```
22:29:36 *** [err :: ip-10-1-4-17.eu-west-1.compute.internal] Migrating to UseTextForLongChangeNotes (20220105221134)
22:29:36 *** [err :: ip-10-1-4-17.eu-west-1.compute.internal] == 20220105221134 UseTextForLongChangeNotes: migrating ========================
22:29:36 *** [err :: ip-10-1-4-17.eu-west-1.compute.internal] -- change_column(:change_notes, :note, :text)
22:29:36 *** [err :: ip-10-1-4-17.eu-west-1.compute.internal] -> 0.0143s
22:29:36 *** [err :: ip-10-1-4-17.eu-west-1.compute.internal] == 20220105221134 UseTextForLongChangeNotes: migrated (0.0144s) ===============
22:29:36 *** [err :: ip-10-1-4-17.eu-west-1.compute.internal]
22:29:36 *** [err :: ip-10-1-4-17.eu-west-1.compute.internal] Migrating to UseTextForLongPathReservations (20220105221906)
22:29:36 *** [err :: ip-10-1-4-17.eu-west-1.compute.internal] == 20220105221906 UseTextForLongPathReservations: migrating ===================
22:29:36 *** [err :: ip-10-1-4-17.eu-west-1.compute.internal] -- change_column(:path_reservations, :base_path, :text)
22:29:36 *** [err :: ip-10-1-4-17.eu-west-1.compute.internal] -> 0.0098s
22:29:36 *** [err :: ip-10-1-4-17.eu-west-1.compute.internal] == 20220105221906 UseTextForLongPathReservations: migrated (0.0099s) ==========
22:29:36 *** [err :: ip-10-1-4-17.eu-west-1.compute.internal]
22:29:36 *** [err :: ip-10-1-4-17.eu-west-1.compute.internal] Migrating to UseTextForLongEditionColumns (20220105222241)
22:29:36 *** [err :: ip-10-1-4-17.eu-west-1.compute.internal] == 20220105222241 UseTextForLongEditionColumns: migrating =====================
22:29:36 *** [err :: ip-10-1-4-17.eu-west-1.compute.internal] -- change_table(:editions, {:bulk=>true})
22:29:36 *** [err :: ip-10-1-4-17.eu-west-1.compute.internal] -> 0.0083s
22:29:36 *** [err :: ip-10-1-4-17.eu-west-1.compute.internal] == 20220105222241 UseTextForLongEditionColumns: migrated (0.0083s) ============
22:29:36 *** [err :: ip-10-1-4-17.eu-west-1.compute.internal]
22:29:36 *** [err :: ip-10-1-4-17.eu-west-1.compute.internal] Migrating to UseTextForLongUnpublishingsColumns (20220105222552)
22:29:36 *** [err :: ip-10-1-4-17.eu-west-1.compute.internal] == 20220105222552 UseTextForLongUnpublishingsColumns: migrating ===============
22:29:36 *** [err :: ip-10-1-4-17.eu-west-1.compute.internal] -- change_table(:unpublishings, {:bulk=>true})
22:29:36 *** [err :: ip-10-1-4-17.eu-west-1.compute.internal] -> 0.0016s
22:29:36 *** [err :: ip-10-1-4-17.eu-west-1.compute.internal] == 20220105222552 UseTextForLongUnpublishingsColumns: migrated (0.0017s) ======
22:29:36 *** [err :: ip-10-1-4-17.eu-west-1.compute.internal]
```