### PR TITLE
Add necessary fields to link expansion for historic appointments

### DIFF
--- a/lib/expansion_rules.rb
+++ b/lib/expansion_rules.rb
@@ -38,6 +38,7 @@ module_function
     %i[ordered_ministers role_appointments role],
     %i[ordered_special_representatives role_appointments role],
     %i[ordered_traffic_commissioners role_appointments role],
+    %i[historical_accounts person],
   ].freeze
 
   REVERSE_LINKS = {
@@ -83,6 +84,7 @@ module_function
   TAXON_FIELDS = (DEFAULT_FIELDS + %i[description details phase]).freeze
   NEED_FIELDS = (DEFAULT_FIELDS + details_fields(:role, :goal, :benefit, :met_when, :justifications)).freeze
   FINDER_FIELDS = (DEFAULT_FIELDS + details_fields(:facets)).freeze
+  HISTORIC_APPOINTMENT_FIELDS = (DEFAULT_FIELDS + details_fields(:political_party, :previous_dates_in_office))
   MINISTERIAL_ROLE_FIELDS = (DEFAULT_FIELDS + details_fields(:body, :role_payment_type, :seniority)).freeze
   PERSON_FIELDS = (DEFAULT_FIELDS + details_fields(:body, :image)).freeze
   PERSON_FIELDS_WITH_IMAGE = (DEFAULT_FIELDS + details_fields(:image)).freeze
@@ -149,6 +151,8 @@ module_function
       { document_type: :finder,
         link_type: :finder,
         fields: FINDER_FIELDS },
+      { document_type: :historic_appointment,
+        fields: HISTORIC_APPOINTMENT_FIELDS },
       { document_type: :mainstream_browse_page,
         fields: DEFAULT_FIELDS_AND_DESCRIPTION },
       { document_type: :person,

--- a/spec/lib/expansion_rules_spec.rb
+++ b/spec/lib/expansion_rules_spec.rb
@@ -45,6 +45,7 @@ RSpec.describe ExpansionRules do
     let(:default_fields_and_description) { default_fields + %i[description] }
     let(:need_fields) { default_fields + [%i[details role], %i[details goal], %i[details benefit], %i[details met_when], %i[details justifications]] }
     let(:finder_fields) { default_fields + [%i[details facets]] }
+    let(:historic_appointment_fields) { default_fields + [%i[details political_party], %i[details previous_dates_in_office]] }
     let(:ministerial_role_fields) { role_fields + [%i[details seniority]] }
     let(:person_fields) { default_fields + [%i[details body], %i[details image]] }
     let(:person_with_image_fields) { default_fields + [%i[details image]] }
@@ -62,6 +63,7 @@ RSpec.describe ExpansionRules do
     specify { expect(rules.expansion_fields(:parent)).to eq(default_fields) }
 
     specify { expect(rules.expansion_fields(:contact)).to eq(contact_fields) }
+    specify { expect(rules.expansion_fields(:historic_appointment)).to eq(historic_appointment_fields) }
     specify { expect(rules.expansion_fields(:mainstream_browse_page)).to eq(default_fields_and_description) }
     specify { expect(rules.expansion_fields(:need)).to eq(need_fields) }
     specify { expect(rules.expansion_fields(:organisation)).to eq(organisation_fields) }


### PR DESCRIPTION
This adds expansion rules for the historic appointments document type (which is currently just for the [past prime ministers index page](https://www.gov.uk/government/history/past-prime-ministers)). 

It adds fields for link expansion that will enable us to render the information we need on the page, going from this:

<img width="1237" alt="Screenshot 2023-02-17 at 09 59 05" src="https://user-images.githubusercontent.com/25515510/219617031-e54a2650-4bbe-4a6b-b813-e48cd729e231.png">


to this:

<img width="1352" alt="Screenshot 2023-02-17 at 10 44 25" src="https://user-images.githubusercontent.com/25515510/219623124-1b95381e-a713-4188-9fb1-ba3fc092e1c2.png">

This enables us to each past prime minister's name, historical account href, political party, dates in office, and image details to render on the page. 

We needed to define a recursive link for the historical account => person, since the image is contained in the person, which is a link in the historical account. So this ensures that the person link is also expanded, within the expanded historical account link.

I have tested this on integration, which is where the above screenshots come from. If you'd also like to do this and the content item has been wiped by the nightly sync, you can use the `publishing_api:republish:republish_past_prime_ministers` task.

[Trello](https://trello.com/c/0NcK4ojz/420-populate-content-item-for-past-prime-ministers-index)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
