### PR TITLE
Correct historic appointments links

### DIFF
--- a/content_schemas/dist/formats/historic_appointment/frontend/schema.json
+++ b/content_schemas/dist/formats/historic_appointment/frontend/schema.json
@@ -116,6 +116,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "person": {
+          "description": "The person who is represented by this historic appointment",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "policies": {
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/content_schemas/dist/formats/historic_appointment/notification/schema.json
+++ b/content_schemas/dist/formats/historic_appointment/notification/schema.json
@@ -134,6 +134,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "person": {
+          "description": "The person who is represented by this historic appointment",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "policies": {
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -227,6 +231,10 @@
           "description": "The parent content item.",
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
+        },
+        "person": {
+          "description": "The person who is represented by this historic appointment",
+          "$ref": "#/definitions/guid_list"
         },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",

--- a/content_schemas/dist/formats/historic_appointment/publisher_v2/links.json
+++ b/content_schemas/dist/formats/historic_appointment/publisher_v2/links.json
@@ -47,6 +47,10 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
+        "person": {
+          "description": "The person who is represented by this historic appointment",
+          "$ref": "#/definitions/guid_list"
+        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/dist/formats/historic_appointments/frontend/schema.json
+++ b/content_schemas/dist/formats/historic_appointments/frontend/schema.json
@@ -253,6 +253,10 @@
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "historical_accounts": {
+          "description": "The historical appointments associated with this role",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "lead_organisations": {
           "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/content_schemas/dist/formats/historic_appointments/notification/schema.json
+++ b/content_schemas/dist/formats/historic_appointments/notification/schema.json
@@ -271,6 +271,10 @@
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "historical_accounts": {
+          "description": "The historical appointments associated with this role",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "lead_organisations": {
           "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -375,6 +379,10 @@
       "properties": {
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
+          "$ref": "#/definitions/guid_list"
+        },
+        "historical_accounts": {
+          "description": "The historical appointments associated with this role",
           "$ref": "#/definitions/guid_list"
         },
         "lead_organisations": {

--- a/content_schemas/dist/formats/historic_appointments/publisher_v2/links.json
+++ b/content_schemas/dist/formats/historic_appointments/publisher_v2/links.json
@@ -14,6 +14,10 @@
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"
         },
+        "historical_accounts": {
+          "description": "The historical appointments associated with this role",
+          "$ref": "#/definitions/guid_list"
+        },
         "lead_organisations": {
           "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/formats/historic_appointment.jsonnet
+++ b/content_schemas/formats/historic_appointment.jsonnet
@@ -38,8 +38,10 @@
         },
       },
     },
-    links: (import "shared/base_links.jsonnet") + {
-      person: "The person who is represented by this historic appointment",
+  },
+  links: (import "shared/base_links.jsonnet") + {
+    person: {
+       description: "The person who is represented by this historic appointment"
     },
   },
 }

--- a/content_schemas/formats/historic_appointments.jsonnet
+++ b/content_schemas/formats/historic_appointments.jsonnet
@@ -24,4 +24,9 @@
       },
     },
   },
+  links: (import "shared/base_links.jsonnet") + {
+    historical_accounts: {
+       description: "The historical appointments associated with this role"
+    },
+  },
 }


### PR DESCRIPTION
This PR corrects links for historic appointment and historic appointments schemas, as these were either previously not defined, or defined incorrectly, meaning we would not be passing validation for content items containing the correct links - cf these failing tests [here](https://github.com/alphagov/whitehall/pull/7415)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Let us know in #govuk-publishing-platform if you have any questions.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
