### PR TITLE
Update PR template with details of team

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,5 @@
 ⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
 
+This application is owned by the publishing platform team. Let us know in #govuk-publishing-platform if you have any questions.
+
 Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.


### PR DESCRIPTION
This makes it easier for those raising PRs external to the team to know who to go to with questions, or if the PR needs to be flagged to the team.

[Trello](https://trello.com/c/iDJMAvR6/497-update-the-pull-request-template-to-say-that-publishing-own-this-app-and-give-a-link-to-our-slack-channel-in-case-they-have-ques)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
