### PR TITLE
Migrate HMRC manuals from 'live' to 'beta'

### DIFF
--- a/lib/tasks/tmp_migrate_hmrc_manuals_from_live_to_beta.rake
+++ b/lib/tasks/tmp_migrate_hmrc_manuals_from_live_to_beta.rake
@@ -1,0 +1,15 @@
+desc "Migrate HMRC manuals from live to beta"
+task tmp_migrate_hmrc_manuals_from_live_to_beta: :environment do
+  hmrc_manuals = Document.presented.where(editions: { publishing_app: "hmrc-manuals-api" })
+
+  hmrc_manuals.each do |document|
+    edition = document.live
+
+    next if edition.blank?
+
+    edition.update!(phase: "beta")
+    if Rails.env.production?
+      Commands::V2::RepresentDownstream.new.call(document.content_id)
+    end
+  end
+end


### PR DESCRIPTION
HMRC manuals are rendered with a 'beta' banner due to custom logic in
Manuals Frontend, as we're migrating to Government Frontend we need to
set the phase value to persist the beta status.

There are questions around whether these pages should still be in 'beta'
but for now we need to keep the same phase.

Data migration template shamelessly copied from https://github.com/alphagov/publishing-api/pull/2047 (thanks @edwardkerry 😄)

Trello:
https://trello.com/c/sCpFwYz6/1213-migrate-hmrc-manuals-from-live-to-beta