### PR TITLE
Fix issue with updating Worldwide Organisation pages

### DIFF
--- a/db/migrate/20221108113755_remove_duplicate_worldwide_organisation.rb
+++ b/db/migrate/20221108113755_remove_duplicate_worldwide_organisation.rb
@@ -1,0 +1,7 @@
+class RemoveDuplicateWorldwideOrganisation < ActiveRecord::Migration[7.0]
+  def up
+    Edition.where(document_type: "worldwide_organisation").each do |worldwide_organisation|
+      Edition.where(base_path: worldwide_organisation.base_path, document_type: "about", state: "draft").delete_all
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_01_05_222552) do
+ActiveRecord::Schema[7.0].define(version: 2022_11_08_113755) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 


### PR DESCRIPTION
Whenever a Worldwide Organisation page is updated in Whitehall, we publish the changes to Publishing API.

Since approximately April 2021, this has been failing and an error being logged in Whitehall.  For example:

```
GdsApi::HTTPUnprocessableEntity
URL: https://publishing-api.integration.govuk-internal.digital/v2/content/f4c3a215-7a30-11e4-a3cb-005056011aef
Response body:
{"error":{"code":422,"message":"base path=/world/organisations/uk-joint-delegation-to-nato conflicts with content_id=5f5bfa0f-7631-11e4-a3cb-005056011aef and locale=en","fields":{"base":["base path=/world/organisations/uk-joint-delegation-to-nato conflicts with content_id=5f5bfa0f-7631-11e4-a3cb-005056011aef and locale=en"]}}}
```

This was occuring because there is a draft edition for a placeholder Corporate Information Page with the same base path as the Worldwide Organisation.  It is not clear how these editions came to be present, but are not needed and are blocking us from publishing updates.

We never noticed this issue previously as Worldwide Organisation pages are rendered by Whitehall directly from its own database, therefore the lack of updates to Publishing API were never an issue.

Users would see a 500 error in Whitehall when updating the Worldwide Organisation, but the changes would appear on the live site.

Now that we are including content from the Worldwide Organisations on International Delegation pages (which are rendered from Content Store), this issue has now become apparent because the content in Content Store for these organisations is very out of date.

This PR adds a migration which removes the draft duplicated pages.

After deploying this migration, we will need to run the following rake task in Whitehall to update all the stale content items:
```
publishing_api:bulk_republish:document_type[WorldwideOrganisation]
```

[Example Sentry issue](https://sentry.io/organizations/govuk/issues/3725268123/?project=202259&referrer=issue-stream)

Issue is related to the work in [Trello card](https://trello.com/c/SHpTX3sI).

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️