### PR TITLE
Update Dockerfile to use new GOV.UK Ruby base images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,27 +1,25 @@
-# (unless we decide to use Bitnami instead)
-ARG base_image=ruby:3.1.2-slim-buster
+ARG base_image=ghcr.io/alphagov/govuk-ruby-base:3.1.2
+ARG builder_image=ghcr.io/alphagov/govuk-ruby-builder:3.1.2
 
-FROM $base_image AS builder
-# TODO: have a separate build image which already contains the build-only deps.
-RUN apt-get update -qy && apt-get upgrade -y
-RUN apt-get update && apt-get install -y build-essential libpq-dev
-ENV RAILS_ENV=production GOVUK_APP_NAME=publishing-api
+FROM $builder_image AS builder
+
+RUN install_packages libpq-dev
+
+ENV GOVUK_APP_NAME=publishing-api
 RUN mkdir /app
 WORKDIR /app
 COPY Gemfile Gemfile.lock .ruby-version /app/
-RUN bundle config set deployment 'true'
-RUN bundle config set without 'development test'
-RUN bundle config set force_ruby_platform true
-RUN bundle install --jobs=8 --retry=2
+RUN bundle install
 COPY . /app
 
 FROM $base_image
-RUN apt-get update -qy && apt-get upgrade -y && \
-    apt-get install -y libpq-dev curl
+
+RUN install_packages curl libpq-dev
+
 # TODO: DATABASE_URL shouldn't be set here but seems to be required by E2E tests, figure out why.
 ENV DATABASE_URL=postgresql://postgres@postgres/publishing-api PORT=3093
 ENV GOVUK_CONTENT_SCHEMAS_PATH=/govuk-content-schemas
-ENV GOVUK_PROMETHEUS_EXPORTER=true RAILS_ENV=production GOVUK_APP_NAME=publishing-api
+ENV GOVUK_APP_NAME=publishing-api
 ENV RABBITMQ_URL=amqp://guest:guest@rabbitmq:5672 RABBITMQ_EXCHANGE=published_documents
 
 COPY --from=builder /usr/local/bundle/ /usr/local/bundle/


### PR DESCRIPTION
Updates the Dockerfile to use the new [GOV.UK Ruby base images](https://github.com/alphagov/govuk-ruby-images). Also updates the .ruby-version file to not specify a patch version, to allow for easier Ruby patching.

Context: https://trello.com/c/Zy0fd25w/970-use-base-builder-images-in-all-the-app-dockerfiles

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️