### PR TITLE
Add the none option to disease control zone types

### DIFF
--- a/content_schemas/dist/formats/specialist_document/frontend/schema.json
+++ b/content_schemas/dist/formats/specialist_document/frontend/schema.json
@@ -392,7 +392,8 @@
               "vaccination",
               "supplementary-movement-control",
               "wild-bird-control",
-              "wild-bird-monitoring"
+              "wild-bird-monitoring",
+              "none"
             ]
           }
         }

--- a/content_schemas/dist/formats/specialist_document/notification/schema.json
+++ b/content_schemas/dist/formats/specialist_document/notification/schema.json
@@ -484,7 +484,8 @@
               "vaccination",
               "supplementary-movement-control",
               "wild-bird-control",
-              "wild-bird-monitoring"
+              "wild-bird-monitoring",
+              "none"
             ]
           }
         }

--- a/content_schemas/dist/formats/specialist_document/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/specialist_document/publisher_v2/schema.json
@@ -308,7 +308,8 @@
               "vaccination",
               "supplementary-movement-control",
               "wild-bird-control",
-              "wild-bird-monitoring"
+              "wild-bird-monitoring",
+              "none"
             ]
           }
         }

--- a/content_schemas/examples/specialist_document/frontend/animal-disease-case.json
+++ b/content_schemas/examples/specialist_document/frontend/animal-disease-case.json
@@ -246,6 +246,10 @@
                 {
                   "label": "Wild bird monitoring area",
                   "value": "wild-bird-monitoring"
+                },
+                {
+                  "label": "None",
+                  "value": "none"
                 }
               ]
             },

--- a/content_schemas/formats/shared/definitions/_specialist_document.jsonnet
+++ b/content_schemas/formats/shared/definitions/_specialist_document.jsonnet
@@ -222,7 +222,8 @@
             "vaccination",
             "supplementary-movement-control",
             "wild-bird-control",
-            "wild-bird-monitoring"
+            "wild-bird-monitoring",
+            "none"
           ]
         }
       },


### PR DESCRIPTION
Add a new option in the animal disease finder, within the disease control zone types section.

Trello card: https://trello.com/c/wYsvb5vV
