### PR TITLE
Updates following move of content schemas

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,6 @@ COPY . /app
 
 FROM $base_image
 
-ENV GOVUK_CONTENT_SCHEMAS_PATH=/govuk-content-schemas
 ENV GOVUK_APP_NAME=publishing-api
 
 COPY --from=builder /usr/local/bundle/ /usr/local/bundle/

--- a/lib/schema_generator/format.rb
+++ b/lib/schema_generator/format.rb
@@ -176,7 +176,7 @@ module SchemaGenerator
         specified_document_types = Array(document_types)
         disallowed = specified_document_types - allowed_document_types
         if disallowed.any?
-          raise InvalidFormat, "Encountered document types which are not allowed in `lib/govuk_content_schemas/allowed_document_types.yml`: #{disallowed.join(', ')}"
+          raise InvalidFormat, "Encountered document types which are not allowed in `content_schemas/allowed_document_types.yml`: #{disallowed.join(', ')}"
         end
 
         build_definition(specified_document_types)


### PR DESCRIPTION
A few more tidy ups from the move of schemas into this repo:

* Updates an error message to reflect a file's new location
* Removes a redundant env var in the dockerfile

[Trello](https://trello.com/c/ZUK2duYI/361-add-govuk-content-schemas-to-publishing-api-repo)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
