### PR TITLE
Update links schema

### DIFF
--- a/content_schemas/dist/formats/document_collection/publisher_v2/links.json
+++ b/content_schemas/dist/formats/document_collection/publisher_v2/links.json
@@ -81,6 +81,10 @@
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
         },
+        "topical_events": {
+          "description": "The topical events that are part of this document collection.",
+          "$ref": "#/definitions/guid_list"
+        },
         "topics": {
           "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/dist/formats/organisation/publisher_v2/links.json
+++ b/content_schemas/dist/formats/organisation/publisher_v2/links.json
@@ -26,12 +26,68 @@
           "description": "The user needs this piece of content meets.",
           "$ref": "#/definitions/guid_list"
         },
+        "ordered_board_members": {
+          "description": "Board members primarily for use with Whitehall organisations.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "ordered_chief_professional_officers": {
+          "description": "Chief professional officers primarily for use with Whitehall organisations.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "ordered_child_organisations": {
+          "description": "Child organisations primarily for use with Whitehall organisations.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "ordered_contacts": {
+          "description": "Contact details primarily for use with Whitehall organisations.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "ordered_featured_policies": {
+          "description": "Featured policies primarily for use with Whitehall organisations.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "ordered_foi_contacts": {
+          "description": "FoI contact details primarily for use with Whitehall organisations.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "ordered_high_profile_groups": {
+          "description": "High profile groups primarily for use with Whitehall organisations.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "ordered_military_personnel": {
+          "description": "Military personnel primarily for use with Whitehall organisations.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "ordered_ministers": {
+          "description": "Ministers primarily for use with Whitehall organisations.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "ordered_parent_organisations": {
+          "description": "Parent organisations primarily for use with Whitehall organisations.",
+          "$ref": "#/definitions/guid_list"
+        },
         "ordered_related_items": {
           "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
           "$ref": "#/definitions/guid_list"
         },
         "ordered_related_items_overrides": {
           "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "ordered_roles": {
+          "description": "Organisational roles primarily for use with Whitehall organisations.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "ordered_special_representatives": {
+          "description": "Special representatives primarily for use with Whitehall organisations.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "ordered_successor_organisations": {
+          "description": "Successor organisations primarily for use with closed Whitehall organisations.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "ordered_traffic_commissioners": {
+          "description": "Traffic commissioners primarily for use with Whitehall organisations.",
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {

--- a/content_schemas/dist/formats/organisation/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/organisation/publisher_v2/schema.json
@@ -59,62 +59,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "ordered_board_members": {
-          "description": "Board members primarily for use with Whitehall organisations.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "ordered_chief_professional_officers": {
-          "description": "Chief professional officers primarily for use with Whitehall organisations.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "ordered_child_organisations": {
-          "description": "Child organisations primarily for use with Whitehall organisations.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "ordered_contacts": {
-          "description": "Contact details primarily for use with Whitehall organisations.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "ordered_featured_policies": {
-          "description": "Featured policies primarily for use with Whitehall organisations.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "ordered_foi_contacts": {
-          "description": "FoI contact details primarily for use with Whitehall organisations.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "ordered_high_profile_groups": {
-          "description": "High profile groups primarily for use with Whitehall organisations.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "ordered_military_personnel": {
-          "description": "Military personnel primarily for use with Whitehall organisations.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "ordered_ministers": {
-          "description": "Ministers primarily for use with Whitehall organisations.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "ordered_parent_organisations": {
-          "description": "Parent organisations primarily for use with Whitehall organisations.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "ordered_roles": {
-          "description": "Organisational roles primarily for use with Whitehall organisations.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "ordered_special_representatives": {
-          "description": "Special representatives primarily for use with Whitehall organisations.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "ordered_successor_organisations": {
-          "description": "Successor organisations primarily for use with closed Whitehall organisations.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "ordered_traffic_commissioners": {
-          "description": "Traffic commissioners primarily for use with Whitehall organisations.",
-          "$ref": "#/definitions/guid_list"
-        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/dist/formats/role/publisher_v2/links.json
+++ b/content_schemas/dist/formats/role/publisher_v2/links.json
@@ -26,6 +26,15 @@
           "description": "The user needs this piece of content meets.",
           "$ref": "#/definitions/guid_list"
         },
+        "ministerial": {
+          "description": "Link to the ministers index page, present if this is a ministerial role.",
+          "$ref": "#/definitions/guid_list",
+          "maxItems": 1
+        },
+        "ordered_parent_organisations": {
+          "description": "Organisations that own this role.",
+          "$ref": "#/definitions/guid_list"
+        },
         "ordered_related_items": {
           "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/dist/formats/role/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/role/publisher_v2/schema.json
@@ -69,15 +69,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "ministerial": {
-          "description": "Link to the ministers index page, present if this is a ministerial role.",
-          "$ref": "#/definitions/guid_list",
-          "maxItems": 1
-        },
-        "ordered_parent_organisations": {
-          "description": "Organisations that own this role.",
-          "$ref": "#/definitions/guid_list"
-        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/dist/formats/role_appointment/publisher_v2/links.json
+++ b/content_schemas/dist/formats/role_appointment/publisher_v2/links.json
@@ -47,6 +47,10 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
+        "person": {
+          "description": "The person that is currently appointed to the relevant role.",
+          "$ref": "#/definitions/guid_list"
+        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"
@@ -55,6 +59,10 @@
           "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
+        },
+        "role": {
+          "description": "The role that the relevant person is currently appointed to.",
+          "$ref": "#/definitions/guid_list"
         },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",

--- a/content_schemas/dist/formats/role_appointment/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/role_appointment/publisher_v2/schema.json
@@ -56,16 +56,8 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "person": {
-          "description": "The person that is currently appointed to the relevant role.",
-          "$ref": "#/definitions/guid_list"
-        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "role": {
-          "description": "The role that the relevant person is currently appointed to.",
           "$ref": "#/definitions/guid_list"
         }
       }

--- a/content_schemas/dist/formats/worldwide_organisation/frontend/schema.json
+++ b/content_schemas/dist/formats/worldwide_organisation/frontend/schema.json
@@ -246,6 +246,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "corporate_information_pages": {
+          "description": "Corporate information pages for this Worldwide Organisation",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "document_collections": {
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -272,6 +276,10 @@
         },
         "ministers": {
           "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "ordered_contacts": {
+          "description": "Contact details for this Worldwide Organisation",
           "$ref": "#/definitions/frontend_links"
         },
         "ordered_related_items": {
@@ -324,6 +332,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "sponsoring_organisations": {
+          "description": "Sponsoring organisations for this Worldwide Organisation",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -339,6 +351,10 @@
         "topics": {
           "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/frontend_links_with_base_path"
+        },
+        "world_locations": {
+          "description": "World Locations associated with this Worldwide Organisation",
+          "$ref": "#/definitions/frontend_links"
         }
       }
     },

--- a/content_schemas/dist/formats/worldwide_organisation/notification/schema.json
+++ b/content_schemas/dist/formats/worldwide_organisation/notification/schema.json
@@ -264,6 +264,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "corporate_information_pages": {
+          "description": "Corporate information pages for this Worldwide Organisation",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "document_collections": {
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -290,6 +294,10 @@
         },
         "ministers": {
           "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links"
+        },
+        "ordered_contacts": {
+          "description": "Contact details for this Worldwide Organisation",
           "$ref": "#/definitions/frontend_links"
         },
         "ordered_related_items": {
@@ -342,6 +350,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "sponsoring_organisations": {
+          "description": "Sponsoring organisations for this Worldwide Organisation",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -357,6 +369,10 @@
         "topics": {
           "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/frontend_links_with_base_path"
+        },
+        "world_locations": {
+          "description": "World Locations associated with this Worldwide Organisation",
+          "$ref": "#/definitions/frontend_links"
         }
       }
     },
@@ -374,6 +390,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "corporate_information_pages": {
+          "description": "Corporate information pages for this Worldwide Organisation",
+          "$ref": "#/definitions/guid_list"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"
@@ -388,6 +408,10 @@
         },
         "meets_user_needs": {
           "description": "The user needs this piece of content meets.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "ordered_contacts": {
+          "description": "Contact details for this Worldwide Organisation",
           "$ref": "#/definitions/guid_list"
         },
         "ordered_related_items": {
@@ -420,6 +444,10 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
+        "sponsoring_organisations": {
+          "description": "Sponsoring organisations for this Worldwide Organisation",
+          "$ref": "#/definitions/guid_list"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/guid_list"
@@ -430,6 +458,10 @@
         },
         "topics": {
           "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "world_locations": {
+          "description": "World Locations associated with this Worldwide Organisation",
           "$ref": "#/definitions/guid_list"
         }
       }

--- a/content_schemas/dist/formats/worldwide_organisation/publisher_v2/links.json
+++ b/content_schemas/dist/formats/worldwide_organisation/publisher_v2/links.json
@@ -10,6 +10,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "corporate_information_pages": {
+          "description": "Corporate information pages for this Worldwide Organisation",
+          "$ref": "#/definitions/guid_list"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"
@@ -24,6 +28,10 @@
         },
         "meets_user_needs": {
           "description": "The user needs this piece of content meets.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "ordered_contacts": {
+          "description": "Contact details for this Worldwide Organisation",
           "$ref": "#/definitions/guid_list"
         },
         "ordered_related_items": {
@@ -56,6 +64,10 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
+        "sponsoring_organisations": {
+          "description": "Sponsoring organisations for this Worldwide Organisation",
+          "$ref": "#/definitions/guid_list"
+        },
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/guid_list"
@@ -66,6 +78,10 @@
         },
         "topics": {
           "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "world_locations": {
+          "description": "World Locations associated with this Worldwide Organisation",
           "$ref": "#/definitions/guid_list"
         }
       }

--- a/content_schemas/formats/document_collection.jsonnet
+++ b/content_schemas/formats/document_collection.jsonnet
@@ -76,5 +76,6 @@
     related_policies: "",
     related_mainstream_content: "",
     documents: "",
+    topical_events: "The topical events that are part of this document collection.",
   },
 }

--- a/content_schemas/formats/organisation.jsonnet
+++ b/content_schemas/formats/organisation.jsonnet
@@ -184,7 +184,7 @@
       },
     },
   },
-  edition_links: (import "shared/base_edition_links.jsonnet") + {
+  links: (import "shared/base_links.jsonnet") + {
     ordered_board_members: "Board members primarily for use with Whitehall organisations.",
     ordered_chief_professional_officers: "Chief professional officers primarily for use with Whitehall organisations.",
     ordered_child_organisations: "Child organisations primarily for use with Whitehall organisations.",

--- a/content_schemas/formats/role.jsonnet
+++ b/content_schemas/formats/role.jsonnet
@@ -67,7 +67,7 @@
       },
     },
   },
-  edition_links: (import "shared/base_edition_links.jsonnet") + {
+  links: (import "shared/base_links.jsonnet") + {
     ordered_parent_organisations: "Organisations that own this role.",
     ministerial: {
       description: "Link to the ministers index page, present if this is a ministerial role.",

--- a/content_schemas/formats/role_appointment.jsonnet
+++ b/content_schemas/formats/role_appointment.jsonnet
@@ -28,7 +28,7 @@
       },
     },
   },
-  edition_links: (import "shared/base_edition_links.jsonnet") + {
+  links: (import "shared/base_links.jsonnet") + {
     person: "The person that is currently appointed to the relevant role.",
     role: "The role that the relevant person is currently appointed to.",
   },

--- a/content_schemas/formats/worldwide_organisation.jsonnet
+++ b/content_schemas/formats/worldwide_organisation.jsonnet
@@ -31,11 +31,11 @@
         social_media_links: (import "shared/definitions/_social_media_links.jsonnet"),
       },
     },
-    links: (import "shared/base_links.jsonnet") + {
-      corporate_information_pages: "Corporate information pages for this Worldwide Organisation",
-      ordered_contacts: "Contact details for this Worldwide Organisation",
-      sponsoring_organisations: "Sponsoring organisations for this Worldwide Organisation",
-      world_locations: "World Locations associated with this Worldwide Organisation"
-    },
+  },
+  links: (import "shared/base_links.jsonnet") + {
+    corporate_information_pages: "Corporate information pages for this Worldwide Organisation",
+    ordered_contacts: "Contact details for this Worldwide Organisation",
+    sponsoring_organisations: "Sponsoring organisations for this Worldwide Organisation",
+    world_locations: "World Locations associated with this Worldwide Organisation"
   },
 }


### PR DESCRIPTION
In https://github.com/alphagov/whitehall/pull/7455, we have added missing tests for link validity in Publishing API presenters.  This identified a number of issues with the schemas where they did not match the content we were presenting.

This makes the updates to ensure the presented links are now valid.

[Trello card](https://trello.com/c/ObOkxMfE)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Let us know in #govuk-publishing-platform if you have any questions.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
