### PR TITLE
Add optimalworkshop.com to allowlist of external domains

### DIFF
--- a/app/validators/routes_and_redirects_validator.rb
+++ b/app/validators/routes_and_redirects_validator.rb
@@ -1,5 +1,5 @@
 class RoutesAndRedirectsValidator < ActiveModel::Validator
-  EXTERNAL_HOST_ALLOW_LIST = %w[.gov.uk .judiciary.uk .nhs.uk .ukri.org .nationalhighways.co.uk].freeze
+  EXTERNAL_HOST_ALLOW_LIST = %w[.gov.uk .judiciary.uk .nhs.uk .ukri.org .nationalhighways.co.uk optimalworkshop.com].freeze
 
   def validate(record, base_path: nil)
     base_path = record.base_path if base_path.nil?

--- a/spec/support/routes_and_redirects_validator.rb
+++ b/spec/support/routes_and_redirects_validator.rb
@@ -212,6 +212,7 @@ RSpec.shared_examples_for RoutesAndRedirectsValidator do
           https://www.nhs.uk/
           https://www.ukri.org/
           https://www.nationalhighways.co.uk/
+          https://GDSUserResearch.optimalworkshop.com/treejack/1234
         ].each do |destination|
           edition.redirects = [{ path: "#{subject.base_path}/new", type: "exact", destination: destination }]
 


### PR DESCRIPTION
The explore team is adding a recruitment banner to subsets of pages
on govuk. The banner contains a link to the online survey at the
above domain. To save us having to redeploy the frontend applications
every time the survey URL is updated we would like to set up a redirect
in short-url manager. Once we have completed this phase of testing
optimalworkshop.com will be removed from the allowlist.