### PR TITLE
Add Content Schema tests

### DIFF
--- a/.github/workflows/test-content-schemas-1.yml
+++ b/.github/workflows/test-content-schemas-1.yml
@@ -1,0 +1,113 @@
+name: Test Content Schemas (1)
+
+on:
+  workflow_dispatch: {}
+  push:
+    branches:
+      - main
+    paths:
+      - "content_schemas/**"
+      - "!content_schemas/README.md"
+  pull_request:
+    paths:
+      - "content_schemas/**"
+      - "!content_schemas/README.md"
+
+jobs:
+  test-collections-publisher:
+    name: Test Collections Publisher
+    uses: alphagov/collections-publisher/.github/workflows/rspec.yml@main
+    with:
+      ref: 'main'
+      publishingApiRef: ${{ github.ref }}
+
+  test-collections:
+    name: Test Collections
+    uses: alphagov/collections/.github/workflows/rspec.yml@main
+    with:
+      ref: 'main'
+      publishingApiRef: ${{ github.ref }}
+
+  test-contacts-admin:
+    name: Test Contacts Admin
+    uses: alphagov/contacts-admin/.github/workflows/rspec.yml@main
+    with:
+      ref: 'main'
+      publishingApiRef: ${{ github.ref }}
+
+  test-content-data-api:
+    name: Test Content Data API
+    uses: alphagov/content-data-api/.github/workflows/rspec.yml@main
+    with:
+      ref: 'main'
+      publishingApiRef: ${{ github.ref }}
+
+  test-content-publisher:
+    name: Test Content Publisher
+    uses: alphagov/content-publisher/.github/workflows/rspec.yml@main
+    with:
+      ref: 'main'
+      publishingApiRef: ${{ github.ref }}
+
+  test-content-store:
+    name: Test Content Store
+    uses: alphagov/content-store/.github/workflows/rspec.yml@main
+    with:
+      ref: 'main'
+      publishingApiRef: ${{ github.ref }}
+
+  test-content-tagger:
+    name: Test Content Tagger
+    uses: alphagov/content-tagger/.github/workflows/rspec.yml@main
+    with:
+      ref: 'main'
+      publishingApiRef: ${{ github.ref }}
+
+  test-email-alert-frontend:
+    name: Test Email Alert Frontend
+    uses: alphagov/email-alert-frontend/.github/workflows/rspec.yml@main
+    with:
+      ref: 'main'
+      publishingApiRef: ${{ github.ref }}
+
+  test-email-alert-service:
+    name: Test Email Alert Service
+    uses: alphagov/email-alert-service/.github/workflows/rspec.yml@main
+    with:
+      ref: 'main'
+      publishingApiRef: ${{ github.ref }}
+
+  test-feedback:
+    name: Test Feedback
+    uses: alphagov/feedback/.github/workflows/rspec.yml@main
+    with:
+      ref: 'main'
+      publishingApiRef: ${{ github.ref }}
+
+  test-finder-frontend:
+    name: Test Finder Frontend
+    uses: alphagov/finder-frontend/.github/workflows/rspec.yml@main
+    with:
+      ref: 'main'
+      publishingApiRef: ${{ github.ref }}
+
+  test-frontend:
+    name: Test Frontend
+    uses: alphagov/frontend/.github/workflows/minitest.yml@main
+    with:
+      ref: 'main'
+      publishingApiRef: ${{ github.ref }}
+
+  test-government-frontend:
+    name: Test Government Frontend
+    uses: alphagov/government-frontend/.github/workflows/minitest.yml@main
+    with:
+      ref: 'main'
+      publishingApiRef: ${{ github.ref }}
+
+  test-hmrc-manuals-api:
+    name: Test HMRC Manuals API
+    uses: alphagov/hmrc-manuals-api/.github/workflows/minitest.yml@main
+    with:
+      ref: 'main'
+      publishingApiRef: ${{ github.ref }}

--- a/.github/workflows/test-content-schemas-2.yml
+++ b/.github/workflows/test-content-schemas-2.yml
@@ -1,0 +1,107 @@
+name: Test Content Schemas (2)
+
+on:
+  workflow_dispatch: {}
+  push:
+    branches:
+      - main
+    paths:
+      - "content_schemas/**"
+      - "!content_schemas/README.md"
+  pull_request:
+    paths:
+      - "content_schemas/**"
+      - "!content_schemas/README.md"
+
+jobs:
+  test-info-frontend:
+    name: Test Info Frontend
+    uses: alphagov/info-frontend/.github/workflows/rspec.yml@main
+    with:
+      ref: 'main'
+      publishingApiRef: ${{ github.ref }}
+
+  test-licence-finder:
+    name: Test Licence Finder
+    uses: alphagov/licence-finder/.github/workflows/rspec.yml@main
+    with:
+      ref: 'main'
+      publishingApiRef: ${{ github.ref }}
+
+  test-manuals-publisher:
+    name: Test Manuals Publisher
+    uses: alphagov/manuals-publisher/.github/workflows/rspec.yml@main
+    with:
+      ref: 'main'
+      publishingApiRef: ${{ github.ref }}
+
+  test-publisher:
+    name: Test Publisher
+    uses: alphagov/publisher/.github/workflows/minitest.yml@main
+    with:
+      ref: 'main'
+      publishingApiRef: ${{ github.ref }}
+
+  test-search-api:
+    name: Test Search API
+    uses: alphagov/search-api/.github/workflows/rspec.yml@main
+    with:
+      ref: 'main'
+      publishingApiRef: ${{ github.ref }}
+
+  test-search-admin:
+    name: Test Search Admin
+    uses: alphagov/search-admin/.github/workflows/rspec.yml@main
+    with:
+      ref: 'main'
+      publishingApiRef: ${{ github.ref }}
+
+  test-service-manual-frontend:
+    name: Test Service Manual Frontend
+    uses: alphagov/service-manual-frontend/.github/workflows/minitest.yml@main
+    with:
+      ref: 'main'
+      publishingApiRef: ${{ github.ref }}
+
+  test-service-manual-publisher:
+    name: Test Service Manual Publisher
+    uses: alphagov/service-manual-publisher/.github/workflows/rspec.yml@main
+    with:
+      ref: 'main'
+      publishingApiRef: ${{ github.ref }}
+
+  test-short-url-manager:
+    name: Test Short URL Manager
+    uses: alphagov/short-url-manager/.github/workflows/rspec.yml@main
+    with:
+      ref: 'main'
+      publishingApiRef: ${{ github.ref }}
+
+  test-smart-answers:
+    name: Test Smart Answers
+    uses: alphagov/smart-answers/.github/workflows/minitest.yml@main
+    with:
+      ref: 'main'
+      publishingApiRef: ${{ github.ref }}
+
+  test-specialist-publisher:
+    name: Test Specialist Publisher
+    uses: alphagov/specialist-publisher/.github/workflows/rspec.yml@main
+    with:
+      ref: 'main'
+      publishingApiRef: ${{ github.ref }}
+
+  test-travel-advice-publisher:
+    name: Test Travel Advice Publisher
+    uses: alphagov/travel-advice-publisher/.github/workflows/rspec.yml@main
+    with:
+      ref: 'main'
+      publishingApiRef: ${{ github.ref }}
+
+  test-whitehall:
+    name: Test Whitehall
+    uses: alphagov/whitehall/.github/workflows/minitest.yml@main
+    with:
+      ref: 'main'
+      publishingApiRef: ${{ github.ref }}
+


### PR DESCRIPTION
When content schemas change we need to run tests for all the dependant
apps. This uses two workflows as GitHub limits the number of workflow
calls to 20.