### PR TITLE
Update schema for Ministers Index page

### DIFF
--- a/content_schemas/dist/formats/ministers_index/frontend/schema.json
+++ b/content_schemas/dist/formats/ministers_index/frontend/schema.json
@@ -91,6 +91,38 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
+        "ordered_also_attends_cabinet": {
+          "description": "Links to the current ministers without a cabinet position who also attend cabinet in the correct order",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
+        "ordered_assistant_whips": {
+          "description": "Links to the current assistant whips in the correct order",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
+        "ordered_baronessess_and_ladies_in_waiting_whips": {
+          "description": "Links to the current Baroness and Ladies in Waiting whips in the correct order",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
+        "ordered_cabinet_ministers": {
+          "description": "Links to the current cabinet ministers in the correct order",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
+        "ordered_house_lords_whips": {
+          "description": "Links to the current House of Lords whips in the correct order",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
+        "ordered_house_of_commons_whips": {
+          "description": "Links to the current House of Commons whips in the correct order",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
+        "ordered_junior_lords_of_the_treasury_whips": {
+          "description": "Links to the current Junior Lords of the Treasury whips in the correct order",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
+        "ordered_ministerial_departments": {
+          "description": "Links to the ministerial department organisations in the correct order",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "ordered_related_items": {
           "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -291,6 +323,10 @@
         "reshuffle"
       ],
       "properties": {
+        "body": {
+          "description": "The main text to show on the page",
+          "type": "string"
+        },
         "change_history": {
           "$ref": "#/definitions/change_history"
         },

--- a/content_schemas/dist/formats/ministers_index/notification/schema.json
+++ b/content_schemas/dist/formats/ministers_index/notification/schema.json
@@ -109,6 +109,38 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
+        "ordered_also_attends_cabinet": {
+          "description": "Links to the current ministers without a cabinet position who also attend cabinet in the correct order",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
+        "ordered_assistant_whips": {
+          "description": "Links to the current assistant whips in the correct order",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
+        "ordered_baronessess_and_ladies_in_waiting_whips": {
+          "description": "Links to the current Baroness and Ladies in Waiting whips in the correct order",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
+        "ordered_cabinet_ministers": {
+          "description": "Links to the current cabinet ministers in the correct order",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
+        "ordered_house_lords_whips": {
+          "description": "Links to the current House of Lords whips in the correct order",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
+        "ordered_house_of_commons_whips": {
+          "description": "Links to the current House of Commons whips in the correct order",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
+        "ordered_junior_lords_of_the_treasury_whips": {
+          "description": "Links to the current Junior Lords of the Treasury whips in the correct order",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
+        "ordered_ministerial_departments": {
+          "description": "Links to the ministerial department organisations in the correct order",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "ordered_related_items": {
           "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -205,6 +237,38 @@
         },
         "meets_user_needs": {
           "description": "The user needs this piece of content meets.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "ordered_also_attends_cabinet": {
+          "description": "Links to the current ministers without a cabinet position who also attend cabinet in the correct order",
+          "$ref": "#/definitions/guid_list"
+        },
+        "ordered_assistant_whips": {
+          "description": "Links to the current assistant whips in the correct order",
+          "$ref": "#/definitions/guid_list"
+        },
+        "ordered_baronessess_and_ladies_in_waiting_whips": {
+          "description": "Links to the current Baroness and Ladies in Waiting whips in the correct order",
+          "$ref": "#/definitions/guid_list"
+        },
+        "ordered_cabinet_ministers": {
+          "description": "Links to the current cabinet ministers in the correct order",
+          "$ref": "#/definitions/guid_list"
+        },
+        "ordered_house_lords_whips": {
+          "description": "Links to the current House of Lords whips in the correct order",
+          "$ref": "#/definitions/guid_list"
+        },
+        "ordered_house_of_commons_whips": {
+          "description": "Links to the current House of Commons whips in the correct order",
+          "$ref": "#/definitions/guid_list"
+        },
+        "ordered_junior_lords_of_the_treasury_whips": {
+          "description": "Links to the current Junior Lords of the Treasury whips in the correct order",
+          "$ref": "#/definitions/guid_list"
+        },
+        "ordered_ministerial_departments": {
+          "description": "Links to the ministerial department organisations in the correct order",
           "$ref": "#/definitions/guid_list"
         },
         "ordered_related_items": {
@@ -382,6 +446,10 @@
         "reshuffle"
       ],
       "properties": {
+        "body": {
+          "description": "The main text to show on the page",
+          "type": "string"
+        },
         "change_history": {
           "$ref": "#/definitions/change_history"
         },

--- a/content_schemas/dist/formats/ministers_index/publisher_v2/links.json
+++ b/content_schemas/dist/formats/ministers_index/publisher_v2/links.json
@@ -26,6 +26,38 @@
           "description": "The user needs this piece of content meets.",
           "$ref": "#/definitions/guid_list"
         },
+        "ordered_also_attends_cabinet": {
+          "description": "Links to the current ministers without a cabinet position who also attend cabinet in the correct order",
+          "$ref": "#/definitions/guid_list"
+        },
+        "ordered_assistant_whips": {
+          "description": "Links to the current assistant whips in the correct order",
+          "$ref": "#/definitions/guid_list"
+        },
+        "ordered_baronessess_and_ladies_in_waiting_whips": {
+          "description": "Links to the current Baroness and Ladies in Waiting whips in the correct order",
+          "$ref": "#/definitions/guid_list"
+        },
+        "ordered_cabinet_ministers": {
+          "description": "Links to the current cabinet ministers in the correct order",
+          "$ref": "#/definitions/guid_list"
+        },
+        "ordered_house_lords_whips": {
+          "description": "Links to the current House of Lords whips in the correct order",
+          "$ref": "#/definitions/guid_list"
+        },
+        "ordered_house_of_commons_whips": {
+          "description": "Links to the current House of Commons whips in the correct order",
+          "$ref": "#/definitions/guid_list"
+        },
+        "ordered_junior_lords_of_the_treasury_whips": {
+          "description": "Links to the current Junior Lords of the Treasury whips in the correct order",
+          "$ref": "#/definitions/guid_list"
+        },
+        "ordered_ministerial_departments": {
+          "description": "Links to the ministerial department organisations in the correct order",
+          "$ref": "#/definitions/guid_list"
+        },
         "ordered_related_items": {
           "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/dist/formats/ministers_index/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/ministers_index/publisher_v2/schema.json
@@ -173,6 +173,10 @@
         "reshuffle"
       ],
       "properties": {
+        "body": {
+          "description": "The main text to show on the page",
+          "type": "string"
+        },
         "reshuffle": {
           "message": "string"
         }

--- a/content_schemas/formats/ministers_index.jsonnet
+++ b/content_schemas/formats/ministers_index.jsonnet
@@ -9,7 +9,37 @@
         reshuffle: {
           message: "string",
         },
+        body: {
+          description: "The main text to show on the page",
+          type: "string",
+        }
       },
     },
   },
+  links: (import "shared/base_links.jsonnet") + {
+    ordered_cabinet_ministers: {
+      description: "Links to the current cabinet ministers in the correct order"
+    },
+    ordered_also_attends_cabinet: {
+      description: "Links to the current ministers without a cabinet position who also attend cabinet in the correct order"
+    },
+    ordered_ministerial_departments: {
+      description: "Links to the ministerial department organisations in the correct order"
+    },
+    ordered_house_of_commons_whips: {
+      description: "Links to the current House of Commons whips in the correct order"
+    },
+    ordered_junior_lords_of_the_treasury_whips: {
+      description: "Links to the current Junior Lords of the Treasury whips in the correct order"
+    },
+    ordered_assistant_whips: {
+      description: "Links to the current assistant whips in the correct order"
+    },
+    ordered_house_lords_whips: {
+      description: "Links to the current House of Lords whips in the correct order"
+    },
+    ordered_baronessess_and_ladies_in_waiting_whips: {
+      description: "Links to the current Baroness and Ladies in Waiting whips in the correct order"
+    }
+  }
 }


### PR DESCRIPTION
The Whitehall presenter for the ministers index page is being updated to include additional links to people and organisations in https://github.com/alphagov/whitehall/pull/7547.

Therefore updating the schema to include these links.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
