### PR TITLE
Remove set last edited at task

### DIFF
--- a/lib/tasks/set_last_edited_at.rake
+++ b/lib/tasks/set_last_edited_at.rake
@@ -1,6 +1,0 @@
-desc "Sets last_edited_at for each edition with the value from public_updated_at"
-task set_last_edited_at: :environment do
-  sql = "UPDATE content_items SET last_edited_at = public_updated_at;"
-
-  ActiveRecord::Base.connection.execute(sql)
-end


### PR DESCRIPTION
This was likely a one off task that can now be removed.

This also has the benefit of boosting our test coverage ahead of CD, but in general it's beneficial for leaving only the regularly used tasks.

[Trello card](https://trello.com/c/FNtolpuM/13-enable-continuous-deployment-for-publishing-api)