### PR TITLE
Add licence_transaction schema

### DIFF
--- a/content_schemas/allowed_document_types.yml
+++ b/content_schemas/allowed_document_types.yml
@@ -73,6 +73,7 @@
 - knowledge_alpha
 - licence
 - license_finder
+- licence_transaction
 - local_transaction
 - maib_report
 - mainstream_browse_page

--- a/content_schemas/dist/formats/generic/frontend/schema.json
+++ b/content_schemas/dist/formats/generic/frontend/schema.json
@@ -109,6 +109,7 @@
         "knowledge_alpha",
         "licence",
         "license_finder",
+        "licence_transaction",
         "local_transaction",
         "maib_report",
         "mainstream_browse_page",

--- a/content_schemas/dist/formats/generic/notification/schema.json
+++ b/content_schemas/dist/formats/generic/notification/schema.json
@@ -133,6 +133,7 @@
         "knowledge_alpha",
         "licence",
         "license_finder",
+        "licence_transaction",
         "local_transaction",
         "maib_report",
         "mainstream_browse_page",

--- a/content_schemas/dist/formats/generic/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/generic/publisher_v2/schema.json
@@ -119,6 +119,7 @@
         "knowledge_alpha",
         "licence",
         "license_finder",
+        "licence_transaction",
         "local_transaction",
         "maib_report",
         "mainstream_browse_page",

--- a/content_schemas/dist/formats/generic_with_external_related_links/frontend/schema.json
+++ b/content_schemas/dist/formats/generic_with_external_related_links/frontend/schema.json
@@ -109,6 +109,7 @@
         "knowledge_alpha",
         "licence",
         "license_finder",
+        "licence_transaction",
         "local_transaction",
         "maib_report",
         "mainstream_browse_page",

--- a/content_schemas/dist/formats/generic_with_external_related_links/notification/schema.json
+++ b/content_schemas/dist/formats/generic_with_external_related_links/notification/schema.json
@@ -133,6 +133,7 @@
         "knowledge_alpha",
         "licence",
         "license_finder",
+        "licence_transaction",
         "local_transaction",
         "maib_report",
         "mainstream_browse_page",

--- a/content_schemas/dist/formats/generic_with_external_related_links/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/generic_with_external_related_links/publisher_v2/schema.json
@@ -119,6 +119,7 @@
         "knowledge_alpha",
         "licence",
         "license_finder",
+        "licence_transaction",
         "local_transaction",
         "maib_report",
         "mainstream_browse_page",

--- a/content_schemas/dist/formats/placeholder/frontend/schema.json
+++ b/content_schemas/dist/formats/placeholder/frontend/schema.json
@@ -109,6 +109,7 @@
         "knowledge_alpha",
         "licence",
         "license_finder",
+        "licence_transaction",
         "local_transaction",
         "maib_report",
         "mainstream_browse_page",

--- a/content_schemas/dist/formats/placeholder/notification/schema.json
+++ b/content_schemas/dist/formats/placeholder/notification/schema.json
@@ -133,6 +133,7 @@
         "knowledge_alpha",
         "licence",
         "license_finder",
+        "licence_transaction",
         "local_transaction",
         "maib_report",
         "mainstream_browse_page",

--- a/content_schemas/dist/formats/placeholder/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/placeholder/publisher_v2/schema.json
@@ -119,6 +119,7 @@
         "knowledge_alpha",
         "licence",
         "license_finder",
+        "licence_transaction",
         "local_transaction",
         "maib_report",
         "mainstream_browse_page",

--- a/content_schemas/dist/formats/special_route/frontend/schema.json
+++ b/content_schemas/dist/formats/special_route/frontend/schema.json
@@ -111,6 +111,7 @@
         "knowledge_alpha",
         "licence",
         "license_finder",
+        "licence_transaction",
         "local_transaction",
         "maib_report",
         "mainstream_browse_page",

--- a/content_schemas/dist/formats/special_route/notification/schema.json
+++ b/content_schemas/dist/formats/special_route/notification/schema.json
@@ -135,6 +135,7 @@
         "knowledge_alpha",
         "licence",
         "license_finder",
+        "licence_transaction",
         "local_transaction",
         "maib_report",
         "mainstream_browse_page",

--- a/content_schemas/dist/formats/special_route/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/special_route/publisher_v2/schema.json
@@ -118,6 +118,7 @@
         "knowledge_alpha",
         "licence",
         "license_finder",
+        "licence_transaction",
         "local_transaction",
         "maib_report",
         "mainstream_browse_page",

--- a/content_schemas/dist/formats/specialist_document/frontend/schema.json
+++ b/content_schemas/dist/formats/specialist_document/frontend/schema.json
@@ -50,6 +50,7 @@
         "export_health_certificate",
         "flood_and_coastal_erosion_risk_management_research_report",
         "international_development_fund",
+        "licence_transaction",
         "maib_report",
         "marine_notice",
         "medical_safety_alert",
@@ -444,6 +445,9 @@
         },
         {
           "$ref": "#/definitions/international_development_fund_metadata"
+        },
+        {
+          "$ref": "#/definitions/licence_transaction_metadata"
         },
         {
           "$ref": "#/definitions/flood_and_coastal_erosion_risk_management_research_report"
@@ -2254,6 +2258,49 @@
         }
       }
     },
+    "licence_transaction_metadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "activity": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "bulk_published": {
+          "type": "boolean"
+        },
+        "continuation_link": {
+          "type": "string",
+          "format": "uri"
+        },
+        "country": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "england",
+              "wales",
+              "scotland",
+              "northern-ireland"
+            ]
+          }
+        },
+        "licence_identifier": {
+          "type": "string"
+        },
+        "sector": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "will_continue_on": {
+          "$ref": "#/definitions/will_continue_on"
+        }
+      }
+    },
     "locale": {
       "type": "string",
       "enum": [
@@ -3997,6 +4044,10 @@
           }
         }
       }
+    },
+    "will_continue_on": {
+      "description": "Description of the website the adjoining external link will be taking the user to",
+      "type": "string"
     },
     "withdrawn_notice": {
       "type": "object",

--- a/content_schemas/dist/formats/specialist_document/notification/schema.json
+++ b/content_schemas/dist/formats/specialist_document/notification/schema.json
@@ -74,6 +74,7 @@
         "export_health_certificate",
         "flood_and_coastal_erosion_risk_management_research_report",
         "international_development_fund",
+        "licence_transaction",
         "maib_report",
         "marine_notice",
         "medical_safety_alert",
@@ -536,6 +537,9 @@
         },
         {
           "$ref": "#/definitions/international_development_fund_metadata"
+        },
+        {
+          "$ref": "#/definitions/licence_transaction_metadata"
         },
         {
           "$ref": "#/definitions/flood_and_coastal_erosion_risk_management_research_report"
@@ -2359,6 +2363,49 @@
         }
       }
     },
+    "licence_transaction_metadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "activity": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "bulk_published": {
+          "type": "boolean"
+        },
+        "continuation_link": {
+          "type": "string",
+          "format": "uri"
+        },
+        "country": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "england",
+              "wales",
+              "scotland",
+              "northern-ireland"
+            ]
+          }
+        },
+        "licence_identifier": {
+          "type": "string"
+        },
+        "sector": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "will_continue_on": {
+          "$ref": "#/definitions/will_continue_on"
+        }
+      }
+    },
     "locale": {
       "type": "string",
       "enum": [
@@ -4149,6 +4196,10 @@
           }
         }
       }
+    },
+    "will_continue_on": {
+      "description": "Description of the website the adjoining external link will be taking the user to",
+      "type": "string"
     },
     "withdrawn_notice": {
       "type": "object",

--- a/content_schemas/dist/formats/specialist_document/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/specialist_document/publisher_v2/schema.json
@@ -60,6 +60,7 @@
         "export_health_certificate",
         "flood_and_coastal_erosion_risk_management_research_report",
         "international_development_fund",
+        "licence_transaction",
         "maib_report",
         "marine_notice",
         "medical_safety_alert",
@@ -360,6 +361,9 @@
         },
         {
           "$ref": "#/definitions/international_development_fund_metadata"
+        },
+        {
+          "$ref": "#/definitions/licence_transaction_metadata"
         },
         {
           "$ref": "#/definitions/flood_and_coastal_erosion_risk_management_research_report"
@@ -2041,6 +2045,49 @@
               "more-than-1000000"
             ]
           }
+        }
+      }
+    },
+    "licence_transaction_metadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "activity": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "bulk_published": {
+          "type": "boolean"
+        },
+        "continuation_link": {
+          "type": "string",
+          "format": "uri"
+        },
+        "country": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "england",
+              "wales",
+              "scotland",
+              "northern-ireland"
+            ]
+          }
+        },
+        "licence_identifier": {
+          "type": "string"
+        },
+        "sector": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "will_continue_on": {
+          "$ref": "#/definitions/will_continue_on"
         }
       }
     },
@@ -3819,6 +3866,10 @@
           }
         }
       }
+    },
+    "will_continue_on": {
+      "description": "Description of the website the adjoining external link will be taking the user to",
+      "type": "string"
     }
   }
 }

--- a/content_schemas/dist/formats/topical_event/frontend/schema.json
+++ b/content_schemas/dist/formats/topical_event/frontend/schema.json
@@ -109,6 +109,7 @@
         "knowledge_alpha",
         "licence",
         "license_finder",
+        "licence_transaction",
         "local_transaction",
         "maib_report",
         "mainstream_browse_page",

--- a/content_schemas/dist/formats/topical_event/notification/schema.json
+++ b/content_schemas/dist/formats/topical_event/notification/schema.json
@@ -133,6 +133,7 @@
         "knowledge_alpha",
         "licence",
         "license_finder",
+        "licence_transaction",
         "local_transaction",
         "maib_report",
         "mainstream_browse_page",

--- a/content_schemas/dist/formats/topical_event/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/topical_event/publisher_v2/schema.json
@@ -119,6 +119,7 @@
         "knowledge_alpha",
         "licence",
         "license_finder",
+        "licence_transaction",
         "local_transaction",
         "maib_report",
         "mainstream_browse_page",

--- a/content_schemas/dist/formats/world_location_news/frontend/schema.json
+++ b/content_schemas/dist/formats/world_location_news/frontend/schema.json
@@ -109,6 +109,7 @@
         "knowledge_alpha",
         "licence",
         "license_finder",
+        "licence_transaction",
         "local_transaction",
         "maib_report",
         "mainstream_browse_page",

--- a/content_schemas/dist/formats/world_location_news/notification/schema.json
+++ b/content_schemas/dist/formats/world_location_news/notification/schema.json
@@ -133,6 +133,7 @@
         "knowledge_alpha",
         "licence",
         "license_finder",
+        "licence_transaction",
         "local_transaction",
         "maib_report",
         "mainstream_browse_page",

--- a/content_schemas/dist/formats/world_location_news/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/world_location_news/publisher_v2/schema.json
@@ -119,6 +119,7 @@
         "knowledge_alpha",
         "licence",
         "license_finder",
+        "licence_transaction",
         "local_transaction",
         "maib_report",
         "mainstream_browse_page",

--- a/content_schemas/dist/formats/worldwide_organisation/frontend/schema.json
+++ b/content_schemas/dist/formats/worldwide_organisation/frontend/schema.json
@@ -109,6 +109,7 @@
         "knowledge_alpha",
         "licence",
         "license_finder",
+        "licence_transaction",
         "local_transaction",
         "maib_report",
         "mainstream_browse_page",

--- a/content_schemas/dist/formats/worldwide_organisation/notification/schema.json
+++ b/content_schemas/dist/formats/worldwide_organisation/notification/schema.json
@@ -133,6 +133,7 @@
         "knowledge_alpha",
         "licence",
         "license_finder",
+        "licence_transaction",
         "local_transaction",
         "maib_report",
         "mainstream_browse_page",

--- a/content_schemas/dist/formats/worldwide_organisation/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/worldwide_organisation/publisher_v2/schema.json
@@ -119,6 +119,7 @@
         "knowledge_alpha",
         "licence",
         "license_finder",
+        "licence_transaction",
         "local_transaction",
         "maib_report",
         "mainstream_browse_page",

--- a/content_schemas/examples/specialist_document/frontend/licence-transaction.json
+++ b/content_schemas/examples/specialist_document/frontend/licence-transaction.json
@@ -1,0 +1,162 @@
+{
+  "content_id": "adb306f3-aa98-4569-99ab-54daa960c633",
+  "locale": "en",
+  "base_path": "/find-licences/new-licence",
+  "title": "New licence",
+  "description": "Some example content",
+  "details": {
+    "body": "<h2 id=\"statutory-timetable\">Statutory timetable</h2>\n\n<table>\n <thead>\n <tr>\n <th>Phase 1 date</th>\n <th>Action</th>\n </tr>\n </thead>\n <tbody>\n <tr>\n <td>7 September 2015</td>\n <td>Deadline for phase 1 decision (*)</td>\n </tr>\n <tr>\n <td>10 to 24 July 2015</td>\n <td>Invitation to comment</td>\n </tr>\n <tr>\n <td>10 July 2015</td>\n <td>Launch of merger inquiry</td>\n </tr>\n </tbody>\n</table>\n\n<p>(*) This date is the current statutory deadline by when the decision will be announced. If any change occurs, the information is refreshed as soon as practicable. However, the CMA cannot guarantee that the decision will be announced on or before this current deadline, as the deadline of a given case may change during the merger assessment process due to different reasons.</p>\n\n<h2 id=\"phase-1\">Phase 1</h2>\n\n<h3 id=\"invitation-to-comment-closes-24-july-2015\">Invitation to comment: closes 24 July 2015</h3>\n\n<p>10 July 2015: The CMA is considering whether it is or may be the case that this transaction has resulted in the creation of a relevant merger situation under the merger provisions of the Enterprise Act 2002 and, if so, whether the creation of that situation has resulted, or may be expected to result, in a substantial lessening of competition within any market or markets in the United Kingdom for goods or services.</p>\n\n<h3 id=\"launch-of-cma-merger-inquiry\">Launch of CMA merger inquiry</h3>\n\n<p>10 July 2015: The CMA announced the launch of its merger inquiry by notice to the parties.</p>\n\n<ul>\n <li><a rel=\"external\" href=\"https://assets.digital.cabinet-office.gov.uk/media/559fc1b240f0b61564000047/Richemont-Yoox-NAP_commencement_of_initial_period_notice.pdf\">Commencement of initial period notice</a> (10.7.15)</li>\n</ul>\n\n<h3 id=\"contact\">Contact</h3>\n\n<p>Please send written representations about any competition issues to:</p>\n\n<div class=\"address\"><div class=\"adr org fn\"><p>\n\nSuzanne Van Scheijen\n<br />Competition and Markets Authority \n<br />Victoria House \n<br />Southampton Row \n<br />London \n<br />WC1B 4AD\n<br />\n</p></div></div>\n\n<p><a href=\"&#109;&#097;&#105;&#108;&#116;&#111;:&#083;&#117;&#122;&#097;&#110;&#110;&#101;&#046;&#086;&#097;&#110;&#083;&#099;&#104;&#101;&#105;&#106;&#101;&#110;&#064;&#099;&#109;&#097;&#046;&#103;&#115;&#105;&#046;&#103;&#111;&#118;&#046;&#117;&#107;\">&#083;&#117;&#122;&#097;&#110;&#110;&#101;&#046;&#086;&#097;&#110;&#083;&#099;&#104;&#101;&#105;&#106;&#101;&#110;&#064;&#099;&#109;&#097;&#046;&#103;&#115;&#105;&#046;&#103;&#111;&#118;&#046;&#117;&#107;</a></p>\n",
+    "metadata": {
+      "bulk_published": false,
+      "country": [
+        "england"
+      ],
+      "sector": [
+        "licenced_nightclubs"
+      ],
+      "activity": [
+        "employ_door_supervisors"
+      ],
+      "will_continue_on": "some external government website",
+      "continuation_link": "https://www.random.gov.uk/licence"
+    },
+    "max_cache_time": 10,
+    "headers": [
+      {
+        "text": "Statutory timetable",
+        "level": 2,
+        "id": "statutory-timetable"
+      },
+      {
+        "text": "Phase 1",
+        "level": 2,
+        "id": "phase-1",
+        "headers": [
+          {
+            "text": "Invitation to comment: closes 24 July 2015",
+            "level": 3,
+            "id": "invitation-to-comment-closes-24-july-2015"
+          },
+          {
+            "text": "Launch of CMA merger inquiry",
+            "level": 3,
+            "id": "launch-of-cma-merger-inquiry"
+          },
+          {
+            "text": "Contact",
+            "level": 3,
+            "id": "contact"
+          }
+        ]
+      }
+    ]
+  },
+  "public_updated_at": "2015-07-10T13:09:46+00:00",
+  "schema_name": "specialist_document",
+  "document_type": "licence_transaction",
+  "links": {
+    "organisations": [
+      {
+        "analytics_identifier": "D7",
+        "api_path": "/api/content/government/organisations/department-for-environment-food-rural-affairs",
+        "base_path": "/government/organisations/department-for-environment-food-rural-affairs",
+        "content_id": "de4e9dc6-cca4-43af-a594-682023b84d6c",
+        "description": null,
+        "document_type": "organisation",
+        "locale": "en",
+        "public_updated_at": "2022-07-12T14:13:48.000+00:00",
+        "schema_name": "organisation",
+        "title": "Department for Environment, Food & Rural Affairs",
+        "withdrawn": false,
+        "details": {
+          "brand": "department-for-environment-food-rural-affairs",
+          "logo": {
+            "formatted_title": "Department<br/>for Environment<br/>Food &amp; Rural Affairs",
+            "crest": "single-identity"
+          }
+        },
+        "api_url": "https://www.gov.uk/api/content/government/organisations/department-for-environment-food-rural-affairs",
+        "web_url": "https://www.gov.uk/government/organisations/department-for-environment-food-rural-affairs"
+      }
+    ],
+    "finder": [
+      {
+        "analytics_identifier": null,
+        "api_path": "/api/content/find-licences",
+        "base_path": "/find-licences",
+        "content_id": "b8327c0c-a90d-47b6-992b-ea226b4d3306",
+        "document_type": "finder",
+        "document_noun": "licence",
+        "locale": "en",
+        "public_updated_at": "2017-03-15T14:44:21Z",
+        "schema_name": "finder",
+        "title": "Find and apply for licences.",
+        "withdrawn": false,
+        "details": {
+          "facets": [
+            {
+              "key": "country",
+              "name": "Country",
+              "type": "text",
+              "preposition": "in country",
+              "display_as_result_metadata": true,
+              "filterable": true,
+              "allowed_values": [
+                {
+                  "label": "England",
+                  "value": "england"
+                },
+                {
+                  "label": "Wales",
+                  "value": "wales"
+                },
+                {
+                  "label": "Scotland",
+                  "value": "scotland"
+                },
+                {
+                  "label": "Northern Ireland",
+                  "value": "northern-ireland"
+                }
+              ]
+            },
+            {
+              "key": "sector",
+              "name": "Sector",
+              "type": "text",
+              "preposition": "of sector",
+              "display_as_result_metadata": true,
+              "filterable": true
+            },
+            {
+              "key": "activity",
+              "name": "Activity",
+              "type": "text",
+              "preposition": "regarding",
+              "display_as_result_metadata": true,
+              "filterable": true
+            }
+          ]
+        }
+      }
+    ],
+    "available_translations": [
+      {
+        "analytics_identifier": null,
+        "content_id": "adb306f3-aa98-4569-99ab-54daa960c633",
+        "description": "Some example content",
+        "document_type": "licence_transaction",
+        "public_updated_at": "2022-10-01T11:00:38Z",
+        "schema_name": "specialist_document",
+        "title": "Example document",
+        "base_path": "/find-licences/new-licence",
+        "locale": "en",
+        "api_path": "/api/content/find-licences/new-licence",
+        "withdrawn": false,
+        "api_url": "https://www.gov.uk/api/content/find-licences/new-licence",
+        "web_url": "https://www.gov.uk/find-licences/new-licence"
+      }
+    ]
+  },
+  "updated_at": "2017-06-30T15:44:11.073Z"
+}

--- a/content_schemas/formats/shared/definitions/_specialist_document.jsonnet
+++ b/content_schemas/formats/shared/definitions/_specialist_document.jsonnet
@@ -48,6 +48,9 @@
         "$ref": "#/definitions/international_development_fund_metadata",
       },
       {
+        "$ref": "#/definitions/licence_transaction_metadata",
+      },
+      {
         "$ref": "#/definitions/flood_and_coastal_erosion_risk_management_research_report",
       },
       {
@@ -2078,6 +2081,49 @@
             "more-than-1000000",
           ],
         },
+      },
+    },
+  },
+  licence_transaction_metadata: {
+    type: "object",
+    additionalProperties: false,
+    properties: {
+      bulk_published: {
+        type: "boolean",
+      },
+      country: {
+        type: "array",
+        items: {
+          type: "string",
+          enum: [
+            "england",
+            "wales",
+            "scotland",
+            "northern-ireland",
+          ],
+        },
+      },
+      sector: {
+        type: "array",
+        items: {
+          type: "string",
+        },
+      },
+      activity: {
+        type: "array",
+        items: {
+          type: "string",
+        },
+      },
+      will_continue_on: {
+        "$ref": "#/definitions/will_continue_on",
+      },
+      continuation_link: {
+        type: "string",
+        format: "uri",
+      },
+      licence_identifier: {
+        type: "string",
       },
     },
   },

--- a/content_schemas/formats/specialist_document.jsonnet
+++ b/content_schemas/formats/specialist_document.jsonnet
@@ -16,6 +16,7 @@
     "export_health_certificate",
     "flood_and_coastal_erosion_risk_management_research_report",
     "international_development_fund",
+    "licence_transaction",
     "maib_report",
     "marine_notice",
     "medical_safety_alert",


### PR DESCRIPTION
Adds schema for the new licence_transaction document type. We'll need the following Specialist Publisher metadata fields:

* country
* sector
* activity 
* continuation_link
* will_continue_on
* licence_identifier

We only hardcode values for 'country' as the values aren't likely to change. `continuation_link` (URL), `will_continue_on` (URL hint) and `licence_identifier` will be user inputted.  We also allow any value for the sector and activity list as 1) it is not yet confirmed and 2) we expect the list to change in time and so only having to update it in Specialist Publisher skips a bit of admin. 

Trello:
https://trello.com/c/mGJ5DIsI/1659-create-licence-document-type-in-specialist-publisher

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
