### PR TITLE
Update organisation crest for missing schemas

### DIFF
--- a/content_schemas/dist/formats/organisations_homepage/frontend/schema.json
+++ b/content_schemas/dist/formats/organisations_homepage/frontend/schema.json
@@ -754,7 +754,7 @@
                 ],
                 "enum": [
                   "bis",
-                  "dit",
+                  "dbt",
                   "eo",
                   "hmrc",
                   "ho",

--- a/content_schemas/dist/formats/organisations_homepage/notification/schema.json
+++ b/content_schemas/dist/formats/organisations_homepage/notification/schema.json
@@ -879,7 +879,7 @@
                 ],
                 "enum": [
                   "bis",
-                  "dit",
+                  "dbt",
                   "eo",
                   "hmrc",
                   "ho",

--- a/content_schemas/dist/formats/organisations_homepage/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/organisations_homepage/publisher_v2/schema.json
@@ -513,7 +513,7 @@
                 ],
                 "enum": [
                   "bis",
-                  "dit",
+                  "dbt",
                   "eo",
                   "hmrc",
                   "ho",

--- a/content_schemas/dist/formats/placeholder/frontend/schema.json
+++ b/content_schemas/dist/formats/placeholder/frontend/schema.json
@@ -518,7 +518,7 @@
               ],
               "enum": [
                 "bis",
-                "dit",
+                "dbt",
                 "eo",
                 "hmrc",
                 "ho",

--- a/content_schemas/dist/formats/placeholder/notification/schema.json
+++ b/content_schemas/dist/formats/placeholder/notification/schema.json
@@ -613,7 +613,7 @@
               ],
               "enum": [
                 "bis",
-                "dit",
+                "dbt",
                 "eo",
                 "hmrc",
                 "ho",

--- a/content_schemas/dist/formats/placeholder/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/placeholder/publisher_v2/schema.json
@@ -397,7 +397,7 @@
               ],
               "enum": [
                 "bis",
-                "dit",
+                "dbt",
                 "eo",
                 "hmrc",
                 "ho",

--- a/content_schemas/formats/placeholder.jsonnet
+++ b/content_schemas/formats/placeholder.jsonnet
@@ -40,7 +40,7 @@
               ],
               enum: [
                 "bis",
-                "dit",
+                "dbt",
                 "eo",
                 "hmrc",
                 "ho",

--- a/content_schemas/formats/shared/definitions/_whitehall.jsonnet
+++ b/content_schemas/formats/shared/definitions/_whitehall.jsonnet
@@ -107,7 +107,7 @@
               ],
               enum: [
                 "bis",
-                "dit",
+                "dbt",
                 "eo",
                 "hmrc",
                 "ho",


### PR DESCRIPTION
This is due to change from Department of International Trade to Department for Business & Trade - updating schemas missed in  https://github.com/alphagov/publishing-api/pull/2356

[Trello card](https://trello.com/c/rtK4IWUx/1206-update-department-of-business-trade-branding-labels-in-publishing-components)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
