### PR TITLE
Remove publishing e2e test run missed in last commit

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,7 +17,6 @@ node {
     beforeTest: {
       govuk.setEnvar("PACT_BROKER_BASE_URL", "https://pact-broker.cloudapps.digital")
     },
-    publishingE2ETests: true,
     afterTest: {
       lock("publishing-api-$NODE_NAME-test") {
         govuk.setEnvar("PACT_CONSUMER_VERSION", "branch-${env.BRANCH_NAME}");


### PR DESCRIPTION
## Description

This was accidentally missed in https://github.com/alphagov/publishing-api/pull/2176. See this PR for details on decommissioning Publishing E2E tests


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️