### PR TITLE
Add casualties to fatality notices

### DIFF
--- a/content_schemas/dist/formats/fatality_notice/frontend/schema.json
+++ b/content_schemas/dist/formats/fatality_notice/frontend/schema.json
@@ -313,6 +313,12 @@
         "body": {
           "$ref": "#/definitions/body"
         },
+        "casualties": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "change_history": {
           "$ref": "#/definitions/change_history"
         },

--- a/content_schemas/dist/formats/fatality_notice/notification/schema.json
+++ b/content_schemas/dist/formats/fatality_notice/notification/schema.json
@@ -417,6 +417,12 @@
         "body": {
           "$ref": "#/definitions/body"
         },
+        "casualties": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "change_history": {
           "$ref": "#/definitions/change_history"
         },

--- a/content_schemas/dist/formats/fatality_notice/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/fatality_notice/publisher_v2/schema.json
@@ -230,6 +230,12 @@
         "body": {
           "$ref": "#/definitions/body"
         },
+        "casualties": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "change_history": {
           "$ref": "#/definitions/change_history"
         },

--- a/content_schemas/examples/fatality_notice/frontend/fatality_notice.json
+++ b/content_schemas/examples/fatality_notice/frontend/fatality_notice.json
@@ -25,7 +25,8 @@
     "emphasised_organisations": [
       "6667cce2-e809-4e21-ae09-cb0bdc1ddda3"
     ],
-    "roll_call_introduction": "Sir George Pomeroy Colley, died in battle in Zululand on 27 February 1881."
+    "roll_call_introduction": "Sir George Pomeroy Colley, died in battle in Zululand on 27 February 1881.",
+    "casualties": ["A person has sadly died", "Another person has sadly died"]
   },
   "links": {
     "organisations": [

--- a/content_schemas/formats/fatality_notice.jsonnet
+++ b/content_schemas/formats/fatality_notice.jsonnet
@@ -14,6 +14,12 @@
         body: {
           "$ref": "#/definitions/body",
         },
+        casualties: {
+          type: "array",
+          items: {
+            type: "string"
+          }
+        },
         first_public_at: {
           "$ref": "#/definitions/first_public_at",
         },


### PR DESCRIPTION
This is so that they can be used on the fronted to provide links to fatality notices

Trello - https://trello.com/c/alzDKosv/472-add-rendering-of-field-of-operation-pages-to-government-frontend

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
