### PR TITLE
Add migration to remove path reservation for `/world`

### DIFF
--- a/db/migrate/20230328161842_remove_world_path_reservation.rb
+++ b/db/migrate/20230328161842_remove_world_path_reservation.rb
@@ -1,0 +1,5 @@
+class RemoveWorldPathReservation < ActiveRecord::Migration[7.0]
+  def up
+    PathReservation.find_by(base_path: "/world")&.delete
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_12_22_145109) do
+ActiveRecord::Schema[7.0].define(version: 2023_03_28_161842) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 


### PR DESCRIPTION
There is a path reservation for `/world` reserved by Content Tagger. No content is currently published to this path and there is no intention for Content Tagger to use this path for anything.

Therefore deleting it so Whitehall is able to publish the world index page at the same path.

Adding this as a migration so there is a record of when this was removed (and why), and also to make it safer to run than executing commands on a console.

[Trello card](https://trello.com/c/7kBEEWUL)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
