### PR TITLE
Regenerate worldwide_office schemas

### DIFF
--- a/content_schemas/dist/formats/worldwide_office/frontend/schema.json
+++ b/content_schemas/dist/formats/worldwide_office/frontend/schema.json
@@ -118,6 +118,7 @@
         "local_transaction",
         "maib_report",
         "mainstream_browse_page",
+        "marine_equipment_approved_recommendation",
         "manual",
         "manual_section",
         "map",

--- a/content_schemas/dist/formats/worldwide_office/notification/schema.json
+++ b/content_schemas/dist/formats/worldwide_office/notification/schema.json
@@ -142,6 +142,7 @@
         "local_transaction",
         "maib_report",
         "mainstream_browse_page",
+        "marine_equipment_approved_recommendation",
         "manual",
         "manual_section",
         "map",

--- a/content_schemas/dist/formats/worldwide_office/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/worldwide_office/publisher_v2/schema.json
@@ -128,6 +128,7 @@
         "local_transaction",
         "maib_report",
         "mainstream_browse_page",
+        "marine_equipment_approved_recommendation",
         "manual",
         "manual_section",
         "map",


### PR DESCRIPTION
To include the `marine_equipment_approved_recommendation` document type in the worldwide_office schemas.

By running `rake build_schemas`.

The `marine_equipment_approved_recommendation` document type was added in [PR 2343][1] and the worldwide_office schema was added in [PR 2361][2]. We're not sure why the tests didn't fail when the second of these was merged into main.

[1]: https://github.com/alphagov/publishing-api/pull/2343
[2]: https://github.com/alphagov/publishing-api/pull/2361

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
