### PR TITLE
Make Dockerfile compatible with govuk-ruby-base.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,11 @@
+.dockerignore
 .git
 .gitignore
+Dockerfile
+Jenkinsfile
+Procfile
 README.md
-log/*
+docs
+spec
+log
+tmp

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,24 +3,21 @@ ARG builder_image=ghcr.io/alphagov/govuk-ruby-builder:3.1.2
 
 FROM $builder_image AS builder
 
-RUN install_packages libpq-dev
-
 ENV GOVUK_APP_NAME=publishing-api
-RUN mkdir /app
 WORKDIR /app
 COPY Gemfile Gemfile.lock .ruby-version /app/
 RUN bundle install
 COPY . /app
 
+
 FROM $base_image
 
-RUN install_packages curl libpq-dev
-
-# TODO: DATABASE_URL shouldn't be set here but seems to be required by E2E tests, figure out why.
+# TODO: don't set DATABASE_URL, PORT or RABBITMQ_URL here. Set them in publishing-e2e-tests.
 ENV DATABASE_URL=postgresql://postgres@postgres/publishing-api PORT=3093
+ENV RABBITMQ_URL=amqp://guest:guest@rabbitmq:5672 RABBITMQ_EXCHANGE=published_documents
+
 ENV GOVUK_CONTENT_SCHEMAS_PATH=/govuk-content-schemas
 ENV GOVUK_APP_NAME=publishing-api
-ENV RABBITMQ_URL=amqp://guest:guest@rabbitmq:5672 RABBITMQ_EXCHANGE=published_documents
 
 COPY --from=builder /usr/local/bundle/ /usr/local/bundle/
 COPY --from=builder /app /app/


### PR DESCRIPTION
- Stop doing `mkdir /app`, since govuk-ruby-base now does this for us (and `WORKDIR` creates its directory anyway if it's doesn't exist).
- Avoid installing a couple of packages which are now in the base image.
- Bring `.dockerignore` into line with most of the other repos.