### PR TITLE
Update Service manual schema examples and remove service-manuals-frontend

### DIFF
--- a/.github/workflows/test-content-schemas-2.yml
+++ b/.github/workflows/test-content-schemas-2.yml
@@ -56,13 +56,6 @@ jobs:
       ref: 'main'
       publishingApiRef: ${{ github.ref }}
 
-  test-service-manual-frontend:
-    name: Test Service Manual Frontend
-    uses: alphagov/service-manual-frontend/.github/workflows/minitest.yml@main
-    with:
-      ref: 'main'
-      publishingApiRef: ${{ github.ref }}
-
   test-service-manual-publisher:
     name: Test Service Manual Publisher
     uses: alphagov/service-manual-publisher/.github/workflows/rspec.yml@main

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -119,7 +119,6 @@ def checkSchemaDependentProjects() {
         'publisher',
         'search-api',
         'search-admin',
-        'service-manual-frontend',
         'service-manual-publisher',
         'short-url-manager',
         'smartanswers',

--- a/content_schemas/dist/formats/answer/frontend/schema.json
+++ b/content_schemas/dist/formats/answer/frontend/schema.json
@@ -623,7 +623,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/answer/notification/schema.json
+++ b/content_schemas/dist/formats/answer/notification/schema.json
@@ -745,7 +745,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/answer/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/answer/publisher_v2/schema.json
@@ -379,7 +379,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/calendar/frontend/schema.json
+++ b/content_schemas/dist/formats/calendar/frontend/schema.json
@@ -593,7 +593,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/calendar/notification/schema.json
+++ b/content_schemas/dist/formats/calendar/notification/schema.json
@@ -696,7 +696,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/calendar/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/calendar/publisher_v2/schema.json
@@ -330,7 +330,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/case_study/frontend/schema.json
+++ b/content_schemas/dist/formats/case_study/frontend/schema.json
@@ -717,7 +717,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/case_study/notification/schema.json
+++ b/content_schemas/dist/formats/case_study/notification/schema.json
@@ -834,7 +834,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/case_study/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/case_study/publisher_v2/schema.json
@@ -464,7 +464,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/coming_soon/frontend/schema.json
+++ b/content_schemas/dist/formats/coming_soon/frontend/schema.json
@@ -596,7 +596,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/coming_soon/notification/schema.json
+++ b/content_schemas/dist/formats/coming_soon/notification/schema.json
@@ -699,7 +699,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/coming_soon/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/coming_soon/publisher_v2/schema.json
@@ -333,7 +333,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/completed_transaction/frontend/schema.json
+++ b/content_schemas/dist/formats/completed_transaction/frontend/schema.json
@@ -688,7 +688,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/completed_transaction/notification/schema.json
+++ b/content_schemas/dist/formats/completed_transaction/notification/schema.json
@@ -791,7 +791,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/completed_transaction/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/completed_transaction/publisher_v2/schema.json
@@ -425,7 +425,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/consultation/frontend/schema.json
+++ b/content_schemas/dist/formats/consultation/frontend/schema.json
@@ -1025,7 +1025,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/consultation/notification/schema.json
+++ b/content_schemas/dist/formats/consultation/notification/schema.json
@@ -1143,7 +1143,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/consultation/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/consultation/publisher_v2/schema.json
@@ -808,7 +808,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/contact/frontend/schema.json
+++ b/content_schemas/dist/formats/contact/frontend/schema.json
@@ -824,7 +824,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/contact/notification/schema.json
+++ b/content_schemas/dist/formats/contact/notification/schema.json
@@ -943,7 +943,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/contact/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/contact/publisher_v2/schema.json
@@ -562,7 +562,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/coronavirus_landing_page/frontend/schema.json
+++ b/content_schemas/dist/formats/coronavirus_landing_page/frontend/schema.json
@@ -586,7 +586,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/coronavirus_landing_page/notification/schema.json
+++ b/content_schemas/dist/formats/coronavirus_landing_page/notification/schema.json
@@ -689,7 +689,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/coronavirus_landing_page/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/coronavirus_landing_page/publisher_v2/schema.json
@@ -322,7 +322,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/corporate_information_page/frontend/schema.json
+++ b/content_schemas/dist/formats/corporate_information_page/frontend/schema.json
@@ -774,7 +774,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/corporate_information_page/notification/schema.json
+++ b/content_schemas/dist/formats/corporate_information_page/notification/schema.json
@@ -885,7 +885,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/corporate_information_page/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/corporate_information_page/publisher_v2/schema.json
@@ -549,7 +549,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/detailed_guide/frontend/schema.json
+++ b/content_schemas/dist/formats/detailed_guide/frontend/schema.json
@@ -851,7 +851,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/detailed_guide/notification/schema.json
+++ b/content_schemas/dist/formats/detailed_guide/notification/schema.json
@@ -967,7 +967,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/detailed_guide/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/detailed_guide/publisher_v2/schema.json
@@ -634,7 +634,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/document_collection/frontend/schema.json
+++ b/content_schemas/dist/formats/document_collection/frontend/schema.json
@@ -719,7 +719,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/document_collection/notification/schema.json
+++ b/content_schemas/dist/formats/document_collection/notification/schema.json
@@ -838,7 +838,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/document_collection/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/document_collection/publisher_v2/schema.json
@@ -496,7 +496,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/email_alert_signup/frontend/schema.json
+++ b/content_schemas/dist/formats/email_alert_signup/frontend/schema.json
@@ -658,7 +658,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/email_alert_signup/notification/schema.json
+++ b/content_schemas/dist/formats/email_alert_signup/notification/schema.json
@@ -761,7 +761,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/email_alert_signup/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/email_alert_signup/publisher_v2/schema.json
@@ -395,7 +395,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/facet/frontend/schema.json
+++ b/content_schemas/dist/formats/facet/frontend/schema.json
@@ -659,7 +659,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/facet/notification/schema.json
+++ b/content_schemas/dist/formats/facet/notification/schema.json
@@ -772,7 +772,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/facet/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/facet/publisher_v2/schema.json
@@ -403,7 +403,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/fatality_notice/frontend/schema.json
+++ b/content_schemas/dist/formats/fatality_notice/frontend/schema.json
@@ -628,7 +628,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/fatality_notice/notification/schema.json
+++ b/content_schemas/dist/formats/fatality_notice/notification/schema.json
@@ -744,7 +744,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/fatality_notice/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/fatality_notice/publisher_v2/schema.json
@@ -403,7 +403,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/finder/frontend/schema.json
+++ b/content_schemas/dist/formats/finder/frontend/schema.json
@@ -959,7 +959,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/finder/notification/schema.json
+++ b/content_schemas/dist/formats/finder/notification/schema.json
@@ -1071,7 +1071,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/finder/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/finder/publisher_v2/schema.json
@@ -691,7 +691,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/finder_email_signup/frontend/schema.json
+++ b/content_schemas/dist/formats/finder_email_signup/frontend/schema.json
@@ -740,7 +740,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/finder_email_signup/notification/schema.json
+++ b/content_schemas/dist/formats/finder_email_signup/notification/schema.json
@@ -845,7 +845,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/finder_email_signup/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/finder_email_signup/publisher_v2/schema.json
@@ -475,7 +475,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/generic/frontend/schema.json
+++ b/content_schemas/dist/formats/generic/frontend/schema.json
@@ -767,7 +767,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/generic/notification/schema.json
+++ b/content_schemas/dist/formats/generic/notification/schema.json
@@ -870,7 +870,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/generic/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/generic/publisher_v2/schema.json
@@ -503,7 +503,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/generic_with_external_related_links/frontend/schema.json
+++ b/content_schemas/dist/formats/generic_with_external_related_links/frontend/schema.json
@@ -793,7 +793,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/generic_with_external_related_links/notification/schema.json
+++ b/content_schemas/dist/formats/generic_with_external_related_links/notification/schema.json
@@ -896,7 +896,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/generic_with_external_related_links/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/generic_with_external_related_links/publisher_v2/schema.json
@@ -530,7 +530,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/get_involved/frontend/schema.json
+++ b/content_schemas/dist/formats/get_involved/frontend/schema.json
@@ -671,7 +671,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/get_involved/notification/schema.json
+++ b/content_schemas/dist/formats/get_involved/notification/schema.json
@@ -774,7 +774,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/get_involved/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/get_involved/publisher_v2/schema.json
@@ -408,7 +408,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/government/frontend/schema.json
+++ b/content_schemas/dist/formats/government/frontend/schema.json
@@ -600,7 +600,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/government/notification/schema.json
+++ b/content_schemas/dist/formats/government/notification/schema.json
@@ -703,7 +703,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/government/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/government/publisher_v2/schema.json
@@ -337,7 +337,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/guide/frontend/schema.json
+++ b/content_schemas/dist/formats/guide/frontend/schema.json
@@ -652,7 +652,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/guide/notification/schema.json
+++ b/content_schemas/dist/formats/guide/notification/schema.json
@@ -774,7 +774,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/guide/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/guide/publisher_v2/schema.json
@@ -408,7 +408,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/help_page/frontend/schema.json
+++ b/content_schemas/dist/formats/help_page/frontend/schema.json
@@ -623,7 +623,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/help_page/notification/schema.json
+++ b/content_schemas/dist/formats/help_page/notification/schema.json
@@ -745,7 +745,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/help_page/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/help_page/publisher_v2/schema.json
@@ -379,7 +379,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/historic_appointment/frontend/schema.json
+++ b/content_schemas/dist/formats/historic_appointment/frontend/schema.json
@@ -629,7 +629,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/historic_appointment/notification/schema.json
+++ b/content_schemas/dist/formats/historic_appointment/notification/schema.json
@@ -732,7 +732,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/historic_appointment/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/historic_appointment/publisher_v2/schema.json
@@ -366,7 +366,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/historic_appointments/frontend/schema.json
+++ b/content_schemas/dist/formats/historic_appointments/frontend/schema.json
@@ -800,7 +800,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/historic_appointments/notification/schema.json
+++ b/content_schemas/dist/formats/historic_appointments/notification/schema.json
@@ -903,7 +903,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/historic_appointments/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/historic_appointments/publisher_v2/schema.json
@@ -537,7 +537,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/history/frontend/schema.json
+++ b/content_schemas/dist/formats/history/frontend/schema.json
@@ -592,7 +592,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/history/notification/schema.json
+++ b/content_schemas/dist/formats/history/notification/schema.json
@@ -695,7 +695,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/history/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/history/publisher_v2/schema.json
@@ -329,7 +329,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/hmrc_manual/frontend/schema.json
+++ b/content_schemas/dist/formats/hmrc_manual/frontend/schema.json
@@ -708,7 +708,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/hmrc_manual/notification/schema.json
+++ b/content_schemas/dist/formats/hmrc_manual/notification/schema.json
@@ -811,7 +811,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/hmrc_manual/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/hmrc_manual/publisher_v2/schema.json
@@ -445,7 +445,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/hmrc_manual_section/frontend/schema.json
+++ b/content_schemas/dist/formats/hmrc_manual_section/frontend/schema.json
@@ -712,7 +712,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/hmrc_manual_section/notification/schema.json
+++ b/content_schemas/dist/formats/hmrc_manual_section/notification/schema.json
@@ -815,7 +815,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/hmrc_manual_section/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/hmrc_manual_section/publisher_v2/schema.json
@@ -449,7 +449,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/homepage/frontend/schema.json
+++ b/content_schemas/dist/formats/homepage/frontend/schema.json
@@ -532,7 +532,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/homepage/notification/schema.json
+++ b/content_schemas/dist/formats/homepage/notification/schema.json
@@ -581,7 +581,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/homepage/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/homepage/publisher_v2/schema.json
@@ -322,7 +322,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/html_publication/frontend/schema.json
+++ b/content_schemas/dist/formats/html_publication/frontend/schema.json
@@ -687,7 +687,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/html_publication/notification/schema.json
+++ b/content_schemas/dist/formats/html_publication/notification/schema.json
@@ -792,7 +792,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/html_publication/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/html_publication/publisher_v2/schema.json
@@ -442,7 +442,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/knowledge_alpha/frontend/schema.json
+++ b/content_schemas/dist/formats/knowledge_alpha/frontend/schema.json
@@ -528,7 +528,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/knowledge_alpha/notification/schema.json
+++ b/content_schemas/dist/formats/knowledge_alpha/notification/schema.json
@@ -565,7 +565,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/knowledge_alpha/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/knowledge_alpha/publisher_v2/schema.json
@@ -317,7 +317,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/licence/frontend/schema.json
+++ b/content_schemas/dist/formats/licence/frontend/schema.json
@@ -642,7 +642,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/licence/notification/schema.json
+++ b/content_schemas/dist/formats/licence/notification/schema.json
@@ -764,7 +764,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/licence/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/licence/publisher_v2/schema.json
@@ -398,7 +398,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/local_transaction/frontend/schema.json
+++ b/content_schemas/dist/formats/local_transaction/frontend/schema.json
@@ -715,7 +715,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/local_transaction/notification/schema.json
+++ b/content_schemas/dist/formats/local_transaction/notification/schema.json
@@ -837,7 +837,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/local_transaction/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/local_transaction/publisher_v2/schema.json
@@ -471,7 +471,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/mainstream_browse_page/frontend/schema.json
+++ b/content_schemas/dist/formats/mainstream_browse_page/frontend/schema.json
@@ -625,7 +625,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/mainstream_browse_page/notification/schema.json
+++ b/content_schemas/dist/formats/mainstream_browse_page/notification/schema.json
@@ -737,7 +737,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/mainstream_browse_page/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/mainstream_browse_page/publisher_v2/schema.json
@@ -339,7 +339,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/manual/frontend/schema.json
+++ b/content_schemas/dist/formats/manual/frontend/schema.json
@@ -702,7 +702,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/manual/notification/schema.json
+++ b/content_schemas/dist/formats/manual/notification/schema.json
@@ -829,7 +829,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/manual/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/manual/publisher_v2/schema.json
@@ -457,7 +457,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/manual_section/frontend/schema.json
+++ b/content_schemas/dist/formats/manual_section/frontend/schema.json
@@ -710,7 +710,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/manual_section/notification/schema.json
+++ b/content_schemas/dist/formats/manual_section/notification/schema.json
@@ -837,7 +837,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/manual_section/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/manual_section/publisher_v2/schema.json
@@ -465,7 +465,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/ministers_index/frontend/schema.json
+++ b/content_schemas/dist/formats/ministers_index/frontend/schema.json
@@ -592,7 +592,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/ministers_index/notification/schema.json
+++ b/content_schemas/dist/formats/ministers_index/notification/schema.json
@@ -695,7 +695,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/ministers_index/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/ministers_index/publisher_v2/schema.json
@@ -329,7 +329,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/need/frontend/schema.json
+++ b/content_schemas/dist/formats/need/frontend/schema.json
@@ -653,7 +653,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/need/notification/schema.json
+++ b/content_schemas/dist/formats/need/notification/schema.json
@@ -756,7 +756,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/need/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/need/publisher_v2/schema.json
@@ -390,7 +390,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/news_article/frontend/schema.json
+++ b/content_schemas/dist/formats/news_article/frontend/schema.json
@@ -787,7 +787,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/news_article/notification/schema.json
+++ b/content_schemas/dist/formats/news_article/notification/schema.json
@@ -918,7 +918,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/news_article/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/news_article/publisher_v2/schema.json
@@ -554,7 +554,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/organisation/frontend/schema.json
+++ b/content_schemas/dist/formats/organisation/frontend/schema.json
@@ -1136,7 +1136,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/organisation/notification/schema.json
+++ b/content_schemas/dist/formats/organisation/notification/schema.json
@@ -1295,7 +1295,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/organisation/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/organisation/publisher_v2/schema.json
@@ -873,7 +873,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/organisations_homepage/frontend/schema.json
+++ b/content_schemas/dist/formats/organisations_homepage/frontend/schema.json
@@ -669,7 +669,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/organisations_homepage/notification/schema.json
+++ b/content_schemas/dist/formats/organisations_homepage/notification/schema.json
@@ -772,7 +772,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/organisations_homepage/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/organisations_homepage/publisher_v2/schema.json
@@ -406,7 +406,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/person/frontend/schema.json
+++ b/content_schemas/dist/formats/person/frontend/schema.json
@@ -655,7 +655,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/person/notification/schema.json
+++ b/content_schemas/dist/formats/person/notification/schema.json
@@ -777,7 +777,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/person/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/person/publisher_v2/schema.json
@@ -411,7 +411,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/place/frontend/schema.json
+++ b/content_schemas/dist/formats/place/frontend/schema.json
@@ -632,7 +632,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/place/notification/schema.json
+++ b/content_schemas/dist/formats/place/notification/schema.json
@@ -754,7 +754,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/place/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/place/publisher_v2/schema.json
@@ -388,7 +388,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/placeholder/frontend/schema.json
+++ b/content_schemas/dist/formats/placeholder/frontend/schema.json
@@ -903,7 +903,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/placeholder/notification/schema.json
+++ b/content_schemas/dist/formats/placeholder/notification/schema.json
@@ -1010,7 +1010,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/placeholder/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/placeholder/publisher_v2/schema.json
@@ -640,7 +640,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/publication/frontend/schema.json
+++ b/content_schemas/dist/formats/publication/frontend/schema.json
@@ -964,7 +964,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/publication/notification/schema.json
+++ b/content_schemas/dist/formats/publication/notification/schema.json
@@ -1088,7 +1088,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/publication/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/publication/publisher_v2/schema.json
@@ -747,7 +747,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/role/frontend/schema.json
+++ b/content_schemas/dist/formats/role/frontend/schema.json
@@ -658,7 +658,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/role/notification/schema.json
+++ b/content_schemas/dist/formats/role/notification/schema.json
@@ -799,7 +799,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/role/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/role/publisher_v2/schema.json
@@ -422,7 +422,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/role_appointment/frontend/schema.json
+++ b/content_schemas/dist/formats/role_appointment/frontend/schema.json
@@ -611,7 +611,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/role_appointment/notification/schema.json
+++ b/content_schemas/dist/formats/role_appointment/notification/schema.json
@@ -732,7 +732,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/role_appointment/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/role_appointment/publisher_v2/schema.json
@@ -355,7 +355,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/service_manual_guide/frontend/schema.json
+++ b/content_schemas/dist/formats/service_manual_guide/frontend/schema.json
@@ -644,7 +644,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/service_manual_guide/notification/schema.json
+++ b/content_schemas/dist/formats/service_manual_guide/notification/schema.json
@@ -755,7 +755,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/service_manual_guide/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/service_manual_guide/publisher_v2/schema.json
@@ -397,7 +397,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/service_manual_homepage/frontend/schema.json
+++ b/content_schemas/dist/formats/service_manual_homepage/frontend/schema.json
@@ -586,7 +586,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/service_manual_homepage/notification/schema.json
+++ b/content_schemas/dist/formats/service_manual_homepage/notification/schema.json
@@ -689,7 +689,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/service_manual_homepage/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/service_manual_homepage/publisher_v2/schema.json
@@ -322,7 +322,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/service_manual_service_standard/frontend/schema.json
+++ b/content_schemas/dist/formats/service_manual_service_standard/frontend/schema.json
@@ -602,7 +602,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/service_manual_service_standard/notification/schema.json
+++ b/content_schemas/dist/formats/service_manual_service_standard/notification/schema.json
@@ -709,7 +709,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/service_manual_service_standard/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/service_manual_service_standard/publisher_v2/schema.json
@@ -335,7 +335,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/service_manual_service_toolkit/frontend/schema.json
+++ b/content_schemas/dist/formats/service_manual_service_toolkit/frontend/schema.json
@@ -635,7 +635,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/service_manual_service_toolkit/notification/schema.json
+++ b/content_schemas/dist/formats/service_manual_service_toolkit/notification/schema.json
@@ -738,7 +738,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/service_manual_service_toolkit/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/service_manual_service_toolkit/publisher_v2/schema.json
@@ -372,7 +372,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/service_manual_topic/frontend/schema.json
+++ b/content_schemas/dist/formats/service_manual_topic/frontend/schema.json
@@ -615,7 +615,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/service_manual_topic/notification/schema.json
+++ b/content_schemas/dist/formats/service_manual_topic/notification/schema.json
@@ -723,7 +723,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/service_manual_topic/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/service_manual_topic/publisher_v2/schema.json
@@ -333,7 +333,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/service_sign_in/frontend/schema.json
+++ b/content_schemas/dist/formats/service_sign_in/frontend/schema.json
@@ -677,7 +677,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/service_sign_in/notification/schema.json
+++ b/content_schemas/dist/formats/service_sign_in/notification/schema.json
@@ -799,7 +799,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/service_sign_in/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/service_sign_in/publisher_v2/schema.json
@@ -433,7 +433,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/simple_smart_answer/frontend/schema.json
+++ b/content_schemas/dist/formats/simple_smart_answer/frontend/schema.json
@@ -685,7 +685,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/simple_smart_answer/notification/schema.json
+++ b/content_schemas/dist/formats/simple_smart_answer/notification/schema.json
@@ -807,7 +807,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/simple_smart_answer/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/simple_smart_answer/publisher_v2/schema.json
@@ -441,7 +441,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/smart_answer/frontend/schema.json
+++ b/content_schemas/dist/formats/smart_answer/frontend/schema.json
@@ -622,7 +622,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/smart_answer/notification/schema.json
+++ b/content_schemas/dist/formats/smart_answer/notification/schema.json
@@ -725,7 +725,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/smart_answer/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/smart_answer/publisher_v2/schema.json
@@ -359,7 +359,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/special_route/frontend/schema.json
+++ b/content_schemas/dist/formats/special_route/frontend/schema.json
@@ -739,7 +739,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/special_route/notification/schema.json
+++ b/content_schemas/dist/formats/special_route/notification/schema.json
@@ -842,7 +842,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/special_route/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/special_route/publisher_v2/schema.json
@@ -497,7 +497,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/specialist_document/frontend/schema.json
+++ b/content_schemas/dist/formats/specialist_document/frontend/schema.json
@@ -3098,7 +3098,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/specialist_document/notification/schema.json
+++ b/content_schemas/dist/formats/specialist_document/notification/schema.json
@@ -3221,7 +3221,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/specialist_document/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/specialist_document/publisher_v2/schema.json
@@ -2891,7 +2891,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/speech/frontend/schema.json
+++ b/content_schemas/dist/formats/speech/frontend/schema.json
@@ -743,7 +743,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/speech/notification/schema.json
+++ b/content_schemas/dist/formats/speech/notification/schema.json
@@ -873,7 +873,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/speech/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/speech/publisher_v2/schema.json
@@ -477,7 +477,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/statistical_data_set/frontend/schema.json
+++ b/content_schemas/dist/formats/statistical_data_set/frontend/schema.json
@@ -843,7 +843,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/statistical_data_set/notification/schema.json
+++ b/content_schemas/dist/formats/statistical_data_set/notification/schema.json
@@ -950,7 +950,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/statistical_data_set/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/statistical_data_set/publisher_v2/schema.json
@@ -609,7 +609,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/statistics_announcement/frontend/schema.json
+++ b/content_schemas/dist/formats/statistics_announcement/frontend/schema.json
@@ -625,7 +625,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/statistics_announcement/notification/schema.json
+++ b/content_schemas/dist/formats/statistics_announcement/notification/schema.json
@@ -727,7 +727,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/statistics_announcement/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/statistics_announcement/publisher_v2/schema.json
@@ -363,7 +363,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/step_by_step_nav/frontend/schema.json
+++ b/content_schemas/dist/formats/step_by_step_nav/frontend/schema.json
@@ -598,7 +598,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/step_by_step_nav/notification/schema.json
+++ b/content_schemas/dist/formats/step_by_step_nav/notification/schema.json
@@ -678,7 +678,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/step_by_step_nav/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/step_by_step_nav/publisher_v2/schema.json
@@ -408,7 +408,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/take_part/frontend/schema.json
+++ b/content_schemas/dist/formats/take_part/frontend/schema.json
@@ -645,7 +645,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/take_part/notification/schema.json
+++ b/content_schemas/dist/formats/take_part/notification/schema.json
@@ -748,7 +748,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/take_part/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/take_part/publisher_v2/schema.json
@@ -382,7 +382,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/taxon/frontend/schema.json
+++ b/content_schemas/dist/formats/taxon/frontend/schema.json
@@ -616,7 +616,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/taxon/notification/schema.json
+++ b/content_schemas/dist/formats/taxon/notification/schema.json
@@ -735,7 +735,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/taxon/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/taxon/publisher_v2/schema.json
@@ -345,7 +345,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/topic/frontend/schema.json
+++ b/content_schemas/dist/formats/topic/frontend/schema.json
@@ -603,7 +603,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/topic/notification/schema.json
+++ b/content_schemas/dist/formats/topic/notification/schema.json
@@ -703,7 +703,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/topic/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/topic/publisher_v2/schema.json
@@ -329,7 +329,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/topical_event/frontend/schema.json
+++ b/content_schemas/dist/formats/topical_event/frontend/schema.json
@@ -912,7 +912,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/topical_event/notification/schema.json
+++ b/content_schemas/dist/formats/topical_event/notification/schema.json
@@ -1015,7 +1015,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/topical_event/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/topical_event/publisher_v2/schema.json
@@ -649,7 +649,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/topical_event_about_page/frontend/schema.json
+++ b/content_schemas/dist/formats/topical_event_about_page/frontend/schema.json
@@ -600,7 +600,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/topical_event_about_page/notification/schema.json
+++ b/content_schemas/dist/formats/topical_event_about_page/notification/schema.json
@@ -703,7 +703,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/topical_event_about_page/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/topical_event_about_page/publisher_v2/schema.json
@@ -337,7 +337,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/transaction/frontend/schema.json
+++ b/content_schemas/dist/formats/transaction/frontend/schema.json
@@ -696,7 +696,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/transaction/notification/schema.json
+++ b/content_schemas/dist/formats/transaction/notification/schema.json
@@ -818,7 +818,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/transaction/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/transaction/publisher_v2/schema.json
@@ -452,7 +452,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/travel_advice/frontend/schema.json
+++ b/content_schemas/dist/formats/travel_advice/frontend/schema.json
@@ -785,7 +785,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/travel_advice/notification/schema.json
+++ b/content_schemas/dist/formats/travel_advice/notification/schema.json
@@ -913,7 +913,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/travel_advice/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/travel_advice/publisher_v2/schema.json
@@ -546,7 +546,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/travel_advice_index/frontend/schema.json
+++ b/content_schemas/dist/formats/travel_advice_index/frontend/schema.json
@@ -610,7 +610,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/travel_advice_index/notification/schema.json
+++ b/content_schemas/dist/formats/travel_advice_index/notification/schema.json
@@ -716,7 +716,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/travel_advice_index/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/travel_advice_index/publisher_v2/schema.json
@@ -355,7 +355,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/unpublishing/frontend/schema.json
+++ b/content_schemas/dist/formats/unpublishing/frontend/schema.json
@@ -609,7 +609,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/unpublishing/notification/schema.json
+++ b/content_schemas/dist/formats/unpublishing/notification/schema.json
@@ -712,7 +712,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/unpublishing/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/unpublishing/publisher_v2/schema.json
@@ -346,7 +346,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/working_group/frontend/schema.json
+++ b/content_schemas/dist/formats/working_group/frontend/schema.json
@@ -656,7 +656,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/working_group/notification/schema.json
+++ b/content_schemas/dist/formats/working_group/notification/schema.json
@@ -759,7 +759,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/working_group/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/working_group/publisher_v2/schema.json
@@ -393,7 +393,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/world_location/frontend/schema.json
+++ b/content_schemas/dist/formats/world_location/frontend/schema.json
@@ -632,7 +632,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/world_location/notification/schema.json
+++ b/content_schemas/dist/formats/world_location/notification/schema.json
@@ -749,7 +749,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/world_location/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/world_location/publisher_v2/schema.json
@@ -377,7 +377,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/world_location_news/frontend/schema.json
+++ b/content_schemas/dist/formats/world_location_news/frontend/schema.json
@@ -900,7 +900,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/world_location_news/notification/schema.json
+++ b/content_schemas/dist/formats/world_location_news/notification/schema.json
@@ -1011,7 +1011,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/world_location_news/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/world_location_news/publisher_v2/schema.json
@@ -629,7 +629,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/worldwide_organisation/frontend/schema.json
+++ b/content_schemas/dist/formats/worldwide_organisation/frontend/schema.json
@@ -900,7 +900,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/worldwide_organisation/notification/schema.json
+++ b/content_schemas/dist/formats/worldwide_organisation/notification/schema.json
@@ -1003,7 +1003,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/dist/formats/worldwide_organisation/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/worldwide_organisation/publisher_v2/schema.json
@@ -637,7 +637,6 @@
         "performanceplatform-big-screen-view",
         "rummager",
         "search-api",
-        "service-manual-frontend",
         "smartanswers",
         "spotlight",
         "static",

--- a/content_schemas/examples/homepage/publisher_v2/service_manual_homepage.json
+++ b/content_schemas/examples/homepage/publisher_v2/service_manual_homepage.json
@@ -1,6 +1,6 @@
 {
   "publishing_app": "service-manual-publisher",
-  "rendering_app": "service-manual-frontend",
+  "rendering_app": "government-frontend",
   "locale": "en",
   "details": {
   },

--- a/content_schemas/examples/service_manual_guide/publisher_v2/point_page.json
+++ b/content_schemas/examples/service_manual_guide/publisher_v2/point_page.json
@@ -1,6 +1,6 @@
 {
   "publishing_app": "service-manual-publisher",
-  "rendering_app": "service-manual-frontend",
+  "rendering_app": "government-frontend",
   "locale": "en",
   "details": {
     "show_description": true,

--- a/content_schemas/examples/service_manual_guide/publisher_v2/service_manual_guide.json
+++ b/content_schemas/examples/service_manual_guide/publisher_v2/service_manual_guide.json
@@ -1,6 +1,6 @@
 {
   "publishing_app": "service-manual-publisher",
-  "rendering_app": "service-manual-frontend",
+  "rendering_app": "government-frontend",
   "locale": "en",
   "details": {
     "body": "<h2 id=\"what\">What it is, why it works and how to do it</h2>\n<p>Agile methodologies will help you and your team to build world-class, user-centred services quickly and affordably.</p>\n",

--- a/content_schemas/examples/service_manual_homepage/publisher_v2/service_manual_homepage.json
+++ b/content_schemas/examples/service_manual_homepage/publisher_v2/service_manual_homepage.json
@@ -1,6 +1,6 @@
 {
   "publishing_app": "service-manual-publisher",
-  "rendering_app": "service-manual-frontend",
+  "rendering_app": "government-frontend",
   "locale": "en",
   "details": {
   },

--- a/content_schemas/examples/service_manual_service_standard/frontend/service_manual_service_standard.json
+++ b/content_schemas/examples/service_manual_service_standard/frontend/service_manual_service_standard.json
@@ -8,7 +8,7 @@
   "phase": "beta",
   "public_updated_at": "2016-06-30T13:28:52.000+00:00",
   "publishing_app": "service-manual-publisher",
-  "rendering_app": "service-manual-frontend",
+  "rendering_app": "government-frontend",
   "schema_name": "service_manual_service_standard",
   "title": "Service Standard",
   "updated_at": "2016-06-30T13:28:53.128Z",

--- a/content_schemas/examples/service_manual_service_standard/publisher_v2/service_manual_service_standard.json
+++ b/content_schemas/examples/service_manual_service_standard/publisher_v2/service_manual_service_standard.json
@@ -1,6 +1,6 @@
 {
   "publishing_app": "service-manual-publisher",
-  "rendering_app": "service-manual-frontend",
+  "rendering_app": "government-frontend",
   "locale": "en",
   "update_type": "major",
   "base_path": "/service-manual/service-standard",

--- a/content_schemas/examples/service_manual_service_toolkit/publisher_v2/service_manual_service_toolkit.json
+++ b/content_schemas/examples/service_manual_service_toolkit/publisher_v2/service_manual_service_toolkit.json
@@ -1,6 +1,6 @@
 {
   "publishing_app": "service-manual-publisher",
-  "rendering_app": "service-manual-frontend",
+  "rendering_app": "government-frontend",
   "locale": "en",
   "details": {
     "collections": [

--- a/content_schemas/examples/service_manual_topic/publisher_v2/service_manual_topic.json
+++ b/content_schemas/examples/service_manual_topic/publisher_v2/service_manual_topic.json
@@ -1,6 +1,6 @@
 {
   "publishing_app": "service-manual-publisher",
-  "rendering_app": "service-manual-frontend",
+  "rendering_app": "government-frontend",
   "locale": "en",
   "update_type": "minor",
   "base_path": "/service-manual/technology",

--- a/content_schemas/formats/shared/definitions/rendering_app.jsonnet
+++ b/content_schemas/formats/shared/definitions/rendering_app.jsonnet
@@ -19,7 +19,6 @@
       "performanceplatform-big-screen-view",
       "rummager",
       "search-api",
-      "service-manual-frontend",
       "smartanswers",
       "spotlight",
       "static",


### PR DESCRIPTION
Service manuals frontend has been retired.

https://trello.com/c/gICwB7Ej/1195-retire-service-manuals-frontend-app-m

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Let us know in #govuk-publishing-platform if you have any questions.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
