### PR TITLE
Add related historic appointments to content item

### DIFF
--- a/content_schemas/formats/historic_appointment.jsonnet
+++ b/content_schemas/formats/historic_appointment.jsonnet
@@ -43,6 +43,7 @@
     },
     links: (import "shared/base_links.jsonnet") + {
       person: "The person who is represented by this historic appointment",
+      ordered_related_items: "A list of related historic appointments"
     },
   },
 }


### PR DESCRIPTION
This is largely for the past PM pages and will provide a list of PM's who's tenure was close in time to the one being shown.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
