### PR TITLE
Replace `Plek.current` with `Plek.new`

### DIFF
--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -230,13 +230,13 @@ class Edition < ApplicationRecord
   def api_url
     return unless api_path
 
-    Plek.current.website_root + api_path
+    Plek.new.website_root + api_path
   end
 
   def web_url
     return unless base_path
 
-    Plek.current.website_root + base_path
+    Plek.new.website_root + base_path
   end
 
 private


### PR DESCRIPTION
Usage of `Plek.current` was marked as deprecated in https://github.com/alphagov/plek/pull/94, therefore we should remove uses of the old syntax now we've upgraded Plek, else we'll log lots of deprecation warnings.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️