### PR TITLE
Remove references of old alphagov domain

### DIFF
--- a/docs/publishing-application-examples.md
+++ b/docs/publishing-application-examples.md
@@ -71,7 +71,7 @@ create and configure tokens:
   https://signon.integration.publishing.service.gov.uk/api_users). You must be
   a superadmin to see this page.
 0. Find your application in the list or create a new API user for it. The app's
-  email address should be `name-of-app@alphagov.co.uk`.
+  email address should be `name-of-app@digital.cabinet-office.gov.uk`.
 0. Add a publishing API application token for that user.
 0. Add the tokens for each environment to [govuk-secrets][govuk-secrets]
   ([example][govuk-secrets-token-example]).

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe User, type: :model do
   it_behaves_like "a gds-sso user class"
 
   context "setting the app_name" do
-    let(:user) { User.new(email: "foobar@alphagov.co.uk") }
+    let(:user) { User.new(email: "foobar@digital.cabinet-office.gov.uk") }
     it "sets the app_name from the email" do
       user.set_app_name!
       expect(user.app_name).to eq("foobar")


### PR DESCRIPTION
https://trello.com/c/CkRb8XcT/3003-audit-usage-of-alphagovcouk-domain-2

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️