### PR TITLE
Remove symlink

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -88,7 +88,7 @@ def checkGeneratedSchemasAreUpToDate(govuk) {
 }
 
 boolean schemasDirChangedInBranch(branchName) {
-  noChangesToSchemasOnBranch = sh(script: "git diff --exit-code origin/main -- 'content_schemas/dist/' ${branchName} --  'content_schemas/dist/' ", returnStatus: true) == 0
+  noChangesToSchemasOnBranch = sh(script: "git diff --exit-code origin/main -- 'content_schemas/' ${branchName} --  'content_schemas/' ", returnStatus: true) == 0
   return !noChangesToSchemasOnBranch
 }
 

--- a/content_schemas/lib/govuk_content_schemas/allowed_document_types.yml
+++ b/content_schemas/lib/govuk_content_schemas/allowed_document_types.yml
@@ -1,1 +1,0 @@
-../../../content_schemas/allowed_document_types.yml


### PR DESCRIPTION
This removes a symlink that was introduced while we switched apps over from using govuk-content-schemas for schemas, to publishing api.

It also updates the jenkinsfile to ensure that this triggers dependent app builds.

[Trello](https://trello.com/c/ZUK2duYI/361-add-govuk-content-schemas-to-publishing-api-repo) 

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
