### PR TITLE
Hold back bad version 2.8.0 of the `mail` rubygem.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,7 @@ gem "govuk_schemas"
 gem "govuk_sidekiq"
 gem "jsonnet", "~>0.4.0" #  0.5 (current latest) does not currently compile on our CI machines
 gem "json-schema", require: false
+gem "mail", "~> 2.7.1" # TODO: remove once https://github.com/mikel/mail/issues/1489 is fixed.
 gem "oj"
 gem "pg"
 gem "plek"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -548,6 +548,7 @@ DEPENDENCIES
   json-schema
   jsonnet (~> 0.4.0)
   listen
+  mail (~> 2.7.1)
   oj
   pact
   pact_broker-client


### PR DESCRIPTION
Version 2.8.0 of the `mail` gem has the wrong filesystem permissions on a few of its .rb files (seems to be the generated tables?), which breaks the app when running as an unprivileged user. We therefore need to hold back this version of the gem until a new version is released that fixes the issue.

The upstream bug is mikel/mail#1489. We can remove this workaround once the bug is fixed.
