### PR TITLE
Make content_ids a required property in topic_groups schema

### DIFF
--- a/content_schemas/dist/formats/mainstream_browse_page/frontend/schema.json
+++ b/content_schemas/dist/formats/mainstream_browse_page/frontend/schema.json
@@ -652,7 +652,7 @@
         "type": "object",
         "required": [
           "name",
-          "contents"
+          "content_ids"
         ],
         "additionalProperties": false,
         "properties": {

--- a/content_schemas/dist/formats/mainstream_browse_page/notification/schema.json
+++ b/content_schemas/dist/formats/mainstream_browse_page/notification/schema.json
@@ -786,7 +786,7 @@
         "type": "object",
         "required": [
           "name",
-          "contents"
+          "content_ids"
         ],
         "additionalProperties": false,
         "properties": {

--- a/content_schemas/dist/formats/mainstream_browse_page/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/mainstream_browse_page/publisher_v2/schema.json
@@ -388,7 +388,7 @@
         "type": "object",
         "required": [
           "name",
-          "contents"
+          "content_ids"
         ],
         "additionalProperties": false,
         "properties": {

--- a/content_schemas/dist/formats/topic/frontend/schema.json
+++ b/content_schemas/dist/formats/topic/frontend/schema.json
@@ -630,7 +630,7 @@
         "type": "object",
         "required": [
           "name",
-          "contents"
+          "content_ids"
         ],
         "additionalProperties": false,
         "properties": {

--- a/content_schemas/dist/formats/topic/notification/schema.json
+++ b/content_schemas/dist/formats/topic/notification/schema.json
@@ -752,7 +752,7 @@
         "type": "object",
         "required": [
           "name",
-          "contents"
+          "content_ids"
         ],
         "additionalProperties": false,
         "properties": {

--- a/content_schemas/dist/formats/topic/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/topic/publisher_v2/schema.json
@@ -378,7 +378,7 @@
         "type": "object",
         "required": [
           "name",
-          "contents"
+          "content_ids"
         ],
         "additionalProperties": false,
         "properties": {

--- a/content_schemas/formats/shared/definitions/topic_groups.jsonnet
+++ b/content_schemas/formats/shared/definitions/topic_groups.jsonnet
@@ -7,7 +7,7 @@
       additionalProperties: false,
       required: [
         "name",
-        "contents",
+        "content_ids",
       ],
       properties: {
         name: {


### PR DESCRIPTION
We migrated to use "content_ids" instead of "contents". We need to make "contents" optional to be able to update the presenter in Collections publisher.

--
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
