### PR TITLE
Update `changing an existing content schema` documentation

### DIFF
--- a/docs/content_schemas/changing-an-existing-content-schema.md
+++ b/docs/content_schemas/changing-an-existing-content-schema.md
@@ -5,7 +5,8 @@
 * create a branch
 * make changes to the relevant schema fragment under `formats/<format name>.jsonnet`
 * change the relevant frontend examples (or add a new example)
-* run `rake` to compile a new schema.json and test the example against the schema
+* run `rake build_schemas` to compile a new schema.json
+* run `rake` to test the example against the schema
 * commit and push
 * open a PR
 * watch the multi-build status to see if all apps are compatible with the change


### PR DESCRIPTION
## What
This PR updates the documentation for changing an existing content schema, adding the step of running `rake build_schemas` prior to running `rake` in the general workflow.

## Why
The current documentation suggests running `rake` will re-generate the content schemas, but this task isn't in the list of default rake tasks. 

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
