### PR TITLE
Update PR template to request we get notified when PRs have been raised

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,5 @@
 ⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
 
-This application is owned by the publishing platform team. Let us know in #govuk-publishing-platform if you have any questions.
+This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.
 
 Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.


### PR DESCRIPTION
This should help us with code ownership.

[Trello](https://trello.com/c/ZWCbtJtk/507-update-the-pr-template-to-request-we-are-told-when-prs-are-opened-and-merged)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Let us know in #govuk-publishing-platform if you have any questions.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
