### PR TITLE
Remove `double_width` field

### DIFF
--- a/content_schemas/dist/formats/organisation/frontend/schema.json
+++ b/content_schemas/dist/formats/organisation/frontend/schema.json
@@ -949,9 +949,6 @@
         }
       }
     },
-    "promotional_feature_item_double_width": {
-      "type": "boolean"
-    },
     "promotional_feature_item_href": {
       "type": [
         "string",
@@ -969,9 +966,6 @@
           ],
           "additionalProperties": false,
           "properties": {
-            "double_width": {
-              "$ref": "#/definitions/promotional_feature_item_double_width"
-            },
             "href": {
               "$ref": "#/definitions/promotional_feature_item_href"
             },
@@ -1030,9 +1024,6 @@
           ],
           "additionalProperties": false,
           "properties": {
-            "double_width": {
-              "$ref": "#/definitions/promotional_feature_item_double_width"
-            },
             "href": {
               "$ref": "#/definitions/promotional_feature_item_href"
             },

--- a/content_schemas/dist/formats/organisation/notification/schema.json
+++ b/content_schemas/dist/formats/organisation/notification/schema.json
@@ -1113,9 +1113,6 @@
       "description": "Counter to indicate when the payload was generated",
       "type": "integer"
     },
-    "promotional_feature_item_double_width": {
-      "type": "boolean"
-    },
     "promotional_feature_item_href": {
       "type": [
         "string",
@@ -1133,9 +1130,6 @@
           ],
           "additionalProperties": false,
           "properties": {
-            "double_width": {
-              "$ref": "#/definitions/promotional_feature_item_double_width"
-            },
             "href": {
               "$ref": "#/definitions/promotional_feature_item_href"
             },
@@ -1194,9 +1188,6 @@
           ],
           "additionalProperties": false,
           "properties": {
-            "double_width": {
-              "$ref": "#/definitions/promotional_feature_item_double_width"
-            },
             "href": {
               "$ref": "#/definitions/promotional_feature_item_href"
             },

--- a/content_schemas/dist/formats/organisation/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/organisation/publisher_v2/schema.json
@@ -702,9 +702,6 @@
         }
       }
     },
-    "promotional_feature_item_double_width": {
-      "type": "boolean"
-    },
     "promotional_feature_item_href": {
       "type": [
         "string",
@@ -722,9 +719,6 @@
           ],
           "additionalProperties": false,
           "properties": {
-            "double_width": {
-              "$ref": "#/definitions/promotional_feature_item_double_width"
-            },
             "href": {
               "$ref": "#/definitions/promotional_feature_item_href"
             },
@@ -783,9 +777,6 @@
           ],
           "additionalProperties": false,
           "properties": {
-            "double_width": {
-              "$ref": "#/definitions/promotional_feature_item_double_width"
-            },
             "href": {
               "$ref": "#/definitions/promotional_feature_item_href"
             },

--- a/content_schemas/examples/organisation/frontend/number_10.json
+++ b/content_schemas/examples/organisation/frontend/number_10.json
@@ -1483,7 +1483,6 @@
               "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/promotional_feature_item/image/2/BorisJohnson.jpg",
               "alt_text": "Boris Johnson"
             },
-            "double_width": false,
             "links": [
               {
                 "title": "Read his biography",
@@ -1512,7 +1511,6 @@
               "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/promotional_feature_item/image/4/Historian.jpg",
               "alt_text": "Anthony Seldon"
             },
-            "double_width": false,
             "links": [
               {
                 "title": "About the Number 10 guest historian series",
@@ -1532,7 +1530,6 @@
               "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/promotional_feature_item/image/5/No10DoorAjar-2.jpg",
               "alt_text": "The door of Number 10 Downing Street"
             },
-            "double_width": false,
             "links": [
               {
                 "title": "Learn about 10 Downing Street",
@@ -1556,7 +1553,6 @@
               "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/promotional_feature_item/image/64/m_thatcher.jpg",
               "alt_text": "Margaret Thatcher"
             },
-            "double_width": false,
             "links": [
               {
                 "title": "View all past Prime Ministers",

--- a/content_schemas/formats/shared/definitions/_whitehall.jsonnet
+++ b/content_schemas/formats/shared/definitions/_whitehall.jsonnet
@@ -387,9 +387,6 @@
           image: {
             "$ref": "#/definitions/image",
           },
-          double_width: {
-            "$ref": "#/definitions/promotional_feature_item_double_width",
-          },
           links: {
             "$ref": "#/definitions/promotional_feature_item_links",
           },
@@ -416,9 +413,6 @@
           },
           summary: {
             "$ref": "#/definitions/promotional_feature_item_summary",
-          },
-          double_width: {
-            "$ref": "#/definitions/promotional_feature_item_double_width",
           },
           links: {
             "$ref": "#/definitions/promotional_feature_item_links",
@@ -456,9 +450,6 @@
   },
   promotional_feature_item_summary: {
     type: "string",
-  },
-  promotional_feature_item_double_width: {
-    type: "boolean",
   },
   promotional_feature_item_links: {
     type: "array",


### PR DESCRIPTION
[Trello ticket link](https://trello.com/c/CXft2Mlr/1013-remove-unused-double-width-field-from-promotional-features)

## What
Removes `double_width` field from the Whitehall definition and No. 10 examples

## Why
The `double_width` field is no longer used and has been removed from the Whitehall codebase

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
