### PR TITLE
Add youtube video url and make images optional for promotional features

### DIFF
--- a/content_schemas/dist/formats/organisation/frontend/schema.json
+++ b/content_schemas/dist/formats/organisation/frontend/schema.json
@@ -474,54 +474,14 @@
               "items": {
                 "type": "array",
                 "items": {
-                  "type": "object",
-                  "required": [
-                    "summary",
-                    "double_width"
-                  ],
-                  "additionalProperties": false,
-                  "properties": {
-                    "double_width": {
-                      "type": "boolean"
+                  "anyOf": [
+                    {
+                      "$ref": "#/definitions/promotional_feature_item_image"
                     },
-                    "href": {
-                      "type": [
-                        "string",
-                        "null"
-                      ]
-                    },
-                    "image": {
-                      "$ref": "#/definitions/image"
-                    },
-                    "links": {
-                      "type": "array",
-                      "items": {
-                        "type": "object",
-                        "required": [
-                          "title",
-                          "href"
-                        ],
-                        "additionalProperties": false,
-                        "properties": {
-                          "href": {
-                            "type": "string"
-                          },
-                          "title": {
-                            "type": "string"
-                          }
-                        }
-                      }
-                    },
-                    "summary": {
-                      "type": "string"
-                    },
-                    "title": {
-                      "type": [
-                        "string",
-                        "null"
-                      ]
+                    {
+                      "$ref": "#/definitions/promotional_feature_youtube"
                     }
-                  }
+                  ]
                 }
               },
               "title": {
@@ -985,6 +945,111 @@
           },
           "title": {
             "type": "string"
+          }
+        }
+      }
+    },
+    "promotional_feature_item_double_width": {
+      "type": "boolean"
+    },
+    "promotional_feature_item_href": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "promotional_feature_item_image": {
+      "items": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "required": [
+            "summary",
+            "double_width",
+            "image"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "double_width": {
+              "$ref": "#/definitions/promotional_feature_item_double_width"
+            },
+            "href": {
+              "$ref": "#/definitions/promotional_feature_item_href"
+            },
+            "image": {
+              "$ref": "#/definitions/image"
+            },
+            "links": {
+              "$ref": "#/definitions/promotional_feature_item_links"
+            },
+            "summary": {
+              "$ref": "#/definitions/promotional_feature_item_summary"
+            },
+            "title": {
+              "$ref": "#/definitions/promotional_feature_item_title"
+            }
+          }
+        }
+      }
+    },
+    "promotional_feature_item_links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "href"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "href": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "promotional_feature_item_summary": {
+      "type": "string"
+    },
+    "promotional_feature_item_title": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "promotional_feature_youtube": {
+      "items": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "required": [
+            "summary",
+            "double_width",
+            "youtube_video_id"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "double_width": {
+              "$ref": "#/definitions/promotional_feature_item_double_width"
+            },
+            "href": {
+              "$ref": "#/definitions/promotional_feature_item_href"
+            },
+            "links": {
+              "$ref": "#/definitions/promotional_feature_item_links"
+            },
+            "summary": {
+              "$ref": "#/definitions/promotional_feature_item_summary"
+            },
+            "title": {
+              "$ref": "#/definitions/promotional_feature_item_title"
+            },
+            "youtube_video_id": {
+              "type": "string"
+            }
           }
         }
       }

--- a/content_schemas/dist/formats/organisation/notification/schema.json
+++ b/content_schemas/dist/formats/organisation/notification/schema.json
@@ -621,54 +621,14 @@
               "items": {
                 "type": "array",
                 "items": {
-                  "type": "object",
-                  "required": [
-                    "summary",
-                    "double_width"
-                  ],
-                  "additionalProperties": false,
-                  "properties": {
-                    "double_width": {
-                      "type": "boolean"
+                  "anyOf": [
+                    {
+                      "$ref": "#/definitions/promotional_feature_item_image"
                     },
-                    "href": {
-                      "type": [
-                        "string",
-                        "null"
-                      ]
-                    },
-                    "image": {
-                      "$ref": "#/definitions/image"
-                    },
-                    "links": {
-                      "type": "array",
-                      "items": {
-                        "type": "object",
-                        "required": [
-                          "title",
-                          "href"
-                        ],
-                        "additionalProperties": false,
-                        "properties": {
-                          "href": {
-                            "type": "string"
-                          },
-                          "title": {
-                            "type": "string"
-                          }
-                        }
-                      }
-                    },
-                    "summary": {
-                      "type": "string"
-                    },
-                    "title": {
-                      "type": [
-                        "string",
-                        "null"
-                      ]
+                    {
+                      "$ref": "#/definitions/promotional_feature_youtube"
                     }
-                  }
+                  ]
                 }
               },
               "title": {
@@ -1152,6 +1112,111 @@
     "payload_version": {
       "description": "Counter to indicate when the payload was generated",
       "type": "integer"
+    },
+    "promotional_feature_item_double_width": {
+      "type": "boolean"
+    },
+    "promotional_feature_item_href": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "promotional_feature_item_image": {
+      "items": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "required": [
+            "summary",
+            "double_width",
+            "image"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "double_width": {
+              "$ref": "#/definitions/promotional_feature_item_double_width"
+            },
+            "href": {
+              "$ref": "#/definitions/promotional_feature_item_href"
+            },
+            "image": {
+              "$ref": "#/definitions/image"
+            },
+            "links": {
+              "$ref": "#/definitions/promotional_feature_item_links"
+            },
+            "summary": {
+              "$ref": "#/definitions/promotional_feature_item_summary"
+            },
+            "title": {
+              "$ref": "#/definitions/promotional_feature_item_title"
+            }
+          }
+        }
+      }
+    },
+    "promotional_feature_item_links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "href"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "href": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "promotional_feature_item_summary": {
+      "type": "string"
+    },
+    "promotional_feature_item_title": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "promotional_feature_youtube": {
+      "items": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "required": [
+            "summary",
+            "double_width",
+            "youtube_video_id"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "double_width": {
+              "$ref": "#/definitions/promotional_feature_item_double_width"
+            },
+            "href": {
+              "$ref": "#/definitions/promotional_feature_item_href"
+            },
+            "links": {
+              "$ref": "#/definitions/promotional_feature_item_links"
+            },
+            "summary": {
+              "$ref": "#/definitions/promotional_feature_item_summary"
+            },
+            "title": {
+              "$ref": "#/definitions/promotional_feature_item_title"
+            },
+            "youtube_video_id": {
+              "type": "string"
+            }
+          }
+        }
+      }
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",

--- a/content_schemas/dist/formats/organisation/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/organisation/publisher_v2/schema.json
@@ -353,54 +353,14 @@
               "items": {
                 "type": "array",
                 "items": {
-                  "type": "object",
-                  "required": [
-                    "summary",
-                    "double_width"
-                  ],
-                  "additionalProperties": false,
-                  "properties": {
-                    "double_width": {
-                      "type": "boolean"
+                  "anyOf": [
+                    {
+                      "$ref": "#/definitions/promotional_feature_item_image"
                     },
-                    "href": {
-                      "type": [
-                        "string",
-                        "null"
-                      ]
-                    },
-                    "image": {
-                      "$ref": "#/definitions/image"
-                    },
-                    "links": {
-                      "type": "array",
-                      "items": {
-                        "type": "object",
-                        "required": [
-                          "title",
-                          "href"
-                        ],
-                        "additionalProperties": false,
-                        "properties": {
-                          "href": {
-                            "type": "string"
-                          },
-                          "title": {
-                            "type": "string"
-                          }
-                        }
-                      }
-                    },
-                    "summary": {
-                      "type": "string"
-                    },
-                    "title": {
-                      "type": [
-                        "string",
-                        "null"
-                      ]
+                    {
+                      "$ref": "#/definitions/promotional_feature_youtube"
                     }
-                  }
+                  ]
                 }
               },
               "title": {
@@ -738,6 +698,111 @@
           },
           "title": {
             "type": "string"
+          }
+        }
+      }
+    },
+    "promotional_feature_item_double_width": {
+      "type": "boolean"
+    },
+    "promotional_feature_item_href": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "promotional_feature_item_image": {
+      "items": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "required": [
+            "summary",
+            "double_width",
+            "image"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "double_width": {
+              "$ref": "#/definitions/promotional_feature_item_double_width"
+            },
+            "href": {
+              "$ref": "#/definitions/promotional_feature_item_href"
+            },
+            "image": {
+              "$ref": "#/definitions/image"
+            },
+            "links": {
+              "$ref": "#/definitions/promotional_feature_item_links"
+            },
+            "summary": {
+              "$ref": "#/definitions/promotional_feature_item_summary"
+            },
+            "title": {
+              "$ref": "#/definitions/promotional_feature_item_title"
+            }
+          }
+        }
+      }
+    },
+    "promotional_feature_item_links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "href"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "href": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "promotional_feature_item_summary": {
+      "type": "string"
+    },
+    "promotional_feature_item_title": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "promotional_feature_youtube": {
+      "items": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "required": [
+            "summary",
+            "double_width",
+            "youtube_video_id"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "double_width": {
+              "$ref": "#/definitions/promotional_feature_item_double_width"
+            },
+            "href": {
+              "$ref": "#/definitions/promotional_feature_item_href"
+            },
+            "links": {
+              "$ref": "#/definitions/promotional_feature_item_links"
+            },
+            "summary": {
+              "$ref": "#/definitions/promotional_feature_item_summary"
+            },
+            "title": {
+              "$ref": "#/definitions/promotional_feature_item_title"
+            },
+            "youtube_video_id": {
+              "type": "string"
+            }
           }
         }
       }

--- a/content_schemas/examples/organisation/frontend/number_10.json
+++ b/content_schemas/examples/organisation/frontend/number_10.json
@@ -1574,10 +1574,7 @@
             "title": "",
             "href": "",
             "summary": "The Number 10 media blog provides an opportunity to share the government’s position on a wide range of issues directly to the public.",
-            "image": {
-              "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/promotional_feature_item/image/67/No10-door-image.png",
-              "alt_text": ""
-            },
+            "youtube_video_id": "fFmDQn9Lbl4",
             "double_width": false,
             "links": [
               {

--- a/content_schemas/formats/organisation.jsonnet
+++ b/content_schemas/formats/organisation.jsonnet
@@ -86,54 +86,10 @@
               items: {
                 type: "array",
                 items: {
-                  type: "object",
-                  additionalProperties: false,
-                  required: [
-                    "summary",
-                    "double_width",
+                  anyOf: [
+                    { "$ref": "#/definitions/promotional_feature_item_image" },
+                    { "$ref": "#/definitions/promotional_feature_youtube" },
                   ],
-                  properties: {
-                    title: {
-                      type: [
-                        "string",
-                        "null",
-                      ],
-                    },
-                    href: {
-                      type: [
-                        "string",
-                        "null",
-                      ],
-                    },
-                    summary: {
-                      type: "string",
-                    },
-                    image: {
-                      "$ref": "#/definitions/image",
-                    },
-                    double_width: {
-                      type: "boolean",
-                    },
-                    links: {
-                      type: "array",
-                      items: {
-                        type: "object",
-                        additionalProperties: false,
-                        required: [
-                          "title",
-                          "href",
-                        ],
-                        properties: {
-                          title: {
-                            type: "string",
-                          },
-                          href: {
-                            type: "string",
-                          },
-                        },
-                      },
-                    },
-                  },
                 },
               },
             },

--- a/content_schemas/formats/shared/definitions/_whitehall.jsonnet
+++ b/content_schemas/formats/shared/definitions/_whitehall.jsonnet
@@ -363,5 +363,110 @@
       },
     },
     description: "A set of featured documents to display.",
+  },
+  promotional_feature_item_image: {
+    items: {
+      type: "array",
+      items: {
+        type: "object",
+        additionalProperties: false,
+        required: [
+          "summary",
+          "double_width",
+          "image",
+        ],
+        properties: {
+          title: {
+            "$ref": "#/definitions/promotional_feature_item_title",
+          },
+          href: {
+            "$ref": "#/definitions/promotional_feature_item_href",
+          },
+          summary: {
+            "$ref": "#/definitions/promotional_feature_item_summary",
+          },
+          image: {
+            "$ref": "#/definitions/image",
+          },
+          double_width: {
+            "$ref": "#/definitions/promotional_feature_item_double_width",
+          },
+          links: {
+            "$ref": "#/definitions/promotional_feature_item_links",
+          },
+        },
+      },
+    },
+  },
+  promotional_feature_youtube: {
+    items: {
+      type: "array",
+      items: {
+        type: "object",
+        additionalProperties: false,
+        required: [
+          "summary",
+          "double_width",
+          "youtube_video_id",
+        ],
+        properties: {
+          title: {
+            "$ref": "#/definitions/promotional_feature_item_title",
+          },
+          href: {
+            "$ref": "#/definitions/promotional_feature_item_href",
+          },
+          summary: {
+            "$ref": "#/definitions/promotional_feature_item_summary",
+          },
+          youtube_video_id: {
+            type: "string",
+          },
+          double_width: {
+            "$ref": "#/definitions/promotional_feature_item_double_width",
+          },
+          links: {
+            "$ref": "#/definitions/promotional_feature_item_links",
+          },
+        },
+      },
+    },
+  },
+  promotional_feature_item_title: {
+    type: [
+      "string",
+      "null",
+    ],
+  },
+  promotional_feature_item_href: {
+    type: [
+      "string",
+      "null",
+    ],
+  },
+  promotional_feature_item_summary: {
+    type: "string",
+  },
+  promotional_feature_item_double_width: {
+    type: "boolean",
+  },
+  promotional_feature_item_links: {
+    type: "array",
+    items: {
+      type: "object",
+      additionalProperties: false,
+      required: [
+        "title",
+        "href",
+      ],
+      properties: {
+        title: {
+          type: "string",
+        },
+        href: {
+          type: "string",
+        },
+      },
+    },
   }
 }


### PR DESCRIPTION
## Description

We're giving executive organisations the option to provide a Youtube video URL instead of an image so they can embed
it on the org page.

This PR does adds functionality to allow a promotional feature to either have an image or a youtube video id passed in the items hash, but not both.

## Related PRs

Collections - https://github.com/alphagov/collections/pull/3116
Whitehall - https://github.com/alphagov/whitehall/pull/7193

## Trello card 

https://trello.com/c/hEEcf7QA/1007-add-a-video-field-to-whitehall-promotional-features


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
