### PR TITLE
Remove manual_edition conditional

### DIFF
--- a/lib/tasks/tmp_update_hmrc_manual_sections.rake
+++ b/lib/tasks/tmp_update_hmrc_manual_sections.rake
@@ -12,17 +12,13 @@ def update_hmrc_manual_section_titles(dry_run: false)
 
     next if edition.blank?
 
-    if manual_edition
-      details = edition.details
-      details[:manual].delete(:title)
+    details = edition.details
+    details[:manual].delete(:title)
 
-      puts("Removing HMRC Manual title from HMRC Section #{document.content_id}")
-      unless dry_run
-        edition.update!(details: details)
-        Commands::V2::RepresentDownstream.new.call(document.content_id)
-      end
-    else
-      puts("Error: no parent manual found for HMRC Manual Section #{document.content_id}")
+    puts("Removing HMRC Manual title from HMRC Section #{document.content_id}")
+    unless dry_run
+      edition.update!(details: details)
+      Commands::V2::RepresentDownstream.new.call(document.content_id)
     end
   end
 end


### PR DESCRIPTION
The var was removed in [1], but the reference wasn't.

[1]: https://github.com/alphagov/publishing-api/commit/ffcbd6f4c4c98a3034798f278d4944bbeb71ca69

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️