### PR TITLE
Use Reusable CI workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,19 @@
+name: Build and publish to ECR
+
+on:
+  workflow_dispatch:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - "Jenkinsfile"
+      - ".git**"
+
+jobs:
+  build-publish-image-to-ecr:
+    uses: alphagov/govuk-infrastructure/.github/workflows/ci-ecr.yaml@main
+    secrets:
+      AWS_GOVUK_ECR_ACCESS_KEY_ID: ${{ secrets.AWS_GOVUK_ECR_ACCESS_KEY_ID }}
+      AWS_GOVUK_ECR_SECRET_ACCESS_KEY: ${{ secrets.AWS_GOVUK_ECR_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
Will build and push images to an ECR repository in AWS Production for use in the Kubernetes platorm.