### PR TITLE
Remove remove_invalid_worldorg_drafts task

### DIFF
--- a/lib/tasks/data_hygiene.rake
+++ b/lib/tasks/data_hygiene.rake
@@ -37,23 +37,4 @@ namespace :data_hygiene do
       puts "rake 'represent_downstream:content_id[#{args[:content_id]}]'"
     end
   end
-
-  desc "Removes invalid about page drafts from world organisations that can prevent editing"
-  task remove_invalid_worldorg_drafts: :environment do
-    about_pages = Edition
-     .where(document_type: "about", state: "draft")
-     .select { |edition| edition.base_path =~ /\A\/world\/organisations\/[^\/]+\z/ }
-     .map { |edition| [edition.document.content_id, edition.document.locale] }
-
-    puts "Found #{about_pages.size} invalid draft Worldwide Organisation editions to remove"
-    about_pages.each do |content_id, locale|
-      puts "Removing draft edition #{content_id}"
-      Commands::V2::DiscardDraft.call(
-        {
-          content_id: content_id,
-          locale: locale,
-        },
-      )
-    end
-  end
 end


### PR DESCRIPTION
This was likely a one-off task so tidying up.

This also has the benefit of boosting our test coverage ahead of CD, but in general it's beneficial for leaving only the regularly used tasks.

[Trello card](https://trello.com/c/FNtolpuM/13-enable-continuous-deployment-for-publishing-api)