### PR TITLE
Fix magic class names for DB migrations.

### DIFF
--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -10,7 +10,6 @@
 #   inflect.uncountable %w( fish sheep )
 # end
 
-# These inflection rules are supported but not enabled by default:
 ActiveSupport::Inflector.inflections(:en) do |inflect|
   inflect.acronym "JSON"
 end

--- a/db/migrate/20151012094145_set_empty_default_for_json_fields.rb
+++ b/db/migrate/20151012094145_set_empty_default_for_json_fields.rb
@@ -1,4 +1,4 @@
-class SetEmptyDefaultForJsonFields < ActiveRecord::Migration[4.2]
+class SetEmptyDefaultForJSONFields < ActiveRecord::Migration[4.2]
   def change
     change_column_default(:events, :payload, {})
 

--- a/db/migrate/20170427103022_remove_description_json_from_editions.rb
+++ b/db/migrate/20170427103022_remove_description_json_from_editions.rb
@@ -1,4 +1,4 @@
-class RemoveDescriptionJsonFromEditions < ActiveRecord::Migration[5.0]
+class RemoveDescriptionJSONFromEditions < ActiveRecord::Migration[5.0]
   def change
     remove_column :editions, :description_json
   end

--- a/db/migrate/20200406130817_rename_json_columns.rb
+++ b/db/migrate/20200406130817_rename_json_columns.rb
@@ -1,4 +1,4 @@
-class RenameJsonColumns < ActiveRecord::Migration[5.2]
+class RenameJSONColumns < ActiveRecord::Migration[5.2]
   def change
     change_table :access_limits, bulk: true do |t|
       t.rename :users, :old_users

--- a/db/migrate/20200506153224_remove_json_columns.rb
+++ b/db/migrate/20200506153224_remove_json_columns.rb
@@ -1,4 +1,4 @@
-class RemoveJsonColumns < ActiveRecord::Migration[6.0]
+class RemoveJSONColumns < ActiveRecord::Migration[6.0]
   def up
     change_table :access_limits, bulk: true do |t|
       t.remove :temp_users, :temp_organisations


### PR DESCRIPTION
7e66d46 / #2048 broke database migrations whose class names contained the string `Json`, because it changed the logic for magically generating the camel-cased class name from the source filename.

Update the class names to match what Rails now expects them to be.

Perfect illustration of why such magic is a terrible idea, but Rails makes it hard to avoid this sort of thing.

Tested: `rails db:migrate` succeeds on integration with this patch.