### PR TITLE
Clean up GitHub Action pact handling following proof of concept

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,24 +51,11 @@ jobs:
         run: bundle exec rake spec
 
       # We upload the generated pact tests so they can be used in a later action
-      - name: Create pact artifact
+      - name: Create and upload pact test artifact
         uses: actions/upload-artifact@v3
         with:
           name: pacts
           path: spec/pacts/*.json
-
-      - name: Publish Pact tests
-        # We only publish the main branch as this is the only one
-        # that automated tests pull from the pact broker. We use GitHub Action
-        # artifacts to test branches.
-        if: ${{ github.ref == 'refs/heads/main' }}
-        env:
-          PACT_BROKER_BASE_URL: https://pact-broker.cloudapps.digital
-          PACT_BROKER_USERNAME: ${{ secrets.GOVUK_PACT_BROKER_USERNAME }}
-          PACT_BROKER_PASSWORD: ${{ secrets.GOVUK_PACT_BROKER_PASSWORD }}
-          PACT_CONSUMER_VERSION: branch-${{ github.ref_name }}
-          PACT_TARGET_BRANCH: branch-${{ github.ref_name }}
-        run: bundle exec rake pact:publish:branch
 
   check-schemas-build:
     name: Check content schemas are built
@@ -97,7 +84,23 @@ jobs:
   run-content-store-pact-tests:
     name: Run Content Store Pact tests
     needs: test-ruby
-    uses: alphagov/content-store/.github/workflows/verify-pact.yml@pact-artifact
+    uses: alphagov/content-store/.github/workflows/verify-pact.yml@main
     with:
       ref: deployed-to-production
       pact_artifact: pacts
+
+  delete-pact-artifact:
+    name: Delete Pact artifact
+    needs:
+      - test-ruby
+      - run-content-store-pact-tests
+    # Run whenever test-ruby is a success regardless of run-content-store-pact-tests outcome
+    if: ${{ needs.test-ruby.result == 'success' && always() }}
+    runs-on: ubuntu-latest
+    steps:
+      # As of Jan 2023, GitHub doesn't provide a delete artifact equivalent to
+      # their upload / download ones
+      - uses: geekyeggo/delete-artifact@v2
+        with:
+          name: pacts
+


### PR DESCRIPTION
This depends on: https://github.com/alphagov/content-store/pull/1046, I've opened this as a draft until that is merged. Once that is done I'll need to change the branch this references.

In https://github.com/alphagov/publishing-api/pull/2276 we explored a proof of concept for having Pact test work with GitHub Actions for Dependabot PRs. This proof of concept was a success and this cleans up the approach for prosperity.

I've removed the step to publish pact tests to the Pact Broker. I realised this was of low value as the Content Store does not use the `branch-main` [1] and instead relies on Jenkins CI. We can always reintroduce this when we have a need for it, I just wanted to not leave something in that didn't provide value.

The other change I've made is the deletion of the artifact after the action run, since I can't think of a situation where we'd need this and we can avoid this contributing to our storage quotas.

[1]: https://github.com/alphagov/content-store/blob/685d3d88e59f3066740bdc3ae177ca811f66d060/.github/workflows/ci.yml#L26-L30

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
