### PR TITLE
Don't set storage backend addresses in the Dockerfile.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,12 +12,10 @@ COPY . /app
 
 FROM $base_image
 
-# TODO: don't set DATABASE_URL, PORT or RABBITMQ_URL here. Set them in publishing-e2e-tests.
-ENV DATABASE_URL=postgresql://postgres@postgres/publishing-api PORT=3093
-ENV RABBITMQ_URL=amqp://guest:guest@rabbitmq:5672 RABBITMQ_EXCHANGE=published_documents
-
 ENV GOVUK_CONTENT_SCHEMAS_PATH=/govuk-content-schemas
 ENV GOVUK_APP_NAME=publishing-api
+# TODO: move this default for RABBITMQ_EXCHANGE to config/initializers/services.rb.
+ENV RABBITMQ_EXCHANGE=published_documents
 
 COPY --from=builder /usr/local/bundle/ /usr/local/bundle/
 COPY --from=builder /app /app/

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,6 @@ FROM $base_image
 
 ENV GOVUK_CONTENT_SCHEMAS_PATH=/govuk-content-schemas
 ENV GOVUK_APP_NAME=publishing-api
-# TODO: move this default for RABBITMQ_EXCHANGE to config/initializers/services.rb.
-ENV RABBITMQ_EXCHANGE=published_documents
 
 COPY --from=builder /usr/local/bundle/ /usr/local/bundle/
 COPY --from=builder /app /app/

--- a/config/initializers/services.rb
+++ b/config/initializers/services.rb
@@ -37,8 +37,8 @@ PublishingAPI.register_service(
 
 rabbitmq_config = if ENV["DISABLE_QUEUE_PUBLISHER"] || (Rails.env.test? && ENV["ENABLE_QUEUE_IN_TEST_MODE"].blank?)
                     { noop: true }
-                  elsif ENV["RABBITMQ_URL"] && ENV["RABBITMQ_EXCHANGE"]
-                    { exchange: ENV["RABBITMQ_EXCHANGE"] }
+                  elsif ENV["RABBITMQ_URL"]
+                    { exchange: ENV.fetch("RABBITMQ_EXCHANGE", "published_documents") }
                   else
                     Rails.application.config_for(:rabbitmq).symbolize_keys
                   end


### PR DESCRIPTION
Setting `RABBITMQ_URL` in the Dockerfile makes it very difficult to use `RABBITMQ_HOSTS` etc. in Kubernetes.

This change doesn't affect anything in EC2.

Requires alphagov/publishing-e2e-tests/pull/518.