### PR TITLE
Update topic_groups definitions: add content_ids, remove description 

### DIFF
--- a/content_schemas/dist/formats/mainstream_browse_page/frontend/schema.json
+++ b/content_schemas/dist/formats/mainstream_browse_page/frontend/schema.json
@@ -667,10 +667,6 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "description": {
-            "description": "DEPRECATED",
-            "type": "string"
-          },
           "name": {
             "type": "string"
           }

--- a/content_schemas/dist/formats/mainstream_browse_page/frontend/schema.json
+++ b/content_schemas/dist/formats/mainstream_browse_page/frontend/schema.json
@@ -657,10 +657,11 @@
         "additionalProperties": false,
         "properties": {
           "content_ids": {
-            "description": "DEPRECATED",
+            "description": "Ordered list of content_ids of content that is in the topic group",
             "$ref": "#/definitions/guid_list"
           },
           "contents": {
+            "description": "DEPRECATED",
             "type": "array",
             "items": {
               "$ref": "#/definitions/absolute_path"

--- a/content_schemas/dist/formats/mainstream_browse_page/notification/schema.json
+++ b/content_schemas/dist/formats/mainstream_browse_page/notification/schema.json
@@ -801,10 +801,6 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "description": {
-            "description": "DEPRECATED",
-            "type": "string"
-          },
           "name": {
             "type": "string"
           }

--- a/content_schemas/dist/formats/mainstream_browse_page/notification/schema.json
+++ b/content_schemas/dist/formats/mainstream_browse_page/notification/schema.json
@@ -791,10 +791,11 @@
         "additionalProperties": false,
         "properties": {
           "content_ids": {
-            "description": "DEPRECATED",
+            "description": "Ordered list of content_ids of content that is in the topic group",
             "$ref": "#/definitions/guid_list"
           },
           "contents": {
+            "description": "DEPRECATED",
             "type": "array",
             "items": {
               "$ref": "#/definitions/absolute_path"

--- a/content_schemas/dist/formats/mainstream_browse_page/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/mainstream_browse_page/publisher_v2/schema.json
@@ -393,10 +393,11 @@
         "additionalProperties": false,
         "properties": {
           "content_ids": {
-            "description": "DEPRECATED",
+            "description": "Ordered list of content_ids of content that is in the topic group",
             "$ref": "#/definitions/guid_list"
           },
           "contents": {
+            "description": "DEPRECATED",
             "type": "array",
             "items": {
               "$ref": "#/definitions/absolute_path"

--- a/content_schemas/dist/formats/mainstream_browse_page/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/mainstream_browse_page/publisher_v2/schema.json
@@ -403,10 +403,6 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "description": {
-            "description": "DEPRECATED",
-            "type": "string"
-          },
           "name": {
             "type": "string"
           }

--- a/content_schemas/dist/formats/topic/frontend/schema.json
+++ b/content_schemas/dist/formats/topic/frontend/schema.json
@@ -645,10 +645,6 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "description": {
-            "description": "DEPRECATED",
-            "type": "string"
-          },
           "name": {
             "type": "string"
           }

--- a/content_schemas/dist/formats/topic/frontend/schema.json
+++ b/content_schemas/dist/formats/topic/frontend/schema.json
@@ -635,10 +635,11 @@
         "additionalProperties": false,
         "properties": {
           "content_ids": {
-            "description": "DEPRECATED",
+            "description": "Ordered list of content_ids of content that is in the topic group",
             "$ref": "#/definitions/guid_list"
           },
           "contents": {
+            "description": "DEPRECATED",
             "type": "array",
             "items": {
               "$ref": "#/definitions/absolute_path"

--- a/content_schemas/dist/formats/topic/notification/schema.json
+++ b/content_schemas/dist/formats/topic/notification/schema.json
@@ -767,10 +767,6 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "description": {
-            "description": "DEPRECATED",
-            "type": "string"
-          },
           "name": {
             "type": "string"
           }

--- a/content_schemas/dist/formats/topic/notification/schema.json
+++ b/content_schemas/dist/formats/topic/notification/schema.json
@@ -757,10 +757,11 @@
         "additionalProperties": false,
         "properties": {
           "content_ids": {
-            "description": "DEPRECATED",
+            "description": "Ordered list of content_ids of content that is in the topic group",
             "$ref": "#/definitions/guid_list"
           },
           "contents": {
+            "description": "DEPRECATED",
             "type": "array",
             "items": {
               "$ref": "#/definitions/absolute_path"

--- a/content_schemas/dist/formats/topic/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/topic/publisher_v2/schema.json
@@ -383,10 +383,11 @@
         "additionalProperties": false,
         "properties": {
           "content_ids": {
-            "description": "DEPRECATED",
+            "description": "Ordered list of content_ids of content that is in the topic group",
             "$ref": "#/definitions/guid_list"
           },
           "contents": {
+            "description": "DEPRECATED",
             "type": "array",
             "items": {
               "$ref": "#/definitions/absolute_path"

--- a/content_schemas/dist/formats/topic/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/topic/publisher_v2/schema.json
@@ -393,10 +393,6 @@
               "$ref": "#/definitions/absolute_path"
             }
           },
-          "description": {
-            "description": "DEPRECATED",
-            "type": "string"
-          },
           "name": {
             "type": "string"
           }

--- a/content_schemas/examples/mainstream_browse_page/frontend/curated_level_2_page.json
+++ b/content_schemas/examples/mainstream_browse_page/frontend/curated_level_2_page.json
@@ -10,6 +10,11 @@
           "/benefit-fraud",
           "/national-benefit-fraud-hotline",
           "/benefit-integrity-centres"
+        ],
+        "content_ids": [
+          "3489076b-8c47-42ac-850d-03181891ab61",
+          "f96fd362-99aa-49b7-9095-914fe762bf16",
+          "ebd9bedd-74bb-456c-a6c6-df96edcbc6f9"
         ]
       },
       {
@@ -17,6 +22,10 @@
         "contents": [
           "/complain-debt-management",
           "/complain-independent-case-examiner"
+        ],
+        "content_ids": [
+          "5f559439-7631-11e4-a3cb-005056011aef",
+          "8828ac41-a83a-4281-81e1-75f7ef84c731"
         ]
       }
     ]

--- a/content_schemas/examples/topic/frontend/best-practice-sub-topic.json
+++ b/content_schemas/examples/topic/frontend/best-practice-sub-topic.json
@@ -6388,6 +6388,11 @@
           "/corporation-tax",
           "/limited-company-formation",
           "/running-a-limited-company"
+        ],
+        "content_ids": [
+          "3489076b-8c47-42ac-850d-03181891ab61",
+          "f96fd362-99aa-49b7-9095-914fe762bf16",
+          "ebd9bedd-74bb-456c-a6c6-df96edcbc6f9"
         ]
       },
       {
@@ -6396,6 +6401,11 @@
           "/prepare-file-annual-accounts-for-limited-company",
           "/first-company-accounts-and-return",
           "/corporation-tax-accounting-period"
+        ],
+        "content_ids": [
+          "c29da376-a38e-49c8-b93a-e1c7416987f7",
+          "4f3b1755-32c1-4a8d-b0f8-30ce1ee57747",
+          "7711eed9-8349-4887-8f49-023eef725531"
         ]
       },
       {
@@ -6406,6 +6416,13 @@
           "/tax-when-your-company-sells-assets",
           "/directors-loans",
           "/guidance/tonnage-tax-for-shipping-companies"
+        ],
+        "content_ids": [
+          "6124e1b7-7bc4-4e88-8c51-c8b58adbd3d2",
+          "a37b1391-cbe2-4c91-8763-6262aaecabf7",
+          "efece9ba-4f80-440a-9e21-c2a49f3340f9",
+          "70607812-4831-4251-bc05-7752aae82d5f",
+          "14b01002-fcc8-4ab1-8736-666f3687c81c"
         ]
       },
       {
@@ -6422,6 +6439,19 @@
           "/charities-and-tax",
           "/tax-relief-cascs",
           "/tax-limited-company-gives-to-charity"
+        ],
+        "content_ids": [
+          "542849d1-76d7-4cab-bb6e-af4a9b4fea71",
+          "de9283f6-a7fe-4972-bf1b-4c7a0cb290c3",
+          "dafebf70-f5c1-42f4-b9b6-b59614267dc7",
+          "0b51f567-78be-4186-9e2d-d4b044d7f224",
+          "96def05b-8e4d-41eb-88dc-4a4615541a67",
+          "f449ad20-8e16-4ece-87ed-42b0e06d5153",
+          "d161aca6-ef09-4164-909e-5ab75feb02f6",
+          "45b6d0f1-7756-499e-af46-40b08e96fd19",
+          "bd11a919-7cff-4b8c-b3cc-ec0c237f0808",
+          "53f1b64f-4cd6-47bf-9dcd-877afcf5ecf5",
+          "01bfe776-32fc-43c7-b961-4b4f157b120c"
         ]
       },
       {
@@ -6432,6 +6462,13 @@
           "/guidance/corporation-tax-interest-charges",
           "/guidance/corporation-tax-group-payment-arrangements",
           "/guidance/corporation-tax-paying-in-instalments"
+        ],
+        "content_ids": [
+          "857d8f26-4bca-4a83-9421-8277b1dc3e60",
+          "46a7ff86-cd81-4f54-9a3c-14b6ee6eed4b",
+          "9bcae969-0a8a-446c-99c8-0e5fd6a37fe3",
+          "41d501c3-ed1d-490a-a8f2-5428619fb4b8",
+          "fdb58e53-a4f7-490e-8ba2-c3c84300c3ba"
         ]
       },
       {
@@ -6443,6 +6480,14 @@
           "/government/publications/corporation-tax-change-adobe-reader-settings",
           "/government/publications/corporation-tax-sample-accounts-and-computation-templates",
           "/guidance/corporation-tax-penalties"
+        ],
+        "content_ids": [
+          "930ecca2-3848-4e13-adb6-ef4ec568ba65",
+          "6972c8f9-569f-4ec5-81b3-911def035c20",
+          "43d84bad-141b-476e-be9f-62c2a9207433",
+          "0033c1de-5a10-45b9-88e1-b697f078abfa",
+          "23b1b97f-0efc-4a23-ae3f-ea2600c5ec8c",
+          "28f6435f-9181-4df1-b603-9296ec246f17"
         ]
       },
       {
@@ -6451,6 +6496,11 @@
           "/guidance/corporation-tax-trading-and-non-trading",
           "/change-your-companys-year-end",
           "/guidance/corporation-tax-selling-or-closing-your-company"
+        ],
+        "content_ids": [
+          "8a334878-50d0-4ad5-b814-7a0f324b8a45",
+          "fc8f43f6-77b4-485c-b337-d2fcc40841b1",
+          "16ebe916-bea3-450c-b39e-161e1d3e0dfb"
         ]
       },
       {
@@ -6459,6 +6509,11 @@
           "/government/collections/corporation-tax-forms",
           "/government/collections/company-taxation-manual",
           "/government/collections/corporation-tax-online-filing-and-electronic-payment"
+        ],
+        "content_ids": [
+          "5b646e40-aed9-4904-a889-88964088e9ec",
+          "ecc76348-9c76-4e99-8d23-0b3474b294ee",
+          "5e1bddec-d2c2-4b25-bb2b-dd4e3f93dd39"
         ]
       }
     ],

--- a/content_schemas/examples/topic/frontend/curated_subtopic.json
+++ b/content_schemas/examples/topic/frontend/curated_subtopic.json
@@ -9,12 +9,19 @@
         "contents": [
           "/oil-rig-safety-requirements",
           "/oil-rig-staffing"
+        ],
+        "content_ids": [
+          "23b1b97f-0efc-4a23-ae3f-ea2600c5ec8c",
+          "28f6435f-9181-4df1-b603-9296ec246f17"
         ]
       },
       {
         "name": "Piping",
         "contents": [
           "/undersea-piping-restrictions"
+        ],
+        "content_ids": [
+          "f84918f1-de82-4a8e-a4c5-d65872307a4f"
         ]
       }
     ]

--- a/content_schemas/formats/shared/definitions/topic_groups.jsonnet
+++ b/content_schemas/formats/shared/definitions/topic_groups.jsonnet
@@ -18,13 +18,14 @@
           type: "string",
         },
         contents: {
+          description: "DEPRECATED",
           type: "array",
           items: {
             "$ref": "#/definitions/absolute_path",
           },
         },
         content_ids: {
-          description: "DEPRECATED",
+          description: "Ordered list of content_ids of content that is in the topic group",
           "$ref": "#/definitions/guid_list",
         },
       },

--- a/content_schemas/formats/shared/definitions/topic_groups.jsonnet
+++ b/content_schemas/formats/shared/definitions/topic_groups.jsonnet
@@ -13,10 +13,6 @@
         name: {
           type: "string",
         },
-        description: {
-          description: "DEPRECATED",
-          type: "string",
-        },
         contents: {
           description: "DEPRECATED",
           type: "array",


### PR DESCRIPTION
## Context

When a content item is tagged to curated Mainstream browse or Specialist topic and this content item’s slug changes the link disappears from the topic page. This is because the curated lists/groups are based on base paths. 
The “contents” slugs don’t get updated as a part of dependency resolution in Publishing API.

We want to base it on content_ids which are less subjected to change (if at all).

## Changes proposed 

- Mark content_ids as not-deprecated.
The content_ids property was added to enable support of service_manual_groups as it was decided that the should use the existing topic groups definition according to https://github.com/alphagov/govuk-content-schemas/pull/203. The schema was then split into "topic_groups" and “service_manual_topic_groups”  in https://github.com/alphagov/govuk-content-schemas/commit/7bad6a241d3b3e178b66df9e81fd9cc8edc54e95 and the properties marked deprecated for later removal.

- Update the description in line with the recently unified topic terminology
- Remove deprecated `description` property from "topic_groups"

### Notes
- There will be a follow-up PR to add `content_ids` to the required parameters
- We will remove `contents` property after the migration

## Related PRs
- https://github.com/alphagov/collections-publisher/pull/1749
- https://github.com/alphagov/collections/pull/3056
---
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
