### PR TITLE
Remove redundant field from historic appointments schema

### DIFF
--- a/content_schemas/dist/formats/historic_appointments/frontend/schema.json
+++ b/content_schemas/dist/formats/historic_appointments/frontend/schema.json
@@ -497,9 +497,6 @@
               "image": {
                 "$ref": "#/definitions/image"
               },
-              "image_url": {
-                "type": "string"
-              },
               "title": {
                 "type": "string"
               }

--- a/content_schemas/dist/formats/historic_appointments/notification/schema.json
+++ b/content_schemas/dist/formats/historic_appointments/notification/schema.json
@@ -588,9 +588,6 @@
               "image": {
                 "$ref": "#/definitions/image"
               },
-              "image_url": {
-                "type": "string"
-              },
               "title": {
                 "type": "string"
               }

--- a/content_schemas/dist/formats/historic_appointments/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/historic_appointments/publisher_v2/schema.json
@@ -379,9 +379,6 @@
               "image": {
                 "$ref": "#/definitions/image"
               },
-              "image_url": {
-                "type": "string"
-              },
               "title": {
                 "type": "string"
               }

--- a/content_schemas/formats/historic_appointments.jsonnet
+++ b/content_schemas/formats/historic_appointments.jsonnet
@@ -15,9 +15,6 @@
                      type: "string"
                  },
                  dates_in_office: (import "shared/definitions/_dates_in_office.jsonnet"),
-                 image_url: {
-                    type: "string"
-                 },
                  image: {
                     "$ref": "#/definitions/image",
                  },


### PR DESCRIPTION
We're switching over to using the standard image definition for past prime ministers without historic accounts listed in the details hash of this content item.

We've introduced the new field (in [this PR](https://github.com/alphagov/publishing-api/pull/2304)), and started populating it instead of the `image_url` field in [this PR](https://github.com/alphagov/whitehall/pull/7410), so now we can remove the unused field.

I have also republished the page to populate the new field in the live content item.

[Trello](https://trello.com/c/LSd8y4zg/421-render-past-prime-ministers-index-page-in-collections)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Let us know in #govuk-publishing-platform if you have any questions.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
