### PR TITLE
Include image in current prime minister link

### DIFF
--- a/lib/expansion_rules.rb
+++ b/lib/expansion_rules.rb
@@ -99,6 +99,7 @@ module_function
 
   CUSTOM_EXPANSION_FIELDS_FOR_PEOPLE = (
     %i[
+      current_prime_minister
       ordered_ministers
       ordered_board_members
       ordered_military_personnel

--- a/spec/lib/expansion_rules_spec.rb
+++ b/spec/lib/expansion_rules_spec.rb
@@ -77,6 +77,7 @@ RSpec.describe ExpansionRules do
     specify { expect(rules.expansion_fields(:service_manual_topic)).to eq(service_manual_topic_fields) }
     specify { expect(rules.expansion_fields(:topical_event)).to eq(default_fields) }
 
+    specify { expect(rules.expansion_fields(:person, link_type: :current_prime_minister)).to eq(person_with_image_fields) }
     specify { expect(rules.expansion_fields(:person, link_type: :ordered_ministers)).to eq(person_with_image_fields) }
     specify { expect(rules.expansion_fields(:person, link_type: :ordered_board_members)).to eq(person_with_image_fields) }
     specify { expect(rules.expansion_fields(:person, link_type: :ordered_military_personnel)).to eq(person_with_image_fields) }


### PR DESCRIPTION
The 'How Government Works' page includes a link to the person page of the current prime minister.

This currently lacks the person's image.

Updating the expansion rules to include this.

[Trello card](https://trello.com/c/lIvye0eU)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Let us know in #govuk-publishing-platform if you have any questions.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
