### PR TITLE
Fix AWS auth methods other than secret key.

### DIFF
--- a/config/initializers/aws.rb
+++ b/config/initializers/aws.rb
@@ -4,6 +4,14 @@ require "aws-sdk-core"
 Aws.config.update(
   logger: ::Rails.logger,
   region: ENV["S3_EXPORT_REGION"] || "eu-west-1",
-  credentials: Aws::Credentials.new(ENV["EVENT_LOG_AWS_ACCESS_ID"] || "id", ENV["EVENT_LOG_AWS_SECRET_KEY"] || "key"),
 )
+
+if ENV["EVENT_LOG_AWS_ACCESS_ID"]
+  Aws.config.update(
+    credentials: Aws::Credentials.new(
+      ENV["EVENT_LOG_AWS_ACCESS_ID"],
+      ENV["EVENT_LOG_AWS_SECRET_KEY"],
+    ),
+  )
+end
 # rubocop:enable Rails/SaveBang


### PR DESCRIPTION
The way we were initialising the AWS SDK was preventing any authentication methods other than secret key from working.

Only pass an access key / secret key if it's actually specified in the environment, otherwise [let the SDK work as documented](https://docs.aws.amazon.com/sdk-for-ruby/v3/api/#Configuration).

This allows, for example, authentication via EC2 instance profile creds so that we can stop using long-lived secret keys.