### PR TITLE
Fix typo on service_manual_guide schema example

### DIFF
--- a/content_schemas/examples/service_manual_guide/frontend/point_page.json
+++ b/content_schemas/examples/service_manual_guide/frontend/point_page.json
@@ -2,7 +2,7 @@
   "content_id": "fb81a47b-7c8f-4280-b6c7-b6fa25822222",
   "public_updated_at": "2015-10-09T08:17:10+00:00",
   "locale": "en",
-  "base_path": "/service-standard/service-standard/understand-user-needs",
+  "base_path": "/service-manual/service-standard/understand-user-needs",
   "description": "Understand user needs. Research to develop a deep knowledge of who the service users are and what that means for the design of the service.",
   "title": "1. Understand user needs",
   "updated_at": "2015-10-12T08:54:30+00:00",


### PR DESCRIPTION
There are no routes registered in router for /service-standard. This typo surfaced during work to migrate the rendering application for service manual doc types from service-manual-frontend to government-frontend.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
