### PR TITLE
Remove service manual frontend from dependent apps for CI

### DIFF
--- a/.github/workflows/test-content-schemas-2.yml
+++ b/.github/workflows/test-content-schemas-2.yml
@@ -56,13 +56,6 @@ jobs:
       ref: 'main'
       publishingApiRef: ${{ github.ref }}
 
-  test-service-manual-frontend:
-    name: Test Service Manual Frontend
-    uses: alphagov/service-manual-frontend/.github/workflows/minitest.yml@main
-    with:
-      ref: 'main'
-      publishingApiRef: ${{ github.ref }}
-
   test-service-manual-publisher:
     name: Test Service Manual Publisher
     uses: alphagov/service-manual-publisher/.github/workflows/rspec.yml@main

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -119,7 +119,6 @@ def checkSchemaDependentProjects() {
         'publisher',
         'search-api',
         'search-admin',
-        'service-manual-frontend',
         'service-manual-publisher',
         'short-url-manager',
         'smartanswers',


### PR DESCRIPTION
Service manual frontend is being retired, so we no longer need to run its CI when we need to make changes to content schemas.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Let us know in #govuk-publishing-platform if you have any questions.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
