### PR TITLE
Update historic appointments schema

### DIFF
--- a/content_schemas/allowed_document_types.yml
+++ b/content_schemas/allowed_document_types.yml
@@ -61,6 +61,7 @@
 - help_page
 - high_commissioner_role
 - historic_appointment
+- historic_appointments
 - history
 - hmrc_manual
 - hmrc_manual_section

--- a/content_schemas/dist/formats/generic/frontend/schema.json
+++ b/content_schemas/dist/formats/generic/frontend/schema.json
@@ -97,6 +97,7 @@
         "help_page",
         "high_commissioner_role",
         "historic_appointment",
+        "historic_appointments",
         "history",
         "hmrc_manual",
         "hmrc_manual_section",

--- a/content_schemas/dist/formats/generic/notification/schema.json
+++ b/content_schemas/dist/formats/generic/notification/schema.json
@@ -121,6 +121,7 @@
         "help_page",
         "high_commissioner_role",
         "historic_appointment",
+        "historic_appointments",
         "history",
         "hmrc_manual",
         "hmrc_manual_section",

--- a/content_schemas/dist/formats/generic/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/generic/publisher_v2/schema.json
@@ -107,6 +107,7 @@
         "help_page",
         "high_commissioner_role",
         "historic_appointment",
+        "historic_appointments",
         "history",
         "hmrc_manual",
         "hmrc_manual_section",

--- a/content_schemas/dist/formats/generic_with_external_related_links/frontend/schema.json
+++ b/content_schemas/dist/formats/generic_with_external_related_links/frontend/schema.json
@@ -97,6 +97,7 @@
         "help_page",
         "high_commissioner_role",
         "historic_appointment",
+        "historic_appointments",
         "history",
         "hmrc_manual",
         "hmrc_manual_section",

--- a/content_schemas/dist/formats/generic_with_external_related_links/notification/schema.json
+++ b/content_schemas/dist/formats/generic_with_external_related_links/notification/schema.json
@@ -121,6 +121,7 @@
         "help_page",
         "high_commissioner_role",
         "historic_appointment",
+        "historic_appointments",
         "history",
         "hmrc_manual",
         "hmrc_manual_section",

--- a/content_schemas/dist/formats/generic_with_external_related_links/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/generic_with_external_related_links/publisher_v2/schema.json
@@ -107,6 +107,7 @@
         "help_page",
         "high_commissioner_role",
         "historic_appointment",
+        "historic_appointments",
         "history",
         "hmrc_manual",
         "hmrc_manual_section",

--- a/content_schemas/dist/formats/historic_appointments/frontend/schema.json
+++ b/content_schemas/dist/formats/historic_appointments/frontend/schema.json
@@ -97,6 +97,7 @@
         "help_page",
         "high_commissioner_role",
         "historic_appointment",
+        "historic_appointments",
         "history",
         "hmrc_manual",
         "hmrc_manual_section",

--- a/content_schemas/dist/formats/historic_appointments/frontend/schema.json
+++ b/content_schemas/dist/formats/historic_appointments/frontend/schema.json
@@ -467,8 +467,41 @@
     },
     "details": {
       "type": "object",
+      "required": [
+        "appointments_without_historical_accounts"
+      ],
       "additionalProperties": false,
       "properties": {
+        "appointments_without_historical_accounts": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "dates_in_office": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "end_year": {
+                      "type": "integer"
+                    },
+                    "start_year": {
+                      "type": "integer"
+                    }
+                  }
+                }
+              },
+              "image_url": {
+                "type": "string"
+              },
+              "title": {
+                "type": "string"
+              }
+            }
+          }
+        },
         "change_history": {
           "$ref": "#/definitions/change_history"
         }

--- a/content_schemas/dist/formats/historic_appointments/notification/schema.json
+++ b/content_schemas/dist/formats/historic_appointments/notification/schema.json
@@ -121,6 +121,7 @@
         "help_page",
         "high_commissioner_role",
         "historic_appointment",
+        "historic_appointments",
         "history",
         "hmrc_manual",
         "hmrc_manual_section",

--- a/content_schemas/dist/formats/historic_appointments/notification/schema.json
+++ b/content_schemas/dist/formats/historic_appointments/notification/schema.json
@@ -558,8 +558,41 @@
     },
     "details": {
       "type": "object",
+      "required": [
+        "appointments_without_historical_accounts"
+      ],
       "additionalProperties": false,
       "properties": {
+        "appointments_without_historical_accounts": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "dates_in_office": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "end_year": {
+                      "type": "integer"
+                    },
+                    "start_year": {
+                      "type": "integer"
+                    }
+                  }
+                }
+              },
+              "image_url": {
+                "type": "string"
+              },
+              "title": {
+                "type": "string"
+              }
+            }
+          }
+        },
         "change_history": {
           "$ref": "#/definitions/change_history"
         }

--- a/content_schemas/dist/formats/historic_appointments/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/historic_appointments/publisher_v2/schema.json
@@ -107,6 +107,7 @@
         "help_page",
         "high_commissioner_role",
         "historic_appointment",
+        "historic_appointments",
         "history",
         "hmrc_manual",
         "hmrc_manual_section",

--- a/content_schemas/dist/formats/historic_appointments/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/historic_appointments/publisher_v2/schema.json
@@ -349,8 +349,42 @@
     },
     "details": {
       "type": "object",
+      "required": [
+        "appointments_without_historical_accounts"
+      ],
       "additionalProperties": false,
-      "properties": {}
+      "properties": {
+        "appointments_without_historical_accounts": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "dates_in_office": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "end_year": {
+                      "type": "integer"
+                    },
+                    "start_year": {
+                      "type": "integer"
+                    }
+                  }
+                }
+              },
+              "image_url": {
+                "type": "string"
+              },
+              "title": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
     },
     "first_published_at": {
       "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",

--- a/content_schemas/dist/formats/placeholder/frontend/schema.json
+++ b/content_schemas/dist/formats/placeholder/frontend/schema.json
@@ -97,6 +97,7 @@
         "help_page",
         "high_commissioner_role",
         "historic_appointment",
+        "historic_appointments",
         "history",
         "hmrc_manual",
         "hmrc_manual_section",

--- a/content_schemas/dist/formats/placeholder/notification/schema.json
+++ b/content_schemas/dist/formats/placeholder/notification/schema.json
@@ -121,6 +121,7 @@
         "help_page",
         "high_commissioner_role",
         "historic_appointment",
+        "historic_appointments",
         "history",
         "hmrc_manual",
         "hmrc_manual_section",

--- a/content_schemas/dist/formats/placeholder/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/placeholder/publisher_v2/schema.json
@@ -107,6 +107,7 @@
         "help_page",
         "high_commissioner_role",
         "historic_appointment",
+        "historic_appointments",
         "history",
         "hmrc_manual",
         "hmrc_manual_section",

--- a/content_schemas/dist/formats/special_route/frontend/schema.json
+++ b/content_schemas/dist/formats/special_route/frontend/schema.json
@@ -99,6 +99,7 @@
         "help_page",
         "high_commissioner_role",
         "historic_appointment",
+        "historic_appointments",
         "history",
         "hmrc_manual",
         "hmrc_manual_section",

--- a/content_schemas/dist/formats/special_route/notification/schema.json
+++ b/content_schemas/dist/formats/special_route/notification/schema.json
@@ -123,6 +123,7 @@
         "help_page",
         "high_commissioner_role",
         "historic_appointment",
+        "historic_appointments",
         "history",
         "hmrc_manual",
         "hmrc_manual_section",

--- a/content_schemas/dist/formats/special_route/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/special_route/publisher_v2/schema.json
@@ -106,6 +106,7 @@
         "help_page",
         "high_commissioner_role",
         "historic_appointment",
+        "historic_appointments",
         "history",
         "hmrc_manual",
         "hmrc_manual_section",

--- a/content_schemas/dist/formats/topical_event/frontend/schema.json
+++ b/content_schemas/dist/formats/topical_event/frontend/schema.json
@@ -97,6 +97,7 @@
         "help_page",
         "high_commissioner_role",
         "historic_appointment",
+        "historic_appointments",
         "history",
         "hmrc_manual",
         "hmrc_manual_section",

--- a/content_schemas/dist/formats/topical_event/notification/schema.json
+++ b/content_schemas/dist/formats/topical_event/notification/schema.json
@@ -121,6 +121,7 @@
         "help_page",
         "high_commissioner_role",
         "historic_appointment",
+        "historic_appointments",
         "history",
         "hmrc_manual",
         "hmrc_manual_section",

--- a/content_schemas/dist/formats/topical_event/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/topical_event/publisher_v2/schema.json
@@ -107,6 +107,7 @@
         "help_page",
         "high_commissioner_role",
         "historic_appointment",
+        "historic_appointments",
         "history",
         "hmrc_manual",
         "hmrc_manual_section",

--- a/content_schemas/dist/formats/world_location_news/frontend/schema.json
+++ b/content_schemas/dist/formats/world_location_news/frontend/schema.json
@@ -97,6 +97,7 @@
         "help_page",
         "high_commissioner_role",
         "historic_appointment",
+        "historic_appointments",
         "history",
         "hmrc_manual",
         "hmrc_manual_section",

--- a/content_schemas/dist/formats/world_location_news/notification/schema.json
+++ b/content_schemas/dist/formats/world_location_news/notification/schema.json
@@ -121,6 +121,7 @@
         "help_page",
         "high_commissioner_role",
         "historic_appointment",
+        "historic_appointments",
         "history",
         "hmrc_manual",
         "hmrc_manual_section",

--- a/content_schemas/dist/formats/world_location_news/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/world_location_news/publisher_v2/schema.json
@@ -107,6 +107,7 @@
         "help_page",
         "high_commissioner_role",
         "historic_appointment",
+        "historic_appointments",
         "history",
         "hmrc_manual",
         "hmrc_manual_section",

--- a/content_schemas/dist/formats/worldwide_organisation/frontend/schema.json
+++ b/content_schemas/dist/formats/worldwide_organisation/frontend/schema.json
@@ -97,6 +97,7 @@
         "help_page",
         "high_commissioner_role",
         "historic_appointment",
+        "historic_appointments",
         "history",
         "hmrc_manual",
         "hmrc_manual_section",

--- a/content_schemas/dist/formats/worldwide_organisation/notification/schema.json
+++ b/content_schemas/dist/formats/worldwide_organisation/notification/schema.json
@@ -121,6 +121,7 @@
         "help_page",
         "high_commissioner_role",
         "historic_appointment",
+        "historic_appointments",
         "history",
         "hmrc_manual",
         "hmrc_manual_section",

--- a/content_schemas/dist/formats/worldwide_organisation/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/worldwide_organisation/publisher_v2/schema.json
@@ -107,6 +107,7 @@
         "help_page",
         "high_commissioner_role",
         "historic_appointment",
+        "historic_appointments",
         "history",
         "hmrc_manual",
         "hmrc_manual_section",

--- a/content_schemas/formats/historic_appointments.jsonnet
+++ b/content_schemas/formats/historic_appointments.jsonnet
@@ -3,7 +3,35 @@
     details: {
       type: "object",
       additionalProperties: false,
-      properties: {},
+      required: ["appointments_without_historical_accounts"],
+      properties: {
+        appointments_without_historical_accounts: {
+            type: "array",
+            items: {
+               type: "object",
+               additionalProperties: false,
+               properties: {
+                 title: {
+                     type: "string"
+                 },
+                 dates_in_office: {
+                     type: "array",
+                     items: {
+                        type: "object",
+                        additionalProperties: false,
+                        properties: {
+                            start_year: { type: "integer" },
+                            end_year: { type: "integer" },
+                        }
+                     }
+                 },
+                 image_url: {
+                    type: "string"
+                 }
+               }
+            }
+        }
+      },
     },
   },
 }


### PR DESCRIPTION
This contains some updates in preparation for publishing the content item for historic appointments. 

It:
* adds historic appointments to the allowed document types
* adds a field to the historical appointments index details schema, to allow us to include information on historic appointments without published historical accounts - for example, when someone has recently resigned from post and their historical account has not yet been written up. 

Change using this schema in whitehall: [PR](https://github.com/alphagov/whitehall/pull/7333)

[Trello](https://trello.com/c/0NcK4ojz/420-populate-content-item-for-past-prime-ministers-index)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
