### PR TITLE
Remove unused new-linkables route

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -38,7 +38,6 @@ Rails.application.routes.draw do
       get "/editions", to: "editions#index"
 
       get "/linkables", to: "content_items#linkables"
-      get "/new-linkables", to: "content_items#new_linkables"
 
       post "/actions/:content_id", to: "actions#create"
 


### PR DESCRIPTION
/new-linkables was a route introduced for a safe change to the way the /linkables endpoint worked in 2016, but it's no longer required and routes to a method that no longer exists, so think this was just missed from a tidy up.

Some relevant history:
[PR](https://github.com/alphagov/publishing-api/commit/0cda22075b6c034099d95c15a4401ee36a01f966) that added the route
[PR](https://github.com/alphagov/publishing-api/commit/c9dd5c66a63011c986ab9d9993d8ac810b790c5e) that removed the new_linkables method
[PR](https://github.com/alphagov/publishing-api/commit/fce593a4aefa74d0832d46b5bc2f4ca33059c448) that fully switched over (but did not remove the route)

Doing this as part of work to bring publishing api up to the standards required for CD. This was a public route so covered under the pact test requirements, but we should remove it rather than adding pact tests for it :-) 

Query used to see usage in kibana: `application: publishing-api AND request: GET\ \/v2\/new-linkables*` (but would be worrying if it was in use given the controller method doesn't exist!)

[Trello card](https://trello.com/c/FNtolpuM/13-enable-continuous-deployment-for-publishing-api)