### PR TITLE
Mark all routes as 'gone', not just the base path

### DIFF
--- a/app/presenters/gone_presenter.rb
+++ b/app/presenters/gone_presenter.rb
@@ -1,5 +1,5 @@
 class Presenters::GonePresenter
-  def initialize(base_path:, content_id:, publishing_app:, public_updated_at:, alternative_path:, explanation:, locale:)
+  def initialize(base_path:, content_id:, publishing_app:, public_updated_at:, alternative_path:, explanation:, locale:, routes:)
     @base_path = base_path
     @content_id = content_id
     @publishing_app = publishing_app
@@ -7,6 +7,7 @@ class Presenters::GonePresenter
     @alternative_path = alternative_path
     @explanation = explanation
     @locale = locale
+    @routes = routes
   end
 
   def self.from_edition(edition)
@@ -18,6 +19,7 @@ class Presenters::GonePresenter
       alternative_path: edition.unpublishing.alternative_path,
       explanation: edition.unpublishing.explanation,
       locale: edition.locale,
+      routes: edition.routes,
     )
   end
 
@@ -35,7 +37,7 @@ class Presenters::GonePresenter
 
 private
 
-  attr_reader :base_path, :content_id, :publishing_app, :public_updated_at, :alternative_path, :explanation, :locale
+  attr_reader :base_path, :content_id, :publishing_app, :public_updated_at, :alternative_path, :explanation, :locale, :routes
 
   def present
     {
@@ -51,18 +53,5 @@ private
       },
       routes:,
     }
-  end
-
-  def routes
-    if base_path
-      [
-        {
-          path: base_path,
-          type: "exact",
-        },
-      ]
-    else
-      []
-    end
   end
 end

--- a/spec/presenters/gone_presenter_spec.rb
+++ b/spec/presenters/gone_presenter_spec.rb
@@ -22,5 +22,32 @@ RSpec.describe Presenters::GonePresenter do
         expect(subject).to be_valid_against_notification_schema("gone")
       end
     end
+
+    context "with more than one route" do
+      let(:base_path) { "/government/document" }
+
+      let(:routes) do
+        [
+          {
+            path: base_path,
+            type: "exact",
+          },
+          {
+            path: "#{base_path}.atom",
+            type: "exact",
+          },
+        ]
+      end
+
+      let(:edition) { create(:gone_unpublished_edition, base_path:, routes:) }
+
+      subject(:result) do
+        described_class.from_edition(edition).for_message_queue(payload_version)
+      end
+
+      it "presents all the routes" do
+        expect(subject[:routes]).to eq(routes)
+      end
+    end
   end
 end


### PR DESCRIPTION
If an edition has more than one route (e.g. an atom feed, in addition to the base path), we currently only mark the base path as 'gone' when unpublishing the content item.  This is a bug, as we would expect all routes to be unpublished in the same way.

This fixes that bug by ensuring we unpublish all routes.

[Trello card](https://trello.com/c/ul5lL6y3)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️