### PR TITLE
Add temporary Rake task to render hmrc_manuals in goverment-frontend

### DIFF
--- a/lib/tasks/tmp_migrate_hmrc_manuals_rendering_to_government_frontend.rake
+++ b/lib/tasks/tmp_migrate_hmrc_manuals_rendering_to_government_frontend.rake
@@ -1,0 +1,19 @@
+# As part of decommissioning manuals-frontend we are moving all previously published
+# manuals to government-frontend as the rendering app. As hnmrc-manuals-api has no DB
+# itself to update and republish from, we are instead updating the rendering app directly
+# in the publishing_api via this temporary Rake task. It will only update editions that are currently
+# live in the content-store, drafts will be updated when published from the API.
+
+desc "Migrate HMRC manuals rendering app to government-frontend"
+task tmp_migrate_hmrc_manuals_rendering_to_government_frontend: :environment do
+  hmrc_manuals = Document.presented.where(editions: { publishing_app: "hmrc-manuals-api" })
+
+  hmrc_manuals.each do |document|
+    edition = document.live
+
+    next if edition.blank?
+
+    edition.update!(rendering_app: "government-frontend")
+    Commands::V2::RepresentDownstream.new.call(document.content_id)
+  end
+end


### PR DESCRIPTION
As part of retiring manuals-frontend we need to update all published manuals to instead render via government-frontend.

As hmrc-manuals-api has no DB, we are unable to update and republish hmrc_manuals and hmrc_manuals_sections directly from the app.

Instead this temporary Rake task will update the rendering app for all live editions published by hmrc-manuals-api and re-represent them to the content store. 

Any previous superceded/unpublished editions will remain unchanged to preserve the historical record.

Any draft editions will be updated in the normal flow when set to live via the hmrc-manuals-api. 

[trello](https://trello.com/c/MtI1Cqvj/1129-manuals-migrate-existing-manuals-rendering-application)