### PR TITLE
Add correctly named field to ministers index

### DIFF
--- a/content_schemas/dist/formats/ministers_index/frontend/schema.json
+++ b/content_schemas/dist/formats/ministers_index/frontend/schema.json
@@ -99,6 +99,10 @@
           "description": "Links to the current assistant whips in the correct order",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "ordered_baronesses_and_lords_in_waiting_whips": {
+          "description": "Links to the current Baronesses and Lords in Waiting whips in the correct order",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "ordered_baronessess_and_ladies_in_waiting_whips": {
           "description": "Links to the current Baroness and Ladies in Waiting whips in the correct order",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/content_schemas/dist/formats/ministers_index/notification/schema.json
+++ b/content_schemas/dist/formats/ministers_index/notification/schema.json
@@ -117,6 +117,10 @@
           "description": "Links to the current assistant whips in the correct order",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "ordered_baronesses_and_lords_in_waiting_whips": {
+          "description": "Links to the current Baronesses and Lords in Waiting whips in the correct order",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "ordered_baronessess_and_ladies_in_waiting_whips": {
           "description": "Links to the current Baroness and Ladies in Waiting whips in the correct order",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -245,6 +249,10 @@
         },
         "ordered_assistant_whips": {
           "description": "Links to the current assistant whips in the correct order",
+          "$ref": "#/definitions/guid_list"
+        },
+        "ordered_baronesses_and_lords_in_waiting_whips": {
+          "description": "Links to the current Baronesses and Lords in Waiting whips in the correct order",
           "$ref": "#/definitions/guid_list"
         },
         "ordered_baronessess_and_ladies_in_waiting_whips": {

--- a/content_schemas/dist/formats/ministers_index/publisher_v2/links.json
+++ b/content_schemas/dist/formats/ministers_index/publisher_v2/links.json
@@ -34,6 +34,10 @@
           "description": "Links to the current assistant whips in the correct order",
           "$ref": "#/definitions/guid_list"
         },
+        "ordered_baronesses_and_lords_in_waiting_whips": {
+          "description": "Links to the current Baronesses and Lords in Waiting whips in the correct order",
+          "$ref": "#/definitions/guid_list"
+        },
         "ordered_baronessess_and_ladies_in_waiting_whips": {
           "description": "Links to the current Baroness and Ladies in Waiting whips in the correct order",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/formats/ministers_index.jsonnet
+++ b/content_schemas/formats/ministers_index.jsonnet
@@ -40,6 +40,9 @@
     },
     ordered_baronessess_and_ladies_in_waiting_whips: {
       description: "Links to the current Baroness and Ladies in Waiting whips in the correct order"
+    },
+    ordered_baronesses_and_lords_in_waiting_whips: {
+      description: "Links to the current Baronesses and Lords in Waiting whips in the correct order"
     }
   }
 }

--- a/lib/expansion_rules.rb
+++ b/lib/expansion_rules.rb
@@ -35,6 +35,7 @@ module_function
     %i[ordered_also_attends_cabinet role_appointments role],
     %i[ordered_assistant_whips role_appointments role],
     %i[ordered_baronessess_and_ladies_in_waiting_whips role_appointments role],
+    %i[ordered_baronesses_and_lords_in_waiting_whips role_appointments role],
     %i[ordered_board_members role_appointments role],
     %i[ordered_cabinet_ministers role_appointments role],
     %i[ordered_chief_professional_officers role_appointments role],
@@ -111,6 +112,7 @@ module_function
       ordered_also_attends_cabinet
       ordered_assistant_whips
       ordered_baronessess_and_ladies_in_waiting_whips
+      ordered_baronesses_and_lords_in_waiting_whips
       ordered_board_members
       ordered_cabinet_ministers
       ordered_chief_professional_officers

--- a/spec/lib/expansion_rules_spec.rb
+++ b/spec/lib/expansion_rules_spec.rb
@@ -81,6 +81,7 @@ RSpec.describe ExpansionRules do
     specify { expect(rules.expansion_fields(:person, link_type: :ordered_also_attends_cabinet)).to eq(person_with_image_fields) }
     specify { expect(rules.expansion_fields(:person, link_type: :ordered_assistant_whips)).to eq(person_with_image_fields) }
     specify { expect(rules.expansion_fields(:person, link_type: :ordered_baronessess_and_ladies_in_waiting_whips)).to eq(person_with_image_fields) }
+    specify { expect(rules.expansion_fields(:person, link_type: :ordered_baronesses_and_lords_in_waiting_whips)).to eq(person_with_image_fields) }
     specify { expect(rules.expansion_fields(:person, link_type: :ordered_board_members)).to eq(person_with_image_fields) }
     specify { expect(rules.expansion_fields(:person, link_type: :ordered_cabinet_ministers)).to eq(person_with_image_fields) }
     specify { expect(rules.expansion_fields(:person, link_type: :ordered_chief_professional_officers)).to eq(person_with_image_fields) }


### PR DESCRIPTION
Once whitehall and any other apps are switched to use the new field, we'll be able to remove the old, misnamed field.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
