### PR TITLE
Add schema for Worldwide Offices

### DIFF
--- a/content_schemas/allowed_document_types.yml
+++ b/content_schemas/allowed_document_types.yml
@@ -182,5 +182,6 @@
 - world_location_news
 - world_news_story
 - worldwide_office_staff_role
+- worldwide_office
 - worldwide_organisation
 - written_statement

--- a/content_schemas/dist/formats/embassies_index/frontend/schema.json
+++ b/content_schemas/dist/formats/embassies_index/frontend/schema.json
@@ -218,6 +218,7 @@
         "world_location_news",
         "world_news_story",
         "worldwide_office_staff_role",
+        "worldwide_office",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/content_schemas/dist/formats/embassies_index/notification/schema.json
+++ b/content_schemas/dist/formats/embassies_index/notification/schema.json
@@ -242,6 +242,7 @@
         "world_location_news",
         "world_news_story",
         "worldwide_office_staff_role",
+        "worldwide_office",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/content_schemas/dist/formats/embassies_index/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/embassies_index/publisher_v2/schema.json
@@ -228,6 +228,7 @@
         "world_location_news",
         "world_news_story",
         "worldwide_office_staff_role",
+        "worldwide_office",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/content_schemas/dist/formats/field_of_operation/frontend/schema.json
+++ b/content_schemas/dist/formats/field_of_operation/frontend/schema.json
@@ -218,6 +218,7 @@
         "world_location_news",
         "world_news_story",
         "worldwide_office_staff_role",
+        "worldwide_office",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/content_schemas/dist/formats/field_of_operation/notification/schema.json
+++ b/content_schemas/dist/formats/field_of_operation/notification/schema.json
@@ -242,6 +242,7 @@
         "world_location_news",
         "world_news_story",
         "worldwide_office_staff_role",
+        "worldwide_office",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/content_schemas/dist/formats/field_of_operation/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/field_of_operation/publisher_v2/schema.json
@@ -228,6 +228,7 @@
         "world_location_news",
         "world_news_story",
         "worldwide_office_staff_role",
+        "worldwide_office",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/content_schemas/dist/formats/generic/frontend/schema.json
+++ b/content_schemas/dist/formats/generic/frontend/schema.json
@@ -218,6 +218,7 @@
         "world_location_news",
         "world_news_story",
         "worldwide_office_staff_role",
+        "worldwide_office",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/content_schemas/dist/formats/generic/notification/schema.json
+++ b/content_schemas/dist/formats/generic/notification/schema.json
@@ -242,6 +242,7 @@
         "world_location_news",
         "world_news_story",
         "worldwide_office_staff_role",
+        "worldwide_office",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/content_schemas/dist/formats/generic/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/generic/publisher_v2/schema.json
@@ -228,6 +228,7 @@
         "world_location_news",
         "world_news_story",
         "worldwide_office_staff_role",
+        "worldwide_office",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/content_schemas/dist/formats/generic_with_external_related_links/frontend/schema.json
+++ b/content_schemas/dist/formats/generic_with_external_related_links/frontend/schema.json
@@ -218,6 +218,7 @@
         "world_location_news",
         "world_news_story",
         "worldwide_office_staff_role",
+        "worldwide_office",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/content_schemas/dist/formats/generic_with_external_related_links/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/generic_with_external_related_links/publisher_v2/schema.json
@@ -228,6 +228,7 @@
         "world_location_news",
         "world_news_story",
         "worldwide_office_staff_role",
+        "worldwide_office",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/content_schemas/dist/formats/historic_appointments/frontend/schema.json
+++ b/content_schemas/dist/formats/historic_appointments/frontend/schema.json
@@ -218,6 +218,7 @@
         "world_location_news",
         "world_news_story",
         "worldwide_office_staff_role",
+        "worldwide_office",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/content_schemas/dist/formats/historic_appointments/notification/schema.json
+++ b/content_schemas/dist/formats/historic_appointments/notification/schema.json
@@ -242,6 +242,7 @@
         "world_location_news",
         "world_news_story",
         "worldwide_office_staff_role",
+        "worldwide_office",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/content_schemas/dist/formats/historic_appointments/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/historic_appointments/publisher_v2/schema.json
@@ -228,6 +228,7 @@
         "world_location_news",
         "world_news_story",
         "worldwide_office_staff_role",
+        "worldwide_office",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/content_schemas/dist/formats/placeholder/frontend/schema.json
+++ b/content_schemas/dist/formats/placeholder/frontend/schema.json
@@ -218,6 +218,7 @@
         "world_location_news",
         "world_news_story",
         "worldwide_office_staff_role",
+        "worldwide_office",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/content_schemas/dist/formats/placeholder/notification/schema.json
+++ b/content_schemas/dist/formats/placeholder/notification/schema.json
@@ -242,6 +242,7 @@
         "world_location_news",
         "world_news_story",
         "worldwide_office_staff_role",
+        "worldwide_office",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/content_schemas/dist/formats/placeholder/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/placeholder/publisher_v2/schema.json
@@ -228,6 +228,7 @@
         "world_location_news",
         "world_news_story",
         "worldwide_office_staff_role",
+        "worldwide_office",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/content_schemas/dist/formats/special_route/frontend/schema.json
+++ b/content_schemas/dist/formats/special_route/frontend/schema.json
@@ -220,6 +220,7 @@
         "world_location_news",
         "world_news_story",
         "worldwide_office_staff_role",
+        "worldwide_office",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/content_schemas/dist/formats/special_route/notification/schema.json
+++ b/content_schemas/dist/formats/special_route/notification/schema.json
@@ -244,6 +244,7 @@
         "world_location_news",
         "world_news_story",
         "worldwide_office_staff_role",
+        "worldwide_office",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/content_schemas/dist/formats/special_route/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/special_route/publisher_v2/schema.json
@@ -227,6 +227,7 @@
         "world_location_news",
         "world_news_story",
         "worldwide_office_staff_role",
+        "worldwide_office",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/content_schemas/dist/formats/topical_event/frontend/schema.json
+++ b/content_schemas/dist/formats/topical_event/frontend/schema.json
@@ -218,6 +218,7 @@
         "world_location_news",
         "world_news_story",
         "worldwide_office_staff_role",
+        "worldwide_office",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/content_schemas/dist/formats/topical_event/notification/schema.json
+++ b/content_schemas/dist/formats/topical_event/notification/schema.json
@@ -242,6 +242,7 @@
         "world_location_news",
         "world_news_story",
         "worldwide_office_staff_role",
+        "worldwide_office",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/content_schemas/dist/formats/topical_event/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/topical_event/publisher_v2/schema.json
@@ -228,6 +228,7 @@
         "world_location_news",
         "world_news_story",
         "worldwide_office_staff_role",
+        "worldwide_office",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/content_schemas/dist/formats/world_location_news/frontend/schema.json
+++ b/content_schemas/dist/formats/world_location_news/frontend/schema.json
@@ -218,6 +218,7 @@
         "world_location_news",
         "world_news_story",
         "worldwide_office_staff_role",
+        "worldwide_office",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/content_schemas/dist/formats/world_location_news/notification/schema.json
+++ b/content_schemas/dist/formats/world_location_news/notification/schema.json
@@ -242,6 +242,7 @@
         "world_location_news",
         "world_news_story",
         "worldwide_office_staff_role",
+        "worldwide_office",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/content_schemas/dist/formats/worldwide_office/frontend/schema.json
+++ b/content_schemas/dist/formats/worldwide_office/frontend/schema.json
@@ -2,29 +2,17 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
   "required": [
-    "analytics_identifier",
     "base_path",
     "content_id",
     "description",
     "details",
     "document_type",
-    "email_document_supertype",
-    "expanded_links",
-    "first_published_at",
-    "government_document_supertype",
-    "govuk_request_id",
     "links",
     "locale",
-    "payload_version",
-    "phase",
     "public_updated_at",
-    "publishing_app",
-    "redirects",
-    "rendering_app",
-    "routes",
     "schema_name",
     "title",
-    "update_type"
+    "updated_at"
   ],
   "additionalProperties": false,
   "properties": {
@@ -36,18 +24,6 @@
     },
     "content_id": {
       "$ref": "#/definitions/guid"
-    },
-    "content_purpose_document_supertype": {
-      "description": "DEPRECATED. Use `content_purpose_subgroup`.",
-      "type": "string"
-    },
-    "content_purpose_subgroup": {
-      "description": "Document subgroup grouping documents by purpose. Narrows down the purpose defined in content_purpose_supergroup.",
-      "type": "string"
-    },
-    "content_purpose_supergroup": {
-      "description": "Document supergroup grouping documents by a purpose",
-      "type": "string"
     },
     "description": {
       "$ref": "#/definitions/description_optional"
@@ -247,11 +223,17 @@
         "written_statement"
       ]
     },
-    "email_document_supertype": {
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
-      "type": "string"
+    "first_published_at": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/first_published_at"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
-    "expanded_links": {
+    "links": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
@@ -265,6 +247,10 @@
         },
         "children": {
           "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
+        "contact": {
+          "description": "Contact details for this Worldwide Office",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "document_collections": {
@@ -363,95 +349,14 @@
         }
       }
     },
-    "first_published_at": {
-      "$ref": "#/definitions/first_published_at"
-    },
-    "government_document_supertype": {
-      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
-      "type": "string"
-    },
-    "govuk_request_id": {
-      "$ref": "#/definitions/govuk_request_id"
-    },
-    "links": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "finder": {
-          "description": "Powers links from content back to finders the content is surfaced on",
-          "$ref": "#/definitions/guid_list"
-        },
-        "lead_organisations": {
-          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "mainstream_browse_pages": {
-          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "meets_user_needs": {
-          "description": "The user needs this piece of content meets.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "ordered_related_items": {
-          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "ordered_related_items_overrides": {
-          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "organisations": {
-          "description": "All organisations linked to this content item. This should include lead organisations.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "original_primary_publishing_organisation": {
-          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "parent": {
-          "description": "The parent content item.",
-          "$ref": "#/definitions/guid_list",
-          "maxItems": 1
-        },
-        "policy_areas": {
-          "description": "A largely deprecated tag currently only used to power email alerts.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "primary_publishing_organisation": {
-          "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
-          "$ref": "#/definitions/guid_list",
-          "maxItems": 1
-        },
-        "suggested_ordered_related_items": {
-          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "taxons": {
-          "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/guid_list"
-        }
-      }
-    },
     "locale": {
       "$ref": "#/definitions/locale"
-    },
-    "navigation_document_supertype": {
-      "description": "Document type grouping powering the new taxonomy-based navigation pages",
-      "type": "string"
     },
     "need_ids": {
       "type": "array",
       "items": {
         "type": "string"
       }
-    },
-    "payload_version": {
-      "$ref": "#/definitions/payload_version"
     },
     "phase": {
       "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
@@ -463,7 +368,14 @@
       ]
     },
     "public_updated_at": {
-      "$ref": "#/definitions/public_updated_at"
+      "anyOf": [
+        {
+          "$ref": "#/definitions/public_updated_at"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "publishing_app": {
       "$ref": "#/definitions/publishing_app_name"
@@ -471,40 +383,41 @@
     "publishing_request_id": {
       "$ref": "#/definitions/publishing_request_id"
     },
-    "redirects": {
-      "type": "array",
-      "additionalItems": false,
-      "items": {}
+    "publishing_scheduled_at": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/publishing_scheduled_at"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "rendering_app": {
       "$ref": "#/definitions/rendering_app"
     },
-    "routes": {
-      "$ref": "#/definitions/routes"
+    "scheduled_publishing_delay_seconds": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/scheduled_publishing_delay_seconds"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "schema_name": {
       "type": "string",
       "enum": [
-        "generic_with_external_related_links"
+        "worldwide_office"
       ]
-    },
-    "search_user_need_document_supertype": {
-      "description": "Document supertype grouping core and government documents",
-      "type": "string"
     },
     "title": {
       "$ref": "#/definitions/title"
     },
-    "update_type": {
-      "$ref": "#/definitions/update_type"
-    },
-    "user_journey_document_supertype": {
-      "description": "Document type grouping powering analytics of user journeys",
-      "type": "string"
-    },
-    "user_need_document_supertype": {
-      "description": "DEPRECATED. Use `content_purpose_document_supertype`.",
-      "type": "string"
+    "updated_at": {
+      "type": "string",
+      "format": "date-time"
     },
     "withdrawn_notice": {
       "$ref": "#/definitions/withdrawn_notice"
@@ -565,35 +478,16 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "access_and_opening_times": {
+          "description": "The access and opening times for this Worldwide Office.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "change_history": {
           "$ref": "#/definitions/change_history"
-        },
-        "external_related_links": {
-          "$ref": "#/definitions/external_related_links"
         }
-      }
-    },
-    "external_link": {
-      "type": "object",
-      "required": [
-        "title",
-        "url"
-      ],
-      "additionalProperties": false,
-      "properties": {
-        "title": {
-          "type": "string"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        }
-      }
-    },
-    "external_related_links": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/external_link"
       }
     },
     "first_published_at": {
@@ -734,22 +628,9 @@
         }
       }
     },
-    "govuk_request_id": {
-      "type": [
-        "string",
-        "null"
-      ]
-    },
     "guid": {
       "type": "string",
       "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
-    },
-    "guid_list": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      },
-      "uniqueItems": true
     },
     "locale": {
       "type": "string",
@@ -822,10 +703,6 @@
         "zh-tw"
       ]
     },
-    "payload_version": {
-      "description": "Counter to indicate when the payload was generated",
-      "type": "integer"
-    },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
@@ -881,6 +758,11 @@
         }
       ]
     },
+    "publishing_scheduled_at": {
+      "description": "When this content was last scheduled for publishing. Determined by the publishing intent sent by the publishing API.",
+      "type": "string",
+      "format": "date-time"
+    },
     "rendering_app": {
       "description": "The application that renders this item.",
       "type": "string",
@@ -909,41 +791,12 @@
         "whitehall-frontend"
       ]
     },
-    "route": {
-      "type": "object",
-      "required": [
-        "path",
-        "type"
-      ],
-      "additionalProperties": false,
-      "properties": {
-        "path": {
-          "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "routes": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/route"
-      },
-      "minItems": 1
+    "scheduled_publishing_delay_seconds": {
+      "description": "The delay between the most recent scheduled and actual publishing times. Determined by the content store based on the publishing intent.",
+      "type": "integer"
     },
     "title": {
       "type": "string"
-    },
-    "update_type": {
-      "enum": [
-        "major",
-        "minor",
-        "republish"
-      ]
     },
     "withdrawn_notice": {
       "type": "object",

--- a/content_schemas/dist/formats/worldwide_office/notification/schema.json
+++ b/content_schemas/dist/formats/worldwide_office/notification/schema.json
@@ -267,6 +267,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "contact": {
+          "description": "Contact details for this Worldwide Office",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "document_collections": {
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -377,6 +381,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "contact": {
+          "description": "Contact details for this Worldwide Office",
+          "$ref": "#/definitions/guid_list"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"
@@ -485,7 +493,7 @@
     "schema_name": {
       "type": "string",
       "enum": [
-        "generic_with_external_related_links"
+        "worldwide_office"
       ]
     },
     "search_user_need_document_supertype": {
@@ -565,35 +573,16 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "access_and_opening_times": {
+          "description": "The access and opening times for this Worldwide Office.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "change_history": {
           "$ref": "#/definitions/change_history"
-        },
-        "external_related_links": {
-          "$ref": "#/definitions/external_related_links"
         }
-      }
-    },
-    "external_link": {
-      "type": "object",
-      "required": [
-        "title",
-        "url"
-      ],
-      "additionalProperties": false,
-      "properties": {
-        "title": {
-          "type": "string"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        }
-      }
-    },
-    "external_related_links": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/external_link"
       }
     },
     "first_published_at": {

--- a/content_schemas/dist/formats/worldwide_office/publisher_v2/links.json
+++ b/content_schemas/dist/formats/worldwide_office/publisher_v2/links.json
@@ -1,0 +1,94 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "bulk_publishing": {
+      "type": "boolean"
+    },
+    "links": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "contact": {
+          "description": "Contact details for this Worldwide Office",
+          "$ref": "#/definitions/guid_list"
+        },
+        "finder": {
+          "description": "Powers links from content back to finders the content is surfaced on",
+          "$ref": "#/definitions/guid_list"
+        },
+        "lead_organisations": {
+          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "mainstream_browse_pages": {
+          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "meets_user_needs": {
+          "description": "The user needs this piece of content meets.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "parent": {
+          "description": "The parent content item.",
+          "$ref": "#/definitions/guid_list",
+          "maxItems": 1
+        },
+        "policy_areas": {
+          "description": "A largely deprecated tag currently only used to power email alerts.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "primary_publishing_organisation": {
+          "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/guid_list",
+          "maxItems": 1
+        },
+        "suggested_ordered_related_items": {
+          "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
+          "$ref": "#/definitions/guid_list"
+        },
+        "topics": {
+          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+          "$ref": "#/definitions/guid_list"
+        }
+      }
+    },
+    "previous_version": {
+      "type": "string"
+    }
+  },
+  "definitions": {
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    }
+  }
+}

--- a/content_schemas/dist/formats/worldwide_office/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/worldwide_office/publisher_v2/schema.json
@@ -292,7 +292,7 @@
     "schema_name": {
       "type": "string",
       "enum": [
-        "world_location_news"
+        "worldwide_office"
       ]
     },
     "title": {
@@ -354,27 +354,13 @@
     },
     "details": {
       "type": "object",
-      "required": [
-        "ordered_featured_links",
-        "mission_statement",
-        "ordered_featured_documents"
-      ],
       "additionalProperties": false,
       "properties": {
-        "mission_statement": {
-          "type": "string"
-        },
-        "ordered_featured_documents": {
-          "$ref": "#/definitions/ordered_featured_documents"
-        },
-        "ordered_featured_links": {
-          "$ref": "#/definitions/ordered_featured_links"
-        },
-        "world_location_news_type": {
-          "type": "string",
-          "enum": [
-            "international_delegation",
-            "world_location"
+        "access_and_opening_times": {
+          "description": "The access and opening times for this Worldwide Office.",
+          "type": [
+            "string",
+            "null"
           ]
         }
       }
@@ -394,48 +380,6 @@
         "$ref": "#/definitions/guid"
       },
       "uniqueItems": true
-    },
-    "image": {
-      "type": "object",
-      "required": [
-        "url"
-      ],
-      "additionalProperties": false,
-      "properties": {
-        "alt_text": {
-          "type": "string"
-        },
-        "caption": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "credit": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ]
-        },
-        "high_resolution_url": {
-          "description": "URL to a high resolution version of the image, for use by third parties such as Twitter, Facebook or Slack. Used by the machine readable metadata component. Don't use this on user-facing web pages, as it might be very large.",
-          "type": "string",
-          "format": "uri"
-        },
-        "url": {
-          "description": "URL to the image. The image should be in a suitable resolution for display on the page.",
-          "type": "string",
-          "format": "uri"
-        }
-      }
     },
     "locale": {
       "type": "string",
@@ -507,68 +451,6 @@
         "zh-hk",
         "zh-tw"
       ]
-    },
-    "ordered_featured_documents": {
-      "description": "A set of featured documents to display.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "required": [
-          "title",
-          "href",
-          "image",
-          "summary",
-          "public_updated_at",
-          "document_type"
-        ],
-        "additionalProperties": false,
-        "properties": {
-          "document_type": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "href": {
-            "type": "string"
-          },
-          "image": {
-            "$ref": "#/definitions/image"
-          },
-          "public_updated_at": {
-            "type": [
-              "string",
-              "null"
-            ]
-          },
-          "summary": {
-            "type": "string"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "ordered_featured_links": {
-      "description": "A set of featured links to display.",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "required": [
-          "title",
-          "href"
-        ],
-        "additionalProperties": false,
-        "properties": {
-          "href": {
-            "type": "string"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",

--- a/content_schemas/dist/formats/worldwide_organisation/frontend/schema.json
+++ b/content_schemas/dist/formats/worldwide_organisation/frontend/schema.json
@@ -218,6 +218,7 @@
         "world_location_news",
         "world_news_story",
         "worldwide_office_staff_role",
+        "worldwide_office",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/content_schemas/dist/formats/worldwide_organisation/notification/schema.json
+++ b/content_schemas/dist/formats/worldwide_organisation/notification/schema.json
@@ -242,6 +242,7 @@
         "world_location_news",
         "world_news_story",
         "worldwide_office_staff_role",
+        "worldwide_office",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/content_schemas/dist/formats/worldwide_organisation/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/worldwide_organisation/publisher_v2/schema.json
@@ -228,6 +228,7 @@
         "world_location_news",
         "world_news_story",
         "worldwide_office_staff_role",
+        "worldwide_office",
         "worldwide_organisation",
         "written_statement"
       ]

--- a/content_schemas/examples/worldwide_office/frontend/worldwide_office.json
+++ b/content_schemas/examples/worldwide_office/frontend/worldwide_office.json
@@ -1,0 +1,17 @@
+{
+  "base_path": "/world/organisations/british-consulate-general-atlanta/office/british-consulate-general-atlanta",
+  "content_id": "e9789264-2d9c-4776-8ecc-2f7aa681d456",
+  "description": "",
+  "locale": "en",
+  "publishing_app": "whitehall",
+  "rendering_app": "collections",
+  "schema_name": "worldwide_office",
+  "document_type": "worldwide_office",
+  "title": "British Consulate General Atlanta",
+  "public_updated_at": "2016-09-14T18:19:27+01:00",
+  "updated_at": "2016-09-14T10:37:00Z",
+  "details": {
+    "access_and_opening_times": "<div class=\"govspeak\"><p>Telephone: 9.00am to 4.00pm Monday to Friday (except Public Holidays), Emergency Consular Service for British nationals available out of hours.</p></div>"
+  },
+  "links": {}
+}

--- a/content_schemas/formats/worldwide_office.jsonnet
+++ b/content_schemas/formats/worldwide_office.jsonnet
@@ -1,0 +1,20 @@
+(import "shared/default_format.jsonnet") + {
+  definitions: (import "shared/definitions/_whitehall.jsonnet") + {
+    details: {
+      type: "object",
+      additionalProperties: false,
+      properties: {
+        access_and_opening_times: {
+           type: [
+             "string",
+             "null",
+           ],
+           description: "The access and opening times for this Worldwide Office.",
+         },
+      },
+    },
+  },
+  links: (import "shared/base_links.jsonnet") + {
+    contact: "Contact details for this Worldwide Office",
+  },
+}


### PR DESCRIPTION
https://trello.com/c/CUp57yUx

### Add schema format for Worldwide Offices
We are moving the rendering of Worldwide Organisations out of Whitehall. As
part of this, we also need to move the related Worldwide Office pages.

### Generate schemas for Worldwide Offices
Generate schemas from the format added in the previous commit.

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
