### PR TITLE
Add vhost for rabbitmq

### DIFF
--- a/config/initializers/services.rb
+++ b/config/initializers/services.rb
@@ -38,7 +38,8 @@ PublishingAPI.register_service(
 rabbitmq_config = if ENV["DISABLE_QUEUE_PUBLISHER"] || (Rails.env.test? && ENV["ENABLE_QUEUE_IN_TEST_MODE"].blank?)
                     { noop: true }
                   elsif ENV["RABBITMQ_URL"]
-                    { exchange: ENV.fetch("RABBITMQ_EXCHANGE", "published_documents") }
+                    { exchange: ENV.fetch("RABBITMQ_EXCHANGE", "published_documents"),
+                      vhost: "/" }
                   else
                     Rails.application.config_for(:rabbitmq).symbolize_keys
                   end


### PR DESCRIPTION
As part of switching to amazonmq, we are now providing many of the env variables needed for bunny via a rabbitMQ URL, rather than individually. However, we still need to explicitly provide the vhost in this case, since this is not contained in the URL.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
