### PR TITLE
Bump i18n gem to 1.9.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1131,7 +1131,7 @@ GEM
     httparty (0.18.1)
       mime-types (~> 3.0)
       multi_xml (>= 0.5.2)
-    i18n (1.9.0)
+    i18n (1.9.1)
       concurrent-ruby (~> 1.0)
     jmespath (1.4.0)
     json (2.5.1)


### PR DESCRIPTION
1.9.0 is no longer available (yanked) and the failing `bundle
install` is causing CI failures on unrelated changes.