### PR TITLE
add body to world wide organisation schema

### DIFF
--- a/content_schemas/dist/formats/worldwide_organisation/frontend/schema.json
+++ b/content_schemas/dist/formats/worldwide_organisation/frontend/schema.json
@@ -434,6 +434,10 @@
         }
       ]
     },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
     "change_history": {
       "type": "array",
       "items": {
@@ -469,6 +473,9 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "body": {
+          "$ref": "#/definitions/body"
+        },
         "change_history": {
           "$ref": "#/definitions/change_history"
         },

--- a/content_schemas/dist/formats/worldwide_organisation/notification/schema.json
+++ b/content_schemas/dist/formats/worldwide_organisation/notification/schema.json
@@ -525,6 +525,10 @@
         }
       ]
     },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
     "change_history": {
       "type": "array",
       "items": {
@@ -560,6 +564,9 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "body": {
+          "$ref": "#/definitions/body"
+        },
         "change_history": {
           "$ref": "#/definitions/change_history"
         },

--- a/content_schemas/dist/formats/worldwide_organisation/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/worldwide_organisation/publisher_v2/schema.json
@@ -337,6 +337,10 @@
         }
       ]
     },
+    "body": {
+      "description": "The main content provided as HTML rendered from govspeak",
+      "type": "string"
+    },
     "description_optional": {
       "anyOf": [
         {
@@ -351,6 +355,9 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "body": {
+          "$ref": "#/definitions/body"
+        },
         "logo": {
           "description": "The organisation's logo, including the logo image and formatted name.",
           "type": "object",

--- a/content_schemas/formats/worldwide_organisation.jsonnet
+++ b/content_schemas/formats/worldwide_organisation.jsonnet
@@ -4,6 +4,9 @@
       type: "object",
       additionalProperties: false,
       properties: {
+        body: {
+          "$ref": "#/definitions/body",
+        },
         logo: (import "shared/definitions/_organisation_logo.jsonnet"),
         ordered_corporate_information_pages: {
           type: "array",


### PR DESCRIPTION
This will allow us to render Worldwide orgs in a different app

https://trello.com/c/LrXHcFUM/382-add-body-to-worldwide-organisation-presenter

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Let us know in #govuk-publishing-platform if you have any questions.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
