### PR TITLE
Fix flaky test by resolving change note accepting empty timestamps

### DIFF
--- a/app/models/edition/timestamps.rb
+++ b/app/models/edition/timestamps.rb
@@ -58,6 +58,10 @@ class Edition::Timestamps
       end
     end
 
+    edition.change_note&.then do |change_note|
+      change_note.update!(public_timestamp: edition.public_updated_at) unless change_note.public_timestamp
+    end
+
     edition.save!
   end
 end

--- a/app/presenters/change_history_presenter.rb
+++ b/app/presenters/change_history_presenter.rb
@@ -30,6 +30,7 @@ module Presenters
         .joins(:edition)
         .where(editions: { document: document })
         .where("user_facing_version <= ?", version_number)
+        .where.not(public_timestamp: nil)
         .order(:public_timestamp)
     end
 

--- a/spec/factories/change_note.rb
+++ b/spec/factories/change_note.rb
@@ -1,3 +1,5 @@
 FactoryBot.define do
-  factory :change_note
+  factory :change_note do
+    public_timestamp { 1.day.ago }
+  end
 end

--- a/spec/models/edition/timestamps_spec.rb
+++ b/spec/models/edition/timestamps_spec.rb
@@ -173,5 +173,19 @@ RSpec.describe Edition::Timestamps do
         expect(edition.public_updated_at).to eq(current_time)
       end
     end
+
+    it "sets the public_timestamp of a change note without one" do
+      edition = create(:edition, public_updated_at: "2022-07-18")
+      change_note = create(:change_note, edition: edition, public_timestamp: nil)
+      expect { described_class.live_transition(edition, "minor") }
+        .to change { change_note.reload.public_timestamp }.to(edition.public_updated_at)
+    end
+
+    it "doesn't change the public_timestamp of a change note with one already set" do
+      edition = create(:edition)
+      change_note = create(:change_note, edition: edition, public_timestamp: "2022-07-18")
+      expect { described_class.live_transition(edition, "minor") }
+        .not_to(change { change_note.reload.public_timestamp })
+    end
   end
 end

--- a/spec/models/edition/timestamps_spec.rb
+++ b/spec/models/edition/timestamps_spec.rb
@@ -4,221 +4,173 @@ RSpec.describe Edition::Timestamps do
   let(:current_time) { Time.zone.now }
 
   describe "#edited" do
-    let(:edition) { build(:edition, update_type: update_type) }
-    let(:previous_live_version) do
-      build(
-        :edition,
-        publishing_api_first_published_at: "2017-01-01",
-        first_published_at: "2017-04-01",
-        major_published_at: "2017-11-11",
-      )
-    end
-
-    let(:update_type) { "major" }
-    let(:payload) do
-      {
-        first_published_at: first_published_at,
-        last_edited_at: last_edited_at,
-        public_updated_at: public_updated_at,
-      }
-    end
-    let(:first_published_at) { nil }
-    let(:last_edited_at) { nil }
-    let(:public_updated_at) { nil }
-
-    before { described_class.edited(edition, payload, previous_live_version) }
-
     it "saves the edition" do
+      edition = build(:edition)
+      described_class.edited(edition, {})
       expect(edition.id).not_to be_nil
     end
 
     it "sets publishing_api_last_edited_at to current time" do
+      edition = build(:edition)
+      described_class.edited(edition, {})
       expect(edition.publishing_api_last_edited_at).to eq current_time
     end
 
     it "sets publishing_api_first_published_at to same value as previous_live_version" do
-      expect(edition.publishing_api_first_published_at).to eq previous_live_version.publishing_api_first_published_at
+      edition = build(:edition)
+      previous_live_version = build(:edition, publishing_api_first_published_at: "2017-01-01")
+      described_class.edited(edition, {}, previous_live_version)
+      expect(edition.publishing_api_first_published_at).to eq(Time.zone.parse("2017-01-01"))
     end
 
-    context "when previous_live_version is nil" do
-      let(:previous_live_version) { nil }
-
-      it "sets publishing_api_first_published_at to nil" do
-        expect(edition.publishing_api_first_published_at).to be_nil
-      end
+    it "sets publishing_api_first_published_at to nil when there isn't a previous live version" do
+      edition = build(:edition)
+      described_class.edited(edition, {})
+      expect(edition.publishing_api_first_published_at).to be_nil
     end
 
-    context "when edition has an update_type that is not major" do
-      let(:update_type) { "minor" }
-
-      it "sets major_published_at to same value as previous_live_version" do
-        expect(edition.major_published_at).to eq previous_live_version.major_published_at
-      end
+    it "sets major_published_at to same value as previous_live_version for a non major update" do
+      edition = build(:edition, update_type: "minor")
+      previous_live_version = build(:edition, major_published_at: "2017-01-01")
+      described_class.edited(edition, {}, previous_live_version)
+      expect(edition.major_published_at).to eq(Time.zone.parse("2017-01-01"))
     end
 
-    context "when first_published_at is provided in payload" do
-      let(:first_published_at) { "2017-12-25" }
-
-      it "sets first_published_at to provided value" do
-        expect(edition.first_published_at).to eq Time.zone.parse(first_published_at)
-      end
+    it "sets first_published_at when it's provided in the payload" do
+      edition = build(:edition)
+      described_class.edited(edition, { first_published_at: "2017-01-01" })
+      expect(edition.first_published_at).to eq(Time.zone.parse("2017-01-01"))
     end
 
-    context "when first_published_at is not provided in payload" do
-      let(:first_published_at) { nil }
-
-      it "sets first_published_at to previous_live_version" do
-        expect(edition.first_published_at).to eq previous_live_version.first_published_at
-      end
+    it "sets first_published_at to the previous_live_version's value when it's not in the payload" do
+      edition = build(:edition)
+      previous_live_version = build(:edition, first_published_at: "2017-01-02")
+      described_class.edited(edition, {}, previous_live_version)
+      expect(edition.first_published_at).to eq(Time.zone.parse("2017-01-02"))
     end
 
-    context "when last_edited_at is provided in payload" do
-      let(:last_edited_at) { "2017-10-30" }
-
-      it "sets last_edited_at to provided value" do
-        expect(edition.last_edited_at).to eq Time.zone.parse(last_edited_at)
-      end
+    it "sets last_edited_at to a value provided in the payload" do
+      edition = build(:edition)
+      described_class.edited(edition, { last_edited_at: "2017-01-01" })
+      expect(edition.last_edited_at).to eq(Time.zone.parse("2017-01-01"))
     end
 
-    context "when last_edited_at is not provided in payload" do
-      let(:last_edited_at) { nil }
-
-      it "sets last_edited_at to current time" do
-        expect(edition.last_edited_at).to eq current_time
-      end
+    it "sets last_edited_at to current time when it's not in the payload" do
+      edition = build(:edition)
+      described_class.edited(edition, {})
+      expect(edition.last_edited_at).to eq(current_time)
     end
 
-    context "when public_updated_at is provided in payload" do
-      let(:public_updated_at) { "2017-10-30" }
-
-      it "sets public_updated_at to provided value" do
-        expect(edition.public_updated_at).to eq Time.zone.parse(public_updated_at)
-      end
+    it "sets public_updated_at to a value provided in the payload" do
+      edition = build(:edition)
+      described_class.edited(edition, { public_updated_at: "2017-01-01" })
+      expect(edition.public_updated_at).to eq(Time.zone.parse("2017-01-01"))
     end
 
-    context "when public_updated_at is not provided in payload" do
-      let(:public_updated_at) { nil }
-
-      it "sets public_updated_at to nil" do
-        expect(edition.public_updated_at).to be_nil
-      end
+    it "leaves public_updated_at as nil when it's not in the payload" do
+      edition = build(:edition)
+      described_class.edited(edition, {})
+      expect(edition.public_updated_at).to be_nil
     end
   end
 
   describe "#live_transition" do
-    let(:edition) do
-      build(
-        :edition,
-        publishing_api_first_published_at: publishing_api_first_published_at,
-        first_published_at: first_published_at,
-        public_updated_at: public_updated_at,
-      )
-    end
-    let(:publishing_api_first_published_at) { nil }
-    let(:first_published_at) { nil }
-    let(:public_updated_at) { nil }
-
-    let(:previous_live_version) do
-      build(
-        :edition,
-        major_published_at: "2017-11-05",
-        public_updated_at: previous_public_updated_at,
-      )
-    end
-    let(:previous_public_updated_at) { "2017-10-30" }
-
-    let(:update_type) { "major" }
-
-    before { described_class.live_transition(edition, update_type, previous_live_version) }
-
     it "saves the edition" do
+      edition = build(:edition)
+      described_class.live_transition(edition, "minor")
       expect(edition.id).not_to be_nil
     end
 
     it "sets the published_at value to current time" do
+      edition = build(:edition)
+      described_class.live_transition(edition, "minor")
       expect(edition.published_at).to eq current_time
     end
 
     context "when the edition is being published for the first time" do
-      let(:publishing_api_first_published_at) { nil }
-      let(:first_published_at) { nil }
+      let(:edition) { build(:edition) }
 
       it "sets publishing_api_first_published_at to current time" do
+        described_class.live_transition(edition, "minor")
         expect(edition.publishing_api_first_published_at).to eq current_time
       end
 
       it "sets first_published_at to current time" do
+        described_class.live_transition(edition, "minor")
         expect(edition.first_published_at).to eq current_time
       end
     end
 
     context "when an edition has already been published" do
-      let(:publishing_api_first_published_at) { "2010-05-01" }
-      let(:first_published_at) { "2011-05-01" }
+      let(:edition) do
+        build(
+          :edition,
+          publishing_api_first_published_at: "2011-05-01",
+          first_published_at: "2011-10-01",
+        )
+      end
 
       it "doesn't change publishing_api_first_published_at" do
-        expect(edition.publishing_api_first_published_at).to eq Time.zone.parse(publishing_api_first_published_at)
+        described_class.live_transition(edition, "minor")
+        expect(edition.publishing_api_first_published_at).to eq Time.zone.parse("2011-05-01")
       end
 
       it "doesn't change first published at" do
-        expect(edition.first_published_at).to eq Time.zone.parse(first_published_at)
+        described_class.live_transition(edition, "minor")
+        expect(edition.first_published_at).to eq Time.zone.parse("2011-10-01")
       end
     end
 
     context "when update type is major" do
       it "sets major_published_at to current time" do
-        expect(edition.major_published_at).to eq current_time
+        edition = build(:edition)
+        described_class.live_transition(edition, "major")
+        expect(edition.major_published_at).to eq(current_time)
       end
 
-      context "and public_updated_at hasn't been set on edition" do
-        let(:public_updated_at) { nil }
-
-        it "sets public_updated_at to current time" do
-          expect(edition.public_updated_at).to eq current_time
-        end
+      it "sets public_updated_at to current time when not already set" do
+        edition = build(:edition, public_updated_at: nil)
+        described_class.live_transition(edition, "major")
+        expect(edition.public_updated_at).to eq(current_time)
       end
 
-      context "and public_updated_at has been set on the edition" do
-        let(:public_updated_at) { "2017-04-01" }
-
-        it "doesn't change public_updated_at" do
-          expect(edition.public_updated_at).to eq Time.zone.parse(public_updated_at)
-        end
+      it "doesn't change an already set public_updated_at" do
+        edition = build(:edition, public_updated_at: "2017-04-01")
+        described_class.live_transition(edition, "major")
+        expect(edition.public_updated_at).to eq(Time.zone.parse("2017-04-01"))
       end
     end
 
     context "when update type is not major" do
-      let(:update_type) { "minor" }
-
-      it "sets major_published_at to the value from the previous live edition" do
-        expect(edition.major_published_at).to eq previous_live_version.major_published_at
+      it "sets major_published_at to the previous_live_edition's value" do
+        edition = build(:edition)
+        previous_live_version = build(:edition, major_published_at: "2017-01-02")
+        described_class.live_transition(edition, "minor", previous_live_version)
+        expect(edition.major_published_at).to eq(previous_live_version.major_published_at)
       end
 
-      context "and public_updated_at isn't set, also previous live edition has a public_updated_at value" do
-        let(:public_updated_at) { nil }
-        let(:previous_public_updated_at) { "2017-07-03" }
-
-        it "sets public_updated_at to the value of the previous edition" do
-          expect(edition.public_updated_at).to eq previous_live_version.public_updated_at
-        end
+      it "doesn't set major_published_at if there isn't a previous_live_edition" do
+        edition = build(:edition)
+        described_class.live_transition(edition, "minor")
+        expect(edition.major_published_at).to be_nil
       end
 
-      context "and neither edition or previous live edition have a public_updated_at value" do
-        let(:first_published_at) { "2017-01-01" }
-        let(:public_updated_at) { nil }
-        let(:previous_public_updated_at) { nil }
-
-        it "sets public_updated_at to first_published_at" do
-          expect(edition.public_updated_at).to eq Time.zone.parse(first_published_at)
-        end
+      it "doesn't change an already set public_updated_at" do
+        edition = build(:edition, public_updated_at: "2017-04-01")
+        described_class.live_transition(edition, "minor")
+        expect(edition.public_updated_at).to eq(Time.zone.parse("2017-04-01"))
       end
 
-      context "and public_updated_at has been set on the edition" do
-        let(:public_updated_at) { "2017-04-01" }
+      it "sets public_updated_at based on a previous_live_edition if it exists" do
+        edition = build(:edition, public_updated_at: "2017-04-01")
+        described_class.live_transition(edition, "minor")
+        expect(edition.public_updated_at).to eq(Time.zone.parse("2017-04-01"))
+      end
 
-        it "doesn't change public_updated_at" do
-          expect(edition.public_updated_at).to eq Time.zone.parse(public_updated_at)
-        end
+      it "sets public_updated_at to current time if a previous_live_edition doesn't exist" do
+        edition = build(:edition)
+        described_class.live_transition(edition, "minor")
+        expect(edition.public_updated_at).to eq(current_time)
       end
     end
   end

--- a/spec/presenters/change_history_presenter_spec.rb
+++ b/spec/presenters/change_history_presenter_spec.rb
@@ -49,6 +49,12 @@ RSpec.describe Presenters::ChangeHistoryPresenter do
       expect(subject.map { |item| item[:note] }).to eq %w[3 2 1]
     end
 
+    it "omits change notes that don't have a public timestamp" do
+      create(:change_note, edition: edition, note: "with-timestamp", public_timestamp: 1.day.ago)
+      create(:change_note, edition: edition, note: "without-timestamp", public_timestamp: nil)
+      expect(subject.map { |item| item[:note] }).to eq %w[with-timestamp]
+    end
+
     context "multiple editions for a single content id" do
       let(:item1) do
         create(

--- a/spec/presenters/change_history_presenter_spec.rb
+++ b/spec/presenters/change_history_presenter_spec.rb
@@ -26,11 +26,7 @@ RSpec.describe Presenters::ChangeHistoryPresenter do
     context "details hash doesn't include content_history" do
       before do
         2.times do |i|
-          ChangeNote.create(
-            edition: edition,
-            note: i.to_s,
-            public_timestamp: Time.zone.now.utc,
-          )
+          create(:change_note, edition: edition, note: i.to_s, public_timestamp: Time.zone.now.utc)
         end
       end
       it "constructs content history from change notes" do
@@ -40,11 +36,7 @@ RSpec.describe Presenters::ChangeHistoryPresenter do
 
     it "orders change notes by public_timestamp (ascending)" do
       [1, 3, 2].to_a.each do |i|
-        ChangeNote.create(
-          edition: edition,
-          note: i.to_s,
-          public_timestamp: i.days.ago,
-        )
+        create(:change_note, edition: edition, note: i.to_s, public_timestamp: i.days.ago)
       end
       expect(subject.map { |item| item[:note] }).to eq %w[3 2 1]
     end
@@ -73,8 +65,8 @@ RSpec.describe Presenters::ChangeHistoryPresenter do
         )
       end
       before do
-        ChangeNote.create!(edition: item1)
-        ChangeNote.create!(edition: item2)
+        create(:change_note, edition: item1)
+        create(:change_note, edition: item2)
       end
 
       context "reviewing latest version of a edition" do


### PR DESCRIPTION
This provides a fix for [a test](https://github.com/alphagov/publishing-api/blob/c92cc3101346c2cb1075c359d32851b970874b3a/spec/integration/message_queue_publishing_spec.rb#L4-L17) that fails in about 10% of Publishing API builds. The test relies on random data and thus exposes an issue in the code:

```
  1) Message queue publishing puts the correct message on the queue
     Failure/Error: expect(errors).to eql([])

       expected: []
            got: [{:failed_attribute=>"TypeV4", :fragment=>"#/details/change_history/0/public_timestamp", :message=>"T...76f-aca8114b1247#", :schema=>#<Addressable::URI:0x16c60 URI:a4923dd9-f21e-5f89-b76f-aca8114b1247#>}]

       (compared using eql?)

       Diff:
       @@ -1,6 +1,11 @@
       -[]
       +[{:failed_attribute=>"TypeV4",
       +  :fragment=>"#/details/change_history/0/public_timestamp",
       +  :message=>
       +   "The property '#/details/change_history/0/public_timestamp' of type null did not match the following type: string in schema a4923dd9-f21e-5f89-b76f-aca8114b1247#",
       +  :schema=>
       +   #<Addressable::URI:0x16c60 URI:a4923dd9-f21e-5f89-b76f-aca8114b1247#>}]

     # ./spec/integration/message_queue_publishing_spec.rb:36:in `block in ensure_message_queue_payload_validates_against_notification_schema'
     # ./spec/integration/message_queue_publishing_spec.rb:30:in `ensure_message_queue_payload_validates_against_notification_schema'
     # ./spec/integration/message_queue_publishing_spec.rb:17:in `block (3 levels) in <top (required)>'
     # ./spec/spec_helper.rb:85:in `block (3 levels) in <top (required)>'
     # ./spec/spec_helper.rb:85:in `block (2 levels) in <top (required)>'
```

The cause of this issue is that Publishing API will present change notes to the frontend and message queue when a change note does not have a timestamp. This is invalid as the schema dictates that [a change history will have a timestamp](https://github.com/alphagov/govuk-content-schemas/blob/0e748b701f657ebb41f871a8d8515d2eb3872228/formats/shared/definitions/publishing_api_base.jsonnet#L96-L116).

The fix for this is two-fold: 

1) Accept that in the draft process we can have change notes without a timestamp and filter them out of data sent to frontend
2) At the point of publishing set any change notes that are missing a timestamp.

I also had to refactor some funky tests (that I wrote 🤦) to be able to implement it.

In practice this issue seems to have caused a very limited impact on the Publishing API with only about 40 documents existing with invalid change notes. This is likely because the change note feature of Publishing API is rather niche and not used by Whitehall and other big Publishing apps.

More info in the commits and definitely easiest reviewed commit by commit.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️