### PR TITLE
Require the world_locations property in embassies_index schema

### DIFF
--- a/content_schemas/dist/formats/embassies_index/frontend/schema.json
+++ b/content_schemas/dist/formats/embassies_index/frontend/schema.json
@@ -473,6 +473,9 @@
     },
     "details": {
       "type": "object",
+      "required": [
+        "world_locations"
+      ],
       "additionalProperties": false,
       "properties": {
         "change_history": {

--- a/content_schemas/dist/formats/embassies_index/notification/schema.json
+++ b/content_schemas/dist/formats/embassies_index/notification/schema.json
@@ -564,6 +564,9 @@
     },
     "details": {
       "type": "object",
+      "required": [
+        "world_locations"
+      ],
       "additionalProperties": false,
       "properties": {
         "change_history": {

--- a/content_schemas/dist/formats/embassies_index/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/embassies_index/publisher_v2/schema.json
@@ -355,6 +355,9 @@
     },
     "details": {
       "type": "object",
+      "required": [
+        "world_locations"
+      ],
       "additionalProperties": false,
       "properties": {
         "world_locations": {

--- a/content_schemas/formats/embassies_index.jsonnet
+++ b/content_schemas/formats/embassies_index.jsonnet
@@ -107,6 +107,9 @@
     details: {
       type: "object",
       additionalProperties: false,
+      required: [
+        "world_locations"
+      ],
       properties: {
         world_locations: {
           type: "array",


### PR DESCRIPTION
We couldn't add this initially as we had to make a backward-compatible change to the schema so that Whitehall could continue to publish the static embassies_index document until we [switched Whitehall to publish the dynamic embassies_index document][1]. Now that Whitehall is publishing the dynamic document we always expected `world_locations` to be present.

[1]: https://github.com/alphagov/whitehall/pull/7596

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
