### PR TITLE
Remove build_schemas from default rake task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -19,4 +19,4 @@ rescue LoadError
 end
 
 Rake::Task[:default].clear if Rake::Task.task_defined?(:default)
-task default: %i[rubocop spec pact:verify build_schemas]
+task default: %i[rubocop spec pact:verify]


### PR DESCRIPTION
This task is intended to be run separately from the default rake task for publishing api. We still build schemas as part of our CI process (in order to check that the schemas on the PR are up to date) so we will still have coverage.

[Trello](https://trello.com/c/iZup32bI/362-only-run-schemas-related-tests-and-build-steps-in-publishing-api-when-changes-are-made)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
