### PR TITLE
Remove unused put links route

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,8 +28,6 @@ Rails.application.routes.draw do
         get "/links/:content_id", to: "link_sets#get_links"
         get "/expanded-links/:content_id", to: "link_sets#expanded_links"
         patch "/links/:content_id", to: "link_sets#patch_links"
-        # put is provided for backwards compatibility.
-        put "/links/:content_id", to: "link_sets#patch_links"
         get "/linked/:content_id", to: "link_sets#get_linked"
       end
 

--- a/spec/requests/content_item_requests/downstream_timeouts_spec.rb
+++ b/spec/requests/content_item_requests/downstream_timeouts_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe "Downstream timeouts", type: :request do
       end
 
       it "returns an error" do
-        put "/v2/links/#{content_id}", params: patch_links_attributes.to_json
+        patch "/v2/links/#{content_id}", params: patch_links_attributes.to_json
 
         expect(response.status).to eq(500)
         expect(parsed_response).to eq(
@@ -73,7 +73,7 @@ RSpec.describe "Downstream timeouts", type: :request do
       end
 
       it "returns an error" do
-        put "/v2/links/#{content_id}", params: patch_links_attributes.to_json
+        patch "/v2/links/#{content_id}", params: patch_links_attributes.to_json
 
         expect(response.status).to eq(500)
         expect(parsed_response).to eq(


### PR DESCRIPTION
This was introduced for backwards compatibility in 2016 but logs show this is now unused, and has been fully replaced by the patch endpoint. It is unused by GDS api adaptors, which instead [uses the patch route](https://github.com/alphagov/gds-api-adapters/blob/355ae4ca64bcc9491d4d30bb011efe62a80512af/lib/gds_api/publishing_api.rb#L322-L330). This route was not listed in the [api docs](https://github.com/alphagov/publishing-api/blob/main/docs/api.md) so there is no change to that as part of this PR.

The following screenshots show usage of PUT (legacy) vs PATCH (current) endpoints over the last 7 days, demonstrating that PUT is no longer used:

<img width="1562" alt="PUT request hits over the last 7 days showing 0 hits" src="https://user-images.githubusercontent.com/25515510/174547944-aa6b3d5d-c6af-4a9a-8e96-84f8e9bd9e3d.png">
<img width="1575" alt="PATCH request hits over the last 7 days showing 235,024 hits" src="https://user-images.githubusercontent.com/25515510/174547976-f65bf4f2-011a-4b98-b4b9-6801c903c090.png">

Doing this as part of work to bring publishing api up to the standards required for CD. This was a public route so covered under the pact test requirements, but we should remove it rather than adding pact tests for it :-) 

[Trello card](https://trello.com/c/FNtolpuM/13-enable-continuous-deployment-for-publishing-api)