### PR TITLE
Allow content items to be redirects to *.police.uk

### DIFF
--- a/app/validators/routes_and_redirects_validator.rb
+++ b/app/validators/routes_and_redirects_validator.rb
@@ -1,5 +1,12 @@
 class RoutesAndRedirectsValidator < ActiveModel::Validator
-  EXTERNAL_HOST_ALLOW_LIST = %w[.gov.uk .judiciary.uk .nhs.uk .ukri.org .nationalhighways.co.uk .police.uk].freeze
+  EXTERNAL_HOST_ALLOW_LIST = %w[
+    .gov.uk
+    .judiciary.uk
+    .nationalhighways.co.uk
+    .nhs.uk
+    .police.uk
+    .ukri.org
+  ].freeze
 
   def validate(record, base_path: nil)
     base_path = record.base_path if base_path.nil?

--- a/app/validators/routes_and_redirects_validator.rb
+++ b/app/validators/routes_and_redirects_validator.rb
@@ -1,5 +1,5 @@
 class RoutesAndRedirectsValidator < ActiveModel::Validator
-  EXTERNAL_HOST_ALLOW_LIST = %w[.gov.uk .judiciary.uk .nhs.uk .ukri.org .nationalhighways.co.uk].freeze
+  EXTERNAL_HOST_ALLOW_LIST = %w[.gov.uk .judiciary.uk .nhs.uk .ukri.org .nationalhighways.co.uk .police.uk].freeze
 
   def validate(record, base_path: nil)
     base_path = record.base_path if base_path.nil?

--- a/spec/support/routes_and_redirects_validator.rb
+++ b/spec/support/routes_and_redirects_validator.rb
@@ -212,6 +212,7 @@ RSpec.shared_examples_for RoutesAndRedirectsValidator do
           https://www.nhs.uk/
           https://www.ukri.org/
           https://www.nationalhighways.co.uk/
+          https://www.police.uk/
         ].each do |destination|
           edition.redirects = [{ path: "#{subject.base_path}/new", type: "exact", destination: destination }]
 


### PR DESCRIPTION
Trello: https://trello.com/c/RgO5jyEF/558-add-policeuk-to-the-list-of-allowed-external-hosts

This is to meet a request from publishers who wish to configure GOV.UK
pages that have been migrated to a *.police.uk hostname.

Adding this is consistent with us adding nhs.uk and police.uk does
represent a UK public sector TLD.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️