### PR TITLE
Update `changing an existing content schema` documentation

### DIFF
--- a/content_schemas/dist/formats/organisation/frontend/schema.json
+++ b/content_schemas/dist/formats/organisation/frontend/schema.json
@@ -965,7 +965,6 @@
           "type": "object",
           "required": [
             "summary",
-            "double_width",
             "image"
           ],
           "additionalProperties": false,
@@ -1027,7 +1026,6 @@
           "type": "object",
           "required": [
             "summary",
-            "double_width",
             "youtube_video_id"
           ],
           "additionalProperties": false,

--- a/content_schemas/dist/formats/organisation/notification/schema.json
+++ b/content_schemas/dist/formats/organisation/notification/schema.json
@@ -1129,7 +1129,6 @@
           "type": "object",
           "required": [
             "summary",
-            "double_width",
             "image"
           ],
           "additionalProperties": false,
@@ -1191,7 +1190,6 @@
           "type": "object",
           "required": [
             "summary",
-            "double_width",
             "youtube_video_id"
           ],
           "additionalProperties": false,

--- a/content_schemas/dist/formats/organisation/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/organisation/publisher_v2/schema.json
@@ -718,7 +718,6 @@
           "type": "object",
           "required": [
             "summary",
-            "double_width",
             "image"
           ],
           "additionalProperties": false,
@@ -780,7 +779,6 @@
           "type": "object",
           "required": [
             "summary",
-            "double_width",
             "youtube_video_id"
           ],
           "additionalProperties": false,

--- a/content_schemas/examples/organisation/frontend/number_10.json
+++ b/content_schemas/examples/organisation/frontend/number_10.json
@@ -1455,7 +1455,6 @@
               "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/promotional_feature_item/image/1/Transparency.jpg",
               "alt_text": "Magnifying glass studying a graph"
             },
-            "double_width": false,
             "links": [
               {
                 "title": "Single departmental plans",
@@ -1575,7 +1574,6 @@
             "href": "",
             "summary": "The Number 10 media blog provides an opportunity to share the government’s position on a wide range of issues directly to the public.",
             "youtube_video_id": "fFmDQn9Lbl4",
-            "double_width": false,
             "links": [
               {
                 "title": "Number 10 media blog",

--- a/content_schemas/formats/shared/definitions/_whitehall.jsonnet
+++ b/content_schemas/formats/shared/definitions/_whitehall.jsonnet
@@ -372,7 +372,6 @@
         additionalProperties: false,
         required: [
           "summary",
-          "double_width",
           "image",
         ],
         properties: {
@@ -406,7 +405,6 @@
         additionalProperties: false,
         required: [
           "summary",
-          "double_width",
           "youtube_video_id",
         ],
         properties: {

--- a/docs/content_schemas/changing-an-existing-content-schema.md
+++ b/docs/content_schemas/changing-an-existing-content-schema.md
@@ -5,7 +5,8 @@
 * create a branch
 * make changes to the relevant schema fragment under `formats/<format name>.jsonnet`
 * change the relevant frontend examples (or add a new example)
-* run `rake` to compile a new schema.json and test the example against the schema
+* run `rake build_schemas` to compile a new schema.json
+* run `rake` to test the example against the schema
 * commit and push
 * open a PR
 * watch the multi-build status to see if all apps are compatible with the change


### PR DESCRIPTION
## What
This PR updates the documentation for changing an existing content schema, adding the step of running `rake build_schemas` prior to running `rake` in the general workflow.

## Why
The current documentation suggests running `rake` will re-generate the content schemas, but this task isn't in the list of default rake tasks. 

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
