### PR TITLE
Add fields of operation schema

### DIFF
--- a/content_schemas/dist/formats/field_of_operation/frontend/schema.json
+++ b/content_schemas/dist/formats/field_of_operation/frontend/schema.json
@@ -248,6 +248,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "fatality_notices": {
+          "description": "Fatality notices for this field of operation",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/content_schemas/dist/formats/field_of_operation/frontend/schema.json
+++ b/content_schemas/dist/formats/field_of_operation/frontend/schema.json
@@ -1,0 +1,798 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "required": [
+    "base_path",
+    "content_id",
+    "description",
+    "details",
+    "document_type",
+    "links",
+    "locale",
+    "public_updated_at",
+    "schema_name",
+    "title",
+    "updated_at"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
+    },
+    "description": {
+      "$ref": "#/definitions/description_optional"
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "document_type": {
+      "type": "string",
+      "enum": [
+        "aaib_report",
+        "about",
+        "about_our_services",
+        "accessible_documents_policy",
+        "access_and_opening",
+        "ambassador_role",
+        "animal_disease_case",
+        "answer",
+        "asylum_support_decision",
+        "authored_article",
+        "board_member_role",
+        "business_finance_support_scheme",
+        "calculator",
+        "calendar",
+        "case_study",
+        "chief_professional_officer_role",
+        "chief_scientific_officer_role",
+        "chief_scientific_advisor_role",
+        "closed_consultation",
+        "cma_case",
+        "coming_soon",
+        "complaints_procedure",
+        "completed_transaction",
+        "consultation",
+        "consultation_outcome",
+        "contact",
+        "coronavirus_landing_page",
+        "corporate_report",
+        "correspondence",
+        "countryside_stewardship_grant",
+        "decision",
+        "deputy_head_of_mission_role",
+        "detailed_guidance",
+        "detailed_guide",
+        "dfid_research_output",
+        "document_collection",
+        "drcf_digital_markets_research",
+        "drug_safety_update",
+        "email_alert_signup",
+        "employment_appeal_tribunal_decision",
+        "employment_tribunal_decision",
+        "equality_and_diversity",
+        "esi_fund",
+        "export_health_certificate",
+        "external_content",
+        "facet",
+        "fatality_notice",
+        "field_of_operation",
+        "finder",
+        "finder_email_signup",
+        "flood_and_coastal_erosion_risk_management_research_report",
+        "foi_release",
+        "form",
+        "get_involved",
+        "gone",
+        "government",
+        "government_response",
+        "governor_role",
+        "guidance",
+        "guide",
+        "help_page",
+        "high_commissioner_role",
+        "historic_appointment",
+        "historic_appointments",
+        "history",
+        "hmrc_manual",
+        "hmrc_manual_section",
+        "homepage",
+        "html_publication",
+        "impact_assessment",
+        "imported",
+        "independent_report",
+        "international_development_fund",
+        "international_treaty",
+        "knowledge_alpha",
+        "licence",
+        "license_finder",
+        "licence_transaction",
+        "local_transaction",
+        "maib_report",
+        "mainstream_browse_page",
+        "manual",
+        "manual_section",
+        "map",
+        "marine_notice",
+        "media_enquiries",
+        "medical_safety_alert",
+        "membership",
+        "military_role",
+        "ministerial_role",
+        "ministers_index",
+        "modern_slavery_statement",
+        "national",
+        "national_statistics",
+        "national_statistics_announcement",
+        "need",
+        "news_article",
+        "news_story",
+        "notice",
+        "official",
+        "official_statistics",
+        "official_statistics_announcement",
+        "oim_project",
+        "open_consultation",
+        "oral_statement",
+        "organisation",
+        "our_energy_use",
+        "our_governance",
+        "person",
+        "personal_information_charter",
+        "petitions_and_campaigns",
+        "place",
+        "placeholder",
+        "placeholder_ministerial_role",
+        "placeholder_organisation",
+        "placeholder_person",
+        "placeholder_policy_area",
+        "placeholder_worldwide_organisation",
+        "policy_area",
+        "policy_paper",
+        "press_release",
+        "procurement",
+        "product_safety_alert_report_recall",
+        "promotional",
+        "protected_food_drink_name",
+        "publication_scheme",
+        "raib_report",
+        "recruitment",
+        "redirect",
+        "regulation",
+        "research",
+        "research_for_development_output",
+        "residential_property_tribunal_decision",
+        "role_appointment",
+        "search",
+        "service_manual_guide",
+        "service_manual_homepage",
+        "service_manual_service_standard",
+        "service_manual_service_toolkit",
+        "service_manual_topic",
+        "service_sign_in",
+        "service_standard_report",
+        "services_and_information",
+        "simple_smart_answer",
+        "smart_answer",
+        "social_media_use",
+        "special_representative_role",
+        "special_route",
+        "speech",
+        "staff_update",
+        "standard",
+        "statistical_data_set",
+        "statistics",
+        "statistics_announcement",
+        "statutory_guidance",
+        "statutory_instrument",
+        "step_by_step_nav",
+        "take_part",
+        "tax_tribunal_decision",
+        "taxon",
+        "terms_of_reference",
+        "topic",
+        "topical_event",
+        "topical_event_about_page",
+        "traffic_commissioner_regulatory_decision",
+        "traffic_commissioner_role",
+        "transaction",
+        "transparency",
+        "travel_advice",
+        "travel_advice_index",
+        "unpublishing",
+        "uk_market_conformity_assessment_body",
+        "utaac_decision",
+        "vanish",
+        "welsh_language_scheme",
+        "working_group",
+        "world_location",
+        "world_location_news",
+        "world_news_story",
+        "worldwide_office_staff_role",
+        "worldwide_organisation",
+        "written_statement"
+      ]
+    },
+    "first_published_at": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/first_published_at"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "links": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "available_translations": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
+        "child_taxons": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
+        "children": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
+        "document_collections": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
+        "finder": {
+          "description": "Powers links from content back to finders the content is surfaced on",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
+        "lead_organisations": {
+          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
+        "level_one_taxons": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
+        "mainstream_browse_pages": {
+          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
+        "meets_user_needs": {
+          "description": "The user needs this piece of content meets.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
+        "ministers": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
+        "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
+        "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
+        "parent": {
+          "description": "The parent content item.",
+          "$ref": "#/definitions/frontend_links_with_base_path",
+          "maxItems": 1
+        },
+        "part_of_step_navs": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
+        "policies": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
+        "policy_areas": {
+          "description": "A largely deprecated tag currently only used to power email alerts.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
+        "primary_publishing_organisation": {
+          "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links_with_base_path",
+          "maxItems": 1
+        },
+        "related_to_step_navs": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
+        "role_appointments": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "secondary_to_step_navs": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
+        "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
+        "topic_taxonomy_taxons": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
+        "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        }
+      }
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "public_updated_at": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/public_updated_at"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
+    "publishing_scheduled_at": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/publishing_scheduled_at"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app"
+    },
+    "scheduled_publishing_delay_seconds": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/scheduled_publishing_delay_seconds"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "field_of_operation"
+      ]
+    },
+    "title": {
+      "$ref": "#/definitions/title"
+    },
+    "updated_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    }
+  },
+  "definitions": {
+    "description": {
+      "type": "string"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
+    "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "description_optional": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/description"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "details": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "change_history": {
+          "$ref": "#/definitions/change_history"
+        }
+      }
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "frontend_links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_id",
+          "locale",
+          "title"
+        ],
+        "additionalProperties": true,
+        "properties": {
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
+          },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "content_id": {
+            "$ref": "#/definitions/guid"
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "links": {
+            "type": "object",
+            "patternProperties": {
+              "^[a-z_]+$": {
+                "$ref": "#/definitions/frontend_links"
+              }
+            }
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
+            "oneOf": [
+              {
+                "$ref": "#/definitions/public_updated_at"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          }
+        }
+      }
+    },
+    "frontend_links_with_base_path": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "content_id",
+          "locale",
+          "title"
+        ],
+        "additionalProperties": true,
+        "properties": {
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
+          },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "content_id": {
+            "$ref": "#/definitions/guid"
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "links": {
+            "type": "object",
+            "patternProperties": {
+              "^[a-z_]+$": {
+                "$ref": "#/definitions/frontend_links_with_base_path"
+              }
+            }
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
+            "oneOf": [
+              {
+                "$ref": "#/definitions/public_updated_at"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          }
+        }
+      }
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "locale": {
+      "type": "string",
+      "enum": [
+        "ar",
+        "az",
+        "be",
+        "bg",
+        "bn",
+        "cs",
+        "cy",
+        "da",
+        "de",
+        "dr",
+        "el",
+        "en",
+        "es",
+        "es-419",
+        "et",
+        "fa",
+        "fi",
+        "fr",
+        "gd",
+        "gu",
+        "he",
+        "hi",
+        "hr",
+        "hu",
+        "hy",
+        "id",
+        "is",
+        "it",
+        "ja",
+        "ka",
+        "kk",
+        "ko",
+        "lt",
+        "lv",
+        "ms",
+        "mt",
+        "ne",
+        "nl",
+        "no",
+        "pa",
+        "pa-pk",
+        "pl",
+        "ps",
+        "pt",
+        "ro",
+        "ru",
+        "si",
+        "sk",
+        "sl",
+        "so",
+        "sq",
+        "sr",
+        "sv",
+        "sw",
+        "ta",
+        "th",
+        "tk",
+        "tr",
+        "uk",
+        "ur",
+        "uz",
+        "vi",
+        "yi",
+        "zh",
+        "zh-hk",
+        "zh-tw"
+      ]
+    },
+    "public_updated_at": {
+      "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "account-api",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-publisher",
+        "content-tagger",
+        "email-alert-frontend",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "government-frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "local-links-manager",
+        "manuals-publisher",
+        "maslow",
+        "performanceplatform-big-screen-view",
+        "publisher",
+        "rummager",
+        "search-admin",
+        "search-api",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "special-route-publisher",
+        "specialist-publisher",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "publishing_scheduled_at": {
+      "description": "When this content was last scheduled for publishing. Determined by the publishing intent sent by the publishing API.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "rendering_app": {
+      "description": "The application that renders this item.",
+      "type": "string",
+      "enum": [
+        "account-api",
+        "calculators",
+        "calendars",
+        "collections",
+        "content-store",
+        "email-alert-frontend",
+        "email-campaign-frontend",
+        "feedback",
+        "finder-frontend",
+        "frontend",
+        "government-frontend",
+        "info-frontend",
+        "licencefinder",
+        "performanceplatform-big-screen-view",
+        "rummager",
+        "search-api",
+        "smartanswers",
+        "spotlight",
+        "static",
+        "tariff",
+        "whitehall-admin",
+        "whitehall-frontend"
+      ]
+    },
+    "scheduled_publishing_delay_seconds": {
+      "description": "The delay between the most recent scheduled and actual publishing times. Determined by the content store based on the publishing intent.",
+      "type": "integer"
+    },
+    "title": {
+      "type": "string"
+    },
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
+    }
+  }
+}

--- a/content_schemas/dist/formats/field_of_operation/notification/schema.json
+++ b/content_schemas/dist/formats/field_of_operation/notification/schema.json
@@ -266,6 +266,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "fatality_notices": {
+          "description": "Fatality notices for this field of operation",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -372,6 +376,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "fatality_notices": {
+          "description": "Fatality notices for this field of operation",
+          "$ref": "#/definitions/guid_list"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/dist/formats/field_of_operation/notification/schema.json
+++ b/content_schemas/dist/formats/field_of_operation/notification/schema.json
@@ -1,0 +1,930 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "required": [
+    "analytics_identifier",
+    "base_path",
+    "content_id",
+    "description",
+    "details",
+    "document_type",
+    "email_document_supertype",
+    "expanded_links",
+    "first_published_at",
+    "government_document_supertype",
+    "govuk_request_id",
+    "links",
+    "locale",
+    "payload_version",
+    "phase",
+    "public_updated_at",
+    "publishing_app",
+    "redirects",
+    "rendering_app",
+    "routes",
+    "schema_name",
+    "title",
+    "update_type"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "content_id": {
+      "$ref": "#/definitions/guid"
+    },
+    "content_purpose_document_supertype": {
+      "description": "DEPRECATED. Use `content_purpose_subgroup`.",
+      "type": "string"
+    },
+    "content_purpose_subgroup": {
+      "description": "Document subgroup grouping documents by purpose. Narrows down the purpose defined in content_purpose_supergroup.",
+      "type": "string"
+    },
+    "content_purpose_supergroup": {
+      "description": "Document supergroup grouping documents by a purpose",
+      "type": "string"
+    },
+    "description": {
+      "$ref": "#/definitions/description_optional"
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "document_type": {
+      "type": "string",
+      "enum": [
+        "aaib_report",
+        "about",
+        "about_our_services",
+        "accessible_documents_policy",
+        "access_and_opening",
+        "ambassador_role",
+        "animal_disease_case",
+        "answer",
+        "asylum_support_decision",
+        "authored_article",
+        "board_member_role",
+        "business_finance_support_scheme",
+        "calculator",
+        "calendar",
+        "case_study",
+        "chief_professional_officer_role",
+        "chief_scientific_officer_role",
+        "chief_scientific_advisor_role",
+        "closed_consultation",
+        "cma_case",
+        "coming_soon",
+        "complaints_procedure",
+        "completed_transaction",
+        "consultation",
+        "consultation_outcome",
+        "contact",
+        "coronavirus_landing_page",
+        "corporate_report",
+        "correspondence",
+        "countryside_stewardship_grant",
+        "decision",
+        "deputy_head_of_mission_role",
+        "detailed_guidance",
+        "detailed_guide",
+        "dfid_research_output",
+        "document_collection",
+        "drcf_digital_markets_research",
+        "drug_safety_update",
+        "email_alert_signup",
+        "employment_appeal_tribunal_decision",
+        "employment_tribunal_decision",
+        "equality_and_diversity",
+        "esi_fund",
+        "export_health_certificate",
+        "external_content",
+        "facet",
+        "fatality_notice",
+        "field_of_operation",
+        "finder",
+        "finder_email_signup",
+        "flood_and_coastal_erosion_risk_management_research_report",
+        "foi_release",
+        "form",
+        "get_involved",
+        "gone",
+        "government",
+        "government_response",
+        "governor_role",
+        "guidance",
+        "guide",
+        "help_page",
+        "high_commissioner_role",
+        "historic_appointment",
+        "historic_appointments",
+        "history",
+        "hmrc_manual",
+        "hmrc_manual_section",
+        "homepage",
+        "html_publication",
+        "impact_assessment",
+        "imported",
+        "independent_report",
+        "international_development_fund",
+        "international_treaty",
+        "knowledge_alpha",
+        "licence",
+        "license_finder",
+        "licence_transaction",
+        "local_transaction",
+        "maib_report",
+        "mainstream_browse_page",
+        "manual",
+        "manual_section",
+        "map",
+        "marine_notice",
+        "media_enquiries",
+        "medical_safety_alert",
+        "membership",
+        "military_role",
+        "ministerial_role",
+        "ministers_index",
+        "modern_slavery_statement",
+        "national",
+        "national_statistics",
+        "national_statistics_announcement",
+        "need",
+        "news_article",
+        "news_story",
+        "notice",
+        "official",
+        "official_statistics",
+        "official_statistics_announcement",
+        "oim_project",
+        "open_consultation",
+        "oral_statement",
+        "organisation",
+        "our_energy_use",
+        "our_governance",
+        "person",
+        "personal_information_charter",
+        "petitions_and_campaigns",
+        "place",
+        "placeholder",
+        "placeholder_ministerial_role",
+        "placeholder_organisation",
+        "placeholder_person",
+        "placeholder_policy_area",
+        "placeholder_worldwide_organisation",
+        "policy_area",
+        "policy_paper",
+        "press_release",
+        "procurement",
+        "product_safety_alert_report_recall",
+        "promotional",
+        "protected_food_drink_name",
+        "publication_scheme",
+        "raib_report",
+        "recruitment",
+        "redirect",
+        "regulation",
+        "research",
+        "research_for_development_output",
+        "residential_property_tribunal_decision",
+        "role_appointment",
+        "search",
+        "service_manual_guide",
+        "service_manual_homepage",
+        "service_manual_service_standard",
+        "service_manual_service_toolkit",
+        "service_manual_topic",
+        "service_sign_in",
+        "service_standard_report",
+        "services_and_information",
+        "simple_smart_answer",
+        "smart_answer",
+        "social_media_use",
+        "special_representative_role",
+        "special_route",
+        "speech",
+        "staff_update",
+        "standard",
+        "statistical_data_set",
+        "statistics",
+        "statistics_announcement",
+        "statutory_guidance",
+        "statutory_instrument",
+        "step_by_step_nav",
+        "take_part",
+        "tax_tribunal_decision",
+        "taxon",
+        "terms_of_reference",
+        "topic",
+        "topical_event",
+        "topical_event_about_page",
+        "traffic_commissioner_regulatory_decision",
+        "traffic_commissioner_role",
+        "transaction",
+        "transparency",
+        "travel_advice",
+        "travel_advice_index",
+        "unpublishing",
+        "uk_market_conformity_assessment_body",
+        "utaac_decision",
+        "vanish",
+        "welsh_language_scheme",
+        "working_group",
+        "world_location",
+        "world_location_news",
+        "world_news_story",
+        "worldwide_office_staff_role",
+        "worldwide_organisation",
+        "written_statement"
+      ]
+    },
+    "email_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "expanded_links": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "available_translations": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
+        "child_taxons": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
+        "children": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
+        "document_collections": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
+        "finder": {
+          "description": "Powers links from content back to finders the content is surfaced on",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
+        "lead_organisations": {
+          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
+        "level_one_taxons": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
+        "mainstream_browse_pages": {
+          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
+        "meets_user_needs": {
+          "description": "The user needs this piece of content meets.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
+        "ministers": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
+        "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
+        "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
+        "parent": {
+          "description": "The parent content item.",
+          "$ref": "#/definitions/frontend_links_with_base_path",
+          "maxItems": 1
+        },
+        "part_of_step_navs": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
+        "policies": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
+        "policy_areas": {
+          "description": "A largely deprecated tag currently only used to power email alerts.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
+        "primary_publishing_organisation": {
+          "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/frontend_links_with_base_path",
+          "maxItems": 1
+        },
+        "related_to_step_navs": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
+        "role_appointments": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "secondary_to_step_navs": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
+        "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
+        "topic_taxonomy_taxons": {
+          "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
+        "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        }
+      }
+    },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "government_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "govuk_request_id": {
+      "$ref": "#/definitions/govuk_request_id"
+    },
+    "links": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "finder": {
+          "description": "Powers links from content back to finders the content is surfaced on",
+          "$ref": "#/definitions/guid_list"
+        },
+        "lead_organisations": {
+          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "mainstream_browse_pages": {
+          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "meets_user_needs": {
+          "description": "The user needs this piece of content meets.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "parent": {
+          "description": "The parent content item.",
+          "$ref": "#/definitions/guid_list",
+          "maxItems": 1
+        },
+        "policy_areas": {
+          "description": "A largely deprecated tag currently only used to power email alerts.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "primary_publishing_organisation": {
+          "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/guid_list",
+          "maxItems": 1
+        },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
+          "$ref": "#/definitions/guid_list"
+        },
+        "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+          "$ref": "#/definitions/guid_list"
+        }
+      }
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "navigation_document_supertype": {
+      "description": "Document type grouping powering the new taxonomy-based navigation pages",
+      "type": "string"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "payload_version": {
+      "$ref": "#/definitions/payload_version"
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "publishing_request_id": {
+      "$ref": "#/definitions/publishing_request_id"
+    },
+    "redirects": {
+      "type": "array",
+      "additionalItems": false,
+      "items": {}
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app"
+    },
+    "routes": {
+      "$ref": "#/definitions/routes"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "field_of_operation"
+      ]
+    },
+    "search_user_need_document_supertype": {
+      "description": "Document supertype grouping core and government documents",
+      "type": "string"
+    },
+    "title": {
+      "$ref": "#/definitions/title"
+    },
+    "update_type": {
+      "$ref": "#/definitions/update_type"
+    },
+    "user_journey_document_supertype": {
+      "description": "Document type grouping powering analytics of user journeys",
+      "type": "string"
+    },
+    "user_need_document_supertype": {
+      "description": "DEPRECATED. Use `content_purpose_document_supertype`.",
+      "type": "string"
+    },
+    "withdrawn_notice": {
+      "$ref": "#/definitions/withdrawn_notice"
+    }
+  },
+  "definitions": {
+    "description": {
+      "type": "string"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
+    "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "change_history": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "public_timestamp",
+          "note"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "note": {
+            "description": "A summary of the change",
+            "type": "string"
+          },
+          "public_timestamp": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    },
+    "description_optional": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/description"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "details": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "change_history": {
+          "$ref": "#/definitions/change_history"
+        }
+      }
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "frontend_links": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_id",
+          "locale",
+          "title"
+        ],
+        "additionalProperties": true,
+        "properties": {
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
+          },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "content_id": {
+            "$ref": "#/definitions/guid"
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "links": {
+            "type": "object",
+            "patternProperties": {
+              "^[a-z_]+$": {
+                "$ref": "#/definitions/frontend_links"
+              }
+            }
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
+            "oneOf": [
+              {
+                "$ref": "#/definitions/public_updated_at"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          }
+        }
+      }
+    },
+    "frontend_links_with_base_path": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "base_path",
+          "content_id",
+          "locale",
+          "title"
+        ],
+        "additionalProperties": true,
+        "properties": {
+          "analytics_identifier": {
+            "$ref": "#/definitions/analytics_identifier"
+          },
+          "api_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "api_url": {
+            "description": "DEPRECATED: api_path should be used instead of api_url. This is due to values of api_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          },
+          "base_path": {
+            "$ref": "#/definitions/absolute_path"
+          },
+          "content_id": {
+            "$ref": "#/definitions/guid"
+          },
+          "document_type": {
+            "type": "string"
+          },
+          "links": {
+            "type": "object",
+            "patternProperties": {
+              "^[a-z_]+$": {
+                "$ref": "#/definitions/frontend_links_with_base_path"
+              }
+            }
+          },
+          "locale": {
+            "$ref": "#/definitions/locale"
+          },
+          "public_updated_at": {
+            "oneOf": [
+              {
+                "$ref": "#/definitions/public_updated_at"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "schema_name": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "web_url": {
+            "description": "DEPRECATED: base_path should be used instead of web_url. This is due to values of web_url being tied to an environment which can cause problems when data is synced between environments. In time this field will be removed by the Publishing Platform team.",
+            "type": "string",
+            "format": "uri"
+          }
+        }
+      }
+    },
+    "govuk_request_id": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "locale": {
+      "type": "string",
+      "enum": [
+        "ar",
+        "az",
+        "be",
+        "bg",
+        "bn",
+        "cs",
+        "cy",
+        "da",
+        "de",
+        "dr",
+        "el",
+        "en",
+        "es",
+        "es-419",
+        "et",
+        "fa",
+        "fi",
+        "fr",
+        "gd",
+        "gu",
+        "he",
+        "hi",
+        "hr",
+        "hu",
+        "hy",
+        "id",
+        "is",
+        "it",
+        "ja",
+        "ka",
+        "kk",
+        "ko",
+        "lt",
+        "lv",
+        "ms",
+        "mt",
+        "ne",
+        "nl",
+        "no",
+        "pa",
+        "pa-pk",
+        "pl",
+        "ps",
+        "pt",
+        "ro",
+        "ru",
+        "si",
+        "sk",
+        "sl",
+        "so",
+        "sq",
+        "sr",
+        "sv",
+        "sw",
+        "ta",
+        "th",
+        "tk",
+        "tr",
+        "uk",
+        "ur",
+        "uz",
+        "vi",
+        "yi",
+        "zh",
+        "zh-hk",
+        "zh-tw"
+      ]
+    },
+    "payload_version": {
+      "description": "Counter to indicate when the payload was generated",
+      "type": "integer"
+    },
+    "public_updated_at": {
+      "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "account-api",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-publisher",
+        "content-tagger",
+        "email-alert-frontend",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "government-frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "local-links-manager",
+        "manuals-publisher",
+        "maslow",
+        "performanceplatform-big-screen-view",
+        "publisher",
+        "rummager",
+        "search-admin",
+        "search-api",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "special-route-publisher",
+        "specialist-publisher",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "publishing_request_id": {
+      "description": "A unique identifier used to track publishing requests to rendered content",
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "rendering_app": {
+      "description": "The application that renders this item.",
+      "type": "string",
+      "enum": [
+        "account-api",
+        "calculators",
+        "calendars",
+        "collections",
+        "content-store",
+        "email-alert-frontend",
+        "email-campaign-frontend",
+        "feedback",
+        "finder-frontend",
+        "frontend",
+        "government-frontend",
+        "info-frontend",
+        "licencefinder",
+        "performanceplatform-big-screen-view",
+        "rummager",
+        "search-api",
+        "smartanswers",
+        "spotlight",
+        "static",
+        "tariff",
+        "whitehall-admin",
+        "whitehall-frontend"
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
+    "title": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    },
+    "withdrawn_notice": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "explanation": {
+          "type": "string"
+        },
+        "withdrawn_at": {
+          "format": "date-time"
+        }
+      }
+    }
+  }
+}

--- a/content_schemas/dist/formats/field_of_operation/publisher_v2/links.json
+++ b/content_schemas/dist/formats/field_of_operation/publisher_v2/links.json
@@ -1,0 +1,90 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "bulk_publishing": {
+      "type": "boolean"
+    },
+    "links": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "finder": {
+          "description": "Powers links from content back to finders the content is surfaced on",
+          "$ref": "#/definitions/guid_list"
+        },
+        "lead_organisations": {
+          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "mainstream_browse_pages": {
+          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "meets_user_needs": {
+          "description": "The user needs this piece of content meets.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "parent": {
+          "description": "The parent content item.",
+          "$ref": "#/definitions/guid_list",
+          "maxItems": 1
+        },
+        "policy_areas": {
+          "description": "A largely deprecated tag currently only used to power email alerts.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "primary_publishing_organisation": {
+          "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/guid_list",
+          "maxItems": 1
+        },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
+          "$ref": "#/definitions/guid_list"
+        },
+        "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+          "$ref": "#/definitions/guid_list"
+        }
+      }
+    },
+    "previous_version": {
+      "type": "string"
+    }
+  },
+  "definitions": {
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    }
+  }
+}

--- a/content_schemas/dist/formats/field_of_operation/publisher_v2/links.json
+++ b/content_schemas/dist/formats/field_of_operation/publisher_v2/links.json
@@ -10,6 +10,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "fatality_notices": {
+          "description": "Fatality notices for this field of operation",
+          "$ref": "#/definitions/guid_list"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/dist/formats/field_of_operation/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/field_of_operation/publisher_v2/schema.json
@@ -1,0 +1,551 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "required": [
+    "base_path",
+    "details",
+    "document_type",
+    "publishing_app",
+    "rendering_app",
+    "routes",
+    "schema_name",
+    "title"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "auth_bypass_ids": {
+      "description": "A list of ids that will allow access to this item for non-authenticated users",
+      "$ref": "#/definitions/guid_list"
+    },
+    "base_path": {
+      "$ref": "#/definitions/absolute_path"
+    },
+    "bulk_publishing": {
+      "type": "boolean"
+    },
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "description": {
+      "$ref": "#/definitions/description_optional"
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "document_type": {
+      "type": "string",
+      "enum": [
+        "aaib_report",
+        "about",
+        "about_our_services",
+        "accessible_documents_policy",
+        "access_and_opening",
+        "ambassador_role",
+        "animal_disease_case",
+        "answer",
+        "asylum_support_decision",
+        "authored_article",
+        "board_member_role",
+        "business_finance_support_scheme",
+        "calculator",
+        "calendar",
+        "case_study",
+        "chief_professional_officer_role",
+        "chief_scientific_officer_role",
+        "chief_scientific_advisor_role",
+        "closed_consultation",
+        "cma_case",
+        "coming_soon",
+        "complaints_procedure",
+        "completed_transaction",
+        "consultation",
+        "consultation_outcome",
+        "contact",
+        "coronavirus_landing_page",
+        "corporate_report",
+        "correspondence",
+        "countryside_stewardship_grant",
+        "decision",
+        "deputy_head_of_mission_role",
+        "detailed_guidance",
+        "detailed_guide",
+        "dfid_research_output",
+        "document_collection",
+        "drcf_digital_markets_research",
+        "drug_safety_update",
+        "email_alert_signup",
+        "employment_appeal_tribunal_decision",
+        "employment_tribunal_decision",
+        "equality_and_diversity",
+        "esi_fund",
+        "export_health_certificate",
+        "external_content",
+        "facet",
+        "fatality_notice",
+        "field_of_operation",
+        "finder",
+        "finder_email_signup",
+        "flood_and_coastal_erosion_risk_management_research_report",
+        "foi_release",
+        "form",
+        "get_involved",
+        "gone",
+        "government",
+        "government_response",
+        "governor_role",
+        "guidance",
+        "guide",
+        "help_page",
+        "high_commissioner_role",
+        "historic_appointment",
+        "historic_appointments",
+        "history",
+        "hmrc_manual",
+        "hmrc_manual_section",
+        "homepage",
+        "html_publication",
+        "impact_assessment",
+        "imported",
+        "independent_report",
+        "international_development_fund",
+        "international_treaty",
+        "knowledge_alpha",
+        "licence",
+        "license_finder",
+        "licence_transaction",
+        "local_transaction",
+        "maib_report",
+        "mainstream_browse_page",
+        "manual",
+        "manual_section",
+        "map",
+        "marine_notice",
+        "media_enquiries",
+        "medical_safety_alert",
+        "membership",
+        "military_role",
+        "ministerial_role",
+        "ministers_index",
+        "modern_slavery_statement",
+        "national",
+        "national_statistics",
+        "national_statistics_announcement",
+        "need",
+        "news_article",
+        "news_story",
+        "notice",
+        "official",
+        "official_statistics",
+        "official_statistics_announcement",
+        "oim_project",
+        "open_consultation",
+        "oral_statement",
+        "organisation",
+        "our_energy_use",
+        "our_governance",
+        "person",
+        "personal_information_charter",
+        "petitions_and_campaigns",
+        "place",
+        "placeholder",
+        "placeholder_ministerial_role",
+        "placeholder_organisation",
+        "placeholder_person",
+        "placeholder_policy_area",
+        "placeholder_worldwide_organisation",
+        "policy_area",
+        "policy_paper",
+        "press_release",
+        "procurement",
+        "product_safety_alert_report_recall",
+        "promotional",
+        "protected_food_drink_name",
+        "publication_scheme",
+        "raib_report",
+        "recruitment",
+        "redirect",
+        "regulation",
+        "research",
+        "research_for_development_output",
+        "residential_property_tribunal_decision",
+        "role_appointment",
+        "search",
+        "service_manual_guide",
+        "service_manual_homepage",
+        "service_manual_service_standard",
+        "service_manual_service_toolkit",
+        "service_manual_topic",
+        "service_sign_in",
+        "service_standard_report",
+        "services_and_information",
+        "simple_smart_answer",
+        "smart_answer",
+        "social_media_use",
+        "special_representative_role",
+        "special_route",
+        "speech",
+        "staff_update",
+        "standard",
+        "statistical_data_set",
+        "statistics",
+        "statistics_announcement",
+        "statutory_guidance",
+        "statutory_instrument",
+        "step_by_step_nav",
+        "take_part",
+        "tax_tribunal_decision",
+        "taxon",
+        "terms_of_reference",
+        "topic",
+        "topical_event",
+        "topical_event_about_page",
+        "traffic_commissioner_regulatory_decision",
+        "traffic_commissioner_role",
+        "transaction",
+        "transparency",
+        "travel_advice",
+        "travel_advice_index",
+        "unpublishing",
+        "uk_market_conformity_assessment_body",
+        "utaac_decision",
+        "vanish",
+        "welsh_language_scheme",
+        "working_group",
+        "world_location",
+        "world_location_news",
+        "world_news_story",
+        "worldwide_office_staff_role",
+        "worldwide_organisation",
+        "written_statement"
+      ]
+    },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policy_areas": {
+          "description": "A largely deprecated tag currently only used to power email alerts.",
+          "$ref": "#/definitions/guid_list"
+        }
+      }
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "redirects": {
+      "type": "array",
+      "additionalItems": false,
+      "items": {}
+    },
+    "rendering_app": {
+      "$ref": "#/definitions/rendering_app"
+    },
+    "routes": {
+      "$ref": "#/definitions/routes"
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "field_of_operation"
+      ]
+    },
+    "title": {
+      "$ref": "#/definitions/title"
+    },
+    "update_type": {
+      "$ref": "#/definitions/update_type"
+    }
+  },
+  "definitions": {
+    "description": {
+      "type": "string"
+    },
+    "absolute_path": {
+      "description": "A path only. Query string and/or fragment are not allowed.",
+      "type": "string",
+      "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "auth_bypass_ids": {
+          "description": "Deprecated: auth_bypass_ids should be sent as a separate field",
+          "$ref": "#/definitions/guid_list"
+        },
+        "organisations": {
+          "description": "A list of organisation content ids permitted access to this item",
+          "$ref": "#/definitions/guid_list"
+        },
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "description_optional": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/description"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "details": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {}
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "locale": {
+      "type": "string",
+      "enum": [
+        "ar",
+        "az",
+        "be",
+        "bg",
+        "bn",
+        "cs",
+        "cy",
+        "da",
+        "de",
+        "dr",
+        "el",
+        "en",
+        "es",
+        "es-419",
+        "et",
+        "fa",
+        "fi",
+        "fr",
+        "gd",
+        "gu",
+        "he",
+        "hi",
+        "hr",
+        "hu",
+        "hy",
+        "id",
+        "is",
+        "it",
+        "ja",
+        "ka",
+        "kk",
+        "ko",
+        "lt",
+        "lv",
+        "ms",
+        "mt",
+        "ne",
+        "nl",
+        "no",
+        "pa",
+        "pa-pk",
+        "pl",
+        "ps",
+        "pt",
+        "ro",
+        "ru",
+        "si",
+        "sk",
+        "sl",
+        "so",
+        "sq",
+        "sr",
+        "sv",
+        "sw",
+        "ta",
+        "th",
+        "tk",
+        "tr",
+        "uk",
+        "ur",
+        "uz",
+        "vi",
+        "yi",
+        "zh",
+        "zh-hk",
+        "zh-tw"
+      ]
+    },
+    "public_updated_at": {
+      "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "account-api",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-publisher",
+        "content-tagger",
+        "email-alert-frontend",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "government-frontend",
+        "hmrc-manuals-api",
+        "info-frontend",
+        "licencefinder",
+        "local-links-manager",
+        "manuals-publisher",
+        "maslow",
+        "performanceplatform-big-screen-view",
+        "publisher",
+        "rummager",
+        "search-admin",
+        "search-api",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "special-route-publisher",
+        "specialist-publisher",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "rendering_app": {
+      "description": "The application that renders this item.",
+      "type": "string",
+      "enum": [
+        "account-api",
+        "calculators",
+        "calendars",
+        "collections",
+        "content-store",
+        "email-alert-frontend",
+        "email-campaign-frontend",
+        "feedback",
+        "finder-frontend",
+        "frontend",
+        "government-frontend",
+        "info-frontend",
+        "licencefinder",
+        "performanceplatform-big-screen-view",
+        "rummager",
+        "search-api",
+        "smartanswers",
+        "spotlight",
+        "static",
+        "tariff",
+        "whitehall-admin",
+        "whitehall-frontend"
+      ]
+    },
+    "route": {
+      "type": "object",
+      "required": [
+        "path",
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "prefix",
+            "exact"
+          ]
+        }
+      }
+    },
+    "routes": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/route"
+      },
+      "minItems": 1
+    },
+    "title": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    }
+  }
+}

--- a/content_schemas/formats/field_of_operation.jsonnet
+++ b/content_schemas/formats/field_of_operation.jsonnet
@@ -1,0 +1,2 @@
+(import "shared/default_format.jsonnet") + {
+}

--- a/content_schemas/formats/field_of_operation.jsonnet
+++ b/content_schemas/formats/field_of_operation.jsonnet
@@ -1,2 +1,7 @@
 (import "shared/default_format.jsonnet") + {
+  links: (import "shared/base_links.jsonnet") + {
+    fatality_notices: {
+        description: "Fatality notices for this field of operation"
+    },
+  },
 }


### PR DESCRIPTION
As part of moving the rendering of these pages (example: [https://www.gov.uk/government/fields-of-operation/iraq](https://www.gov.uk/government/fields-of-operation/iraq)) out of whitehall, we need to introduce a schema for this document type.

A lot of the content on these pages actually comes from individual fatality notices, so these are added as links here, and will be expanded as part of link expansion.

PR to use this schema in whitehall [here](https://github.com/alphagov/whitehall/pull/7391)

[Trello ](https://trello.com/c/4UszwKWR/471-update-content-item-for-field-of-operation-pages)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Let us know in #govuk-publishing-platform if you have any questions.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
