### PR TITLE
Add migration for fixing bad organisation state

### DIFF
--- a/db/migrate/20221222145109_fix_organisation_redirects.rb
+++ b/db/migrate/20221222145109_fix_organisation_redirects.rb
@@ -1,0 +1,69 @@
+class FixOrganisationRedirects < ActiveRecord::Migration[7.0]
+  def up
+    false_redirects = Edition
+      .where(
+        document_type: "redirect",
+        schema_name: "redirect",
+      )
+      .where("created_at > :date", date: "2022-12-21 10:45")
+      .where("base_path LIKE ?", "/government/organisations/%")
+
+    Rails.logger.debug "deleting redirects: #{false_redirects.pluck(:base_path).join}"
+
+    false_redirects.destroy_all
+
+    published_organisations = Edition
+      .where(
+        document_type: "organisation",
+        schema_name: "organisation",
+        state: "published",
+      )
+      .where("created_at > :date", date: "2022-12-21 10:45")
+      .where("base_path LIKE ?", "/government/organisations/%")
+
+    published_organisations.each do |organisation|
+      locale = organisation.document.locale
+
+      next if locale == "en"
+
+      next if organisation.base_path.ends_with?(".#{locale}")
+
+      base_path = organisation.base_path
+
+      correct_base_path = "#{base_path}.#{locale}"
+
+      correct_routes = [{ "path" => correct_base_path, "type" => "exact" },
+                        { "path" => "#{correct_base_path}.atom", "type" => "exact" }]
+
+      Rails.logger.debug "updating route #{base_path} to #{correct_base_path}"
+
+      organisation.update!(base_path: correct_base_path, routes: correct_routes)
+    end
+
+    unpublished_organisations = Edition
+      .where(
+        document_type: "organisation",
+        schema_name: "organisation",
+        state: "unpublished",
+      )
+      .where("created_at > :date", date: "2022-12-21 10:45")
+      .where("base_path LIKE ?", "/government/organisations/%")
+
+    unpublished_organisations.each do |organisation|
+      locale = organisation.document.locale
+
+      base_path = organisation.base_path
+
+      if locale != "en" && !base_path.ends_with?(".#{locale}")
+        correct_base_path = "#{base_path}.#{locale}"
+        correct_routes = [{ "path" => correct_base_path, "type" => "exact" }, { "path" => "#{correct_base_path}.atom", "type" => "exact" }]
+
+        Rails.logger.debug "updating route #{base_path} to #{correct_base_path}"
+
+        organisation.update!(base_path: correct_base_path, routes: correct_routes)
+      end
+
+      organisation.update!(state: "published")
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_11_08_113755) do
+ActiveRecord::Schema[7.0].define(version: 2022_12_22_145109) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 


### PR DESCRIPTION
In https://github.com/alphagov/whitehall/pull/7154, we made changes to how Whitehall deals with routes. This had the unfortunate side effect of breaking some routing that was presented to Publishing API.

This left some organisations with a state that their translation(s) were unpublished and redirected back to the English page.

This adds a migration which restores these organisations pages back to their previous state, with the translations correct.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
