### PR TITLE
Add fields for Worldwide Organisations

### DIFF
--- a/content_schemas/dist/formats/organisation/frontend/schema.json
+++ b/content_schemas/dist/formats/organisation/frontend/schema.json
@@ -405,12 +405,13 @@
         "logo": {
           "description": "The organisation's logo, including the logo image and formatted name.",
           "type": "object",
+          "required": [
+            "formatted_title"
+          ],
+          "additionalProperties": false,
           "properties": {
             "crest": {
-              "type": [
-                "string",
-                "null"
-              ],
+              "type": "string",
               "enum": [
                 "bis",
                 "dit",
@@ -422,8 +423,7 @@
                 "single-identity",
                 "so",
                 "ukaea",
-                "wales",
-                null
+                "wales"
               ]
             },
             "formatted_title": {
@@ -609,7 +609,7 @@
           "type": "string"
         },
         "social_media_links": {
-          "description": "A set of links to social media profiles for the organisation.",
+          "description": "A set of links to social media profiles for the object.",
           "type": "array",
           "items": {
             "type": "object",

--- a/content_schemas/dist/formats/organisation/notification/schema.json
+++ b/content_schemas/dist/formats/organisation/notification/schema.json
@@ -552,12 +552,13 @@
         "logo": {
           "description": "The organisation's logo, including the logo image and formatted name.",
           "type": "object",
+          "required": [
+            "formatted_title"
+          ],
+          "additionalProperties": false,
           "properties": {
             "crest": {
-              "type": [
-                "string",
-                "null"
-              ],
+              "type": "string",
               "enum": [
                 "bis",
                 "dit",
@@ -569,8 +570,7 @@
                 "single-identity",
                 "so",
                 "ukaea",
-                "wales",
-                null
+                "wales"
               ]
             },
             "formatted_title": {
@@ -756,7 +756,7 @@
           "type": "string"
         },
         "social_media_links": {
-          "description": "A set of links to social media profiles for the organisation.",
+          "description": "A set of links to social media profiles for the object.",
           "type": "array",
           "items": {
             "type": "object",

--- a/content_schemas/dist/formats/organisation/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/organisation/publisher_v2/schema.json
@@ -284,12 +284,13 @@
         "logo": {
           "description": "The organisation's logo, including the logo image and formatted name.",
           "type": "object",
+          "required": [
+            "formatted_title"
+          ],
+          "additionalProperties": false,
           "properties": {
             "crest": {
-              "type": [
-                "string",
-                "null"
-              ],
+              "type": "string",
               "enum": [
                 "bis",
                 "dit",
@@ -301,8 +302,7 @@
                 "single-identity",
                 "so",
                 "ukaea",
-                "wales",
-                null
+                "wales"
               ]
             },
             "formatted_title": {
@@ -488,7 +488,7 @@
           "type": "string"
         },
         "social_media_links": {
-          "description": "A set of links to social media profiles for the organisation.",
+          "description": "A set of links to social media profiles for the object.",
           "type": "array",
           "items": {
             "type": "object",

--- a/content_schemas/dist/formats/topical_event/frontend/schema.json
+++ b/content_schemas/dist/formats/topical_event/frontend/schema.json
@@ -524,7 +524,7 @@
           }
         },
         "social_media_links": {
-          "description": "A set of links to social media profiles for the topical event.",
+          "description": "A set of links to social media profiles for the object.",
           "type": "array",
           "items": {
             "type": "object",

--- a/content_schemas/dist/formats/topical_event/notification/schema.json
+++ b/content_schemas/dist/formats/topical_event/notification/schema.json
@@ -615,7 +615,7 @@
           }
         },
         "social_media_links": {
-          "description": "A set of links to social media profiles for the topical event.",
+          "description": "A set of links to social media profiles for the object.",
           "type": "array",
           "items": {
             "type": "object",

--- a/content_schemas/dist/formats/topical_event/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/topical_event/publisher_v2/schema.json
@@ -403,7 +403,7 @@
           }
         },
         "social_media_links": {
-          "description": "A set of links to social media profiles for the topical event.",
+          "description": "A set of links to social media profiles for the object.",
           "type": "array",
           "items": {
             "type": "object",

--- a/content_schemas/dist/formats/worldwide_organisation/frontend/schema.json
+++ b/content_schemas/dist/formats/worldwide_organisation/frontend/schema.json
@@ -469,6 +469,97 @@
       "properties": {
         "change_history": {
           "$ref": "#/definitions/change_history"
+        },
+        "logo": {
+          "description": "The organisation's logo, including the logo image and formatted name.",
+          "type": "object",
+          "required": [
+            "formatted_title"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "crest": {
+              "type": "string",
+              "enum": [
+                "bis",
+                "dit",
+                "eo",
+                "hmrc",
+                "ho",
+                "mod",
+                "portcullis",
+                "single-identity",
+                "so",
+                "ukaea",
+                "wales"
+              ]
+            },
+            "formatted_title": {
+              "type": "string"
+            },
+            "image": {
+              "$ref": "#/definitions/image"
+            }
+          }
+        },
+        "ordered_corporate_information_pages": {
+          "description": "A set of links to corporate information pages to display for the worldwide organisation.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "content_id",
+              "title"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "content_id": {
+                "$ref": "#/definitions/guid"
+              },
+              "title": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "social_media_links": {
+          "description": "A set of links to social media profiles for the object.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "service_type",
+              "title",
+              "href"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "href": {
+                "type": "string",
+                "format": "uri"
+              },
+              "service_type": {
+                "type": "string",
+                "enum": [
+                  "blog",
+                  "email",
+                  "facebook",
+                  "flickr",
+                  "foursquare",
+                  "google-plus",
+                  "instagram",
+                  "linkedin",
+                  "other",
+                  "pinterest",
+                  "twitter",
+                  "youtube"
+                ]
+              },
+              "title": {
+                "type": "string"
+              }
+            }
+          }
         }
       }
     },
@@ -613,6 +704,48 @@
     "guid": {
       "type": "string",
       "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "credit": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "high_resolution_url": {
+          "description": "URL to a high resolution version of the image, for use by third parties such as Twitter, Facebook or Slack. Used by the machine readable metadata component. Don't use this on user-facing web pages, as it might be very large.",
+          "type": "string",
+          "format": "uri"
+        },
+        "url": {
+          "description": "URL to the image. The image should be in a suitable resolution for display on the page.",
+          "type": "string",
+          "format": "uri"
+        }
+      }
     },
     "locale": {
       "type": "string",

--- a/content_schemas/dist/formats/worldwide_organisation/notification/schema.json
+++ b/content_schemas/dist/formats/worldwide_organisation/notification/schema.json
@@ -560,6 +560,97 @@
       "properties": {
         "change_history": {
           "$ref": "#/definitions/change_history"
+        },
+        "logo": {
+          "description": "The organisation's logo, including the logo image and formatted name.",
+          "type": "object",
+          "required": [
+            "formatted_title"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "crest": {
+              "type": "string",
+              "enum": [
+                "bis",
+                "dit",
+                "eo",
+                "hmrc",
+                "ho",
+                "mod",
+                "portcullis",
+                "single-identity",
+                "so",
+                "ukaea",
+                "wales"
+              ]
+            },
+            "formatted_title": {
+              "type": "string"
+            },
+            "image": {
+              "$ref": "#/definitions/image"
+            }
+          }
+        },
+        "ordered_corporate_information_pages": {
+          "description": "A set of links to corporate information pages to display for the worldwide organisation.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "content_id",
+              "title"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "content_id": {
+                "$ref": "#/definitions/guid"
+              },
+              "title": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "social_media_links": {
+          "description": "A set of links to social media profiles for the object.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "service_type",
+              "title",
+              "href"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "href": {
+                "type": "string",
+                "format": "uri"
+              },
+              "service_type": {
+                "type": "string",
+                "enum": [
+                  "blog",
+                  "email",
+                  "facebook",
+                  "flickr",
+                  "foursquare",
+                  "google-plus",
+                  "instagram",
+                  "linkedin",
+                  "other",
+                  "pinterest",
+                  "twitter",
+                  "youtube"
+                ]
+              },
+              "title": {
+                "type": "string"
+              }
+            }
+          }
         }
       }
     },
@@ -717,6 +808,48 @@
         "$ref": "#/definitions/guid"
       },
       "uniqueItems": true
+    },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "credit": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "high_resolution_url": {
+          "description": "URL to a high resolution version of the image, for use by third parties such as Twitter, Facebook or Slack. Used by the machine readable metadata component. Don't use this on user-facing web pages, as it might be very large.",
+          "type": "string",
+          "format": "uri"
+        },
+        "url": {
+          "description": "URL to the image. The image should be in a suitable resolution for display on the page.",
+          "type": "string",
+          "format": "uri"
+        }
+      }
     },
     "locale": {
       "type": "string",

--- a/content_schemas/dist/formats/worldwide_organisation/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/worldwide_organisation/publisher_v2/schema.json
@@ -348,7 +348,99 @@
     "details": {
       "type": "object",
       "additionalProperties": false,
-      "properties": {}
+      "properties": {
+        "logo": {
+          "description": "The organisation's logo, including the logo image and formatted name.",
+          "type": "object",
+          "required": [
+            "formatted_title"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "crest": {
+              "type": "string",
+              "enum": [
+                "bis",
+                "dit",
+                "eo",
+                "hmrc",
+                "ho",
+                "mod",
+                "portcullis",
+                "single-identity",
+                "so",
+                "ukaea",
+                "wales"
+              ]
+            },
+            "formatted_title": {
+              "type": "string"
+            },
+            "image": {
+              "$ref": "#/definitions/image"
+            }
+          }
+        },
+        "ordered_corporate_information_pages": {
+          "description": "A set of links to corporate information pages to display for the worldwide organisation.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "content_id",
+              "title"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "content_id": {
+                "$ref": "#/definitions/guid"
+              },
+              "title": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "social_media_links": {
+          "description": "A set of links to social media profiles for the object.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "service_type",
+              "title",
+              "href"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "href": {
+                "type": "string",
+                "format": "uri"
+              },
+              "service_type": {
+                "type": "string",
+                "enum": [
+                  "blog",
+                  "email",
+                  "facebook",
+                  "flickr",
+                  "foursquare",
+                  "google-plus",
+                  "instagram",
+                  "linkedin",
+                  "other",
+                  "pinterest",
+                  "twitter",
+                  "youtube"
+                ]
+              },
+              "title": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
     },
     "first_published_at": {
       "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
@@ -365,6 +457,48 @@
         "$ref": "#/definitions/guid"
       },
       "uniqueItems": true
+    },
+    "image": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "credit": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "high_resolution_url": {
+          "description": "URL to a high resolution version of the image, for use by third parties such as Twitter, Facebook or Slack. Used by the machine readable metadata component. Don't use this on user-facing web pages, as it might be very large.",
+          "type": "string",
+          "format": "uri"
+        },
+        "url": {
+          "description": "URL to the image. The image should be in a suitable resolution for display on the page.",
+          "type": "string",
+          "format": "uri"
+        }
+      }
     },
     "locale": {
       "type": "string",

--- a/content_schemas/formats/organisation.jsonnet
+++ b/content_schemas/formats/organisation.jsonnet
@@ -218,45 +218,7 @@
           "description": "Determines whether content published by this organisation represents governments policies and can be eligible for history mode",
           "type": "boolean"
         },
-        social_media_links: {
-          type: "array",
-          items: {
-            type: "object",
-            additionalProperties: false,
-            required: [
-              "service_type",
-              "title",
-              "href",
-            ],
-            properties: {
-              service_type: {
-                type: "string",
-                enum: [
-                  "blog",
-                  "email",
-                  "facebook",
-                  "flickr",
-                  "foursquare",
-                  "google-plus",
-                  "instagram",
-                  "linkedin",
-                  "other",
-                  "pinterest",
-                  "twitter",
-                  "youtube",
-                ],
-              },
-              title: {
-                type: "string",
-              },
-              href: {
-                type: "string",
-                format: "uri",
-              },
-            },
-          },
-          description: "A set of links to social media profiles for the organisation.",
-        },
+        social_media_links: (import "shared/definitions/_social_media_links.jsonnet"),
         external_related_links: {
           "$ref": "#/definitions/external_related_links",
         },

--- a/content_schemas/formats/organisation.jsonnet
+++ b/content_schemas/formats/organisation.jsonnet
@@ -39,38 +39,7 @@
           type: "boolean",
           description: "Whether the organisation is exempt from Freedom of Information requests.",
         },
-        logo: {
-          type: "object",
-          properties: {
-            formatted_title: {
-              type: "string",
-            },
-            crest: {
-              type: [
-                "string",
-                "null",
-              ],
-              enum: [
-                "bis",
-                "dit",
-                "eo",
-                "hmrc",
-                "ho",
-                "mod",
-                "portcullis",
-                "single-identity",
-                "so",
-                "ukaea",
-                "wales",
-                null,
-              ],
-            },
-            image: {
-              "$ref": "#/definitions/image",
-            },
-          },
-          description: "The organisation's logo, including the logo image and formatted name.",
-        },
+        logo: (import "shared/definitions/_organisation_logo.jsonnet"),
         ordered_corporate_information_pages: {
           type: "array",
           items: {

--- a/content_schemas/formats/shared/definitions/_organisation_logo.jsonnet
+++ b/content_schemas/formats/shared/definitions/_organisation_logo.jsonnet
@@ -8,10 +8,7 @@
       type: "string",
     },
     crest: {
-      type: [
-        "string",
-        "null",
-      ],
+      type: "string",
       enum: [
         "bis",
         "dit",
@@ -24,7 +21,6 @@
         "so",
         "ukaea",
         "wales",
-        null,
       ],
     },
     image: {

--- a/content_schemas/formats/shared/definitions/_organisation_logo.jsonnet
+++ b/content_schemas/formats/shared/definitions/_organisation_logo.jsonnet
@@ -1,0 +1,32 @@
+{
+  type: "object",
+  properties: {
+    formatted_title: {
+      type: "string",
+    },
+    crest: {
+      type: [
+        "string",
+        "null",
+      ],
+      enum: [
+        "bis",
+        "dit",
+        "eo",
+        "hmrc",
+        "ho",
+        "mod",
+        "portcullis",
+        "single-identity",
+        "so",
+        "ukaea",
+        "wales",
+        null,
+      ],
+    },
+    image: {
+      "$ref": "#/definitions/image",
+    },
+  },
+  description: "The organisation's logo, including the logo image and formatted name.",
+}

--- a/content_schemas/formats/shared/definitions/_organisation_logo.jsonnet
+++ b/content_schemas/formats/shared/definitions/_organisation_logo.jsonnet
@@ -3,6 +3,7 @@
   required: [
     "formatted_title",
   ],
+  additionalProperties: false,
   properties: {
     formatted_title: {
       type: "string",

--- a/content_schemas/formats/shared/definitions/_organisation_logo.jsonnet
+++ b/content_schemas/formats/shared/definitions/_organisation_logo.jsonnet
@@ -1,5 +1,8 @@
 {
   type: "object",
+  required: [
+    "formatted_title",
+  ],
   properties: {
     formatted_title: {
       type: "string",

--- a/content_schemas/formats/shared/definitions/_social_media_links.jsonnet
+++ b/content_schemas/formats/shared/definitions/_social_media_links.jsonnet
@@ -1,0 +1,39 @@
+{
+  type: "array",
+  items: {
+    type: "object",
+    additionalProperties: false,
+    required: [
+      "service_type",
+      "title",
+      "href",
+    ],
+    properties: {
+      service_type: {
+        type: "string",
+        enum: [
+          "blog",
+          "email",
+          "facebook",
+          "flickr",
+          "foursquare",
+          "google-plus",
+          "instagram",
+          "linkedin",
+          "other",
+          "pinterest",
+          "twitter",
+          "youtube",
+        ],
+      },
+      title: {
+        type: "string",
+      },
+      href: {
+        type: "string",
+        format: "uri",
+      },
+    },
+  },
+  description: "A set of links to social media profiles for the object.",
+}

--- a/content_schemas/formats/topical_event.jsonnet
+++ b/content_schemas/formats/topical_event.jsonnet
@@ -61,45 +61,7 @@
           },
           description: "A set of featured documents to display for the Topical Event.",
         },
-        social_media_links: {
-          type: "array",
-          items: {
-            type: "object",
-            additionalProperties: false,
-            required: [
-              "service_type",
-              "title",
-              "href",
-            ],
-            properties: {
-              service_type: {
-                type: "string",
-                enum: [
-                  "blog",
-                  "email",
-                  "facebook",
-                  "flickr",
-                  "foursquare",
-                  "google-plus",
-                  "instagram",
-                  "linkedin",
-                  "other",
-                  "pinterest",
-                  "twitter",
-                  "youtube",
-                ],
-              },
-              title: {
-                type: "string",
-              },
-              href: {
-                type: "string",
-                format: "uri",
-              },
-            },
-          },
-          description: "A set of links to social media profiles for the topical event.",
-        },
+        social_media_links: (import "shared/definitions/_social_media_links.jsonnet"),
       },
     },
   },

--- a/content_schemas/formats/worldwide_organisation.jsonnet
+++ b/content_schemas/formats/worldwide_organisation.jsonnet
@@ -4,6 +4,7 @@
       type: "object",
       additionalProperties: false,
       properties: {
+        logo: (import "shared/definitions/_organisation_logo.jsonnet"),
         ordered_corporate_information_pages: {
           type: "array",
           items: {

--- a/content_schemas/formats/worldwide_organisation.jsonnet
+++ b/content_schemas/formats/worldwide_organisation.jsonnet
@@ -30,6 +30,9 @@
     },
     links: (import "shared/base_links.jsonnet") + {
       corporate_information_pages: "Corporate information pages for this Worldwide Organisation"
+      ordered_contacts: "Contact details for this Worldwide Organisation",
+      sponsoring_organisations: "Sponsoring organisations for this Worldwide Organisation",
+      world_locations: "World Locations associated with this Worldwide Organisation"
     },
   },
 }

--- a/content_schemas/formats/worldwide_organisation.jsonnet
+++ b/content_schemas/formats/worldwide_organisation.jsonnet
@@ -29,7 +29,7 @@
       },
     },
     links: (import "shared/base_links.jsonnet") + {
-      corporate_information_pages: "Corporate information pages for this Worldwide Organisation"
+      corporate_information_pages: "Corporate information pages for this Worldwide Organisation",
       ordered_contacts: "Contact details for this Worldwide Organisation",
       sponsoring_organisations: "Sponsoring organisations for this Worldwide Organisation",
       world_locations: "World Locations associated with this Worldwide Organisation"

--- a/content_schemas/formats/worldwide_organisation.jsonnet
+++ b/content_schemas/formats/worldwide_organisation.jsonnet
@@ -4,7 +4,30 @@
       type: "object",
       additionalProperties: false,
       properties: {
+        ordered_corporate_information_pages: {
+          type: "array",
+          items: {
+            type: "object",
+            additionalProperties: false,
+            required: [
+              "content_id",
+              "title",
+            ],
+            properties: {
+              content_id: {
+                "$ref": "#/definitions/guid",
+              },
+              title: {
+                type: "string",
+              },
+            },
+          },
+          description: "A set of links to corporate information pages to display for the worldwide organisation.",
+        },
       },
+    },
+    links: (import "shared/base_links.jsonnet") + {
+      corporate_information_pages: "Corporate information pages for this Worldwide Organisation"
     },
   },
 }

--- a/content_schemas/formats/worldwide_organisation.jsonnet
+++ b/content_schemas/formats/worldwide_organisation.jsonnet
@@ -25,6 +25,7 @@
           },
           description: "A set of links to corporate information pages to display for the worldwide organisation.",
         },
+        social_media_links: (import "shared/definitions/_social_media_links.jsonnet"),
       },
     },
     links: (import "shared/base_links.jsonnet") + {


### PR DESCRIPTION
In https://github.com/alphagov/whitehall/pull/7191, we have added additional fields to be presented as part of Worldwide Organisation content items.  This adds those additional fields to the schema.

Ultimately, this work will enable us to get the content for Worldwide Organisations into the content item, meaning the rendering can be moved out of Whitehall.

[Trello card](https://trello.com/c/3r6TFSCF)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
