### PR TITLE
Add roll call to fatality notice

### DIFF
--- a/content_schemas/dist/formats/fatality_notice/frontend/schema.json
+++ b/content_schemas/dist/formats/fatality_notice/frontend/schema.json
@@ -305,7 +305,8 @@
       "required": [
         "body",
         "change_history",
-        "emphasised_organisations"
+        "emphasised_organisations",
+        "roll_call_introduction"
       ],
       "additionalProperties": false,
       "properties": {
@@ -320,6 +321,9 @@
         },
         "first_public_at": {
           "$ref": "#/definitions/first_public_at"
+        },
+        "roll_call_introduction": {
+          "type": "string"
         }
       }
     },

--- a/content_schemas/dist/formats/fatality_notice/notification/schema.json
+++ b/content_schemas/dist/formats/fatality_notice/notification/schema.json
@@ -409,7 +409,8 @@
       "required": [
         "body",
         "change_history",
-        "emphasised_organisations"
+        "emphasised_organisations",
+        "roll_call_introduction"
       ],
       "additionalProperties": false,
       "properties": {
@@ -424,6 +425,9 @@
         },
         "first_public_at": {
           "$ref": "#/definitions/first_public_at"
+        },
+        "roll_call_introduction": {
+          "type": "string"
         }
       }
     },

--- a/content_schemas/dist/formats/fatality_notice/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/fatality_notice/publisher_v2/schema.json
@@ -222,7 +222,8 @@
       "required": [
         "body",
         "change_history",
-        "emphasised_organisations"
+        "emphasised_organisations",
+        "roll_call_introduction"
       ],
       "additionalProperties": false,
       "properties": {
@@ -237,6 +238,9 @@
         },
         "first_public_at": {
           "$ref": "#/definitions/first_public_at"
+        },
+        "roll_call_introduction": {
+          "type": "string"
         }
       }
     },

--- a/content_schemas/examples/fatality_notice/frontend/fatality_notice.json
+++ b/content_schemas/examples/fatality_notice/frontend/fatality_notice.json
@@ -24,7 +24,8 @@
     ],
     "emphasised_organisations": [
       "6667cce2-e809-4e21-ae09-cb0bdc1ddda3"
-    ]
+    ],
+    "roll_call_introduction": "Sir George Pomeroy Colley, died in battle in Zululand on 27 February 1881."
   },
   "links": {
     "organisations": [

--- a/content_schemas/examples/fatality_notice/frontend/fatality_notice_with_minister.json
+++ b/content_schemas/examples/fatality_notice/frontend/fatality_notice_with_minister.json
@@ -23,7 +23,8 @@
     ],
     "emphasised_organisations": [
       "6667cce2-e809-4e21-ae09-cb0bdc1ddda3"
-    ]
+    ],
+    "roll_call_introduction": "Sir George Pomeroy Colley, died in battle in Zululand on 27 February 1881."
   },
   "links": {
     "organisations": [

--- a/content_schemas/examples/fatality_notice/frontend/withdrawn_fatality_notice.json
+++ b/content_schemas/examples/fatality_notice/frontend/withdrawn_fatality_notice.json
@@ -27,7 +27,8 @@
     ],
     "emphasised_organisations": [
       "6667cce2-e809-4e21-ae09-cb0bdc1ddda3"
-    ]
+    ],
+    "roll_call_introduction": "Sir George Pomeroy Colley, died in battle in Zululand on 27 February 1881."
   },
   "links": {
     "organisations": [

--- a/content_schemas/formats/fatality_notice.jsonnet
+++ b/content_schemas/formats/fatality_notice.jsonnet
@@ -8,6 +8,7 @@
         "body",
         "change_history",
         "emphasised_organisations",
+        "roll_call_introduction"
       ],
       properties: {
         body: {
@@ -21,6 +22,9 @@
         },
         emphasised_organisations: {
           "$ref": "#/definitions/emphasised_organisations",
+        },
+        roll_call_introduction: {
+          type: "string",
         },
       },
     },


### PR DESCRIPTION
While this is not rendered on the fatality notice page, we will need it present in the fatality notice content item when rendering the fields of operation pages, which present this information for each fatality notice. Adding it in to the content item here will allow us to link to a fatality notice in the field of operation and add the roll call introduction to the expansion rules.

Additionally, we may choose to render this information on the fatality notice page in future, so having it in the content item makes sense.

[Trello](https://trello.com/c/4UszwKWR/471-update-content-item-for-field-of-operation-pages)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Let us know in #govuk-publishing-platform if you have any questions.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
