### PR TITLE
Remove pact configuration to clone govuk-content-schemas

### DIFF
--- a/.github/workflows/pact-verify.yml
+++ b/.github/workflows/pact-verify.yml
@@ -36,19 +36,12 @@ jobs:
     env:
       PACT_CONSUMER_VERSION: ${{ inputs.pact_consumer_version || 'branch-main' }}
       TEST_DATABASE_URL: postgresql://postgres@localhost/test-db
-      GOVUK_CONTENT_SCHEMAS_PATH: vendor/govuk-content-schemas
       RAILS_ENV: test
     steps:
       - uses: actions/checkout@v3
         with:
           repository: alphagov/publishing-api
           ref: ${{ inputs.commitish || github.sha }}
-      - uses: actions/checkout@v3
-        name: Clone content schemas
-        with:
-          repository: alphagov/govuk-content-schemas
-          ref: deployed-to-production
-          path: vendor/govuk-content-schemas
       - uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true


### PR DESCRIPTION
These have now been moved into publishing-api, which configures schemas to point to its own version of schemas on startup.

[Trello](https://trello.com/c/ZUK2duYI/361-add-govuk-content-schemas-to-publishing-api-repo)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
