### PR TITLE
Make YouTube video alt text required

### DIFF
--- a/content_schemas/dist/formats/organisation/frontend/schema.json
+++ b/content_schemas/dist/formats/organisation/frontend/schema.json
@@ -1048,7 +1048,8 @@
             "youtube_video": {
               "type": "object",
               "required": [
-                "id"
+                "id",
+                "alt_text"
               ],
               "additionalProperties": false,
               "properties": {

--- a/content_schemas/dist/formats/organisation/frontend/schema.json
+++ b/content_schemas/dist/formats/organisation/frontend/schema.json
@@ -1026,7 +1026,7 @@
           "type": "object",
           "required": [
             "summary",
-            "youtube_video_id"
+            "youtube_video"
           ],
           "additionalProperties": false,
           "properties": {
@@ -1045,8 +1045,20 @@
             "title": {
               "$ref": "#/definitions/promotional_feature_item_title"
             },
-            "youtube_video_id": {
-              "type": "string"
+            "youtube_video": {
+              "type": "object",
+              "required": [
+                "id"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "alt_text": {
+                  "type": "string"
+                },
+                "id": {
+                  "type": "string"
+                }
+              }
             }
           }
         }

--- a/content_schemas/dist/formats/organisation/notification/schema.json
+++ b/content_schemas/dist/formats/organisation/notification/schema.json
@@ -1212,7 +1212,8 @@
             "youtube_video": {
               "type": "object",
               "required": [
-                "id"
+                "id",
+                "alt_text"
               ],
               "additionalProperties": false,
               "properties": {

--- a/content_schemas/dist/formats/organisation/notification/schema.json
+++ b/content_schemas/dist/formats/organisation/notification/schema.json
@@ -1190,7 +1190,7 @@
           "type": "object",
           "required": [
             "summary",
-            "youtube_video_id"
+            "youtube_video"
           ],
           "additionalProperties": false,
           "properties": {
@@ -1209,8 +1209,20 @@
             "title": {
               "$ref": "#/definitions/promotional_feature_item_title"
             },
-            "youtube_video_id": {
-              "type": "string"
+            "youtube_video": {
+              "type": "object",
+              "required": [
+                "id"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "alt_text": {
+                  "type": "string"
+                },
+                "id": {
+                  "type": "string"
+                }
+              }
             }
           }
         }

--- a/content_schemas/dist/formats/organisation/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/organisation/publisher_v2/schema.json
@@ -801,7 +801,8 @@
             "youtube_video": {
               "type": "object",
               "required": [
-                "id"
+                "id",
+                "alt_text"
               ],
               "additionalProperties": false,
               "properties": {

--- a/content_schemas/dist/formats/organisation/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/organisation/publisher_v2/schema.json
@@ -779,7 +779,7 @@
           "type": "object",
           "required": [
             "summary",
-            "youtube_video_id"
+            "youtube_video"
           ],
           "additionalProperties": false,
           "properties": {
@@ -798,8 +798,20 @@
             "title": {
               "$ref": "#/definitions/promotional_feature_item_title"
             },
-            "youtube_video_id": {
-              "type": "string"
+            "youtube_video": {
+              "type": "object",
+              "required": [
+                "id"
+              ],
+              "additionalProperties": false,
+              "properties": {
+                "alt_text": {
+                  "type": "string"
+                },
+                "id": {
+                  "type": "string"
+                }
+              }
             }
           }
         }

--- a/content_schemas/examples/organisation/frontend/number_10.json
+++ b/content_schemas/examples/organisation/frontend/number_10.json
@@ -1573,7 +1573,10 @@
             "title": "",
             "href": "",
             "summary": "The Number 10 media blog provides an opportunity to share the government’s position on a wide range of issues directly to the public.",
-            "youtube_video_id": "fFmDQn9Lbl4",
+            "youtube_video": {
+              "id": "fFmDQn9Lbl4",
+              "alt_text": "Video of a cat picking the Euros winner."
+            },
             "links": [
               {
                 "title": "Number 10 media blog",

--- a/content_schemas/formats/shared/definitions/_whitehall.jsonnet
+++ b/content_schemas/formats/shared/definitions/_whitehall.jsonnet
@@ -428,6 +428,7 @@
             additionalProperties: false,
             required: [
               "id",
+              "alt_text",
             ],
             properties: {
               id: {

--- a/content_schemas/formats/shared/definitions/_whitehall.jsonnet
+++ b/content_schemas/formats/shared/definitions/_whitehall.jsonnet
@@ -405,7 +405,7 @@
         additionalProperties: false,
         required: [
           "summary",
-          "youtube_video_id",
+          "youtube_video",
         ],
         properties: {
           title: {
@@ -417,14 +417,26 @@
           summary: {
             "$ref": "#/definitions/promotional_feature_item_summary",
           },
-          youtube_video_id: {
-            type: "string",
-          },
           double_width: {
             "$ref": "#/definitions/promotional_feature_item_double_width",
           },
           links: {
             "$ref": "#/definitions/promotional_feature_item_links",
+          },
+          youtube_video: {
+            type: "object",
+            additionalProperties: false,
+            required: [
+              "id",
+            ],
+            properties: {
+              id: {
+                type: "string",
+              },
+              alt_text: {
+                type: "string",
+              },
+            },
           },
         },
       },


### PR DESCRIPTION
## Description

Now https://github.com/alphagov/whitehall/pull/7235 has been merged and the YouTube video alt text fields are present in Whitehall we can make this field required.

## Trello card

https://trello.com/c/hEEcf7QA/1007-add-a-video-field-to-whitehall-promotional-features

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
