### PR TITLE
Enable Document Collection to use shareable previews

### DIFF
--- a/lib/expansion_rules.rb
+++ b/lib/expansion_rules.rb
@@ -90,6 +90,7 @@ module_function
   ROLE_APPOINTMENT_FIELDS = (DEFAULT_FIELDS + details_fields(:started_on, :ended_on, :current, :person_appointment_order)).freeze
   STEP_BY_STEP_FIELDS = (DEFAULT_FIELDS + [%i[details step_by_step_nav title], %i[details step_by_step_nav steps]]).freeze
   STEP_BY_STEP_AUTH_BYPASS_FIELDS = (STEP_BY_STEP_FIELDS + %i[auth_bypass_ids]).freeze
+  DOCUMENT_COLLECTION_AUTH_BYPASS_FIELDS = (DEFAULT_FIELDS + %i[auth_bypass_ids]).freeze
   TAKE_PART_PAGE_FIELDS = (DEFAULT_FIELDS + %i[description details]).freeze
   TRAVEL_ADVICE_FIELDS = (DEFAULT_FIELDS + details_fields(:country, :change_description)).freeze
   WORLD_LOCATION_FIELDS = %i[content_id title schema_name locale analytics_identifier].freeze
@@ -161,6 +162,9 @@ module_function
       { document_type: :step_by_step_nav,
         link_type: :part_of_step_navs,
         fields: STEP_BY_STEP_AUTH_BYPASS_FIELDS },
+      { document_type: :document_collection,
+        link_type: :document_collections,
+        fields: DOCUMENT_COLLECTION_AUTH_BYPASS_FIELDS },
       { document_type: :step_by_step_nav,
         link_type: :related_to_step_navs,
         fields: STEP_BY_STEP_AUTH_BYPASS_FIELDS },

--- a/spec/lib/expansion_rules_spec.rb
+++ b/spec/lib/expansion_rules_spec.rb
@@ -53,6 +53,7 @@ RSpec.describe ExpansionRules do
     let(:service_manual_topic_fields) { default_fields + %i[description] }
     let(:step_by_step_fields) { default_fields + [%i[details step_by_step_nav title], %i[details step_by_step_nav steps]] }
     let(:step_by_step_auth_bypass_fields) { step_by_step_fields + %i[auth_bypass_ids] }
+    let(:document_collection_auth_bypass_fields) { default_fields + %i[auth_bypass_ids] }
     let(:travel_advice_fields) { default_fields + [%i[details country], %i[details change_description]] }
     let(:world_location_fields) { %i[content_id title schema_name locale analytics_identifier] }
 
@@ -101,6 +102,7 @@ RSpec.describe ExpansionRules do
     specify { expect(rules.expansion_fields(:step_by_step_nav, link_type: :related_to_step_navs, draft: false)).to eq(step_by_step_fields) }
     specify { expect(rules.expansion_fields(:step_by_step_nav, link_type: :unspecified_link)).to eq(step_by_step_fields) }
     specify { expect(rules.expansion_fields(:step_by_step_nav)).to eq(step_by_step_auth_bypass_fields) }
+    specify { expect(rules.expansion_fields(:document_collection)).to eq(document_collection_auth_bypass_fields) }
 
     specify { expect(rules.expansion_fields(:taxon)).to eq(taxon_fields) }
     specify { expect(rules.expansion_fields(:travel_advice)).to eq(travel_advice_fields) }


### PR DESCRIPTION
This involves adding config which specifies that auth_bypass_ids should be added for linked content.

https://trello.com/c/q6mdu7Or/518-make-document-collections-accessible-by-shareable-previews

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️