### PR TITLE
Add whip organisation to ministerial role details

### DIFF
--- a/lib/expansion_rules.rb
+++ b/lib/expansion_rules.rb
@@ -95,7 +95,7 @@ module_function
   FINDER_FIELDS = (DEFAULT_FIELDS + details_fields(:facets)).freeze
   FATALITY_NOTICE_FIELDS = (DEFAULT_FIELDS + details_fields(:roll_call_introduction, :casualties))
   HISTORIC_APPOINTMENT_FIELDS = (DEFAULT_FIELDS + details_fields(:political_party, :dates_in_office))
-  MINISTERIAL_ROLE_FIELDS = (DEFAULT_FIELDS + details_fields(:body, :role_payment_type, :seniority)).freeze
+  MINISTERIAL_ROLE_FIELDS = (DEFAULT_FIELDS + details_fields(:body, :role_payment_type, :seniority, :whip_organisation)).freeze
   PERSON_FIELDS = (DEFAULT_FIELDS + details_fields(:body, :image)).freeze
   PERSON_FIELDS_WITH_IMAGE = (DEFAULT_FIELDS + details_fields(:image, :privy_counsellor)).freeze
   ROLE_FIELDS = (DEFAULT_FIELDS + details_fields(:body, :role_payment_type)).freeze

--- a/spec/lib/expansion_rules_spec.rb
+++ b/spec/lib/expansion_rules_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe ExpansionRules do
     let(:fatality_notice_fields) { default_fields + [%i[details roll_call_introduction], %i[details casualties]] }
     let(:finder_fields) { default_fields + [%i[details facets]] }
     let(:historic_appointment_fields) { default_fields + [%i[details political_party], %i[details dates_in_office]] }
-    let(:ministerial_role_fields) { role_fields + [%i[details seniority]] }
+    let(:ministerial_role_fields) { role_fields + [%i[details seniority], %i[details whip_organisation]] }
     let(:person_fields) { default_fields + [%i[details body], %i[details image]] }
     let(:person_with_image_fields) { default_fields + [%i[details image], %i[details privy_counsellor]] }
     let(:role_fields) { default_fields + [%i[details body], %i[details role_payment_type]] }


### PR DESCRIPTION
We're in the process of moving the rendering of the Ministers page from whitehall into collections.

At the moment, the ministers content item includes (via expansion) all the person's roles. For most page sections, this is fine, as we show all of a minister's current roles.

However, the Whips section only needs to show current whip roles, so we need to get the role's whip organisation information into the content item.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
