### PR TITLE
Proof of concept for using pact artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,18 @@ jobs:
           TEST_DATABASE_URL: ${{ steps.setup-postgres.outputs.db-url }}
         run: bundle exec rake spec
 
+      # We upload the generated pact tests so they can be used in a later action
+      - name: Create pact artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: pacts
+          path: spec/pacts/*.json
+
       - name: Publish Pact tests
+        # We only publish the main branch as this is the only one
+        # that automated tests pull from the pact broker. We use GitHub Action
+        # artifacts to test branches.
+        if: ${{ github.ref == 'refs/heads/main' }}
         env:
           PACT_BROKER_BASE_URL: https://pact-broker.cloudapps.digital
           PACT_BROKER_USERNAME: ${{ secrets.GOVUK_PACT_BROKER_USERNAME }}
@@ -82,11 +93,11 @@ jobs:
             echo "::error title=Uncommited changes to content schemas::If these are your changes, build the content schemas and commit the changes."
             exit 1
           fi
-            
+
   run-content-store-pact-tests:
     name: Run Content Store Pact tests
     needs: test-ruby
-    uses: alphagov/content-store/.github/workflows/verify-pact.yml@main
+    uses: alphagov/content-store/.github/workflows/verify-pact.yml@pact-artifact
     with:
       ref: deployed-to-production
-      pact_consumer_version: branch-${{ github.ref_name }}
+      pact_artifact: pacts


### PR DESCRIPTION
We have a problem that GitHub Actions fail when Dependabot raises a pull request. The reason this fails is because Dependabot pull requests do not have access to secrets and thus cannot write to the pact broker.

I'm trying out a different approach for the pact test and making use of artifacts [1] as a way to share data between jobs to avoid the use of the pact broker and it's requirement for secrets.

This is something of an experiment as I've not been able to fully assert that Dependabot PRs will be able to create artifacts, but I've not found anything to suggest they wouldn't. So, I'm hoping to get this merged in and test it against our open Dependabot requests for Publishing API. It only tests against a branch of content-store: https://github.com/alphagov/content-store/pull/1046

Should this be a success I plan to do a little bit of extra work to neaten things up and get the change to Content Store merged in. Then I plan to take the same approach with GDS API Adapters, which also has this problem (however it's less visible as Dependabot PRs are much less frequent).

As an aside, it's driving me a bit crazy using the US spelling for artifact and deciding whether to use the British one for non-noun contexts or just be consistent throughout 🙀.

[1]: https://docs.github.com/en/actions/using-workflows/storing-workflow-data-as-artifacts

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
