### PR TITLE
Add new definitions for `large` and `open_on_load`

### DIFF
--- a/content_schemas/dist/formats/finder/frontend/schema.json
+++ b/content_schemas/dist/formats/finder/frontend/schema.json
@@ -447,9 +447,17 @@
               "type": "string"
             }
           },
+          "large": {
+            "description": "When set to true, the height of the option select facet will be larger",
+            "type": "boolean"
+          },
           "name": {
             "description": "Label for the facet.",
             "type": "string"
+          },
+          "open_on_load": {
+            "description": "When set to true, the option select facet will always be open on page load",
+            "type": "boolean"
           },
           "open_value": {
             "description": "Value that determines the open state (the key field is in the future) of a topical facet.",

--- a/content_schemas/dist/formats/finder/notification/schema.json
+++ b/content_schemas/dist/formats/finder/notification/schema.json
@@ -547,9 +547,17 @@
               "type": "string"
             }
           },
+          "large": {
+            "description": "When set to true, the height of the option select facet will be larger",
+            "type": "boolean"
+          },
           "name": {
             "description": "Label for the facet.",
             "type": "string"
+          },
+          "open_on_load": {
+            "description": "When set to true, the option select facet will always be open on page load",
+            "type": "boolean"
           },
           "open_value": {
             "description": "Value that determines the open state (the key field is in the future) of a topical facet.",

--- a/content_schemas/dist/formats/finder/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/finder/publisher_v2/schema.json
@@ -321,9 +321,17 @@
               "type": "string"
             }
           },
+          "large": {
+            "description": "When set to true, the height of the option select facet will be larger",
+            "type": "boolean"
+          },
           "name": {
             "description": "Label for the facet.",
             "type": "string"
+          },
+          "open_on_load": {
+            "description": "When set to true, the option select facet will always be open on page load",
+            "type": "boolean"
           },
           "open_value": {
             "description": "Value that determines the open state (the key field is in the future) of a topical facet.",

--- a/content_schemas/formats/shared/definitions/finder.jsonnet
+++ b/content_schemas/formats/shared/definitions/finder.jsonnet
@@ -171,6 +171,14 @@
           description: "Include this in search result metadata. Can be set for non-filterable facets.",
           type: "boolean",
         },
+        large: {
+          description: "When set to true, the height of the option select facet will be larger",
+          type: "boolean",
+        },
+        open_on_load: {
+          description: "When set to true, the option select facet will always be open on page load",
+          type: "boolean",
+        },
         name: {
           description: "Label for the facet.",
           type: "string",


### PR DESCRIPTION
## What
Add new definitions `large` and `open_on_load` for finder frontend.

## Why
- These definitions will be used in the option select component on finder frontend
- Ensure the tests pass for the [related changes](https://github.com/alphagov/specialist-publisher/pull/2248) in `specialist-publisher`

### Related Trello cards:
- https://trello.com/c/WpDLBxS1/1885-expand-both-location-and-industry-filters-by-default
- https://trello.com/c/Urpavm6J/1886-increase-the-height-of-the-industries-facet-filter-box 

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
