### PR TITLE
Add expansion rule for fatality notice

### DIFF
--- a/lib/expansion_rules.rb
+++ b/lib/expansion_rules.rb
@@ -84,6 +84,7 @@ module_function
   TAXON_FIELDS = (DEFAULT_FIELDS + %i[description details phase]).freeze
   NEED_FIELDS = (DEFAULT_FIELDS + details_fields(:role, :goal, :benefit, :met_when, :justifications)).freeze
   FINDER_FIELDS = (DEFAULT_FIELDS + details_fields(:facets)).freeze
+  FATALITY_NOTICE_FIELDS = (DEFAULT_FIELDS + details_fields(:roll_call_introduction))
   HISTORIC_APPOINTMENT_FIELDS = (DEFAULT_FIELDS + details_fields(:political_party, :dates_in_office))
   MINISTERIAL_ROLE_FIELDS = (DEFAULT_FIELDS + details_fields(:body, :role_payment_type, :seniority)).freeze
   PERSON_FIELDS = (DEFAULT_FIELDS + details_fields(:body, :image)).freeze
@@ -148,6 +149,8 @@ module_function
         fields: TAXON_FIELDS },
       { document_type: :need,
         fields: NEED_FIELDS },
+      { document_type: :fatality_notice,
+        fields: FATALITY_NOTICE_FIELDS },
       { document_type: :finder,
         link_type: :finder,
         fields: FINDER_FIELDS },

--- a/spec/lib/expansion_rules_spec.rb
+++ b/spec/lib/expansion_rules_spec.rb
@@ -44,6 +44,7 @@ RSpec.describe ExpansionRules do
     let(:taxon_fields) { default_fields + %i[description details phase] }
     let(:default_fields_and_description) { default_fields + %i[description] }
     let(:need_fields) { default_fields + [%i[details role], %i[details goal], %i[details benefit], %i[details met_when], %i[details justifications]] }
+    let(:fatality_notice_fields) { default_fields + [%i[details roll_call_introduction]] }
     let(:finder_fields) { default_fields + [%i[details facets]] }
     let(:historic_appointment_fields) { default_fields + [%i[details political_party], %i[details dates_in_office]] }
     let(:ministerial_role_fields) { role_fields + [%i[details seniority]] }
@@ -64,6 +65,7 @@ RSpec.describe ExpansionRules do
 
     specify { expect(rules.expansion_fields(:contact)).to eq(contact_fields) }
     specify { expect(rules.expansion_fields(:historic_appointment)).to eq(historic_appointment_fields) }
+    specify { expect(rules.expansion_fields(:fatality_notice)).to eq(fatality_notice_fields) }
     specify { expect(rules.expansion_fields(:mainstream_browse_page)).to eq(default_fields_and_description) }
     specify { expect(rules.expansion_fields(:need)).to eq(need_fields) }
     specify { expect(rules.expansion_fields(:organisation)).to eq(organisation_fields) }


### PR DESCRIPTION
This ensure that linked fatality notices have their role call introduction added as part of link expansion. This will enable us to render this information on the fields of operation page.

Depends on work to add this field to fatality notices (in [whitehall](https://github.com/alphagov/whitehall/pull/7388) and [content schemas)](https://github.com/alphagov/publishing-api/pull/2297)

[Trello](https://trello.com/c/z7OjzD4y/477-remove-rendering-code-for-fields-of-operation-from-whitehall)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Let us know in #govuk-publishing-platform if you have any questions.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
