### PR TITLE
Add GitHub Action workflow for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,15 @@ jobs:
           TEST_DATABASE_URL: ${{ steps.setup-postgres.outputs.db-url }}
         run: bundle exec rake spec
 
+      - name: Publish Pact tests
+        env:
+          PACT_BROKER_BASE_URL: https://pact-broker.cloudapps.digital
+          PACT_BROKER_USERNAME: ${{ secrets.GOVUK_PACT_BROKER_USERNAME }}
+          PACT_BROKER_PASSWORD: ${{ secrets.GOVUK_PACT_BROKER_PASSWORD }}
+          PACT_CONSUMER_VERSION: branch-${{ github.ref_name }}
+          PACT_TARGET_BRANCH: branch-${{ github.ref_name }}
+        run: bundle exec rake pact:publish:branch
+
   check-schemas-build:
     name: Check content schemas are built
     runs-on: ubuntu-latest
@@ -74,3 +83,10 @@ jobs:
             exit 1
           fi
             
+  run-content-store-pact-tests:
+    name: Run Content Store Pact tests
+    needs: test-ruby
+    uses: alphagov/content-store/.github/workflows/verify-pact.yml@main
+    with:
+      ref: deployed-to-production
+      pact_consumer_version: branch-${{ github.ref_name }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,76 @@
+name: CI
+
+on:
+  workflow_dispatch: {}
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - "Jenkinsfile"
+      - ".git**"
+  pull_request:
+
+jobs:
+  security-analysis:
+    name: Security Analysis
+    uses: alphagov/govuk-infrastructure/.github/workflows/brakeman.yml@main
+
+  lint-ruby:
+    name: Lint Ruby
+    uses: alphagov/govuk-infrastructure/.github/workflows/rubocop.yml@main
+
+  test-ruby:
+    name: Test Ruby
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup Postgres
+        id: setup-postgres
+        uses: alphagov/govuk-infrastructure/.github/actions/setup-postgres@main
+
+      - name: Setup Redis
+        uses: alphagov/govuk-infrastructure/.github/actions/setup-redis@main
+
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+
+      - name: Initialize database
+        env:
+          RAILS_ENV: test
+          TEST_DATABASE_URL: ${{ steps.setup-postgres.outputs.db-url }}
+        run: bundle exec rails db:setup
+
+      - name: Run RSpec
+        env:
+          RAILS_ENV: test
+          TEST_DATABASE_URL: ${{ steps.setup-postgres.outputs.db-url }}
+        run: bundle exec rake spec
+
+  check-schemas-build:
+    name: Check content schemas are built
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+
+      - name: Build content schemas
+        run: bundle exec rake build_schemas
+
+      - name: Check for uncommited changes
+        run: |
+          if git diff --exit-code; then
+            echo "No uncommit changes detected."
+          else
+            echo "::error title=Uncommited changes to content schemas::If these are your changes, build the content schemas and commit the changes."
+            exit 1
+          fi
+            


### PR DESCRIPTION
This is an initial workflow to enable CI using GitHub Actions. It makes use of
reusable workflows and composite actions defined in govuk-infrastructure. The
CI workflow is initially only used to support deployments to the new EKS
infrastructure and not to immediately replace the CI workflow in Jenkins.

The CI workflow makes use of individual jobs to run each testing and linting
tool. This allows the processes to run concurrently and improves the visibility
of status in the GitHub UI.

Most jobs make use of reusable workflows as they are consistent across the
majority of our repositories - this allows us to easily maintain them in a
single place. However, the test-ruby job (and/or integration-tests) is defined
per repo as backing services and other dependencies vary greatly between repos.
Backing services (such as databases) are created using a composite action
instead of a job service. This is because they contain a lot of shared config
and makes it easier for us to maintain.
