### PR TITLE
Add ordered_roles to ministerial departments

### DIFF
--- a/lib/expansion_rules.rb
+++ b/lib/expansion_rules.rb
@@ -43,6 +43,7 @@ module_function
     %i[ordered_junior_lords_of_the_treasury_whips role_appointments role],
     %i[ordered_military_personnel role_appointments role],
     %i[ordered_ministerial_departments ordered_ministers role_appointments role],
+    %i[ordered_ministerial_departments ordered_roles],
     %i[ordered_ministers role_appointments role],
     %i[ordered_special_representatives role_appointments role],
     %i[ordered_traffic_commissioners role_appointments role],


### PR DESCRIPTION
Collections is going to be responsible for rendering the Ministers index page, which includes a Ministers by department section showing each department's ministers and their relevant roles.

Whitehall publishes the departments and associated ministers, with their correct order, but the roles are added later, in the link expansion process. This lists all the roles, whether they are relevant for the department being shown or not.

In order to show only a minister's relevant roles within the org being shown, collections needs to know which roles are associated with it.

We tried[1] expanding `ordered_parent_organisations` into the role, but for some reason the ministerial department at the root link isn't included in the "leaf" node. (We suspect this may be intentional to avoid including a record in itself, but we weren't able to determine this for certain in a reasonable amount of time.)

I haven't added a spec because we don't seem to have specs for inclusion in `MULTI_LEVEL_LINK_PATHS`. The existing specs are testing that custom fields are included, but `ordered_ministerial_departments` aren't customised in any way.

[1] https://github.com/alphagov/publishing-api/pull/2364

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
