### PR TITLE
Add srcset support to the logo image for topical events

### DIFF
--- a/content_schemas/dist/formats/topical_event/frontend/schema.json
+++ b/content_schemas/dist/formats/topical_event/frontend/schema.json
@@ -490,15 +490,7 @@
           "format": "date-time"
         },
         "image": {
-          "properties": {
-            "alt_text": {
-              "type": "string"
-            },
-            "url": {
-              "type": "string",
-              "format": "uri"
-            }
-          }
+          "$ref": "#/definitions/image_with_srcset"
         },
         "ordered_featured_documents": {
           "description": "A set of featured documents to display for the Topical Event.",
@@ -756,6 +748,60 @@
           "description": "URL to a high resolution version of the image, for use by third parties such as Twitter, Facebook or Slack. Used by the machine readable metadata component. Don't use this on user-facing web pages, as it might be very large.",
           "type": "string",
           "format": "uri"
+        },
+        "url": {
+          "description": "URL to the image. The image should be in a suitable resolution for display on the page.",
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "image_with_srcset": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "credit": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "srcset": {
+          "description": "List of images URLs with sizes that can be used to create a srcset.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "size": {
+                "type": "string"
+              },
+              "url": {
+                "type": "string",
+                "format": "uri"
+              }
+            }
+          }
         },
         "url": {
           "description": "URL to the image. The image should be in a suitable resolution for display on the page.",

--- a/content_schemas/dist/formats/topical_event/notification/schema.json
+++ b/content_schemas/dist/formats/topical_event/notification/schema.json
@@ -581,15 +581,7 @@
           "format": "date-time"
         },
         "image": {
-          "properties": {
-            "alt_text": {
-              "type": "string"
-            },
-            "url": {
-              "type": "string",
-              "format": "uri"
-            }
-          }
+          "$ref": "#/definitions/image_with_srcset"
         },
         "ordered_featured_documents": {
           "description": "A set of featured documents to display for the Topical Event.",
@@ -860,6 +852,60 @@
           "description": "URL to a high resolution version of the image, for use by third parties such as Twitter, Facebook or Slack. Used by the machine readable metadata component. Don't use this on user-facing web pages, as it might be very large.",
           "type": "string",
           "format": "uri"
+        },
+        "url": {
+          "description": "URL to the image. The image should be in a suitable resolution for display on the page.",
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "image_with_srcset": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "credit": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "srcset": {
+          "description": "List of images URLs with sizes that can be used to create a srcset.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "size": {
+                "type": "string"
+              },
+              "url": {
+                "type": "string",
+                "format": "uri"
+              }
+            }
+          }
         },
         "url": {
           "description": "URL to the image. The image should be in a suitable resolution for display on the page.",

--- a/content_schemas/dist/formats/topical_event/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/topical_event/publisher_v2/schema.json
@@ -369,15 +369,7 @@
           "format": "date-time"
         },
         "image": {
-          "properties": {
-            "alt_text": {
-              "type": "string"
-            },
-            "url": {
-              "type": "string",
-              "format": "uri"
-            }
-          }
+          "$ref": "#/definitions/image_with_srcset"
         },
         "ordered_featured_documents": {
           "description": "A set of featured documents to display for the Topical Event.",
@@ -509,6 +501,60 @@
           "description": "URL to a high resolution version of the image, for use by third parties such as Twitter, Facebook or Slack. Used by the machine readable metadata component. Don't use this on user-facing web pages, as it might be very large.",
           "type": "string",
           "format": "uri"
+        },
+        "url": {
+          "description": "URL to the image. The image should be in a suitable resolution for display on the page.",
+          "type": "string",
+          "format": "uri"
+        }
+      }
+    },
+    "image_with_srcset": {
+      "type": "object",
+      "required": [
+        "url"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "alt_text": {
+          "type": "string"
+        },
+        "caption": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "credit": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "srcset": {
+          "description": "List of images URLs with sizes that can be used to create a srcset.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "size": {
+                "type": "string"
+              },
+              "url": {
+                "type": "string",
+                "format": "uri"
+              }
+            }
+          }
         },
         "url": {
           "description": "URL to the image. The image should be in a suitable resolution for display on the page.",

--- a/content_schemas/formats/shared/definitions/_image_with_srcset.jsonnet
+++ b/content_schemas/formats/shared/definitions/_image_with_srcset.jsonnet
@@ -1,0 +1,51 @@
+{
+  image_with_srcset: {
+    type: "object",
+    additionalProperties: false,
+    required: [
+      "url",
+    ],
+    properties: {
+      url: {
+        description: "URL to the image. The image should be in a suitable resolution for display on the page.",
+        type: "string",
+        format: "uri",
+      },
+      srcset: {
+        description: "List of images URLs with sizes that can be used to create a srcset.",
+        type: "array",
+        items: {
+            type: "object",
+            additionalProperties: false,
+            properties: {
+                url: { type: "string", format: "uri" },
+                size: { type: "string" },
+            }
+        }
+      },
+      alt_text: {
+        type: "string",
+      },
+      caption: {
+        anyOf: [
+          {
+            type: "string",
+          },
+          {
+            type: "null",
+          },
+        ],
+      },
+      credit: {
+        anyOf: [
+          {
+            type: "string",
+          },
+          {
+            type: "null",
+          },
+        ],
+      },
+    },
+  },
+}

--- a/content_schemas/formats/topical_event.jsonnet
+++ b/content_schemas/formats/topical_event.jsonnet
@@ -1,5 +1,6 @@
 (import "shared/default_format.jsonnet") + {
-  definitions: (import "shared/definitions/_whitehall.jsonnet") + {
+  definitions: (import "shared/definitions/_whitehall.jsonnet") +
+               (import "shared/definitions/_image_with_srcset.jsonnet") + {
     details: {
       type: "object",
       additionalProperties: false,
@@ -12,15 +13,7 @@
           type: "string",
         },
         image: {
-          properties: {
-           url: {
-             type: "string",
-             format: "uri",
-           },
-           alt_text: {
-             type: "string",
-           },
-          },
+          "$ref": "#/definitions/image_with_srcset",
         },
         start_date: {
           type: "string",


### PR DESCRIPTION
Draft for this https://trello.com/c/uW5kvqga/1961-using-srcset-functionality-to-make-images-less-blurry-on-govuk to demonstrate the concept

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

- [ ] This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.
