### PR TITLE
Update expansion rules for Worldwide Organisations

### DIFF
--- a/lib/expansion_rules.rb
+++ b/lib/expansion_rules.rb
@@ -172,6 +172,8 @@ module_function
         fields: TRAVEL_ADVICE_FIELDS },
       { document_type: :world_location,
         fields: WORLD_LOCATION_FIELDS },
+      { document_type: :worldwide_organisation,
+        fields: DEFAULT_FIELDS_AND_DESCRIPTION },
       { document_type: :government,
         fields: GOVERNMENT_FIELDS },
       { document_type: :coronavirus_landing_page,

--- a/spec/lib/expansion_rules_spec.rb
+++ b/spec/lib/expansion_rules_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe ExpansionRules do
     let(:contact_fields) { default_fields + [%i[details description], %i[details title], %i[details contact_form_links], %i[details post_addresses], %i[details email_addresses], %i[details phone_numbers]] }
     let(:organisation_fields) { default_fields - [:public_updated_at] + [%i[details logo], %i[details brand], %i[details default_news_image], %i[details organisation_govuk_status]] }
     let(:taxon_fields) { default_fields + %i[description details phase] }
-    let(:mainstream_browser_page_fields) { default_fields + %i[description] }
+    let(:default_fields_and_description) { default_fields + %i[description] }
     let(:need_fields) { default_fields + [%i[details role], %i[details goal], %i[details benefit], %i[details met_when], %i[details justifications]] }
     let(:finder_fields) { default_fields + [%i[details facets]] }
     let(:ministerial_role_fields) { role_fields + [%i[details seniority]] }
@@ -62,7 +62,7 @@ RSpec.describe ExpansionRules do
     specify { expect(rules.expansion_fields(:parent)).to eq(default_fields) }
 
     specify { expect(rules.expansion_fields(:contact)).to eq(contact_fields) }
-    specify { expect(rules.expansion_fields(:mainstream_browse_page)).to eq(mainstream_browser_page_fields) }
+    specify { expect(rules.expansion_fields(:mainstream_browse_page)).to eq(default_fields_and_description) }
     specify { expect(rules.expansion_fields(:need)).to eq(need_fields) }
     specify { expect(rules.expansion_fields(:organisation)).to eq(organisation_fields) }
     specify { expect(rules.expansion_fields(:placeholder_organisation)).to eq(organisation_fields) }
@@ -105,6 +105,7 @@ RSpec.describe ExpansionRules do
     specify { expect(rules.expansion_fields(:taxon)).to eq(taxon_fields) }
     specify { expect(rules.expansion_fields(:travel_advice)).to eq(travel_advice_fields) }
     specify { expect(rules.expansion_fields(:world_location)).to eq(world_location_fields) }
+    specify { expect(rules.expansion_fields(:worldwide_organisation)).to eq(default_fields_and_description) }
 
     specify { expect(rules.expansion_fields(:finder, link_type: :finder)).to eq(finder_fields) }
     specify { expect(rules.expansion_fields(:parent, link_type: :finder)).to eq(default_fields) }


### PR DESCRIPTION
For Worldwide Organisations pages, we want to include the page's description in the link so it can be included in the linked page.

This will allow us to display the summary of a Worldwide Organisation (which is edited by updating the 'About' corporate information page for the organisation) on the associated International Delegation page.

[Trello card](https://trello.com/c/4FWd2mRD/363-add-international-delegation-page-content-to-their-content-item)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️