### PR TITLE
Add temporary rake task for FOI request

### DIFF
--- a/lib/tasks/temp_foi.rake
+++ b/lib/tasks/temp_foi.rake
@@ -1,0 +1,30 @@
+desc "Temporary rake task to extract data for a FOI request"
+task temp_foi: :environment do
+  role_appointments = Edition
+    .where("published_at >= ?", "2022-01-01")
+    .where(schema_name: "role_appointment", content_store: "live")
+    .order(:published_at)
+
+  ministerial_role_appointments = role_appointments.select do |role_appointment|
+    all_links = Queries::LinksForEditionIds.new(role_appointment.id).merged_links
+    role_link_content_id = all_links.dig(role_appointment.id, "role", 0)
+    role_edition = Document.find_by(content_id: role_link_content_id).editions.last
+    role_edition.document_type == "ministerial_role"
+  end
+
+  final = ministerial_role_appointments.map do |role_appointment|
+    {
+      name: role_appointment.title,
+      started_on: role_appointment.details[:started_on],
+      ended_on: role_appointment.details[:ended_on],
+      current: role_appointment.details[:current],
+      published_at: role_appointment.published_at,
+    }
+  end
+
+  puts %w[name published_at started_on ended_on current].join(",")
+
+  final.each do |line|
+    puts ["\"#{line[:name]}\"", line[:published_at], line[:started_on], line[:ended_on], line[:current]].join(",")
+  end
+end

--- a/spec/lib/tasks/temp_foi_spec.rb
+++ b/spec/lib/tasks/temp_foi_spec.rb
@@ -1,0 +1,87 @@
+RSpec.describe "Temporary FOI rake tasks" do
+  describe "temp_foi" do
+    let(:task) { Rake::Task["temp_foi"] }
+    before do
+      task.reenable
+
+      ministerial_role_1 = create(:live_edition, schema_name: "role", document_type: "ministerial_role")
+      ministerial_role_2 = create(:live_edition, schema_name: "role", document_type: "ministerial_role")
+      non_ministerial_role = create(:live_edition, schema_name: "role", document_type: "chief_scientific_officer_role")
+
+      create(:live_edition,
+             published_at: "2021-12-31 01:00",
+             schema_name: "role_appointment",
+             content_store: "live",
+             title: "MP 1 - Secretary of State",
+             details: {
+               started_on: "2021-12-30 00:00",
+               ended_on: nil,
+               current: true,
+             },
+             links_hash: {
+               role: [
+                 ministerial_role_1.content_id,
+               ],
+             })
+
+      create(:live_edition,
+             published_at: "2022-01-01 01:00",
+             schema_name: "role_appointment",
+             content_store: "live",
+             title: "MP 2 - Parliamentary Under Secretary of State",
+             details: {
+               started_on: "2022-01-01 00:00",
+               ended_on: nil,
+               current: true,
+             },
+             links_hash: {
+               role: [
+                 ministerial_role_2.content_id,
+               ],
+             })
+
+      create(:live_edition,
+             published_at: "2022-01-04 01:00",
+             schema_name: "role_appointment",
+             content_store: "live",
+             title: "Not an MP 1 - Chief Scientific Officer",
+             details: {
+               started_on: "2021-12-30 00:00",
+               ended_on: nil,
+               current: true,
+             },
+             links_hash: {
+               role: [
+                 non_ministerial_role.content_id,
+               ],
+             })
+
+      create(:live_edition,
+             published_at: "2022-01-05 01:00",
+             schema_name: "role_appointment",
+             content_store: "live",
+             title: "MP 1 - Secretary of State",
+             details: {
+               started_on: "2021-12-30 00:00",
+               ended_on: "2022-01-04 00:00",
+               current: false,
+             },
+             links_hash: {
+               role: [
+                 ministerial_role_1.content_id,
+               ],
+             })
+    end
+
+    it "includes only records for ministerial role appointments that were updated on or after 2022-01-01" do
+      csv = <<~CSV
+        name,published_at,started_on,ended_on,current
+        "MP 2 - Parliamentary Under Secretary of State",2022-01-01 01:00:00 UTC,2022-01-01 00:00,,true
+        "MP 1 - Secretary of State",2022-01-05 01:00:00 UTC,2021-12-30 00:00,2022-01-04 00:00,false
+      CSV
+
+      expect { task.invoke("2020-01-01 00:00", "2020-01-04 00:00") }
+        .to output(csv).to_stdout
+    end
+  end
+end


### PR DESCRIPTION
We have received a FOI request for a report on updates to ministers on GOV.UK since 2022-01-01.

This rake task will allow us to produce that report.

The task will be deleted after it has been run once.

[Trello card](https://trello.com/c/pTGig4hE)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Let us know in #govuk-publishing-platform if you have any questions.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
