### PR TITLE
Remove the deprecated misnamed field

### DIFF
--- a/content_schemas/dist/formats/ministers_index/frontend/schema.json
+++ b/content_schemas/dist/formats/ministers_index/frontend/schema.json
@@ -103,10 +103,6 @@
           "description": "Links to the current Baronesses and Lords in Waiting whips in the correct order",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "ordered_baronessess_and_ladies_in_waiting_whips": {
-          "description": "Links to the current Baroness and Ladies in Waiting whips in the correct order",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "ordered_cabinet_ministers": {
           "description": "Links to the current cabinet ministers in the correct order",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/content_schemas/dist/formats/ministers_index/notification/schema.json
+++ b/content_schemas/dist/formats/ministers_index/notification/schema.json
@@ -121,10 +121,6 @@
           "description": "Links to the current Baronesses and Lords in Waiting whips in the correct order",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "ordered_baronessess_and_ladies_in_waiting_whips": {
-          "description": "Links to the current Baroness and Ladies in Waiting whips in the correct order",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "ordered_cabinet_ministers": {
           "description": "Links to the current cabinet ministers in the correct order",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -253,10 +249,6 @@
         },
         "ordered_baronesses_and_lords_in_waiting_whips": {
           "description": "Links to the current Baronesses and Lords in Waiting whips in the correct order",
-          "$ref": "#/definitions/guid_list"
-        },
-        "ordered_baronessess_and_ladies_in_waiting_whips": {
-          "description": "Links to the current Baroness and Ladies in Waiting whips in the correct order",
           "$ref": "#/definitions/guid_list"
         },
         "ordered_cabinet_ministers": {

--- a/content_schemas/dist/formats/ministers_index/publisher_v2/links.json
+++ b/content_schemas/dist/formats/ministers_index/publisher_v2/links.json
@@ -38,10 +38,6 @@
           "description": "Links to the current Baronesses and Lords in Waiting whips in the correct order",
           "$ref": "#/definitions/guid_list"
         },
-        "ordered_baronessess_and_ladies_in_waiting_whips": {
-          "description": "Links to the current Baroness and Ladies in Waiting whips in the correct order",
-          "$ref": "#/definitions/guid_list"
-        },
         "ordered_cabinet_ministers": {
           "description": "Links to the current cabinet ministers in the correct order",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/formats/ministers_index.jsonnet
+++ b/content_schemas/formats/ministers_index.jsonnet
@@ -38,9 +38,6 @@
     ordered_house_lords_whips: {
       description: "Links to the current House of Lords whips in the correct order"
     },
-    ordered_baronessess_and_ladies_in_waiting_whips: {
-      description: "Links to the current Baroness and Ladies in Waiting whips in the correct order"
-    },
     ordered_baronesses_and_lords_in_waiting_whips: {
       description: "Links to the current Baronesses and Lords in Waiting whips in the correct order"
     }

--- a/lib/expansion_rules.rb
+++ b/lib/expansion_rules.rb
@@ -34,7 +34,6 @@ module_function
     %i[ministers role_appointments person],
     %i[ordered_also_attends_cabinet role_appointments role],
     %i[ordered_assistant_whips role_appointments role],
-    %i[ordered_baronessess_and_ladies_in_waiting_whips role_appointments role],
     %i[ordered_baronesses_and_lords_in_waiting_whips role_appointments role],
     %i[ordered_board_members role_appointments role],
     %i[ordered_cabinet_ministers role_appointments role],
@@ -111,7 +110,6 @@ module_function
       current_prime_minister
       ordered_also_attends_cabinet
       ordered_assistant_whips
-      ordered_baronessess_and_ladies_in_waiting_whips
       ordered_baronesses_and_lords_in_waiting_whips
       ordered_board_members
       ordered_cabinet_ministers

--- a/spec/lib/expansion_rules_spec.rb
+++ b/spec/lib/expansion_rules_spec.rb
@@ -80,7 +80,6 @@ RSpec.describe ExpansionRules do
     specify { expect(rules.expansion_fields(:person, link_type: :current_prime_minister)).to eq(person_with_image_fields) }
     specify { expect(rules.expansion_fields(:person, link_type: :ordered_also_attends_cabinet)).to eq(person_with_image_fields) }
     specify { expect(rules.expansion_fields(:person, link_type: :ordered_assistant_whips)).to eq(person_with_image_fields) }
-    specify { expect(rules.expansion_fields(:person, link_type: :ordered_baronessess_and_ladies_in_waiting_whips)).to eq(person_with_image_fields) }
     specify { expect(rules.expansion_fields(:person, link_type: :ordered_baronesses_and_lords_in_waiting_whips)).to eq(person_with_image_fields) }
     specify { expect(rules.expansion_fields(:person, link_type: :ordered_board_members)).to eq(person_with_image_fields) }
     specify { expect(rules.expansion_fields(:person, link_type: :ordered_cabinet_ministers)).to eq(person_with_image_fields) }


### PR DESCRIPTION
Now that [no applications rely on its existence](https://github.com/alphagov/whitehall/pull/7609), we can remove the old field from the schema.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
