### PR TITLE
Add casualties to operational fields

### DIFF
--- a/content_schemas/dist/formats/field_of_operation/frontend/schema.json
+++ b/content_schemas/dist/formats/field_of_operation/frontend/schema.json
@@ -475,6 +475,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "casualties": {
+          "description": "A list of casualties associated with a given fatality notice",
+          "type": "object"
+        },
         "change_history": {
           "$ref": "#/definitions/change_history"
         }

--- a/content_schemas/dist/formats/field_of_operation/notification/schema.json
+++ b/content_schemas/dist/formats/field_of_operation/notification/schema.json
@@ -570,6 +570,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "casualties": {
+          "description": "A list of casualties associated with a given fatality notice",
+          "type": "object"
+        },
         "change_history": {
           "$ref": "#/definitions/change_history"
         }

--- a/content_schemas/dist/formats/field_of_operation/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/field_of_operation/publisher_v2/schema.json
@@ -352,7 +352,12 @@
     "details": {
       "type": "object",
       "additionalProperties": false,
-      "properties": {}
+      "properties": {
+        "casualties": {
+          "description": "A list of casualties associated with a given fatality notice",
+          "type": "object"
+        }
+      }
     },
     "first_published_at": {
       "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",

--- a/content_schemas/examples/field_of_operation/frontend/field_of_operation.json
+++ b/content_schemas/examples/field_of_operation/frontend/field_of_operation.json
@@ -102,5 +102,12 @@
     ]
   },
   "description": "It is with very deep regret that the following fatalities are announced.",
-  "details": {}
+  "details": {
+    "casualties": {
+      "654": [
+        "Person A has sadly passed away",
+        "Person B has sadly passed away"
+      ]
+    }
+  }
 }

--- a/content_schemas/formats/field_of_operation.jsonnet
+++ b/content_schemas/formats/field_of_operation.jsonnet
@@ -1,7 +1,19 @@
 (import "shared/default_format.jsonnet") + {
+  definitions: (import "shared/definitions/_whitehall.jsonnet") + {
+    details: {
+      type: "object",
+      additionalProperties: false,
+      properties: {
+        casualties: {
+          type: "object",
+          description: "A list of casualties associated with a given fatality notice",
+        },
+      },
+    },
+  },
   links: (import "shared/base_links.jsonnet") + {
     fatality_notices: {
-        description: "Fatality notices for this field of operation"
+      description: "Fatality notices for this field of operation"
     },
   },
 }


### PR DESCRIPTION
This is so that they can be used on the fronted to provide links to fatality notices

Trello - https://trello.com/c/alzDKosv/472-add-rendering-of-field-of-operation-pages-to-government-frontend

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Let us know in #govuk-publishing-platform if you have any questions.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
