### PR TITLE
Make `double-width` an optional field

### DIFF
--- a/content_schemas/dist/formats/organisation/frontend/schema.json
+++ b/content_schemas/dist/formats/organisation/frontend/schema.json
@@ -965,7 +965,6 @@
           "type": "object",
           "required": [
             "summary",
-            "double_width",
             "image"
           ],
           "additionalProperties": false,
@@ -1027,7 +1026,6 @@
           "type": "object",
           "required": [
             "summary",
-            "double_width",
             "youtube_video_id"
           ],
           "additionalProperties": false,

--- a/content_schemas/dist/formats/organisation/notification/schema.json
+++ b/content_schemas/dist/formats/organisation/notification/schema.json
@@ -1129,7 +1129,6 @@
           "type": "object",
           "required": [
             "summary",
-            "double_width",
             "image"
           ],
           "additionalProperties": false,
@@ -1191,7 +1190,6 @@
           "type": "object",
           "required": [
             "summary",
-            "double_width",
             "youtube_video_id"
           ],
           "additionalProperties": false,

--- a/content_schemas/dist/formats/organisation/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/organisation/publisher_v2/schema.json
@@ -718,7 +718,6 @@
           "type": "object",
           "required": [
             "summary",
-            "double_width",
             "image"
           ],
           "additionalProperties": false,
@@ -780,7 +779,6 @@
           "type": "object",
           "required": [
             "summary",
-            "double_width",
             "youtube_video_id"
           ],
           "additionalProperties": false,

--- a/content_schemas/examples/organisation/frontend/number_10.json
+++ b/content_schemas/examples/organisation/frontend/number_10.json
@@ -1455,7 +1455,6 @@
               "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/promotional_feature_item/image/1/Transparency.jpg",
               "alt_text": "Magnifying glass studying a graph"
             },
-            "double_width": false,
             "links": [
               {
                 "title": "Single departmental plans",
@@ -1575,7 +1574,6 @@
             "href": "",
             "summary": "The Number 10 media blog provides an opportunity to share the government’s position on a wide range of issues directly to the public.",
             "youtube_video_id": "fFmDQn9Lbl4",
-            "double_width": false,
             "links": [
               {
                 "title": "Number 10 media blog",

--- a/content_schemas/formats/shared/definitions/_whitehall.jsonnet
+++ b/content_schemas/formats/shared/definitions/_whitehall.jsonnet
@@ -372,7 +372,6 @@
         additionalProperties: false,
         required: [
           "summary",
-          "double_width",
           "image",
         ],
         properties: {
@@ -406,7 +405,6 @@
         additionalProperties: false,
         required: [
           "summary",
-          "double_width",
           "youtube_video_id",
         ],
         properties: {


### PR DESCRIPTION
[Trello ticket link](https://trello.com/c/CXft2Mlr/1013-remove-unused-double-width-field-from-promotional-features)

This PR is part of the work to remove the redundant `double_width` field from promotional features in Whitehall. It **removes the `double-width` field from the required attribute and removes the `double-width` field from frontend examples**, in line with the documentation on removing fields from content schemas.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️