### PR TITLE
Add CDEI Assurance Techniques finder

### DIFF
--- a/content_schemas/allowed_document_types.yml
+++ b/content_schemas/allowed_document_types.yml
@@ -3,6 +3,7 @@
 - about_our_services
 - accessible_documents_policy
 - access_and_opening
+- ai_assurance_portfolio_technique
 - ambassador_role
 - animal_disease_case
 - answer

--- a/content_schemas/dist/formats/embassies_index/frontend/schema.json
+++ b/content_schemas/dist/formats/embassies_index/frontend/schema.json
@@ -39,6 +39,7 @@
         "about_our_services",
         "accessible_documents_policy",
         "access_and_opening",
+        "ai_assurance_portfolio_technique",
         "ambassador_role",
         "animal_disease_case",
         "answer",

--- a/content_schemas/dist/formats/embassies_index/notification/schema.json
+++ b/content_schemas/dist/formats/embassies_index/notification/schema.json
@@ -63,6 +63,7 @@
         "about_our_services",
         "accessible_documents_policy",
         "access_and_opening",
+        "ai_assurance_portfolio_technique",
         "ambassador_role",
         "animal_disease_case",
         "answer",

--- a/content_schemas/dist/formats/embassies_index/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/embassies_index/publisher_v2/schema.json
@@ -49,6 +49,7 @@
         "about_our_services",
         "accessible_documents_policy",
         "access_and_opening",
+        "ai_assurance_portfolio_technique",
         "ambassador_role",
         "animal_disease_case",
         "answer",

--- a/content_schemas/dist/formats/field_of_operation/frontend/schema.json
+++ b/content_schemas/dist/formats/field_of_operation/frontend/schema.json
@@ -39,6 +39,7 @@
         "about_our_services",
         "accessible_documents_policy",
         "access_and_opening",
+        "ai_assurance_portfolio_technique",
         "ambassador_role",
         "animal_disease_case",
         "answer",

--- a/content_schemas/dist/formats/field_of_operation/notification/schema.json
+++ b/content_schemas/dist/formats/field_of_operation/notification/schema.json
@@ -63,6 +63,7 @@
         "about_our_services",
         "accessible_documents_policy",
         "access_and_opening",
+        "ai_assurance_portfolio_technique",
         "ambassador_role",
         "animal_disease_case",
         "answer",

--- a/content_schemas/dist/formats/field_of_operation/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/field_of_operation/publisher_v2/schema.json
@@ -49,6 +49,7 @@
         "about_our_services",
         "accessible_documents_policy",
         "access_and_opening",
+        "ai_assurance_portfolio_technique",
         "ambassador_role",
         "animal_disease_case",
         "answer",

--- a/content_schemas/dist/formats/generic/frontend/schema.json
+++ b/content_schemas/dist/formats/generic/frontend/schema.json
@@ -39,6 +39,7 @@
         "about_our_services",
         "accessible_documents_policy",
         "access_and_opening",
+        "ai_assurance_portfolio_technique",
         "ambassador_role",
         "animal_disease_case",
         "answer",

--- a/content_schemas/dist/formats/generic/notification/schema.json
+++ b/content_schemas/dist/formats/generic/notification/schema.json
@@ -63,6 +63,7 @@
         "about_our_services",
         "accessible_documents_policy",
         "access_and_opening",
+        "ai_assurance_portfolio_technique",
         "ambassador_role",
         "animal_disease_case",
         "answer",

--- a/content_schemas/dist/formats/generic/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/generic/publisher_v2/schema.json
@@ -49,6 +49,7 @@
         "about_our_services",
         "accessible_documents_policy",
         "access_and_opening",
+        "ai_assurance_portfolio_technique",
         "ambassador_role",
         "animal_disease_case",
         "answer",

--- a/content_schemas/dist/formats/generic_with_external_related_links/frontend/schema.json
+++ b/content_schemas/dist/formats/generic_with_external_related_links/frontend/schema.json
@@ -39,6 +39,7 @@
         "about_our_services",
         "accessible_documents_policy",
         "access_and_opening",
+        "ai_assurance_portfolio_technique",
         "ambassador_role",
         "animal_disease_case",
         "answer",

--- a/content_schemas/dist/formats/generic_with_external_related_links/notification/schema.json
+++ b/content_schemas/dist/formats/generic_with_external_related_links/notification/schema.json
@@ -63,6 +63,7 @@
         "about_our_services",
         "accessible_documents_policy",
         "access_and_opening",
+        "ai_assurance_portfolio_technique",
         "ambassador_role",
         "animal_disease_case",
         "answer",

--- a/content_schemas/dist/formats/generic_with_external_related_links/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/generic_with_external_related_links/publisher_v2/schema.json
@@ -49,6 +49,7 @@
         "about_our_services",
         "accessible_documents_policy",
         "access_and_opening",
+        "ai_assurance_portfolio_technique",
         "ambassador_role",
         "animal_disease_case",
         "answer",

--- a/content_schemas/dist/formats/historic_appointments/frontend/schema.json
+++ b/content_schemas/dist/formats/historic_appointments/frontend/schema.json
@@ -39,6 +39,7 @@
         "about_our_services",
         "accessible_documents_policy",
         "access_and_opening",
+        "ai_assurance_portfolio_technique",
         "ambassador_role",
         "animal_disease_case",
         "answer",

--- a/content_schemas/dist/formats/historic_appointments/notification/schema.json
+++ b/content_schemas/dist/formats/historic_appointments/notification/schema.json
@@ -63,6 +63,7 @@
         "about_our_services",
         "accessible_documents_policy",
         "access_and_opening",
+        "ai_assurance_portfolio_technique",
         "ambassador_role",
         "animal_disease_case",
         "answer",

--- a/content_schemas/dist/formats/historic_appointments/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/historic_appointments/publisher_v2/schema.json
@@ -49,6 +49,7 @@
         "about_our_services",
         "accessible_documents_policy",
         "access_and_opening",
+        "ai_assurance_portfolio_technique",
         "ambassador_role",
         "animal_disease_case",
         "answer",

--- a/content_schemas/dist/formats/placeholder/frontend/schema.json
+++ b/content_schemas/dist/formats/placeholder/frontend/schema.json
@@ -39,6 +39,7 @@
         "about_our_services",
         "accessible_documents_policy",
         "access_and_opening",
+        "ai_assurance_portfolio_technique",
         "ambassador_role",
         "animal_disease_case",
         "answer",

--- a/content_schemas/dist/formats/placeholder/notification/schema.json
+++ b/content_schemas/dist/formats/placeholder/notification/schema.json
@@ -63,6 +63,7 @@
         "about_our_services",
         "accessible_documents_policy",
         "access_and_opening",
+        "ai_assurance_portfolio_technique",
         "ambassador_role",
         "animal_disease_case",
         "answer",

--- a/content_schemas/dist/formats/placeholder/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/placeholder/publisher_v2/schema.json
@@ -49,6 +49,7 @@
         "about_our_services",
         "accessible_documents_policy",
         "access_and_opening",
+        "ai_assurance_portfolio_technique",
         "ambassador_role",
         "animal_disease_case",
         "answer",

--- a/content_schemas/dist/formats/special_route/frontend/schema.json
+++ b/content_schemas/dist/formats/special_route/frontend/schema.json
@@ -41,6 +41,7 @@
         "about_our_services",
         "accessible_documents_policy",
         "access_and_opening",
+        "ai_assurance_portfolio_technique",
         "ambassador_role",
         "animal_disease_case",
         "answer",

--- a/content_schemas/dist/formats/special_route/notification/schema.json
+++ b/content_schemas/dist/formats/special_route/notification/schema.json
@@ -65,6 +65,7 @@
         "about_our_services",
         "accessible_documents_policy",
         "access_and_opening",
+        "ai_assurance_portfolio_technique",
         "ambassador_role",
         "animal_disease_case",
         "answer",

--- a/content_schemas/dist/formats/special_route/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/special_route/publisher_v2/schema.json
@@ -48,6 +48,7 @@
         "about_our_services",
         "accessible_documents_policy",
         "access_and_opening",
+        "ai_assurance_portfolio_technique",
         "ambassador_role",
         "animal_disease_case",
         "answer",

--- a/content_schemas/dist/formats/specialist_document/frontend/schema.json
+++ b/content_schemas/dist/formats/specialist_document/frontend/schema.json
@@ -35,6 +35,7 @@
       "type": "string",
       "enum": [
         "aaib_report",
+        "ai_assurance_portfolio_technique",
         "animal_disease_case",
         "asylum_support_decision",
         "business_finance_support_scheme",
@@ -323,6 +324,107 @@
       "type": "string",
       "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
     },
+    "ai_assurance_portfolio_technique_metadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "ai_assurance_technique": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "data-assurance",
+              "compliance-audit",
+              "formal-verification",
+              "performance-testing",
+              "certification",
+              "risk-assessment",
+              "impact-assessment",
+              "impact-evaluation",
+              "conformity-assessment",
+              "bias-audit"
+            ]
+          }
+        },
+        "bulk_published": {
+          "type": "boolean"
+        },
+        "key_function": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "r-and-d",
+              "product-and-service-development",
+              "manufacturing",
+              "service-operations",
+              "supply-chain-management",
+              "human-resources",
+              "marketing-and-sales",
+              "customer-services",
+              "risk-management",
+              "strategy-and-corporate-finance"
+            ]
+          }
+        },
+        "principle": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "safety-security-and-robustness",
+              "appropriate-transparency-and-explainability",
+              "fairness",
+              "accountability-and-governance",
+              "contestability-and-redress"
+            ]
+          }
+        },
+        "sector": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "agriculture-forestry-and-fishing",
+              "mining-and-quarrying",
+              "manufacturing",
+              "energy-and-utilities",
+              "construction",
+              "retail",
+              "transportation-and-storage",
+              "accommodation-and-food-service",
+              "digital-and-comms",
+              "financial-and-insurance",
+              "real-estate",
+              "professional-scientific-and-professional-activities",
+              "administrative-and-support-services",
+              "public-administration-and-defence",
+              "education",
+              "healthcare-and-social-work",
+              "arts-entertainment-and-recreation",
+              "other-services"
+            ]
+          }
+        },
+        "use_case": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "big-data-analytics",
+              "data-driven-profiling",
+              "natural-language-processing-and-generation",
+              "image-recognition-and-video-processing",
+              "machine-learning",
+              "deep-learning",
+              "virtual-agents-or-artificial-conversational-interfaces",
+              "robotic-process-automation-and-decision-management",
+              "robotics-and-autonomous-vehicles-systems"
+            ]
+          }
+        }
+      }
+    },
     "analytics_identifier": {
       "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
       "anyOf": [
@@ -404,6 +506,9 @@
       "anyOf": [
         {
           "$ref": "#/definitions/aaib_report_metadata"
+        },
+        {
+          "$ref": "#/definitions/ai_assurance_portfolio_technique_metadata"
         },
         {
           "$ref": "#/definitions/animal_disease_case_metadata"

--- a/content_schemas/dist/formats/specialist_document/notification/schema.json
+++ b/content_schemas/dist/formats/specialist_document/notification/schema.json
@@ -59,6 +59,7 @@
       "type": "string",
       "enum": [
         "aaib_report",
+        "ai_assurance_portfolio_technique",
         "animal_disease_case",
         "asylum_support_decision",
         "business_finance_support_scheme",
@@ -415,6 +416,107 @@
       "type": "string",
       "pattern": "^/(([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})+(/([a-zA-Z0-9._~!$&'()*+,;=:@-]|%[0-9a-fA-F]{2})*)*)?$"
     },
+    "ai_assurance_portfolio_technique_metadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "ai_assurance_technique": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "data-assurance",
+              "compliance-audit",
+              "formal-verification",
+              "performance-testing",
+              "certification",
+              "risk-assessment",
+              "impact-assessment",
+              "impact-evaluation",
+              "conformity-assessment",
+              "bias-audit"
+            ]
+          }
+        },
+        "bulk_published": {
+          "type": "boolean"
+        },
+        "key_function": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "r-and-d",
+              "product-and-service-development",
+              "manufacturing",
+              "service-operations",
+              "supply-chain-management",
+              "human-resources",
+              "marketing-and-sales",
+              "customer-services",
+              "risk-management",
+              "strategy-and-corporate-finance"
+            ]
+          }
+        },
+        "principle": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "safety-security-and-robustness",
+              "appropriate-transparency-and-explainability",
+              "fairness",
+              "accountability-and-governance",
+              "contestability-and-redress"
+            ]
+          }
+        },
+        "sector": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "agriculture-forestry-and-fishing",
+              "mining-and-quarrying",
+              "manufacturing",
+              "energy-and-utilities",
+              "construction",
+              "retail",
+              "transportation-and-storage",
+              "accommodation-and-food-service",
+              "digital-and-comms",
+              "financial-and-insurance",
+              "real-estate",
+              "professional-scientific-and-professional-activities",
+              "administrative-and-support-services",
+              "public-administration-and-defence",
+              "education",
+              "healthcare-and-social-work",
+              "arts-entertainment-and-recreation",
+              "other-services"
+            ]
+          }
+        },
+        "use_case": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "big-data-analytics",
+              "data-driven-profiling",
+              "natural-language-processing-and-generation",
+              "image-recognition-and-video-processing",
+              "machine-learning",
+              "deep-learning",
+              "virtual-agents-or-artificial-conversational-interfaces",
+              "robotic-process-automation-and-decision-management",
+              "robotics-and-autonomous-vehicles-systems"
+            ]
+          }
+        }
+      }
+    },
     "analytics_identifier": {
       "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
       "anyOf": [
@@ -496,6 +598,9 @@
       "anyOf": [
         {
           "$ref": "#/definitions/aaib_report_metadata"
+        },
+        {
+          "$ref": "#/definitions/ai_assurance_portfolio_technique_metadata"
         },
         {
           "$ref": "#/definitions/animal_disease_case_metadata"

--- a/content_schemas/dist/formats/specialist_document/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/specialist_document/publisher_v2/schema.json
@@ -45,6 +45,7 @@
       "type": "string",
       "enum": [
         "aaib_report",
+        "ai_assurance_portfolio_technique",
         "animal_disease_case",
         "asylum_support_decision",
         "business_finance_support_scheme",
@@ -239,6 +240,107 @@
         }
       }
     },
+    "ai_assurance_portfolio_technique_metadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "ai_assurance_technique": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "data-assurance",
+              "compliance-audit",
+              "formal-verification",
+              "performance-testing",
+              "certification",
+              "risk-assessment",
+              "impact-assessment",
+              "impact-evaluation",
+              "conformity-assessment",
+              "bias-audit"
+            ]
+          }
+        },
+        "bulk_published": {
+          "type": "boolean"
+        },
+        "key_function": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "r-and-d",
+              "product-and-service-development",
+              "manufacturing",
+              "service-operations",
+              "supply-chain-management",
+              "human-resources",
+              "marketing-and-sales",
+              "customer-services",
+              "risk-management",
+              "strategy-and-corporate-finance"
+            ]
+          }
+        },
+        "principle": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "safety-security-and-robustness",
+              "appropriate-transparency-and-explainability",
+              "fairness",
+              "accountability-and-governance",
+              "contestability-and-redress"
+            ]
+          }
+        },
+        "sector": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "agriculture-forestry-and-fishing",
+              "mining-and-quarrying",
+              "manufacturing",
+              "energy-and-utilities",
+              "construction",
+              "retail",
+              "transportation-and-storage",
+              "accommodation-and-food-service",
+              "digital-and-comms",
+              "financial-and-insurance",
+              "real-estate",
+              "professional-scientific-and-professional-activities",
+              "administrative-and-support-services",
+              "public-administration-and-defence",
+              "education",
+              "healthcare-and-social-work",
+              "arts-entertainment-and-recreation",
+              "other-services"
+            ]
+          }
+        },
+        "use_case": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "big-data-analytics",
+              "data-driven-profiling",
+              "natural-language-processing-and-generation",
+              "image-recognition-and-video-processing",
+              "machine-learning",
+              "deep-learning",
+              "virtual-agents-or-artificial-conversational-interfaces",
+              "robotic-process-automation-and-decision-management",
+              "robotics-and-autonomous-vehicles-systems"
+            ]
+          }
+        }
+      }
+    },
     "analytics_identifier": {
       "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
       "anyOf": [
@@ -320,6 +422,9 @@
       "anyOf": [
         {
           "$ref": "#/definitions/aaib_report_metadata"
+        },
+        {
+          "$ref": "#/definitions/ai_assurance_portfolio_technique_metadata"
         },
         {
           "$ref": "#/definitions/animal_disease_case_metadata"

--- a/content_schemas/dist/formats/topical_event/frontend/schema.json
+++ b/content_schemas/dist/formats/topical_event/frontend/schema.json
@@ -39,6 +39,7 @@
         "about_our_services",
         "accessible_documents_policy",
         "access_and_opening",
+        "ai_assurance_portfolio_technique",
         "ambassador_role",
         "animal_disease_case",
         "answer",

--- a/content_schemas/dist/formats/topical_event/notification/schema.json
+++ b/content_schemas/dist/formats/topical_event/notification/schema.json
@@ -63,6 +63,7 @@
         "about_our_services",
         "accessible_documents_policy",
         "access_and_opening",
+        "ai_assurance_portfolio_technique",
         "ambassador_role",
         "animal_disease_case",
         "answer",

--- a/content_schemas/dist/formats/topical_event/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/topical_event/publisher_v2/schema.json
@@ -49,6 +49,7 @@
         "about_our_services",
         "accessible_documents_policy",
         "access_and_opening",
+        "ai_assurance_portfolio_technique",
         "ambassador_role",
         "animal_disease_case",
         "answer",

--- a/content_schemas/dist/formats/world_location_news/frontend/schema.json
+++ b/content_schemas/dist/formats/world_location_news/frontend/schema.json
@@ -39,6 +39,7 @@
         "about_our_services",
         "accessible_documents_policy",
         "access_and_opening",
+        "ai_assurance_portfolio_technique",
         "ambassador_role",
         "animal_disease_case",
         "answer",

--- a/content_schemas/dist/formats/world_location_news/notification/schema.json
+++ b/content_schemas/dist/formats/world_location_news/notification/schema.json
@@ -63,6 +63,7 @@
         "about_our_services",
         "accessible_documents_policy",
         "access_and_opening",
+        "ai_assurance_portfolio_technique",
         "ambassador_role",
         "animal_disease_case",
         "answer",

--- a/content_schemas/dist/formats/world_location_news/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/world_location_news/publisher_v2/schema.json
@@ -49,6 +49,7 @@
         "about_our_services",
         "accessible_documents_policy",
         "access_and_opening",
+        "ai_assurance_portfolio_technique",
         "ambassador_role",
         "animal_disease_case",
         "answer",

--- a/content_schemas/dist/formats/worldwide_office/frontend/schema.json
+++ b/content_schemas/dist/formats/worldwide_office/frontend/schema.json
@@ -39,6 +39,7 @@
         "about_our_services",
         "accessible_documents_policy",
         "access_and_opening",
+        "ai_assurance_portfolio_technique",
         "ambassador_role",
         "animal_disease_case",
         "answer",

--- a/content_schemas/dist/formats/worldwide_office/notification/schema.json
+++ b/content_schemas/dist/formats/worldwide_office/notification/schema.json
@@ -63,6 +63,7 @@
         "about_our_services",
         "accessible_documents_policy",
         "access_and_opening",
+        "ai_assurance_portfolio_technique",
         "ambassador_role",
         "animal_disease_case",
         "answer",

--- a/content_schemas/dist/formats/worldwide_office/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/worldwide_office/publisher_v2/schema.json
@@ -49,6 +49,7 @@
         "about_our_services",
         "accessible_documents_policy",
         "access_and_opening",
+        "ai_assurance_portfolio_technique",
         "ambassador_role",
         "animal_disease_case",
         "answer",

--- a/content_schemas/dist/formats/worldwide_organisation/frontend/schema.json
+++ b/content_schemas/dist/formats/worldwide_organisation/frontend/schema.json
@@ -39,6 +39,7 @@
         "about_our_services",
         "accessible_documents_policy",
         "access_and_opening",
+        "ai_assurance_portfolio_technique",
         "ambassador_role",
         "animal_disease_case",
         "answer",

--- a/content_schemas/dist/formats/worldwide_organisation/notification/schema.json
+++ b/content_schemas/dist/formats/worldwide_organisation/notification/schema.json
@@ -63,6 +63,7 @@
         "about_our_services",
         "accessible_documents_policy",
         "access_and_opening",
+        "ai_assurance_portfolio_technique",
         "ambassador_role",
         "animal_disease_case",
         "answer",

--- a/content_schemas/dist/formats/worldwide_organisation/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/worldwide_organisation/publisher_v2/schema.json
@@ -49,6 +49,7 @@
         "about_our_services",
         "accessible_documents_policy",
         "access_and_opening",
+        "ai_assurance_portfolio_technique",
         "ambassador_role",
         "animal_disease_case",
         "answer",

--- a/content_schemas/examples/specialist_document/frontend/ai-assurance-portfolio-technique.json
+++ b/content_schemas/examples/specialist_document/frontend/ai-assurance-portfolio-technique.json
@@ -1,0 +1,440 @@
+{
+  "content_id": "5e5890a0-329a-42d2-9637-9d8433fe97ae",
+  "locale": "en",
+  "base_path": "/ai-assurance-techniques/bleep-bloop-robot",
+  "title": "Bleep bloop robot",
+  "description": "The CMA is investigating the anticipated acquisition relating to Compagnie Financière Richemont S.A., Yoox S.p.A and The Net-A-Porter Group Limited. ",
+  "details": {
+    "body": "superfluous",
+    "attachments": [
+      {
+        "attachment_type": "file",
+        "id": "02338779-d8ce-4f9f-ae3c-dc21fb886219",
+        "content_id": "02338779-d8ce-4f9f-ae3c-dc21fb886219",
+        "title": "Commencement of initial period notice",
+        "url": "https://assets.digital.cabinet-office.gov.uk/media/559fc1b240f0b61564000047/Richemont-Yoox-NAP_commencement_of_initial_period_notice.pdf",
+        "updated_at": "2015-10-01T09:37:23Z",
+        "created_at": "2015-07-10T12:59:30Z",
+        "content_type": "application/pdf"
+      },
+      {
+        "attachment_type": "file",
+        "id": "5e099aef-0ea7-4af1-a1ee-0a12443079d8",
+        "content_id": "5e099aef-0ea7-4af1-a1ee-0a12443079d8",
+        "title": "Full text decision",
+        "url": "https://assets.digital.cabinet-office.gov.uk/media/560cfe8940f0b6036a000001/Richemont_Yoox_Net-A-Porter_full_text_decision.pdf",
+        "updated_at": "2015-10-01T09:37:23Z",
+        "created_at": "2015-10-01T09:36:09Z",
+        "content_type": "application/pdf"
+      }
+    ],
+    "metadata": {
+      "bulk_published": false,
+      "use_case": [
+        "deep-learning"
+      ],
+      "sector": [
+        "retail"
+      ],
+      "principle": [
+        "fairness"
+      ],
+      "key_function": [
+        "r-and-d",
+        "manufacturing"
+      ],
+      "ai_assurance_technique": [
+       "bias-audit"
+      ]
+    },
+    "max_cache_time": 10,
+    "change_history": [
+      {
+        "note": "First published.",
+        "public_timestamp": "2015-07-10T13:09:46+00:00"
+      }
+    ],
+    "headers": [
+      {
+        "text": "Statutory timetable",
+        "level": 2,
+        "id": "statutory-timetable"
+      },
+      {
+        "text": "Phase 1",
+        "level": 2,
+        "id": "phase-1",
+        "headers": [
+          {
+            "text": "Invitation to comment: closes 24 July 2015",
+            "level": 3,
+            "id": "invitation-to-comment-closes-24-july-2015"
+          },
+          {
+            "text": "Launch of CMA merger inquiry",
+            "level": 3,
+            "id": "launch-of-cma-merger-inquiry"
+          },
+          {
+            "text": "Contact",
+            "level": 3,
+            "id": "contact"
+          }
+        ]
+      }
+    ]
+  },
+  "public_updated_at": "2015-07-10T13:09:46+00:00",
+  "schema_name": "specialist_document",
+  "document_type": "ai_assurance_portfolio_technique",
+  "links": {
+    "organisations": [
+      {
+        "analytics_identifier": "OT1280",
+        "api_path": "/api/content/government/organisations/centre-for-data-ethics-and-innovation",
+        "base_path": "/government/organisations/centre-for-data-ethics-and-innovation",
+        "content_id": "1405edcb-943d-42d2-8ec8-c51cd58335a5",
+        "description": "The CDEI is a government expert body enabling the trustworthy use of data and AI. CDEI is part of the Department for Science, Innovation and Technology.",
+        "document_type": "organisation",
+        "locale": "en",
+        "public_updated_at": "2015-03-10T16:23:14Z",
+        "schema_name": "placeholder",
+        "title": "Centre for Data Ethics and Innovation",
+        "withdrawn": false,
+        "details": {
+          "brand": "cabinet-office",
+          "logo": {
+            "formatted_title": "Centre for<br/>Data Ethics<br/>and Innovation",
+            "crest": null
+          }
+        },
+        "links": {},
+        "api_url": "https://www.gov.uk/api/content/government/organisations/centre-for-data-ethics-and-innovation",
+        "web_url": "https://www.gov.uk/government/organisations/centre-for-data-ethics-and-innovation"
+      },
+      {
+        "analytics_identifier": "D1381",
+        "api_path": "/api/content/government/organisations/department-for-science-innovation-and-technology",
+        "base_path": "/government/organisations/department-for-science-innovation-and-technology",
+        "content_id": "c352c234-8083-47ec-8a4b-0edd45c31263",
+        "description": "Driving innovation that will deliver improved public services, create new better-paid jobs and grow the economy. DSIT is a ministerial department, supported by 14 agencies and public bodies.",
+        "document_type": "organisation",
+        "locale": "en",
+        "public_updated_at": "2015-03-10T16:23:14Z",
+        "schema_name": "placeholder",
+        "title": "Department for Science, Innovation and Technology",
+        "withdrawn": false,
+        "details": {
+          "brand": "department-for-science-innovation-and-technology",
+          "logo": {
+            "formatted_title": "Department for<br/>Science, Innovation<br/>& Technology",
+            "crest": null
+          }
+        },
+        "links": {},
+        "api_url": "https://www.gov.uk/api/content/government/organisations/department-for-science-innovation-and-technology",
+        "web_url": "https://www.gov.uk/government/organisations/department-for-science-innovation-and-technology"
+      }
+    ],
+    "finder": [
+      {
+        "analytics_identifier": null,
+        "api_path": "/api/content/ai-assurance-techniques",
+        "base_path": "/ai-assurance-techniques",
+
+        "content_id": "5e5890a0-329a-42d2-9637-9d8433fe97ae",
+        "description": "Find out what AI assurance is and what AI assurance techniques you can use in your organisation.",
+        "document_type": "finder",
+        "locale": "en",
+        "public_updated_at": "2017-03-15T14:44:21Z",
+        "schema_name": "finder",
+        "title": "Find out about artificial intelligence (AI) assurance techniques",
+        "withdrawn": false,
+        "details": {
+          "facets": [
+            {
+              "key": "use_case",
+              "name": "Use case",
+              "type": "text",
+              "preposition": "Use case",
+              "display_as_result_metadata": true,
+              "filterable": true,
+              "allowed_values": [
+                {
+                  "label": "Big data analytics",
+                  "value": "big-data-analytics"
+                },
+                {
+                  "label": "Data-driven profiling",
+                  "value": "data-driven-profiling"
+                },
+                {
+                  "label": "Natural language processing and generation",
+                  "value": "natural-language-processing-and-generation"
+                },
+                {
+                  "label": "Image recognition and video processing",
+                  "value": "image-recognition-and-video-processing"
+                },
+                {
+                  "label": "Machine learning",
+                  "value": "machine-learning"
+                },
+                {
+                  "label": "Deep learning",
+                  "value": "deep-learning"
+                },
+                {
+                  "label": "Virtual agents or artificial conversational interfaces",
+                  "value": "virtual-agents-or-artificial-conversational-interfaces"
+                },
+                {
+                  "label": "Robotic process automation and decision management",
+                  "value": "robotic-process-automation-and-decision-management"
+                },
+                {
+                  "label": "Robotics and autonomous vehicles/systems",
+                  "value": "robotics-and-autonomous-vehicles-systems"
+                }
+              ]
+            },
+            {
+              "key": "sector",
+              "name": "Sector",
+              "type": "text",
+              "preposition": "sector",
+              "display_as_result_metadata": true,
+              "filterable": true,
+              "allowed_values": [
+                {
+                  "label": "Agriculture, Forestry and Fishing (SIC Code Section A)",
+                  "value": "agriculture-forestry-and-fishing"
+                },
+                {
+                  "label": "Mining and Quarrying (SIC Code Section B)",
+                  "value": "mining-and-quarrying"
+                },
+                {
+                  "label": "Manufacturing (SIC Code Section C)",
+                  "value": "manufacturing"
+                },
+                {
+                  "label": "Energy & Utilities (SIC Code Sections D & E)",
+                  "value": "energy-and-utilities"
+                },
+                {
+                  "label": "Construction (SIC Code Section F)",
+                  "value": "construction"
+                },
+                {
+                  "label": "Retail (SIC Code Section G)",
+                  "value": "retail"
+                },
+                {
+                  "label": "Transportation & Storage (SIC Code Section H)",
+                  "value": "transportation-and-storage"
+                },
+                {
+                  "label": "Accommodation and Food Service (SIC Code Section I)",
+                  "value": "accommodation-and-food-service"
+                },
+                {
+                  "label": "Digital & Comms (SIC Code Section J)",
+                  "value": "digital-and-comms"
+                },
+                {
+                  "label": "Financial and Insurance (SIC Code Section K)",
+                  "value": "financial-and-insurance"
+                },
+                {
+                  "label": "Real Estate (SIC Code Section L)",
+                  "value": "real-estate"
+                },
+                {
+                  "label": "Professional, Scientific & Professional Activities (SIC Code Section M)",
+                  "value":"professional-scientific-and-professional-activities"
+                },
+                {
+                  "label": "Administrative & Support Services (SIC Code Section N)",
+                  "value": "administrative-and-support-services"
+                },
+                {
+                  "label": "Public Administration & Defence (SIC Code Section O)",
+                  "value": "public-administration-and-defence"
+                },
+                {
+                  "label": "Education (SIC Code Section P)",
+                  "value": "education"
+                },
+                {
+                  "label": "Healthcare & Social Work (SIC Code Section Q)",
+                  "value": "healthcare-and-social-work"
+                },
+                {
+                  "label": "Arts, Entertainment & Recreation (SIC Code Section R)",
+                  "value": "arts-entertainment-and-recreation"
+                },
+                {
+                "label": "Other Services (SIC Code Section S)",
+                "value": "other-services"
+                }
+              ]
+            },
+            {
+              "key": "principle",
+              "name": "Principle",
+              "type": "text",
+              "preposition": "Principle",
+              "display_as_result_metadata": true,
+              "filterable": true,
+              "allowed_values": [
+                {
+                  "label": "Safety, security and robustness",
+                  "value": "safety-security-and-robustness"
+                },
+                {
+                  "label": "Appropriate transparency and explainability",
+                  "value": "appropriate-transparency-and-explainability"
+                },
+                {
+                  "label": "Fairness",
+                  "value": "fairness"
+                },
+                {
+                  "label": "Accountability and governance",
+                  "value": "accountability-and-governance"
+                },
+                {
+                  "label": "Contestability and redress",
+                  "value": "contestability-and-redress"
+                }
+              ]
+            },
+            {
+              "key": "key_function",
+              "name": "Key function",
+              "type": "text",
+              "preposition": "function",
+              "display_as_result_metadata": true,
+              "filterable": true,
+              "allowed_values": [
+                {
+                  "label": "R&D",
+                  "value": "r-and-d"
+                },
+                {
+                  "label": "Product and service development",
+                  "value": "product-and-service-development"
+                },
+                {
+                  "label": "Manufacturing",
+                  "value": "manufacturing"
+                },
+                {
+                  "label": "Service operations",
+                  "value": "service-operations"
+                },
+                {
+                  "label": "Supply chain management",
+                  "value": "supply-chain-management"
+                },
+                {
+                  "label": "Human Resources",
+                  "value": "human-resources"
+                },
+                {
+                  "label": "Marketing and sales",
+                  "value": "marketing-and-sales"
+                },
+                {
+                  "label": "Customer services",
+                  "value": "customer-services"
+                },
+                {
+                  "label": "Risk management",
+                  "value": "risk-management"
+                },
+                {
+                  "label": "Strategy and corporate finance",
+                  "value": "strategy-and-corporate-finance"
+                }
+              ]
+            },
+            {
+              "key": "ai_assurance_technique",
+              "name": "AI Assurance Technique",
+              "type": "text",
+              "preposition": "AI Assurance Technique",
+              "display_as_result_metadata": true,
+              "filterable": true,
+              "allowed_values": [
+                {
+                  "label": "Data assurance",
+                  "value": "data-assurance"
+                },
+                {
+                  "label": "Compliance audit",
+                  "value": "compliance-audit"
+                },
+                {
+                  "label": "Formal verification",
+                  "value": "formal-verification"
+                },
+                {
+                  "label": "Performance testing",
+                  "value": "performance-testing"
+                },
+                {
+                  "label": "Certification",
+                  "value": "certification"
+                },
+                {
+                  "label": "Risk Assessment",
+                  "value": "risk-assessment"
+                },
+                {
+                  "label": "Impact Assessment",
+                  "value": "impact-assessment"
+                },
+                {
+                  "label": "Impact Evaluation",
+                  "value": "impact-evaluation"
+                },
+                {
+                  "label": "Conformity Assessment",
+                  "value": "conformity-assessment"
+                },
+                {
+                  "label": "Bias Audit",
+                  "value": "bias-audit"
+                }
+              ]
+            }
+          ]
+        },
+        "links": {},
+        "api_url": "https://www.gov.uk/api/content/ai-assurance-techniques",
+        "web_url": "https://www.gov.uk/ai-assurance-techniques"
+      }
+    ],
+    "available_translations": [
+      {
+        "analytics_identifier": null,
+        "content_id": "5e5890a0-329a-42d2-9637-9d8433fe97ae",
+        "description": "Find out what AI assurance is and what AI assurance techniques you can use in your organisation.",
+        "document_type": "ai_assurance_portfolio_technique",
+        "public_updated_at": "2015-10-01T11:00:38Z",
+        "schema_name": "specialist_document",
+        "title": "bleep bloop robot",
+        "base_path": "/ai-assurance-techniques/bleep-bloop-robot",
+        "locale": "en",
+        "api_path": "/api/content/ai-assurance-techniques/bleep-bloop-robot",
+        "withdrawn": false,
+        "api_url": "https://www.gov.uk/api/content/ai-assurance-techniques/bleep-bloop-robot",
+        "web_url": "https://www.gov.uk/ai-assurance-techniques/bleep-bloop-robot",
+        "links": {}
+      }
+    ]
+  },
+  "updated_at": "2017-06-30T15:44:11.073Z"
+}

--- a/content_schemas/formats/shared/definitions/_specialist_document.jsonnet
+++ b/content_schemas/formats/shared/definitions/_specialist_document.jsonnet
@@ -6,6 +6,9 @@
         "$ref": "#/definitions/aaib_report_metadata",
       },
       {
+        "$ref": "#/definitions/ai_assurance_portfolio_technique_metadata",
+      },
+      {
         "$ref": "#/definitions/animal_disease_case_metadata",
       },
       {
@@ -175,6 +178,107 @@
       },
     },
   },
+  ai_assurance_portfolio_technique_metadata: {
+    type: "object",
+    additionalProperties: false,
+    properties: {
+      bulk_published: {
+        type: "boolean",
+      },
+      use_case: {
+        type: "array",
+        items: {
+          type: "string",
+          enum: [
+            "big-data-analytics",
+            "data-driven-profiling",
+            "natural-language-processing-and-generation",
+            "image-recognition-and-video-processing",
+            "machine-learning",
+            "deep-learning",
+            "virtual-agents-or-artificial-conversational-interfaces",
+            "robotic-process-automation-and-decision-management",
+            "robotics-and-autonomous-vehicles-systems",
+          ],
+        },
+      },
+      sector: {
+        type: "array",
+        items: {
+          type: "string",
+          enum: [
+            "agriculture-forestry-and-fishing",
+            "mining-and-quarrying",
+            "manufacturing",
+            "energy-and-utilities",
+            "construction",
+            "retail",
+            "transportation-and-storage",
+            "accommodation-and-food-service",
+            "digital-and-comms",
+            "financial-and-insurance",
+            "real-estate",
+            "professional-scientific-and-professional-activities",
+            "administrative-and-support-services",
+            "public-administration-and-defence",
+            "education",
+            "healthcare-and-social-work",
+            "arts-entertainment-and-recreation",
+            "other-services"
+          ]
+        },
+      },
+      principle: {
+        type: "array",
+        items: {
+          type: "string",
+          enum: [
+            "safety-security-and-robustness",
+            "appropriate-transparency-and-explainability",
+            "fairness",
+            "accountability-and-governance",
+            "contestability-and-redress"
+          ],
+        },
+      },
+      key_function: { 
+        type: "array",
+        items: {
+          type: "string",
+          enum: [
+            "r-and-d",
+            "product-and-service-development",
+            "manufacturing",
+            "service-operations",
+            "supply-chain-management",
+            "human-resources",
+            "marketing-and-sales",
+            "customer-services",
+            "risk-management",
+            "strategy-and-corporate-finance",
+          ],
+        },
+      },
+      ai_assurance_technique: {
+        type: "array",
+        items: {
+          type: "string",
+          enum: [
+            "data-assurance",
+            "compliance-audit",
+            "formal-verification",
+            "performance-testing",
+            "certification",
+            "risk-assessment",
+            "impact-assessment",
+            "impact-evaluation",
+            "conformity-assessment",
+            "bias-audit"
+          ],
+        },
+      },
+    },
+  }, 
   animal_disease_case_metadata: {
     type: "object",
     additionalProperties: false,

--- a/content_schemas/formats/specialist_document.jsonnet
+++ b/content_schemas/formats/specialist_document.jsonnet
@@ -1,6 +1,7 @@
 (import "shared/default_format.jsonnet") + {
   document_type: [
     "aaib_report",
+    "ai_assurance_portfolio_technique",
     "animal_disease_case",
     "asylum_support_decision",
     "business_finance_support_scheme",


### PR DESCRIPTION
Following the Developer Docs on creating a specialist finder, this commit updates the relevant files in content schemas.

Trello card link:
https://trello.com/c/1LeqkG5a/1245-create-a-cdei-finder

Link to steps followed in Developer Docs:
https://docs.publishing.service.gov.uk/repos/specialist-publisher/creating-and-editing-specialist-document-types.html#1-add-a-schema-to-govuk-content-schemas

Co-authored-by: Johnny Young <jonathan.young@digital.cabinet-office.gov.uk>