### PR TITLE
Skip if document type is a redirect

### DIFF
--- a/lib/tasks/tmp_migrate_hmrc_manuals_rendering_to_government_frontend.rake
+++ b/lib/tasks/tmp_migrate_hmrc_manuals_rendering_to_government_frontend.rake
@@ -12,6 +12,7 @@ task tmp_migrate_hmrc_manuals_rendering_to_government_frontend: :environment do
     edition = document.live
 
     next if edition.blank?
+    next if edition.document_type == "redirect"
 
     edition.update!(rendering_app: "government-frontend")
     Commands::V2::RepresentDownstream.new.call(document.content_id)


### PR DESCRIPTION
Currently the task updates the edition if the document type is
'redirect'. This doesn't cause any issues downstream but the
`rendering_app` is populated when it should be `nil`.