### PR TITLE
Remove logging to file for containers that run in EKS.

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,7 +1,9 @@
 ---
 :verbose: false
 :concurrency: 12
-:logfile: ./log/sidekiq.json.log
+<% if ENV.key?('SIDEKIQ_LOGFILE') %>
+:logfile: <%= ENV['SIDEKIQ_LOGFILE'] %>
+<% end %>
 :queues:
   - downstream_high
   - dependency_resolution


### PR DESCRIPTION
Sidekig is defaulting to log to STDOUT, removing additionally log file which causes permission errors in non-root containers.

https://trello.com/c/Jef1t4xU/903-fix-app-permission-errors-due-to-nonroot

Same change as https://github.com/alphagov/publisher/pull/1603