### PR TITLE
Fix bug where downtime messages are not removed

### DIFF
--- a/app/workers/downstream_draft_worker.rb
+++ b/app/workers/downstream_draft_worker.rb
@@ -7,7 +7,8 @@ class DownstreamDraftWorker
 
   sidekiq_options queue: HIGH_QUEUE,
                   lock: :until_executing,
-                  unique_args: :uniq_args
+                  lock_args_method: :uniq_args,
+                  on_conflict: :log
 
   def self.uniq_args(args)
     [

--- a/app/workers/downstream_live_worker.rb
+++ b/app/workers/downstream_live_worker.rb
@@ -7,7 +7,8 @@ class DownstreamLiveWorker
 
   sidekiq_options queue: HIGH_QUEUE,
                   lock: :until_executing,
-                  unique_args: :uniq_args
+                  lock_args_method: :uniq_args,
+                  on_conflict: :log
 
   def self.uniq_args(args)
     [

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,7 +1,22 @@
 Sidekiq.configure_client do |config|
   config.client_middleware do |chain|
     chain.add SidekiqLoggerMiddleware
-    # See https://github.com/mhenrixon/sidekiq-unique-jobs/blob/921aaa4efc998b102790d1f4ecce2ebac609e464/README.md#add-the-middleware
     chain.add SidekiqUniqueJobs::Middleware::Client
   end
 end
+
+Sidekiq.configure_server do |config|
+  config.client_middleware do |chain|
+    chain.add SidekiqLoggerMiddleware
+    chain.add SidekiqUniqueJobs::Middleware::Client
+  end
+
+  config.server_middleware do |chain|
+    chain.add SidekiqUniqueJobs::Middleware::Server
+  end
+
+  SidekiqUniqueJobs::Server.configure(config)
+end
+
+# SidekiqUniqueJobs recommends not testing this behaviour https://github.com/mhenrixon/sidekiq-unique-jobs#uniqueness
+SidekiqUniqueJobs.config.enabled = !Rails.env.test?

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -13,6 +13,7 @@ require "database_cleaner"
 require "rspec/rails"
 # Add additional requires below this line. Rails is not loaded until this point!
 require "sidekiq/testing"
+require "sidekiq_unique_jobs/testing"
 Sidekiq::Logging.logger = nil
 # Sidekiq in test mode won't run server middleware by default.
 Sidekiq::Testing.server_middleware do |chain|

--- a/spec/workers/downstream_draft_worker_spec.rb
+++ b/spec/workers/downstream_draft_worker_spec.rb
@@ -20,6 +20,8 @@ RSpec.describe DownstreamDraftWorker do
     stub_request(:put, %r{.*content-store.*/content/.*})
   end
 
+  specify { expect(described_class).to have_valid_sidekiq_options }
+
   describe "arguments" do
     it "requires content_item_id or content_id" do
       expect {

--- a/spec/workers/downstream_live_worker_spec.rb
+++ b/spec/workers/downstream_live_worker_spec.rb
@@ -22,6 +22,8 @@ RSpec.describe DownstreamLiveWorker do
     stub_request(:put, %r{.*content-store.*/content/.*})
   end
 
+  specify { expect(described_class).to have_valid_sidekiq_options }
+
   describe "arguments" do
     it "requires content_item_id or content_id" do
       expect {


### PR DESCRIPTION
## Overview of bug

While upgrading the sidekiq-unique-jobs gem. Some of the required updates were not applied which caused some fairly subtle behaviour changes.

The main way that it exhibited itself was not clearing downtime messages applied by Mainstream Publisher (see here for reference
https://publisher.integration.publishing.service.gov.uk/downtimes)

When a downtime is created, two jobs are scheduled. One for midnight before the services downtime, and another 15 seconds after the downtime ends.

When a worker picks up the first job, it makes several requests to the PublishingAPI which persists a new edition of the document with the downtime message. It then pushes these changes to the Content Store.

Once the downtime has ended, a worker picks up the second job on Mainstream. This follows the journey as above, firstly pushing changes to PublishingAPI, which in turn pushes changes down to the Content Store.

After investigation, it became clear that the second job ran on mainstream and hit PublishingAPI which persisted a new edition of the document. However, the changes were not being pushed to the Content Store.

This meant that the downtime message was not being cleared and was still being shown on the GOV.UK page.

## Issue 1 - Deprecated `uniq_args` sidekiq option 

sidekiq-unique-jobs constructs a key is Redis based off the queue, class of the worker and the arguments passsed in
(see here https://github.com/mhenrixon/sidekiq-unique-jobs#introduction)

Before a job is enqueued, it checks to see if this key exists in Redis. If it does, it employs you're chosen conflict strategy (reject, replace retry etc.). In our case, we choose to reject the job as there should only ever need to be a maximum of one job enqueued for each document for each endpoint we hit on the Content Store.

This is because we pass in a content_id and action as arguments and construct the payload within the perform method.

After some investigation we were able to establish that the sidekiq-unique-gem was hitting our conflict strategy for the jobs
generated by the second set of requests made from Mainstream when it tries to clear the downtime message. This meant that the `DownstreamLiveWorker` and `DownstreamDraftWorker` which as responsible for pushing changes to the Content Store were not being enqueued.

The issue was being caused by the deprecation of the `uniq_args` option. While upgrading to version 7 of the gem, `uniq_args` option was deprecated in favour of the `lock_args_method`.

This meant that it defaulted to use all arguments passed in, rather than the set of arguments we had passed in via the `uniq_args` method.

Due to this, several extra arguments were used to construct the key, including govuk_request_id. This is an id that is assigned in Mainstream and passed through associated downstream operations, allowing us to easily track a requests E2E journey.

Essentially, this meant that all enqueued jobs were uniq by default with one notable exception. Jobs that were scheduled within the same set of operations would not be unqiue as they share a govuk_request_id.

## Issue 2 - Missed server side config for sidekiq-unique-jobs 7.0

When we upgraded sidekiq-unique-gems to 7.0 we didn't add in all the required config.

Default config was removed from 7.0 of the unique sidekicksjob gem. As a result, you have to manually configure the client and server middleware (see https://github.com/mhenrixon/sidekiq-unique-jobs#add-the-middleware)

We missed adding in the server side config. This config deals with removing the key from Redis after a job has run. This has led to us having over 7 million keys which should have been expunged still being persisted.

While you would think this issue would fail fast, and loudly, it didn't in this situation. This is due to nearly all jobs having uniq
args passed in. As far as we can tell, conflicts only occurred on the PublishingAPI when downtimes were scheduled on Mainstream.

These two issues combined caused surprisingly subtle behaviour which took a lengthy time to investigate and fix. Around 2 weeks, with a couple of mobbing sessions and several pairing sessions.

## How we're ensuring we don't miss deprecated config going forward

Going forward we're testing that the sidekiq arguments passed in are valid would have highlighted that the uniq_args option had been deprecated. Allowing us to establish one of the issues far more quickly.

Going forward if any further deprecations occur, these tests will fail, informing us.

## Trello card

https://trello.com/c/FVyZIFGH/97-downtime-messages-not-being-removed-from-publisher-documents