### PR TITLE
Add expansion rules for `ordered_cabinet_ministers`

### DIFF
--- a/lib/expansion_rules.rb
+++ b/lib/expansion_rules.rb
@@ -36,6 +36,7 @@ module_function
     %i[ordered_assistant_whips role_appointments role],
     %i[ordered_baronessess_and_ladies_in_waiting_whips role_appointments role],
     %i[ordered_board_members role_appointments role],
+    %i[ordered_cabinet_ministers role_appointments role],
     %i[ordered_chief_professional_officers role_appointments role],
     %i[ordered_house_lords_whips role_appointments role],
     %i[ordered_house_of_commons_whips role_appointments role],


### PR DESCRIPTION
This was missed in https://github.com/alphagov/publishing-api/commit/a5b897773465d5e48e326cb1c118fbb881ff2516.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
