### PR TITLE
Update embassies_index schema

### DIFF
--- a/content_schemas/allowed_document_types.yml
+++ b/content_schemas/allowed_document_types.yml
@@ -37,6 +37,7 @@
 - drcf_digital_markets_research
 - drug_safety_update
 - email_alert_signup
+- embassies_index
 - employment_appeal_tribunal_decision
 - employment_tribunal_decision
 - equality_and_diversity

--- a/content_schemas/dist/formats/embassies_index/frontend/schema.json
+++ b/content_schemas/dist/formats/embassies_index/frontend/schema.json
@@ -73,6 +73,7 @@
         "drcf_digital_markets_research",
         "drug_safety_update",
         "email_alert_signup",
+        "embassies_index",
         "employment_appeal_tribunal_decision",
         "employment_tribunal_decision",
         "equality_and_diversity",

--- a/content_schemas/dist/formats/embassies_index/frontend/schema.json
+++ b/content_schemas/dist/formats/embassies_index/frontend/schema.json
@@ -475,6 +475,22 @@
       "properties": {
         "change_history": {
           "$ref": "#/definitions/change_history"
+        },
+        "world_locations": {
+          "type": "array",
+          "items": {
+            "oneOf": [
+              {
+                "$ref": "#/definitions/local_offices"
+              },
+              {
+                "$ref": "#/definitions/remote_offices"
+              },
+              {
+                "$ref": "#/definitions/no_offices"
+              }
+            ]
+          }
         }
       }
     },
@@ -620,6 +636,53 @@
       "type": "string",
       "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
     },
+    "local_offices": {
+      "type": "object",
+      "required": [
+        "name",
+        "assistance_available",
+        "organisations_with_embassy_offices"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "assistance_available": {
+          "type": "string",
+          "enum": [
+            "local"
+          ]
+        },
+        "name": {
+          "description": "The name of the world location e.g. Argentina",
+          "type": "string"
+        },
+        "organisations_with_embassy_offices": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "locality",
+              "name",
+              "path"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "locality": {
+                "description": "The locality of the office as set by Whitehall, e.g. Sydney",
+                "type": "string"
+              },
+              "name": {
+                "description": "The name of the worldwide organisation that this office belongs to, e.g. British Embassy Buenos Aires",
+                "type": "string"
+              },
+              "path": {
+                "description": "The path to the worldwide organisation that this office belongs to, e.g. /world/organisations/british-embassy-buenos-aires",
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    },
     "locale": {
       "type": "string",
       "enum": [
@@ -691,6 +754,26 @@
         "zh-tw"
       ]
     },
+    "no_offices": {
+      "type": "object",
+      "required": [
+        "name",
+        "assistance_available"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "assistance_available": {
+          "type": "string",
+          "enum": [
+            "none"
+          ]
+        },
+        "name": {
+          "description": "The name of the world location e.g. Anguilla",
+          "type": "string"
+        }
+      }
+    },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
@@ -750,6 +833,49 @@
       "description": "When this content was last scheduled for publishing. Determined by the publishing intent sent by the publishing API.",
       "type": "string",
       "format": "date-time"
+    },
+    "remote_offices": {
+      "type": "object",
+      "required": [
+        "name",
+        "assistance_available",
+        "remote_office"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "assistance_available": {
+          "type": "string",
+          "enum": [
+            "remote"
+          ]
+        },
+        "name": {
+          "description": "The name of the world location e.g. Argentina",
+          "type": "string"
+        },
+        "remote_office": {
+          "type": "object",
+          "required": [
+            "name",
+            "country",
+            "path"
+          ],
+          "properties": {
+            "country": {
+              "description": "The remote country that this office is located in, e.g. Qatar",
+              "type": "string"
+            },
+            "name": {
+              "description": "The name of the worldwide organisation that this office belongs to, e.g. British Embassy Kabul",
+              "type": "string"
+            },
+            "path": {
+              "description": "The path to the worldwide organisation that this office belongs to, e.g. /world/organisations/british-embassy-kabul",
+              "type": "string"
+            }
+          }
+        }
+      }
     },
     "rendering_app": {
       "description": "The application that renders this item.",

--- a/content_schemas/dist/formats/embassies_index/notification/schema.json
+++ b/content_schemas/dist/formats/embassies_index/notification/schema.json
@@ -566,6 +566,22 @@
       "properties": {
         "change_history": {
           "$ref": "#/definitions/change_history"
+        },
+        "world_locations": {
+          "type": "array",
+          "items": {
+            "oneOf": [
+              {
+                "$ref": "#/definitions/local_offices"
+              },
+              {
+                "$ref": "#/definitions/remote_offices"
+              },
+              {
+                "$ref": "#/definitions/no_offices"
+              }
+            ]
+          }
         }
       }
     },
@@ -724,6 +740,53 @@
       },
       "uniqueItems": true
     },
+    "local_offices": {
+      "type": "object",
+      "required": [
+        "name",
+        "assistance_available",
+        "organisations_with_embassy_offices"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "assistance_available": {
+          "type": "string",
+          "enum": [
+            "local"
+          ]
+        },
+        "name": {
+          "description": "The name of the world location e.g. Argentina",
+          "type": "string"
+        },
+        "organisations_with_embassy_offices": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "locality",
+              "name",
+              "path"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "locality": {
+                "description": "The locality of the office as set by Whitehall, e.g. Sydney",
+                "type": "string"
+              },
+              "name": {
+                "description": "The name of the worldwide organisation that this office belongs to, e.g. British Embassy Buenos Aires",
+                "type": "string"
+              },
+              "path": {
+                "description": "The path to the worldwide organisation that this office belongs to, e.g. /world/organisations/british-embassy-buenos-aires",
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    },
     "locale": {
       "type": "string",
       "enum": [
@@ -795,6 +858,26 @@
         "zh-tw"
       ]
     },
+    "no_offices": {
+      "type": "object",
+      "required": [
+        "name",
+        "assistance_available"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "assistance_available": {
+          "type": "string",
+          "enum": [
+            "none"
+          ]
+        },
+        "name": {
+          "description": "The name of the world location e.g. Anguilla",
+          "type": "string"
+        }
+      }
+    },
     "payload_version": {
       "description": "Counter to indicate when the payload was generated",
       "type": "integer"
@@ -853,6 +936,49 @@
           "type": "null"
         }
       ]
+    },
+    "remote_offices": {
+      "type": "object",
+      "required": [
+        "name",
+        "assistance_available",
+        "remote_office"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "assistance_available": {
+          "type": "string",
+          "enum": [
+            "remote"
+          ]
+        },
+        "name": {
+          "description": "The name of the world location e.g. Argentina",
+          "type": "string"
+        },
+        "remote_office": {
+          "type": "object",
+          "required": [
+            "name",
+            "country",
+            "path"
+          ],
+          "properties": {
+            "country": {
+              "description": "The remote country that this office is located in, e.g. Qatar",
+              "type": "string"
+            },
+            "name": {
+              "description": "The name of the worldwide organisation that this office belongs to, e.g. British Embassy Kabul",
+              "type": "string"
+            },
+            "path": {
+              "description": "The path to the worldwide organisation that this office belongs to, e.g. /world/organisations/british-embassy-kabul",
+              "type": "string"
+            }
+          }
+        }
+      }
     },
     "rendering_app": {
       "description": "The application that renders this item.",

--- a/content_schemas/dist/formats/embassies_index/notification/schema.json
+++ b/content_schemas/dist/formats/embassies_index/notification/schema.json
@@ -97,6 +97,7 @@
         "drcf_digital_markets_research",
         "drug_safety_update",
         "email_alert_signup",
+        "embassies_index",
         "employment_appeal_tribunal_decision",
         "employment_tribunal_decision",
         "equality_and_diversity",

--- a/content_schemas/dist/formats/embassies_index/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/embassies_index/publisher_v2/schema.json
@@ -83,6 +83,7 @@
         "drcf_digital_markets_research",
         "drug_safety_update",
         "email_alert_signup",
+        "embassies_index",
         "employment_appeal_tribunal_decision",
         "employment_tribunal_decision",
         "equality_and_diversity",

--- a/content_schemas/dist/formats/embassies_index/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/embassies_index/publisher_v2/schema.json
@@ -354,7 +354,24 @@
     "details": {
       "type": "object",
       "additionalProperties": false,
-      "properties": {}
+      "properties": {
+        "world_locations": {
+          "type": "array",
+          "items": {
+            "oneOf": [
+              {
+                "$ref": "#/definitions/local_offices"
+              },
+              {
+                "$ref": "#/definitions/remote_offices"
+              },
+              {
+                "$ref": "#/definitions/no_offices"
+              }
+            ]
+          }
+        }
+      }
     },
     "first_published_at": {
       "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
@@ -371,6 +388,53 @@
         "$ref": "#/definitions/guid"
       },
       "uniqueItems": true
+    },
+    "local_offices": {
+      "type": "object",
+      "required": [
+        "name",
+        "assistance_available",
+        "organisations_with_embassy_offices"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "assistance_available": {
+          "type": "string",
+          "enum": [
+            "local"
+          ]
+        },
+        "name": {
+          "description": "The name of the world location e.g. Argentina",
+          "type": "string"
+        },
+        "organisations_with_embassy_offices": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "locality",
+              "name",
+              "path"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "locality": {
+                "description": "The locality of the office as set by Whitehall, e.g. Sydney",
+                "type": "string"
+              },
+              "name": {
+                "description": "The name of the worldwide organisation that this office belongs to, e.g. British Embassy Buenos Aires",
+                "type": "string"
+              },
+              "path": {
+                "description": "The path to the worldwide organisation that this office belongs to, e.g. /world/organisations/british-embassy-buenos-aires",
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
     },
     "locale": {
       "type": "string",
@@ -443,6 +507,26 @@
         "zh-tw"
       ]
     },
+    "no_offices": {
+      "type": "object",
+      "required": [
+        "name",
+        "assistance_available"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "assistance_available": {
+          "type": "string",
+          "enum": [
+            "none"
+          ]
+        },
+        "name": {
+          "description": "The name of the world location e.g. Anguilla",
+          "type": "string"
+        }
+      }
+    },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
@@ -486,6 +570,49 @@
         "travel-advice-publisher",
         "whitehall"
       ]
+    },
+    "remote_offices": {
+      "type": "object",
+      "required": [
+        "name",
+        "assistance_available",
+        "remote_office"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "assistance_available": {
+          "type": "string",
+          "enum": [
+            "remote"
+          ]
+        },
+        "name": {
+          "description": "The name of the world location e.g. Argentina",
+          "type": "string"
+        },
+        "remote_office": {
+          "type": "object",
+          "required": [
+            "name",
+            "country",
+            "path"
+          ],
+          "properties": {
+            "country": {
+              "description": "The remote country that this office is located in, e.g. Qatar",
+              "type": "string"
+            },
+            "name": {
+              "description": "The name of the worldwide organisation that this office belongs to, e.g. British Embassy Kabul",
+              "type": "string"
+            },
+            "path": {
+              "description": "The path to the worldwide organisation that this office belongs to, e.g. /world/organisations/british-embassy-kabul",
+              "type": "string"
+            }
+          }
+        }
+      }
     },
     "rendering_app": {
       "description": "The application that renders this item.",

--- a/content_schemas/dist/formats/field_of_operation/frontend/schema.json
+++ b/content_schemas/dist/formats/field_of_operation/frontend/schema.json
@@ -73,6 +73,7 @@
         "drcf_digital_markets_research",
         "drug_safety_update",
         "email_alert_signup",
+        "embassies_index",
         "employment_appeal_tribunal_decision",
         "employment_tribunal_decision",
         "equality_and_diversity",

--- a/content_schemas/dist/formats/field_of_operation/notification/schema.json
+++ b/content_schemas/dist/formats/field_of_operation/notification/schema.json
@@ -97,6 +97,7 @@
         "drcf_digital_markets_research",
         "drug_safety_update",
         "email_alert_signup",
+        "embassies_index",
         "employment_appeal_tribunal_decision",
         "employment_tribunal_decision",
         "equality_and_diversity",

--- a/content_schemas/dist/formats/field_of_operation/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/field_of_operation/publisher_v2/schema.json
@@ -83,6 +83,7 @@
         "drcf_digital_markets_research",
         "drug_safety_update",
         "email_alert_signup",
+        "embassies_index",
         "employment_appeal_tribunal_decision",
         "employment_tribunal_decision",
         "equality_and_diversity",

--- a/content_schemas/dist/formats/generic/frontend/schema.json
+++ b/content_schemas/dist/formats/generic/frontend/schema.json
@@ -73,6 +73,7 @@
         "drcf_digital_markets_research",
         "drug_safety_update",
         "email_alert_signup",
+        "embassies_index",
         "employment_appeal_tribunal_decision",
         "employment_tribunal_decision",
         "equality_and_diversity",

--- a/content_schemas/dist/formats/generic/notification/schema.json
+++ b/content_schemas/dist/formats/generic/notification/schema.json
@@ -97,6 +97,7 @@
         "drcf_digital_markets_research",
         "drug_safety_update",
         "email_alert_signup",
+        "embassies_index",
         "employment_appeal_tribunal_decision",
         "employment_tribunal_decision",
         "equality_and_diversity",

--- a/content_schemas/dist/formats/generic/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/generic/publisher_v2/schema.json
@@ -83,6 +83,7 @@
         "drcf_digital_markets_research",
         "drug_safety_update",
         "email_alert_signup",
+        "embassies_index",
         "employment_appeal_tribunal_decision",
         "employment_tribunal_decision",
         "equality_and_diversity",

--- a/content_schemas/dist/formats/generic_with_external_related_links/frontend/schema.json
+++ b/content_schemas/dist/formats/generic_with_external_related_links/frontend/schema.json
@@ -73,6 +73,7 @@
         "drcf_digital_markets_research",
         "drug_safety_update",
         "email_alert_signup",
+        "embassies_index",
         "employment_appeal_tribunal_decision",
         "employment_tribunal_decision",
         "equality_and_diversity",

--- a/content_schemas/dist/formats/generic_with_external_related_links/notification/schema.json
+++ b/content_schemas/dist/formats/generic_with_external_related_links/notification/schema.json
@@ -97,6 +97,7 @@
         "drcf_digital_markets_research",
         "drug_safety_update",
         "email_alert_signup",
+        "embassies_index",
         "employment_appeal_tribunal_decision",
         "employment_tribunal_decision",
         "equality_and_diversity",

--- a/content_schemas/dist/formats/generic_with_external_related_links/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/generic_with_external_related_links/publisher_v2/schema.json
@@ -83,6 +83,7 @@
         "drcf_digital_markets_research",
         "drug_safety_update",
         "email_alert_signup",
+        "embassies_index",
         "employment_appeal_tribunal_decision",
         "employment_tribunal_decision",
         "equality_and_diversity",

--- a/content_schemas/dist/formats/historic_appointments/frontend/schema.json
+++ b/content_schemas/dist/formats/historic_appointments/frontend/schema.json
@@ -73,6 +73,7 @@
         "drcf_digital_markets_research",
         "drug_safety_update",
         "email_alert_signup",
+        "embassies_index",
         "employment_appeal_tribunal_decision",
         "employment_tribunal_decision",
         "equality_and_diversity",

--- a/content_schemas/dist/formats/historic_appointments/notification/schema.json
+++ b/content_schemas/dist/formats/historic_appointments/notification/schema.json
@@ -97,6 +97,7 @@
         "drcf_digital_markets_research",
         "drug_safety_update",
         "email_alert_signup",
+        "embassies_index",
         "employment_appeal_tribunal_decision",
         "employment_tribunal_decision",
         "equality_and_diversity",

--- a/content_schemas/dist/formats/historic_appointments/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/historic_appointments/publisher_v2/schema.json
@@ -83,6 +83,7 @@
         "drcf_digital_markets_research",
         "drug_safety_update",
         "email_alert_signup",
+        "embassies_index",
         "employment_appeal_tribunal_decision",
         "employment_tribunal_decision",
         "equality_and_diversity",

--- a/content_schemas/dist/formats/placeholder/frontend/schema.json
+++ b/content_schemas/dist/formats/placeholder/frontend/schema.json
@@ -73,6 +73,7 @@
         "drcf_digital_markets_research",
         "drug_safety_update",
         "email_alert_signup",
+        "embassies_index",
         "employment_appeal_tribunal_decision",
         "employment_tribunal_decision",
         "equality_and_diversity",

--- a/content_schemas/dist/formats/placeholder/notification/schema.json
+++ b/content_schemas/dist/formats/placeholder/notification/schema.json
@@ -97,6 +97,7 @@
         "drcf_digital_markets_research",
         "drug_safety_update",
         "email_alert_signup",
+        "embassies_index",
         "employment_appeal_tribunal_decision",
         "employment_tribunal_decision",
         "equality_and_diversity",

--- a/content_schemas/dist/formats/placeholder/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/placeholder/publisher_v2/schema.json
@@ -83,6 +83,7 @@
         "drcf_digital_markets_research",
         "drug_safety_update",
         "email_alert_signup",
+        "embassies_index",
         "employment_appeal_tribunal_decision",
         "employment_tribunal_decision",
         "equality_and_diversity",

--- a/content_schemas/dist/formats/special_route/frontend/schema.json
+++ b/content_schemas/dist/formats/special_route/frontend/schema.json
@@ -75,6 +75,7 @@
         "drcf_digital_markets_research",
         "drug_safety_update",
         "email_alert_signup",
+        "embassies_index",
         "employment_appeal_tribunal_decision",
         "employment_tribunal_decision",
         "equality_and_diversity",

--- a/content_schemas/dist/formats/special_route/notification/schema.json
+++ b/content_schemas/dist/formats/special_route/notification/schema.json
@@ -99,6 +99,7 @@
         "drcf_digital_markets_research",
         "drug_safety_update",
         "email_alert_signup",
+        "embassies_index",
         "employment_appeal_tribunal_decision",
         "employment_tribunal_decision",
         "equality_and_diversity",

--- a/content_schemas/dist/formats/special_route/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/special_route/publisher_v2/schema.json
@@ -82,6 +82,7 @@
         "drcf_digital_markets_research",
         "drug_safety_update",
         "email_alert_signup",
+        "embassies_index",
         "employment_appeal_tribunal_decision",
         "employment_tribunal_decision",
         "equality_and_diversity",

--- a/content_schemas/dist/formats/topical_event/frontend/schema.json
+++ b/content_schemas/dist/formats/topical_event/frontend/schema.json
@@ -73,6 +73,7 @@
         "drcf_digital_markets_research",
         "drug_safety_update",
         "email_alert_signup",
+        "embassies_index",
         "employment_appeal_tribunal_decision",
         "employment_tribunal_decision",
         "equality_and_diversity",

--- a/content_schemas/dist/formats/topical_event/notification/schema.json
+++ b/content_schemas/dist/formats/topical_event/notification/schema.json
@@ -97,6 +97,7 @@
         "drcf_digital_markets_research",
         "drug_safety_update",
         "email_alert_signup",
+        "embassies_index",
         "employment_appeal_tribunal_decision",
         "employment_tribunal_decision",
         "equality_and_diversity",

--- a/content_schemas/dist/formats/topical_event/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/topical_event/publisher_v2/schema.json
@@ -83,6 +83,7 @@
         "drcf_digital_markets_research",
         "drug_safety_update",
         "email_alert_signup",
+        "embassies_index",
         "employment_appeal_tribunal_decision",
         "employment_tribunal_decision",
         "equality_and_diversity",

--- a/content_schemas/dist/formats/world_location_news/frontend/schema.json
+++ b/content_schemas/dist/formats/world_location_news/frontend/schema.json
@@ -73,6 +73,7 @@
         "drcf_digital_markets_research",
         "drug_safety_update",
         "email_alert_signup",
+        "embassies_index",
         "employment_appeal_tribunal_decision",
         "employment_tribunal_decision",
         "equality_and_diversity",

--- a/content_schemas/dist/formats/world_location_news/notification/schema.json
+++ b/content_schemas/dist/formats/world_location_news/notification/schema.json
@@ -97,6 +97,7 @@
         "drcf_digital_markets_research",
         "drug_safety_update",
         "email_alert_signup",
+        "embassies_index",
         "employment_appeal_tribunal_decision",
         "employment_tribunal_decision",
         "equality_and_diversity",

--- a/content_schemas/dist/formats/world_location_news/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/world_location_news/publisher_v2/schema.json
@@ -83,6 +83,7 @@
         "drcf_digital_markets_research",
         "drug_safety_update",
         "email_alert_signup",
+        "embassies_index",
         "employment_appeal_tribunal_decision",
         "employment_tribunal_decision",
         "equality_and_diversity",

--- a/content_schemas/dist/formats/worldwide_organisation/frontend/schema.json
+++ b/content_schemas/dist/formats/worldwide_organisation/frontend/schema.json
@@ -73,6 +73,7 @@
         "drcf_digital_markets_research",
         "drug_safety_update",
         "email_alert_signup",
+        "embassies_index",
         "employment_appeal_tribunal_decision",
         "employment_tribunal_decision",
         "equality_and_diversity",

--- a/content_schemas/dist/formats/worldwide_organisation/notification/schema.json
+++ b/content_schemas/dist/formats/worldwide_organisation/notification/schema.json
@@ -97,6 +97,7 @@
         "drcf_digital_markets_research",
         "drug_safety_update",
         "email_alert_signup",
+        "embassies_index",
         "employment_appeal_tribunal_decision",
         "employment_tribunal_decision",
         "equality_and_diversity",

--- a/content_schemas/dist/formats/worldwide_organisation/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/worldwide_organisation/publisher_v2/schema.json
@@ -83,6 +83,7 @@
         "drcf_digital_markets_research",
         "drug_safety_update",
         "email_alert_signup",
+        "embassies_index",
         "employment_appeal_tribunal_decision",
         "employment_tribunal_decision",
         "equality_and_diversity",

--- a/content_schemas/examples/embassies_index/frontend/embassies_index.json
+++ b/content_schemas/examples/embassies_index/frontend/embassies_index.json
@@ -1,0 +1,56 @@
+{
+  "base_path": "/world/embassies",
+  "content_id": "8e2cb457-81c1-484e-baa5-d714538c7c66",
+  "description": "",
+  "details": {
+    "world_locations": [
+      {
+        "name": "Afghanistan",
+        "assistance_available": "remote",
+        "remote_office": {
+          "name": "British Embassy Kabul",
+          "country": "Qatar",
+          "path": "/world/organisations/british-embassy-kabul"
+        }
+      },
+      {
+        "name": "Anguilla",
+        "assistance_available": "none"
+      },
+      {
+        "name": "Argentina",
+        "assistance_available": "local",
+        "organisations_with_embassy_offices": [
+          {
+            "locality": "",
+            "name": "British Embassy Buenos Aires",
+            "path": "/world/organisations/british-embassy-buenos-aires"
+          },
+          {
+            "locality": "",
+            "name": "UK Science & Innovation Network in Argentina",
+            "path": "/world/organisations/uk-science-innovation-network-in-argentina--2"
+          }
+        ]
+      }
+    ]
+  },
+  "document_type": "embassies_index",
+  "links": {
+    "parent": [
+      {
+        "base_path": "/world",
+        "content_id": "369729ba-7776-4123-96be-2e3e98e153e1",
+        "locale": "en",
+        "title": ""
+      }
+    ]
+  },
+  "locale": "en",
+  "publishing_app": "whitehall",
+  "rendering_app": "collections",
+  "schema_name": "embassies_index",
+  "title": "Find a British embassy, high commission or consulate",
+  "public_updated_at": "2016-09-14T18:19:27+01:00",
+  "updated_at": "2016-09-14T10:37:00Z"
+}

--- a/content_schemas/examples/embassies_index/publisher_v2/embassies_index.json
+++ b/content_schemas/examples/embassies_index/publisher_v2/embassies_index.json
@@ -1,0 +1,47 @@
+{
+  "base_path": "/world/embassies",
+  "details": {
+    "world_locations": [
+      {
+        "name": "Afghanistan",
+        "assistance_available": "remote",
+        "remote_office": {
+          "name": "British Embassy Kabul",
+          "country": "Qatar",
+          "path": "/world/organisations/british-embassy-kabul"
+        }
+      },
+      {
+        "name": "Anguilla",
+        "assistance_available": "none"
+      },
+      {
+        "name": "Argentina",
+        "assistance_available": "local",
+        "organisations_with_embassy_offices": [
+          {
+            "locality": "",
+            "name": "British Embassy Buenos Aires",
+            "path": "/world/organisations/british-embassy-buenos-aires"
+          },
+          {
+            "locality": "",
+            "name": "UK Science & Innovation Network in Argentina",
+            "path": "/world/organisations/uk-science-innovation-network-in-argentina--2"
+          }
+        ]
+      }
+    ]
+  },
+  "document_type": "embassies_index",
+  "publishing_app": "whitehall",
+  "rendering_app": "collections",
+  "routes": [
+    {
+      "path": "/world/embassies",
+      "type": "exact"
+    }
+  ],
+  "schema_name": "embassies_index",
+  "title": "Find a British embassy, high commission or consulate"
+}

--- a/content_schemas/formats/embassies_index.jsonnet
+++ b/content_schemas/formats/embassies_index.jsonnet
@@ -1,1 +1,124 @@
-(import "shared/default_format.jsonnet")
+(import "shared/default_format.jsonnet") + {
+  definitions: {
+    local_offices: {
+      type: "object",
+      additionalProperties: false,
+      required: [
+        'name',
+        'assistance_available',
+        'organisations_with_embassy_offices'
+      ],
+      properties: {
+        name: {
+          type: "string",
+          description: "The name of the world location e.g. Argentina",
+        },
+        assistance_available: {
+          type: "string",
+          enum: ["local"],
+        },
+        organisations_with_embassy_offices: {
+          type: "array",
+          items: {
+            type: "object",
+            additionalProperties: false,
+            required: [
+              'locality',
+              'name',
+              'path',
+            ],
+            properties: {
+              locality: {
+                type: "string",
+                description: "The locality of the office as set by Whitehall, e.g. Sydney",
+              },
+              name: {
+                type: "string",
+                description: "The name of the worldwide organisation that this office belongs to, e.g. British Embassy Buenos Aires",
+              },
+              path: {
+                type: "string",
+                description: "The path to the worldwide organisation that this office belongs to, e.g. /world/organisations/british-embassy-buenos-aires",
+              },
+            },
+          },
+        },
+      },
+    },
+    remote_offices: {
+      type: "object",
+      additionalProperties: false,
+      required: [
+        'name',
+        'assistance_available',
+        'remote_office',
+      ],
+      properties: {
+        name: {
+          type: "string",
+          description: "The name of the world location e.g. Argentina",
+        },
+        assistance_available: {
+          type: "string",
+          enum: ["remote"],
+        },
+        remote_office: {
+          type: "object",
+          required: [
+            'name',
+            'country',
+            'path',
+          ],
+          properties: {
+            name: {
+              type: "string",
+              description: "The name of the worldwide organisation that this office belongs to, e.g. British Embassy Kabul",
+            },
+            country: {
+              type: "string",
+              description: "The remote country that this office is located in, e.g. Qatar",
+            },
+            path: {
+              type: "string",
+              description: "The path to the worldwide organisation that this office belongs to, e.g. /world/organisations/british-embassy-kabul",
+            },
+          },
+        },
+      },
+    },
+    no_offices: {
+      type: "object",
+      additionalProperties: false,
+      required: [
+        'name',
+        'assistance_available',
+      ],
+      properties: {
+        name: {
+          type: "string",
+          description: "The name of the world location e.g. Anguilla",
+        },
+        assistance_available: {
+          type: "string",
+          enum: ["none"],
+        },
+      },
+    },
+    details: {
+      type: "object",
+      additionalProperties: false,
+      properties: {
+        world_locations: {
+          type: "array",
+          items: {
+            oneOf: [
+              { "$ref": "#/definitions/local_offices" },
+              { "$ref": "#/definitions/remote_offices" },
+              { "$ref": "#/definitions/no_offices" }
+            ],
+          },
+        },
+      },
+    },
+  },
+}


### PR DESCRIPTION
Trello link: https://trello.com/c/MMUcRbIT

We are moving the rendering of the [embassies index page](https://www.gov.uk/world/embassies) from Whitehall to a rendering app (probably Collections).

The embassies index page displays information about the embassy or embassies available in each World Location. Each World Location can have either:

- a list of one or more local offices that British nationals can contact for assistance (e.g. Australia has "Canberra", "Sydney" etc.)
- a single remote office that British nationals can contact for assistance (e.g. Afghanisation currently has a remote office in Qatar)
- no offices that a British national can contact (in which case we currently display "contact local authorities").

We've modelled these three cases in this schema.

We've tested that the schema is fit for purpose by generating a JSON document conforming to the schema in Whitehall (see WIP PR https://github.com/alphagov/whitehall/pull/7596) and then rendering that JSON document in the Collections app (see WIP PR https://github.com/alphagov/collections/pull/3227).
