### PR TITLE
Add example for ministers index schema

### DIFF
--- a/content_schemas/dist/formats/ministers_index/frontend/schema.json
+++ b/content_schemas/dist/formats/ministers_index/frontend/schema.json
@@ -93,35 +93,35 @@
         },
         "ordered_also_attends_cabinet": {
           "description": "Links to the current ministers without a cabinet position who also attend cabinet in the correct order",
-          "$ref": "#/definitions/frontend_links_with_base_path"
+          "$ref": "#/definitions/frontend_links"
         },
         "ordered_assistant_whips": {
           "description": "Links to the current assistant whips in the correct order",
-          "$ref": "#/definitions/frontend_links_with_base_path"
+          "$ref": "#/definitions/frontend_links"
         },
         "ordered_baronesses_and_lords_in_waiting_whips": {
           "description": "Links to the current Baronesses and Lords in Waiting whips in the correct order",
-          "$ref": "#/definitions/frontend_links_with_base_path"
+          "$ref": "#/definitions/frontend_links"
         },
         "ordered_cabinet_ministers": {
           "description": "Links to the current cabinet ministers in the correct order",
-          "$ref": "#/definitions/frontend_links_with_base_path"
+          "$ref": "#/definitions/frontend_links"
         },
         "ordered_house_lords_whips": {
           "description": "Links to the current House of Lords whips in the correct order",
-          "$ref": "#/definitions/frontend_links_with_base_path"
+          "$ref": "#/definitions/frontend_links"
         },
         "ordered_house_of_commons_whips": {
           "description": "Links to the current House of Commons whips in the correct order",
-          "$ref": "#/definitions/frontend_links_with_base_path"
+          "$ref": "#/definitions/frontend_links"
         },
         "ordered_junior_lords_of_the_treasury_whips": {
           "description": "Links to the current Junior Lords of the Treasury whips in the correct order",
-          "$ref": "#/definitions/frontend_links_with_base_path"
+          "$ref": "#/definitions/frontend_links"
         },
         "ordered_ministerial_departments": {
           "description": "Links to the ministerial department organisations in the correct order",
-          "$ref": "#/definitions/frontend_links_with_base_path"
+          "$ref": "#/definitions/frontend_links"
         },
         "ordered_related_items": {
           "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",

--- a/content_schemas/dist/formats/ministers_index/notification/schema.json
+++ b/content_schemas/dist/formats/ministers_index/notification/schema.json
@@ -111,35 +111,35 @@
         },
         "ordered_also_attends_cabinet": {
           "description": "Links to the current ministers without a cabinet position who also attend cabinet in the correct order",
-          "$ref": "#/definitions/frontend_links_with_base_path"
+          "$ref": "#/definitions/frontend_links"
         },
         "ordered_assistant_whips": {
           "description": "Links to the current assistant whips in the correct order",
-          "$ref": "#/definitions/frontend_links_with_base_path"
+          "$ref": "#/definitions/frontend_links"
         },
         "ordered_baronesses_and_lords_in_waiting_whips": {
           "description": "Links to the current Baronesses and Lords in Waiting whips in the correct order",
-          "$ref": "#/definitions/frontend_links_with_base_path"
+          "$ref": "#/definitions/frontend_links"
         },
         "ordered_cabinet_ministers": {
           "description": "Links to the current cabinet ministers in the correct order",
-          "$ref": "#/definitions/frontend_links_with_base_path"
+          "$ref": "#/definitions/frontend_links"
         },
         "ordered_house_lords_whips": {
           "description": "Links to the current House of Lords whips in the correct order",
-          "$ref": "#/definitions/frontend_links_with_base_path"
+          "$ref": "#/definitions/frontend_links"
         },
         "ordered_house_of_commons_whips": {
           "description": "Links to the current House of Commons whips in the correct order",
-          "$ref": "#/definitions/frontend_links_with_base_path"
+          "$ref": "#/definitions/frontend_links"
         },
         "ordered_junior_lords_of_the_treasury_whips": {
           "description": "Links to the current Junior Lords of the Treasury whips in the correct order",
-          "$ref": "#/definitions/frontend_links_with_base_path"
+          "$ref": "#/definitions/frontend_links"
         },
         "ordered_ministerial_departments": {
           "description": "Links to the ministerial department organisations in the correct order",
-          "$ref": "#/definitions/frontend_links_with_base_path"
+          "$ref": "#/definitions/frontend_links"
         },
         "ordered_related_items": {
           "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",

--- a/content_schemas/examples/ministers_index/frontend/ministers_index-reshuffle-mode-off.json
+++ b/content_schemas/examples/ministers_index/frontend/ministers_index-reshuffle-mode-off.json
@@ -1,0 +1,5339 @@
+{
+  "analytics_identifier": null,
+  "base_path": "/government/ministers",
+  "content_id": "324e4708-2285-40a0-b3aa-cb13af14ec5f",
+  "document_type": "ministers_index",
+  "first_published_at": "2016-11-14T16:28:54.000+00:00",
+  "locale": "en",
+  "phase": "live",
+  "public_updated_at": "2023-05-16T16:32:31.000+00:00",
+  "publishing_app": "whitehall",
+  "publishing_scheduled_at": null,
+  "rendering_app": "whitehall-frontend",
+  "scheduled_publishing_delay_seconds": null,
+  "schema_name": "ministers_index",
+  "title": "Ministers",
+  "updated_at": "2023-05-16T16:33:12.247Z",
+  "withdrawn_notice": {},
+  "publishing_request_id": "21-1684254751.844-10.1.28.61-389",
+  "links": {
+    "ordered_also_attends_cabinet": [
+      {
+        "content_id": "44f73b9f-58d3-493a-9d78-3f177e177cac",
+        "title": "The Rt Hon Simon Hart MP",
+        "locale": "en",
+        "api_path": "/api/content/government/people/simon-hart",
+        "base_path": "/government/people/simon-hart",
+        "document_type": "person",
+        "public_updated_at": "2022-10-25T15:43:50Z",
+        "schema_name": "person",
+        "withdrawn": false,
+        "details": {
+          "image": {
+            "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/person/image/3188/s465_Simon_Hart_960-640.jpg",
+            "alt_text": "The Rt Hon Simon Hart MP"
+          },
+          "privy_counsellor": true
+        },
+        "links": {
+          "role_appointments": [
+            {
+              "content_id": "8a982e70-4b8f-408b-9d8b-127e65059c6e",
+              "title": "Simon Hart - Member",
+              "locale": "en",
+              "document_type": "role_appointment",
+              "public_updated_at": "2019-11-06T16:37:00Z",
+              "schema_name": "role_appointment",
+              "withdrawn": false,
+              "details": {
+                "started_on": "2017-08-08T00:00:00+01:00",
+                "ended_on": "2019-07-28T00:00:00+01:00",
+                "current": false,
+                "person_appointment_order": 4264
+              },
+              "links": {
+                "role": [
+                  {
+                    "content_id": "f92922a3-1364-40eb-a0df-95d1c4b477da",
+                    "title": "Member, Committee on Standards in Public Life",
+                    "locale": "en",
+                    "document_type": "board_member_role",
+                    "public_updated_at": "2023-03-13T10:28:40Z",
+                    "schema_name": "role",
+                    "withdrawn": false,
+                    "details": {
+                      "body": "<p>See <a href=\"https://www.gov.uk/government/publications/cspl-latest-register-of-interests--2\">CSPL’s register of interests for Committee members</a></p>\n",
+                      "role_payment_type": null
+                    },
+                    "links": {}
+                  }
+                ]
+              }
+            },
+            {
+              "content_id": "7fdc5051-b0b3-468e-86aa-99095f79a870",
+              "title": "Simon Hart - Parliamentary Secretary (Minister for Implementation)",
+              "locale": "en",
+              "document_type": "role_appointment",
+              "public_updated_at": "2019-12-16T18:05:57Z",
+              "schema_name": "role_appointment",
+              "withdrawn": false,
+              "details": {
+                "started_on": "2019-07-27T00:00:00+01:00",
+                "ended_on": "2019-12-16T00:00:00+00:00",
+                "current": false,
+                "person_appointment_order": 5729
+              },
+              "links": {
+                "role": [
+                  {
+                    "content_id": "7a07c083-4faf-43d9-8eac-676855289d39",
+                    "title": "Parliamentary Secretary (Minister for Implementation)",
+                    "locale": "en",
+                    "api_path": "/api/content/government/ministers/parliamentary-under-secretary-of-state--86",
+                    "base_path": "/government/ministers/parliamentary-under-secretary-of-state--86",
+                    "document_type": "ministerial_role",
+                    "public_updated_at": "2019-08-27T13:17:40Z",
+                    "schema_name": "role",
+                    "withdrawn": false,
+                    "details": {
+                      "body": "<ul>\n  <li>Supporting MCO on cross-government delivery and implementation</li>\n  <li>Controls (commercial, digital, property)</li>\n  <li>Commercial models</li>\n  <li>Cyber and resilience</li>\n  <li>Civil Service HR and Shared Services</li>\n  <li>Fraud, Error, Debt and Grants</li>\n  <li>Geospatial Commission</li>\n  <li>Government Digital Service</li>\n  <li>Government Security Group</li>\n  <li>Infrastructure and Projects Authority</li>\n  <li>Government Property</li>\n  <li>Government Commercial Function</li>\n  <li>Public bodies and appointments policy</li>\n</ul>\n\n",
+                      "role_payment_type": null,
+                      "seniority": 100,
+                      "whip_organisation": {}
+                    },
+                    "links": {},
+                    "api_url": "https://www.gov.uk/api/content/government/ministers/parliamentary-under-secretary-of-state--86",
+                    "web_url": "https://www.gov.uk/government/ministers/parliamentary-under-secretary-of-state--86"
+                  }
+                ]
+              }
+            },
+            {
+              "content_id": "1aeb27cf-1be2-493d-ad32-214360295c6d",
+              "title": "The Rt Hon Simon Hart MP - Secretary of State for Wales",
+              "locale": "en",
+              "document_type": "role_appointment",
+              "public_updated_at": "2022-07-07T09:15:07Z",
+              "schema_name": "role_appointment",
+              "withdrawn": false,
+              "details": {
+                "started_on": "2019-12-16T00:00:00+00:00",
+                "ended_on": "2022-07-06T00:00:00+01:00",
+                "current": false,
+                "person_appointment_order": 5926
+              },
+              "links": {
+                "role": [
+                  {
+                    "content_id": "845e661b-c0f1-11e4-8223-005056011aef",
+                    "title": "Secretary of State for Wales",
+                    "locale": "en",
+                    "api_path": "/api/content/government/ministers/secretary-of-state-for-wales",
+                    "base_path": "/government/ministers/secretary-of-state-for-wales",
+                    "document_type": "ministerial_role",
+                    "public_updated_at": "2023-03-09T15:06:29Z",
+                    "schema_name": "role",
+                    "withdrawn": false,
+                    "details": {
+                      "body": "<p>The Secretary of State is responsible for the overall strategic direction of the UK Government in Wales.</p>\n\n<p>Responsibilities include:</p>\n\n<ul>\n  <li>Fiscal</li>\n  <li>Constitutional and Electoral issues</li>\n  <li>Cost of living</li>\n  <li>Welsh language</li>\n  <li>Investment Zones</li>\n  <li>Freeports</li>\n  <li>Steel</li>\n  <li>Funds (eg SPF, Levelling Up)</li>\n  <li>Home Affairs (policing, immigration, security)</li>\n  <li>Defence</li>\n  <li>Foreign Affairs</li>\n  <li>Major Growth Deal Announcements</li>\n  <li>Public Appointments</li>\n  <li>Honours</li>\n  <li>Places for Growth</li>\n</ul>\n\n<p>The Secretary of State shares responsibility with the Parliamentary Under Secretary of State in these areas:</p>\n\n<ul>\n  <li>Union</li>\n  <li>Welsh Government / Senedd / Assembly Liaison</li>\n  <li>Economy</li>\n  <li>Transport (partially devolved)</li>\n  <li>International Trade</li>\n  <li>Research and Development, Innovation</li>\n  <li>Agriculture</li>\n  <li>Global Britain</li>\n  <li>Western Gateway</li>\n  <li>Third Sector</li>\n  <li>Local Government</li>\n</ul>\n\n",
+                      "role_payment_type": null,
+                      "seniority": 32,
+                      "whip_organisation": {}
+                    },
+                    "links": {},
+                    "api_url": "https://www.gov.uk/api/content/government/ministers/secretary-of-state-for-wales",
+                    "web_url": "https://www.gov.uk/government/ministers/secretary-of-state-for-wales"
+                  }
+                ]
+              }
+            },
+            {
+              "content_id": "cf56d569-534d-4cfc-8db1-61115f87fca8",
+              "title": "The Rt Hon Simon Hart MP - Parliamentary Secretary to the Treasury (Chief Whip)",
+              "locale": "en",
+              "document_type": "role_appointment",
+              "public_updated_at": "2022-10-25T15:47:07Z",
+              "schema_name": "role_appointment",
+              "withdrawn": false,
+              "details": {
+                "started_on": "2022-10-25T00:00:00+01:00",
+                "ended_on": null,
+                "current": true,
+                "person_appointment_order": 8154
+              },
+              "links": {
+                "role": [
+                  {
+                    "content_id": "845e6a56-c0f1-11e4-8223-005056011aef",
+                    "title": "Parliamentary Secretary to the Treasury (Chief Whip)",
+                    "locale": "en",
+                    "api_path": "/api/content/government/ministers/parliamentary-secretary-to-the-treasury-and-chief-whip",
+                    "base_path": "/government/ministers/parliamentary-secretary-to-the-treasury-and-chief-whip",
+                    "document_type": "ministerial_role",
+                    "public_updated_at": "2018-01-10T10:54:33Z",
+                    "schema_name": "role",
+                    "withdrawn": false,
+                    "details": {
+                      "body": "<p>The Chief Whip is responsible for administering the whipping system that ensures that members of the party attend and vote in Parliament as the party leadership desires.</p>\n\n<p>Whips are MPs or Lords appointed by each party in Parliament to help organise their party’s contribution to parliamentary business. One of their responsibilities is making sure the maximum number of their party members vote, and vote the way their party wants.</p>\n\n<h2 id=\"other-whip-duties\">Other whip duties</h2>\n\n<p>Whips frequently act as tellers (counting votes in divisions). They also manage the pairing system whereby Members of opposing parties both agree not to vote when other business (such as a select committee visit) prevents them from being present at Westminster.</p>\n\n<p>Whips are also largely responsible (together with the Leader of the House in the Commons) for arranging the business of Parliament. In this role they are frequently referred to as ‘the usual channels’.</p>\n",
+                      "role_payment_type": null,
+                      "seniority": 0,
+                      "whip_organisation": {
+                        "label": "House of Commons",
+                        "sort_order": 1
+                      }
+                    },
+                    "links": {},
+                    "api_url": "https://www.gov.uk/api/content/government/ministers/parliamentary-secretary-to-the-treasury-and-chief-whip",
+                    "web_url": "https://www.gov.uk/government/ministers/parliamentary-secretary-to-the-treasury-and-chief-whip"
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        "api_url": "https://www.gov.uk/api/content/government/people/simon-hart",
+        "web_url": "https://www.gov.uk/government/people/simon-hart"
+      },
+      {
+        "content_id": "bd1b94ef-9392-4ca4-aed8-0135bcd9ec46",
+        "title": "The Rt Hon John Glen MP",
+        "locale": "en",
+        "api_path": "/api/content/government/people/john-glen",
+        "base_path": "/government/people/john-glen",
+        "document_type": "person",
+        "public_updated_at": "2023-01-06T13:54:42Z",
+        "schema_name": "person",
+        "withdrawn": false,
+        "details": {
+          "image": {
+            "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/person/image/3123/s465_John_Glen_GOVUK.jpg",
+            "alt_text": "The Rt Hon John Glen MP"
+          },
+          "privy_counsellor": true
+        },
+        "links": {
+          "role_appointments": [
+            {
+              "content_id": "2ef6ac98-1a41-453c-bdb1-bb3d631021f8",
+              "title": "John Glen - Parliamentary Under Secretary of State for Arts, Heritage and Tourism",
+              "locale": "en",
+              "document_type": "role_appointment",
+              "public_updated_at": "2019-11-06T16:24:15Z",
+              "schema_name": "role_appointment",
+              "withdrawn": false,
+              "details": {
+                "started_on": "2017-06-14T00:00:00+01:00",
+                "ended_on": "2018-01-08T00:00:00+00:00",
+                "current": false,
+                "person_appointment_order": 4135
+              },
+              "links": {
+                "role": [
+                  {
+                    "content_id": "8c01e828-365f-4715-a318-abf89d303276",
+                    "title": "Parliamentary Under Secretary of State for Arts, Heritage and Tourism",
+                    "locale": "en",
+                    "api_path": "/api/content/government/ministers/parliamentary-under-secretary-of-state--81",
+                    "base_path": "/government/ministers/parliamentary-under-secretary-of-state--81",
+                    "document_type": "ministerial_role",
+                    "public_updated_at": "2017-06-15T12:26:10Z",
+                    "schema_name": "role",
+                    "withdrawn": false,
+                    "details": {
+                      "body": "<p>Ministerial responsibilities:</p>\n\n<ul>\n  <li>arts</li>\n  <li>culture</li>\n  <li>heritage</li>\n  <li>public libraries</li>\n  <li>museums</li>\n  <li>National Archives</li>\n  <li>tourism</li>\n</ul>\n",
+                      "role_payment_type": null,
+                      "seniority": 100,
+                      "whip_organisation": {}
+                    },
+                    "links": {},
+                    "api_url": "https://www.gov.uk/api/content/government/ministers/parliamentary-under-secretary-of-state--81",
+                    "web_url": "https://www.gov.uk/government/ministers/parliamentary-under-secretary-of-state--81"
+                  }
+                ]
+              }
+            },
+            {
+              "content_id": "ef77450f-5b9a-4aa9-b30f-c18dd4276863",
+              "title": "John Glen MP - Economic Secretary to the Treasury",
+              "locale": "en",
+              "document_type": "role_appointment",
+              "public_updated_at": "2021-09-17T16:23:23Z",
+              "schema_name": "role_appointment",
+              "withdrawn": false,
+              "details": {
+                "started_on": "2018-01-09T00:00:00+00:00",
+                "ended_on": "2021-09-16T00:00:00+01:00",
+                "current": false,
+                "person_appointment_order": 4560
+              },
+              "links": {
+                "role": [
+                  {
+                    "content_id": "845e8915-c0f1-11e4-8223-005056011aef",
+                    "title": "Economic Secretary to the Treasury",
+                    "locale": "en",
+                    "api_path": "/api/content/government/ministers/economic-secretary-to-the-treasury",
+                    "base_path": "/government/ministers/economic-secretary-to-the-treasury",
+                    "document_type": "ministerial_role",
+                    "public_updated_at": "2020-02-17T13:17:38Z",
+                    "schema_name": "role",
+                    "withdrawn": false,
+                    "details": {
+                      "body": "<p>The Economic Secretary (EST) is the City Minister responsible for financial services, including:</p>\n\n<ul>\n  <li>banking and financial services reform and regulation</li>\n  <li>financial stability, including relationship with the <abbr title=\"Prudential Regulation Authority\">PRA</abbr>\n</li>\n  <li>financial conduct, including relationship with the <abbr title=\"Financial Conduct Authority\">FCA</abbr>\n</li>\n  <li>financial services including all banking, insurance, asset management</li>\n  <li>retail financial services, including banking competition, consumer finance, financial advice and capability</li>\n  <li>bank lending and access to finance</li>\n  <li>financial Inclusion (lead on the government’s financial inclusion agenda)</li>\n  <li>access to affordable credit, including credit unions</li>\n  <li>women in finance agenda</li>\n  <li>EU financial services including EU exit and decisions as a member state</li>\n  <li>city competitiveness, including global financial markets, Global Financial Partnerships and financial services trade</li>\n  <li>green finance, Islamic finance, and Fintech</li>\n  <li>financial services taxation, including bank levy, bank corp. tax surcharge, IPT</li>\n  <li>personal savings tax and pensions tax policy</li>\n  <li>sponsorship of <abbr title=\"UK Government Investments\">UKGI</abbr> and State owned financial assets – RBS, <abbr title=\"UK Asset Resolution Limited\">UKAR</abbr>\n</li>\n  <li>financial sanctions and countering economic crime and illicit finance</li>\n  <li>foreign exchange reserves and debt management policy, National Savings and Investments and the Debt Management Office</li>\n  <li>cash and payments including, Royal Mint</li>\n  <li>parliamentary deputy on economy issues</li>\n</ul>\n\n",
+                      "role_payment_type": "Paid as a Parliamentary Secretary",
+                      "seniority": 100,
+                      "whip_organisation": {}
+                    },
+                    "links": {},
+                    "api_url": "https://www.gov.uk/api/content/government/ministers/economic-secretary-to-the-treasury",
+                    "web_url": "https://www.gov.uk/government/ministers/economic-secretary-to-the-treasury"
+                  }
+                ]
+              }
+            },
+            {
+              "content_id": "9fef5652-c11f-4c6c-84f5-d54466071120",
+              "title": "John Glen MP - Minister of State (Economic Secretary)",
+              "locale": "en",
+              "document_type": "role_appointment",
+              "public_updated_at": "2022-07-11T13:55:15Z",
+              "schema_name": "role_appointment",
+              "withdrawn": false,
+              "details": {
+                "started_on": "2021-09-17T00:00:00+01:00",
+                "ended_on": "2022-07-06T00:00:00+01:00",
+                "current": false,
+                "person_appointment_order": 7167
+              },
+              "links": {
+                "role": [
+                  {
+                    "content_id": "36285dc5-1022-43e6-88d3-9f9694b2a841",
+                    "title": "Minister of State (Economic Secretary)",
+                    "locale": "en",
+                    "api_path": "/api/content/government/ministers/minister-of-state-economic-secretary",
+                    "base_path": "/government/ministers/minister-of-state-economic-secretary",
+                    "document_type": "ministerial_role",
+                    "public_updated_at": "2021-09-24T10:38:52Z",
+                    "schema_name": "role",
+                    "withdrawn": false,
+                    "details": {
+                      "body": "\n",
+                      "role_payment_type": "Unpaid",
+                      "seniority": 100,
+                      "whip_organisation": {}
+                    },
+                    "links": {},
+                    "api_url": "https://www.gov.uk/api/content/government/ministers/minister-of-state-economic-secretary",
+                    "web_url": "https://www.gov.uk/government/ministers/minister-of-state-economic-secretary"
+                  }
+                ]
+              }
+            },
+            {
+              "content_id": "f97fb63e-dfcb-41d4-b3d9-7a8853531e58",
+              "title": "John Glen MP - Chief Secretary to the Treasury",
+              "locale": "en",
+              "document_type": "role_appointment",
+              "public_updated_at": "2022-10-25T18:55:46Z",
+              "schema_name": "role_appointment",
+              "withdrawn": false,
+              "details": {
+                "started_on": "2022-10-25T00:00:00+01:00",
+                "ended_on": null,
+                "current": true,
+                "person_appointment_order": 8170
+              },
+              "links": {
+                "role": [
+                  {
+                    "content_id": "845e6667-c0f1-11e4-8223-005056011aef",
+                    "title": "Chief Secretary to the Treasury",
+                    "locale": "en",
+                    "api_path": "/api/content/government/ministers/chief-secretary-to-the-treasury",
+                    "base_path": "/government/ministers/chief-secretary-to-the-treasury",
+                    "document_type": "ministerial_role",
+                    "public_updated_at": "2022-11-22T15:30:28Z",
+                    "schema_name": "role",
+                    "withdrawn": false,
+                    "details": {
+                      "body": "<p>The Chief Secretary (<abbr title=\"Chief Secretary to the Treasury\">CST</abbr>) is responsible for public expenditure, including:</p>\n\n<ul>\n  <li>spending reviews and strategic planning</li>\n  <li>in-year spending control</li>\n  <li>public sector pay and pensions</li>\n  <li>Annually Managed Expenditure (<abbr title=\"Annually Managed Expenditure\">AME</abbr>) and welfare reform</li>\n  <li>efficiency and value for money in public service</li>\n  <li>procurement</li>\n  <li>capital investment</li>\n  <li>infrastructure spending</li>\n  <li>housing and planning</li>\n  <li>spending issues related to trade</li>\n  <li>transport policy, including HS2, Crossrail 2, Roads, Network Rail,\nOxford/Cambridge corridor</li>\n  <li>Treasury interest in devolution to Scotland, Wales and Northern Ireland</li>\n  <li>women in the economy</li>\n  <li>skills, labour market policy and childcare policy, including tax free childcare</li>\n  <li>tax credits policy</li>\n  <li>housing and planning</li>\n  <li>legislative strategy</li>\n  <li>state pensions/ pensioner benefits</li>\n  <li>freeports – with support from <abbr title=\"Economic Secretary to the Treasury\">EST</abbr> on customs aspects\n.</li>\n</ul>\n\n",
+                      "role_payment_type": "Unpaid",
+                      "seniority": 1,
+                      "whip_organisation": {}
+                    },
+                    "links": {},
+                    "api_url": "https://www.gov.uk/api/content/government/ministers/chief-secretary-to-the-treasury",
+                    "web_url": "https://www.gov.uk/government/ministers/chief-secretary-to-the-treasury"
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        "api_url": "https://www.gov.uk/api/content/government/people/john-glen",
+        "web_url": "https://www.gov.uk/government/people/john-glen"
+      }
+    ],
+    "ordered_assistant_whips": [
+      {
+        "content_id": "848ffffc-9eca-4c6a-823b-335fc180b3e5",
+        "title": "Ruth Edwards MP",
+        "locale": "en",
+        "api_path": "/api/content/government/people/ruth-edwards",
+        "base_path": "/government/people/ruth-edwards",
+        "document_type": "person",
+        "public_updated_at": "2023-02-16T15:27:28Z",
+        "schema_name": "person",
+        "withdrawn": false,
+        "details": {
+          "image": {
+            "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/person/image/5345/s465_Ruth_Edwards.jpg",
+            "alt_text": "Ruth Edwards MP"
+          },
+          "privy_counsellor": false
+        },
+        "links": {
+          "role_appointments": [
+            {
+              "content_id": "597c9ded-8bdb-40a0-bb9b-4240ff2006ae",
+              "title": "Ruth Edwards MP - Assistant Government Whip",
+              "locale": "en",
+              "document_type": "role_appointment",
+              "public_updated_at": "2023-02-16T15:30:24Z",
+              "schema_name": "role_appointment",
+              "withdrawn": false,
+              "details": {
+                "started_on": "2023-02-16T00:00:00+00:00",
+                "ended_on": null,
+                "current": true,
+                "person_appointment_order": 2
+              },
+              "links": {
+                "role": [
+                  {
+                    "content_id": "c4760cc3-8145-4d5f-a0f0-a7b43fe53396",
+                    "title": "Assistant Government Whip",
+                    "locale": "en",
+                    "api_path": "/api/content/government/ministers/assistant-government-whip--27",
+                    "base_path": "/government/ministers/assistant-government-whip--27",
+                    "document_type": "ministerial_role",
+                    "public_updated_at": "2022-07-08T19:48:39Z",
+                    "schema_name": "role",
+                    "withdrawn": false,
+                    "details": {
+                      "body": "\n",
+                      "role_payment_type": null,
+                      "seniority": 100,
+                      "whip_organisation": {
+                        "label": "Assistant Whips",
+                        "sort_order": 3
+                      }
+                    },
+                    "links": {},
+                    "api_url": "https://www.gov.uk/api/content/government/ministers/assistant-government-whip--27",
+                    "web_url": "https://www.gov.uk/government/ministers/assistant-government-whip--27"
+                  }
+                ]
+              }
+            },
+            {
+              "content_id": "e94b9a26-fab7-4890-ba7e-f75764ba0b30",
+              "title": "Ruth Edwards MP - Government Whip (Lord Commissioner of HM Treasury)",
+              "locale": "en",
+              "document_type": "role_appointment",
+              "public_updated_at": "2023-02-16T15:28:42Z",
+              "schema_name": "role_appointment",
+              "withdrawn": false,
+              "details": {
+                "started_on": "2023-02-07T00:00:00+00:00",
+                "ended_on": "2023-02-16T00:00:00+00:00",
+                "current": false,
+                "person_appointment_order": 1
+              },
+              "links": {
+                "role": [
+                  {
+                    "content_id": "9cd173ff-a850-444f-8097-404c682fdc83",
+                    "title": "Government Whip (Lord Commissioner of HM Treasury)",
+                    "locale": "en",
+                    "api_path": "/api/content/government/ministers/government-whip-lord-commissioner-of-hm-treasury--22",
+                    "base_path": "/government/ministers/government-whip-lord-commissioner-of-hm-treasury--22",
+                    "document_type": "ministerial_role",
+                    "public_updated_at": "2023-02-13T14:40:16Z",
+                    "schema_name": "role",
+                    "withdrawn": false,
+                    "details": {
+                      "body": "\n",
+                      "role_payment_type": null,
+                      "seniority": 100,
+                      "whip_organisation": {
+                        "label": "Junior Lords of the Treasury",
+                        "sort_order": 2
+                      }
+                    },
+                    "links": {},
+                    "api_url": "https://www.gov.uk/api/content/government/ministers/government-whip-lord-commissioner-of-hm-treasury--22",
+                    "web_url": "https://www.gov.uk/government/ministers/government-whip-lord-commissioner-of-hm-treasury--22"
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        "api_url": "https://www.gov.uk/api/content/government/people/ruth-edwards",
+        "web_url": "https://www.gov.uk/government/people/ruth-edwards"
+      },
+      {
+        "content_id": "f637cddf-f71b-45ad-93c4-4db6864a4c29",
+        "title": "Joy Morrissey MP",
+        "locale": "en",
+        "api_path": "/api/content/government/people/joy-morrissey",
+        "base_path": "/government/people/joy-morrissey",
+        "document_type": "person",
+        "public_updated_at": "2022-07-09T08:51:15Z",
+        "schema_name": "person",
+        "withdrawn": false,
+        "details": {
+          "image": null,
+          "privy_counsellor": false
+        },
+        "links": {
+          "role_appointments": [
+            {
+              "content_id": "86467f91-c427-481e-964e-949488f5e16f",
+              "title": "Joy Morrissey MP - Assistant Government Whip",
+              "locale": "en",
+              "document_type": "role_appointment",
+              "public_updated_at": "2022-07-09T08:59:22Z",
+              "schema_name": "role_appointment",
+              "withdrawn": false,
+              "details": {
+                "started_on": "2022-07-08T00:00:00+01:00",
+                "ended_on": null,
+                "current": true,
+                "person_appointment_order": 7809
+              },
+              "links": {
+                "role": [
+                  {
+                    "content_id": "bac019ff-68c6-4ea3-b997-864ec4e01f05",
+                    "title": "Assistant Government Whip",
+                    "locale": "en",
+                    "api_path": "/api/content/government/ministers/assistant-government-whip--31",
+                    "base_path": "/government/ministers/assistant-government-whip--31",
+                    "document_type": "ministerial_role",
+                    "public_updated_at": "2022-07-09T08:58:00Z",
+                    "schema_name": "role",
+                    "withdrawn": false,
+                    "details": {
+                      "body": "\n",
+                      "role_payment_type": null,
+                      "seniority": 100,
+                      "whip_organisation": {
+                        "label": "Assistant Whips",
+                        "sort_order": 3
+                      }
+                    },
+                    "links": {},
+                    "api_url": "https://www.gov.uk/api/content/government/ministers/assistant-government-whip--31",
+                    "web_url": "https://www.gov.uk/government/ministers/assistant-government-whip--31"
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        "api_url": "https://www.gov.uk/api/content/government/people/joy-morrissey",
+        "web_url": "https://www.gov.uk/government/people/joy-morrissey"
+      }
+    ],
+    "ordered_baronesses_and_lords_in_waiting_whips": [
+      {
+        "content_id": "82c71f2c-7d28-40a1-b3e8-3b606cf4a9b7",
+        "title": "Baroness Bloomfield of Hinton Waldrist",
+        "locale": "en",
+        "api_path": "/api/content/government/people/baroness-bloomfield-of-hinton-waldrist",
+        "base_path": "/government/people/baroness-bloomfield-of-hinton-waldrist",
+        "document_type": "person",
+        "public_updated_at": "2019-07-29T18:59:25Z",
+        "schema_name": "person",
+        "withdrawn": false,
+        "details": {
+          "image": null,
+          "privy_counsellor": false
+        },
+        "links": {
+          "role_appointments": [
+            {
+              "content_id": "39d2d622-828c-40c1-9ff7-eb25e2bb14dd",
+              "title": "Baroness Bloomfield of Hinton Waldrist - Baroness in Waiting (Government Whip)",
+              "locale": "en",
+              "document_type": "role_appointment",
+              "public_updated_at": "2019-08-12T13:40:41Z",
+              "schema_name": "role_appointment",
+              "withdrawn": false,
+              "details": {
+                "started_on": "2019-07-29T00:00:00+01:00",
+                "ended_on": null,
+                "current": true,
+                "person_appointment_order": 5659
+              },
+              "links": {
+                "role": [
+                  {
+                    "content_id": "84614ae7-c0f1-11e4-8223-005056011aef",
+                    "title": "Baroness in Waiting (Government Whip)",
+                    "locale": "en",
+                    "api_path": "/api/content/government/ministers/baroness-northover",
+                    "base_path": "/government/ministers/baroness-northover",
+                    "document_type": "ministerial_role",
+                    "public_updated_at": "2019-08-12T13:40:41Z",
+                    "schema_name": "role",
+                    "withdrawn": false,
+                    "details": {
+                      "body": "<p>Lords Whips have the same constitutional position as departmental ministers. Their role in the House of Lords is different from that of Whips in the Commons, which is predominantly party management.</p>\n\n<p>A Lords Whip has an active role at the despatch box promoting and defending departmental policy which involves:</p>\n\n<ul>\n  <li>answering questions</li>\n  <li>responding to debates</li>\n  <li>taking through primary and secondary legislation</li>\n</ul>\n\n<p>If the department concerned does not have a departmental minister in the House of Lords, all of that department’s business will fall to a Whip.</p>\n",
+                      "role_payment_type": null,
+                      "seniority": 100,
+                      "whip_organisation": {
+                        "label": "Baronesses and Lords in Waiting",
+                        "sort_order": 5
+                      }
+                    },
+                    "links": {},
+                    "api_url": "https://www.gov.uk/api/content/government/ministers/baroness-northover",
+                    "web_url": "https://www.gov.uk/government/ministers/baroness-northover"
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        "api_url": "https://www.gov.uk/api/content/government/people/baroness-bloomfield-of-hinton-waldrist",
+        "web_url": "https://www.gov.uk/government/people/baroness-bloomfield-of-hinton-waldrist"
+      },
+      {
+        "content_id": "d08c4b0f-0064-4ed7-bd8f-a6cc5c09c62f",
+        "title": "Lord Caine",
+        "locale": "en",
+        "api_path": "/api/content/government/people/lord-caine",
+        "base_path": "/government/people/lord-caine",
+        "document_type": "person",
+        "public_updated_at": "2021-12-01T14:47:56Z",
+        "schema_name": "person",
+        "withdrawn": false,
+        "details": {
+          "image": {
+            "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/person/image/4907/s465_Untitled_design__3___1_.png",
+            "alt_text": "Lord Caine"
+          },
+          "privy_counsellor": false
+        },
+        "links": {
+          "role_appointments": [
+            {
+              "content_id": "e332be24-3b94-4b6f-9c1f-b5e3033b3375",
+              "title": "Lord Caine - Parliamentary Under Secretary of State ",
+              "locale": "en",
+              "document_type": "role_appointment",
+              "public_updated_at": "2021-11-05T16:11:17Z",
+              "schema_name": "role_appointment",
+              "withdrawn": false,
+              "details": {
+                "started_on": "2021-11-05T00:00:00+00:00",
+                "ended_on": null,
+                "current": true,
+                "person_appointment_order": 7310
+              },
+              "links": {
+                "role": [
+                  {
+                    "content_id": "5b63ecfc-583e-4193-82ec-ddec3daaae74",
+                    "title": "Parliamentary Under Secretary of State ",
+                    "locale": "en",
+                    "api_path": "/api/content/government/ministers/parliamentary-under-secretary-of-state--154",
+                    "base_path": "/government/ministers/parliamentary-under-secretary-of-state--154",
+                    "document_type": "ministerial_role",
+                    "public_updated_at": "2021-11-30T20:40:19Z",
+                    "schema_name": "role",
+                    "withdrawn": false,
+                    "details": {
+                      "body": "<p>The Parliamentary Under Secretary of State leads on supporting the Secretary of State in his responsibilities, specifically:</p>\n\n<ul>\n  <li>Supporting the Secretary of State on legacy, New Decade, New Approach and Protocol.</li>\n  <li>Reviewing planning for future political negotiations and developing plans to help achieve greater levels of Integrated Education in Northern Ireland.</li>\n  <li>Leading the department’s work on Constitution and Rights such as abortion and ensuring women have access to services.</li>\n  <li>Responsible for legislation and engagement in the House of Lords.</li>\n  <li>Aiding political stability such as reviewing plans for the 25th Anniversary of the Good Friday Agreement.</li>\n  <li>Building substantive relationships across sectors and communities through engagement.</li>\n</ul>\n",
+                      "role_payment_type": "Unpaid",
+                      "seniority": 100,
+                      "whip_organisation": {}
+                    },
+                    "links": {},
+                    "api_url": "https://www.gov.uk/api/content/government/ministers/parliamentary-under-secretary-of-state--154",
+                    "web_url": "https://www.gov.uk/government/ministers/parliamentary-under-secretary-of-state--154"
+                  }
+                ]
+              }
+            },
+            {
+              "content_id": "5b02b18e-2035-4e67-acdc-bd2bcd572635",
+              "title": "Lord Caine - Lord in Waiting",
+              "locale": "en",
+              "document_type": "role_appointment",
+              "public_updated_at": "2022-11-25T09:25:24Z",
+              "schema_name": "role_appointment",
+              "withdrawn": false,
+              "details": {
+                "started_on": "2022-11-24T00:00:00+00:00",
+                "ended_on": null,
+                "current": true,
+                "person_appointment_order": 8294
+              },
+              "links": {
+                "role": [
+                  {
+                    "content_id": "bed8196a-257f-4389-b254-3aee0606477d",
+                    "title": "Lord in Waiting",
+                    "locale": "en",
+                    "api_path": "/api/content/government/ministers/lord-in-waiting--4",
+                    "base_path": "/government/ministers/lord-in-waiting--4",
+                    "document_type": "ministerial_role",
+                    "public_updated_at": "2022-11-25T09:24:53Z",
+                    "schema_name": "role",
+                    "withdrawn": false,
+                    "details": {
+                      "body": "\n",
+                      "role_payment_type": null,
+                      "seniority": 100,
+                      "whip_organisation": {
+                        "label": "Baronesses and Lords in Waiting",
+                        "sort_order": 5
+                      }
+                    },
+                    "links": {},
+                    "api_url": "https://www.gov.uk/api/content/government/ministers/lord-in-waiting--4",
+                    "web_url": "https://www.gov.uk/government/ministers/lord-in-waiting--4"
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        "api_url": "https://www.gov.uk/api/content/government/people/lord-caine",
+        "web_url": "https://www.gov.uk/government/people/lord-caine"
+      }
+    ],
+    "ordered_cabinet_ministers": [
+      {
+        "content_id": "361b04ed-731a-4f55-82c0-14cdf129afac",
+        "title": "The Rt Hon Rishi Sunak MP",
+        "locale": "en",
+        "api_path": "/api/content/government/people/rishi-sunak",
+        "base_path": "/government/people/rishi-sunak",
+        "document_type": "person",
+        "public_updated_at": "2022-10-27T10:43:34Z",
+        "schema_name": "person",
+        "withdrawn": false,
+        "details": {
+          "image": {
+            "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/person/image/3339/s465_Rishi_profile.jpg",
+            "alt_text": "The Rt Hon Rishi Sunak MP"
+          },
+          "privy_counsellor": true
+        },
+        "links": {
+          "role_appointments": [
+            {
+              "content_id": "fa81796a-8b47-40b1-ab11-507aecae480f",
+              "title": "The Rt Hon Rishi Sunak - Parliamentary Under Secretary of State (Minister for Local Government)",
+              "locale": "en",
+              "document_type": "role_appointment",
+              "public_updated_at": "2019-11-06T16:37:58Z",
+              "schema_name": "role_appointment",
+              "withdrawn": false,
+              "details": {
+                "started_on": "2018-01-09T00:00:00+00:00",
+                "ended_on": "2019-07-24T00:00:00+01:00",
+                "current": false,
+                "person_appointment_order": 4541
+              },
+              "links": {
+                "role": [
+                  {
+                    "content_id": "8b9f67df-4acd-4c91-b48e-3635952fb4a7",
+                    "title": "Parliamentary Under Secretary of State (Minister for Local Government)",
+                    "locale": "en",
+                    "api_path": "/api/content/government/ministers/parliamentary-under-secretary-of-state--91",
+                    "base_path": "/government/ministers/parliamentary-under-secretary-of-state--91",
+                    "document_type": "ministerial_role",
+                    "public_updated_at": "2018-01-15T15:36:31Z",
+                    "schema_name": "role",
+                    "withdrawn": false,
+                    "details": {
+                      "body": "<p>The minister is responsible for:</p>\n\n<ul>\n  <li>Local government policy, including local government reform</li>\n  <li>Local government finances (including local authority sustainability and business rates retention)</li>\n  <li>Adult social care</li>\n  <li>Local government interventions policy and oversight of existing interventions</li>\n  <li>Local government pensions</li>\n  <li>Troubled Families</li>\n  <li>Parks / green space</li>\n</ul>\n",
+                      "role_payment_type": null,
+                      "seniority": 100,
+                      "whip_organisation": {}
+                    },
+                    "links": {},
+                    "api_url": "https://www.gov.uk/api/content/government/ministers/parliamentary-under-secretary-of-state--91",
+                    "web_url": "https://www.gov.uk/government/ministers/parliamentary-under-secretary-of-state--91"
+                  }
+                ]
+              }
+            },
+            {
+              "content_id": "d7d06a50-8250-4de9-b196-5c6b07a77229",
+              "title": "The Rt Hon Rishi Sunak MP - Chief Secretary to the Treasury",
+              "locale": "en",
+              "document_type": "role_appointment",
+              "public_updated_at": "2020-02-13T12:28:53Z",
+              "schema_name": "role_appointment",
+              "withdrawn": false,
+              "details": {
+                "started_on": "2019-07-24T00:00:00+01:00",
+                "ended_on": "2020-02-13T00:00:00+00:00",
+                "current": false,
+                "person_appointment_order": 5594
+              },
+              "links": {
+                "role": [
+                  {
+                    "content_id": "845e6667-c0f1-11e4-8223-005056011aef",
+                    "title": "Chief Secretary to the Treasury",
+                    "locale": "en",
+                    "api_path": "/api/content/government/ministers/chief-secretary-to-the-treasury",
+                    "base_path": "/government/ministers/chief-secretary-to-the-treasury",
+                    "document_type": "ministerial_role",
+                    "public_updated_at": "2022-11-22T15:30:28Z",
+                    "schema_name": "role",
+                    "withdrawn": false,
+                    "details": {
+                      "body": "<p>The Chief Secretary (<abbr title=\"Chief Secretary to the Treasury\">CST</abbr>) is responsible for public expenditure, including:</p>\n\n<ul>\n  <li>spending reviews and strategic planning</li>\n  <li>in-year spending control</li>\n  <li>public sector pay and pensions</li>\n  <li>Annually Managed Expenditure (<abbr title=\"Annually Managed Expenditure\">AME</abbr>) and welfare reform</li>\n  <li>efficiency and value for money in public service</li>\n  <li>procurement</li>\n  <li>capital investment</li>\n  <li>infrastructure spending</li>\n  <li>housing and planning</li>\n  <li>spending issues related to trade</li>\n  <li>transport policy, including HS2, Crossrail 2, Roads, Network Rail,\nOxford/Cambridge corridor</li>\n  <li>Treasury interest in devolution to Scotland, Wales and Northern Ireland</li>\n  <li>women in the economy</li>\n  <li>skills, labour market policy and childcare policy, including tax free childcare</li>\n  <li>tax credits policy</li>\n  <li>housing and planning</li>\n  <li>legislative strategy</li>\n  <li>state pensions/ pensioner benefits</li>\n  <li>freeports – with support from <abbr title=\"Economic Secretary to the Treasury\">EST</abbr> on customs aspects\n.</li>\n</ul>\n\n",
+                      "role_payment_type": "Unpaid",
+                      "seniority": 1,
+                      "whip_organisation": {}
+                    },
+                    "links": {},
+                    "api_url": "https://www.gov.uk/api/content/government/ministers/chief-secretary-to-the-treasury",
+                    "web_url": "https://www.gov.uk/government/ministers/chief-secretary-to-the-treasury"
+                  }
+                ]
+              }
+            },
+            {
+              "content_id": "e119bc68-d989-4243-802f-0486299c82ca",
+              "title": "The Rt Hon Rishi Sunak MP - Chancellor of the Exchequer",
+              "locale": "en",
+              "document_type": "role_appointment",
+              "public_updated_at": "2022-07-05T20:57:43Z",
+              "schema_name": "role_appointment",
+              "withdrawn": false,
+              "details": {
+                "started_on": "2020-02-13T00:00:00+00:00",
+                "ended_on": "2022-07-05T00:00:00+01:00",
+                "current": false,
+                "person_appointment_order": 6018
+              },
+              "links": {
+                "role": [
+                  {
+                    "content_id": "845e5c6b-c0f1-11e4-8223-005056011aef",
+                    "title": "Chancellor of the Exchequer",
+                    "locale": "en",
+                    "api_path": "/api/content/government/ministers/chancellor-of-the-exchequer",
+                    "base_path": "/government/ministers/chancellor-of-the-exchequer",
+                    "document_type": "ministerial_role",
+                    "public_updated_at": "2020-09-03T09:54:34Z",
+                    "schema_name": "role",
+                    "withdrawn": false,
+                    "details": {
+                      "body": "<p>The Chancellor of the Exchequer is the government’s chief financial minister and as such is responsible for raising revenue through taxation or borrowing and for controlling public spending. He has overall responsibility for the work of the Treasury.</p>\n\n<p>The Chancellor’s responsibilities cover:</p>\n\n<ul>\n  <li>fiscal policy (including the presenting of the annual Budget)</li>\n  <li>monetary policy, setting inflation targets</li>\n  <li>ministerial arrangements (in his role as Second Lord of the Treasury)</li>\n  <li>overall responsibility for the Treasury’s response to COVID-19</li>\n</ul>\n\n",
+                      "role_payment_type": null,
+                      "seniority": 6,
+                      "whip_organisation": {}
+                    },
+                    "links": {},
+                    "api_url": "https://www.gov.uk/api/content/government/ministers/chancellor-of-the-exchequer",
+                    "web_url": "https://www.gov.uk/government/ministers/chancellor-of-the-exchequer"
+                  }
+                ]
+              }
+            },
+            {
+              "content_id": "d4c7c6ae-5597-443a-88c0-e8770e162121",
+              "title": "The Rt Hon Rishi Sunak MP - Prime Minister",
+              "locale": "en",
+              "document_type": "role_appointment",
+              "public_updated_at": "2022-10-25T11:08:03Z",
+              "schema_name": "role_appointment",
+              "withdrawn": false,
+              "details": {
+                "started_on": "2022-10-25T00:00:00+01:00",
+                "ended_on": null,
+                "current": true,
+                "person_appointment_order": 8145
+              },
+              "links": {
+                "role": [
+                  {
+                    "content_id": "845e5811-c0f1-11e4-8223-005056011aef",
+                    "title": "Prime Minister",
+                    "locale": "en",
+                    "api_path": "/api/content/government/ministers/prime-minister",
+                    "base_path": "/government/ministers/prime-minister",
+                    "document_type": "ministerial_role",
+                    "public_updated_at": "2022-10-05T07:44:54Z",
+                    "schema_name": "role",
+                    "withdrawn": false,
+                    "details": {
+                      "body": "<p>The Prime Minister is the leader of His Majesty’s Government and is ultimately responsible for the policy and decisions of the government.</p>\n\n<p>As leader of the UK government the Prime Minister also:</p>\n\n<ul>\n  <li>oversees the <a href=\"https://www.gov.uk/government/ministers/minister-for-the-civil-service\">operation of the Civil Service</a> and government agencies</li>\n  <li>chooses members of the government</li>\n  <li>is the principal government figure in the House of Commons</li>\n</ul>\n\n<p>As <a href=\"https://www.gov.uk/government/ministers/minister-for-the-union\">Minister for the Union</a>, the Prime Minister works to ensure that all of government is acting on behalf of the entire United Kingdom: England, Northern Ireland, Scotland, and Wales.</p>\n",
+                      "role_payment_type": null,
+                      "seniority": 0,
+                      "whip_organisation": {}
+                    },
+                    "links": {},
+                    "api_url": "https://www.gov.uk/api/content/government/ministers/prime-minister",
+                    "web_url": "https://www.gov.uk/government/ministers/prime-minister"
+                  }
+                ]
+              }
+            },
+            {
+              "content_id": "78f96893-faa3-49f1-82ed-7bc2b4dde144",
+              "title": "The Rt Hon Rishi Sunak MP - First Lord of the Treasury",
+              "locale": "en",
+              "document_type": "role_appointment",
+              "public_updated_at": "2022-10-25T11:09:37Z",
+              "schema_name": "role_appointment",
+              "withdrawn": false,
+              "details": {
+                "started_on": "2022-10-25T00:00:00+01:00",
+                "ended_on": null,
+                "current": true,
+                "person_appointment_order": 8146
+              },
+              "links": {
+                "role": [
+                  {
+                    "content_id": "846a754c-c0f1-11e4-8223-005056011aef",
+                    "title": "First Lord of the Treasury",
+                    "locale": "en",
+                    "api_path": "/api/content/government/ministers/first-lord-of-the-treasury",
+                    "base_path": "/government/ministers/first-lord-of-the-treasury",
+                    "document_type": "ministerial_role",
+                    "public_updated_at": "2022-10-05T07:44:10Z",
+                    "schema_name": "role",
+                    "withdrawn": false,
+                    "details": {
+                      "body": "<p>The First Lord of the Treasury is one of the Lords Commissioners of the Treasury. This role is usually held by the <a href=\"https://www.gov.uk/government/ministers/prime-minister\">Prime Minister</a>.</p>\n\n<p>Since the 17th century, the Lords Commissioners of the Treasury have collectively carried out duties that were previously held by the Lord High Treasurer (head of His Majesty’s Treasury).</p>\n\n<p>The Lords Commissioners of the Treasury also include:</p>\n\n<ul>\n  <li>the Second Lord of the Treasury - the <a href=\"https://www.gov.uk/government/ministers/chancellor-of-the-exchequer\">Chancellor of the Exchequer</a>, who has most of the functional financial responsibilities</li>\n  <li>Junior Lords Commissioners of the Treasury - other members of the government, usually <a href=\"https://www.gov.uk/government/ministers#whips\">government whips in the House of Commons</a>\n</li>\n</ul>\n\n<p>10 Downing Street is the official residence of the First Lord of the Treasury, and not of the Prime Minister.</p>\n",
+                      "role_payment_type": null,
+                      "seniority": 1,
+                      "whip_organisation": {}
+                    },
+                    "links": {},
+                    "api_url": "https://www.gov.uk/api/content/government/ministers/first-lord-of-the-treasury",
+                    "web_url": "https://www.gov.uk/government/ministers/first-lord-of-the-treasury"
+                  }
+                ]
+              }
+            },
+            {
+              "content_id": "bfef43a3-4f05-4f2a-9b53-ef0810229eaf",
+              "title": "The Rt Hon Rishi Sunak MP - Minister for the Union",
+              "locale": "en",
+              "document_type": "role_appointment",
+              "public_updated_at": "2022-10-25T14:23:21Z",
+              "schema_name": "role_appointment",
+              "withdrawn": false,
+              "details": {
+                "started_on": "2022-10-25T00:00:00+01:00",
+                "ended_on": null,
+                "current": true,
+                "person_appointment_order": 8148
+              },
+              "links": {
+                "role": [
+                  {
+                    "content_id": "041f4e4c-45f8-44b0-a7d8-ae1eb11370a2",
+                    "title": "Minister for the Union",
+                    "locale": "en",
+                    "api_path": "/api/content/government/ministers/minister-for-the-union",
+                    "base_path": "/government/ministers/minister-for-the-union",
+                    "document_type": "ministerial_role",
+                    "public_updated_at": "2020-09-01T15:38:15Z",
+                    "schema_name": "role",
+                    "withdrawn": false,
+                    "details": {
+                      "body": "<p>As Minister for the Union, the Prime Minister works to ensure that all of government is acting on behalf of the entire United Kingdom: England, Northern Ireland, Scotland, and Wales.</p>\n",
+                      "role_payment_type": null,
+                      "seniority": 3,
+                      "whip_organisation": {}
+                    },
+                    "links": {},
+                    "api_url": "https://www.gov.uk/api/content/government/ministers/minister-for-the-union",
+                    "web_url": "https://www.gov.uk/government/ministers/minister-for-the-union"
+                  }
+                ]
+              }
+            },
+            {
+              "content_id": "dc7ea91a-0219-41e6-8891-83b47698349b",
+              "title": "The Rt Hon Rishi Sunak MP - Minister for the Civil Service",
+              "locale": "en",
+              "document_type": "role_appointment",
+              "public_updated_at": "2022-10-25T14:24:03Z",
+              "schema_name": "role_appointment",
+              "withdrawn": false,
+              "details": {
+                "started_on": "2022-10-25T00:00:00+01:00",
+                "ended_on": null,
+                "current": true,
+                "person_appointment_order": 8149
+              },
+              "links": {
+                "role": [
+                  {
+                    "content_id": "846a7351-c0f1-11e4-8223-005056011aef",
+                    "title": "Minister for the Civil Service",
+                    "locale": "en",
+                    "api_path": "/api/content/government/ministers/minister-for-the-civil-service",
+                    "base_path": "/government/ministers/minister-for-the-civil-service",
+                    "document_type": "ministerial_role",
+                    "public_updated_at": "2022-09-28T11:40:15Z",
+                    "schema_name": "role",
+                    "withdrawn": false,
+                    "details": {
+                      "body": "<p>The Minister for the Civil Service is responsible for regulating the <a rel=\"external\" href=\"http://www.civilservice.gov.uk/\">Civil Service</a>.</p>\n\n<p>The <a rel=\"external\" href=\"http://www.legislation.gov.uk/ukpga/1992/61/contents\">Civil Service (Management Functions) Act of 1992</a>, allows the Minister for the Civil Service to delegate power to other ministers and devolved administrations.</p>\n\n<p>This role was created in 1968 and is always held by the <a href=\"https://www.gov.uk/government/ministers/prime-minister\">Prime Minister</a>.</p>\n",
+                      "role_payment_type": null,
+                      "seniority": 2,
+                      "whip_organisation": {}
+                    },
+                    "links": {},
+                    "api_url": "https://www.gov.uk/api/content/government/ministers/minister-for-the-civil-service",
+                    "web_url": "https://www.gov.uk/government/ministers/minister-for-the-civil-service"
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        "api_url": "https://www.gov.uk/api/content/government/people/rishi-sunak",
+        "web_url": "https://www.gov.uk/government/people/rishi-sunak"
+      },
+      {
+        "content_id": "852e83e6-c0f1-11e4-8223-005056011aef",
+        "title": "The Rt Hon Greg Hands MP",
+        "locale": "en",
+        "api_path": "/api/content/government/people/greg-hands",
+        "base_path": "/government/people/greg-hands",
+        "document_type": "person",
+        "public_updated_at": "2023-02-07T11:54:39Z",
+        "schema_name": "person",
+        "withdrawn": false,
+        "details": {
+          "image": {
+            "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/person/image/397/s465_Greg_Hands_May2015_GOVUK.jpg",
+            "alt_text": "The Rt Hon Greg Hands MP"
+          },
+          "privy_counsellor": true
+        },
+        "links": {
+          "role_appointments": [
+            {
+              "content_id": "86968de6-3407-48ac-95fe-79b677644e1e",
+              "title": "The Rt Hon Greg Hands MP - Minister of State",
+              "locale": "en",
+              "document_type": "role_appointment",
+              "public_updated_at": "2021-11-19T13:57:56Z",
+              "schema_name": "role_appointment",
+              "withdrawn": false,
+              "details": {
+                "started_on": "2021-09-16T00:00:00+01:00",
+                "ended_on": "2021-09-16T00:00:00+01:00",
+                "current": false,
+                "person_appointment_order": 7128
+              },
+              "links": {
+                "role": [
+                  {
+                    "content_id": "385a8215-a8d3-4d45-9f38-3c74f79d9ea1",
+                    "title": "Minister of State",
+                    "locale": "en",
+                    "api_path": "/api/content/government/ministers/minister-of-state--110",
+                    "base_path": "/government/ministers/minister-of-state--110",
+                    "document_type": "ministerial_role",
+                    "public_updated_at": "2021-10-26T11:37:11Z",
+                    "schema_name": "role",
+                    "withdrawn": false,
+                    "details": {
+                      "body": "<p>Responsibilities include:</p>\n\n<ul>\n  <li>Net Zero Strategy</li>\n  <li>carbon budgets</li>\n  <li>green finance, joint with HMT</li>\n  <li>low carbon generation</li>\n  <li>energy retail markets</li>\n  <li>oil and gas</li>\n  <li>security of supply</li>\n  <li>electricity and gas wholesale markets and networks</li>\n  <li>international energy, climate change and climate finance</li>\n  <li>energy security, including resilience</li>\n  <li>hydrogen</li>\n  <li>industrial decarbonisation</li>\n  <li>nuclear</li>\n</ul>\n",
+                      "role_payment_type": null,
+                      "seniority": 100,
+                      "whip_organisation": {}
+                    },
+                    "links": {},
+                    "api_url": "https://www.gov.uk/api/content/government/ministers/minister-of-state--110",
+                    "web_url": "https://www.gov.uk/government/ministers/minister-of-state--110"
+                  }
+                ]
+              }
+            },
+            {
+              "content_id": "707fc660-b5dc-4b22-b078-2b960c2f1ee0",
+              "title": "The Rt Hon Greg Hands - Assistant Whip",
+              "locale": "en",
+              "document_type": "role_appointment",
+              "public_updated_at": "2019-11-06T00:11:00Z",
+              "schema_name": "role_appointment",
+              "withdrawn": false,
+              "details": {
+                "started_on": "2011-10-01T00:00:00+01:00",
+                "ended_on": "2013-10-07T00:00:00+01:00",
+                "current": false,
+                "person_appointment_order": 485
+              },
+              "links": {
+                "role": [
+                  {
+                    "content_id": "84618559-c0f1-11e4-8223-005056011aef",
+                    "title": "Assistant Whip",
+                    "locale": "en",
+                    "api_path": "/api/content/government/ministers/assistant-government-whip--4",
+                    "base_path": "/government/ministers/assistant-government-whip--4",
+                    "document_type": "ministerial_role",
+                    "public_updated_at": "2013-02-20T11:26:04Z",
+                    "schema_name": "role",
+                    "withdrawn": false,
+                    "details": {
+                      "body": "<p>Whips are MPs or Lords appointed by each party to help organise their party’s contribution to parliamentary business. They are responsible for making sure the maximum number of their party members vote, and vote the way their party wants.</p>\n",
+                      "role_payment_type": null,
+                      "seniority": 100,
+                      "whip_organisation": {
+                        "label": "Assistant Whips",
+                        "sort_order": 3
+                      }
+                    },
+                    "links": {},
+                    "api_url": "https://www.gov.uk/api/content/government/ministers/assistant-government-whip--4",
+                    "web_url": "https://www.gov.uk/government/ministers/assistant-government-whip--4"
+                  }
+                ]
+              }
+            },
+            {
+              "content_id": "4f452681-c7d7-4912-9a5b-13ef34ef21b3",
+              "title": "The Rt Hon Greg Hands - Treasurer of HM Household (Deputy Chief Whip)",
+              "locale": "en",
+              "document_type": "role_appointment",
+              "public_updated_at": "2019-11-06T00:11:00Z",
+              "schema_name": "role_appointment",
+              "withdrawn": false,
+              "details": {
+                "started_on": "2013-10-07T00:00:00+01:00",
+                "ended_on": "2015-05-11T00:00:00+01:00",
+                "current": false,
+                "person_appointment_order": 1403
+              },
+              "links": {
+                "role": [
+                  {
+                    "content_id": "84619b8e-c0f1-11e4-8223-005056011aef",
+                    "title": "Treasurer of HM Household (Deputy Chief Whip)",
+                    "locale": "en",
+                    "api_path": "/api/content/government/ministers/deputy-chief-whip-comptroller-of-hm-household--2",
+                    "base_path": "/government/ministers/deputy-chief-whip-comptroller-of-hm-household--2",
+                    "document_type": "ministerial_role",
+                    "public_updated_at": "2018-01-10T10:55:16Z",
+                    "schema_name": "role",
+                    "withdrawn": false,
+                    "details": {
+                      "body": "<p>Whips are MPs or Lords appointed by each party to help organise their party’s contribution to parliamentary business. They are responsible for making sure the maximum number of their party members vote, and vote the way their party wants.</p>\n",
+                      "role_payment_type": null,
+                      "seniority": 100,
+                      "whip_organisation": {
+                        "label": "House of Commons",
+                        "sort_order": 1
+                      }
+                    },
+                    "links": {},
+                    "api_url": "https://www.gov.uk/api/content/government/ministers/deputy-chief-whip-comptroller-of-hm-household--2",
+                    "web_url": "https://www.gov.uk/government/ministers/deputy-chief-whip-comptroller-of-hm-household--2"
+                  }
+                ]
+              }
+            },
+            {
+              "content_id": "94bb6277-5ab7-4fd9-84dd-e85fc753d952",
+              "title": "The Rt Hon Greg Hands - Chief Secretary to the Treasury",
+              "locale": "en",
+              "document_type": "role_appointment",
+              "public_updated_at": "2019-11-06T00:11:00Z",
+              "schema_name": "role_appointment",
+              "withdrawn": false,
+              "details": {
+                "started_on": "2015-05-11T00:00:00+01:00",
+                "ended_on": "2016-07-14T00:00:00+01:00",
+                "current": false,
+                "person_appointment_order": 2640
+              },
+              "links": {
+                "role": [
+                  {
+                    "content_id": "845e6667-c0f1-11e4-8223-005056011aef",
+                    "title": "Chief Secretary to the Treasury",
+                    "locale": "en",
+                    "api_path": "/api/content/government/ministers/chief-secretary-to-the-treasury",
+                    "base_path": "/government/ministers/chief-secretary-to-the-treasury",
+                    "document_type": "ministerial_role",
+                    "public_updated_at": "2022-11-22T15:30:28Z",
+                    "schema_name": "role",
+                    "withdrawn": false,
+                    "details": {
+                      "body": "<p>The Chief Secretary (<abbr title=\"Chief Secretary to the Treasury\">CST</abbr>) is responsible for public expenditure, including:</p>\n\n<ul>\n  <li>spending reviews and strategic planning</li>\n  <li>in-year spending control</li>\n  <li>public sector pay and pensions</li>\n  <li>Annually Managed Expenditure (<abbr title=\"Annually Managed Expenditure\">AME</abbr>) and welfare reform</li>\n  <li>efficiency and value for money in public service</li>\n  <li>procurement</li>\n  <li>capital investment</li>\n  <li>infrastructure spending</li>\n  <li>housing and planning</li>\n  <li>spending issues related to trade</li>\n  <li>transport policy, including HS2, Crossrail 2, Roads, Network Rail,\nOxford/Cambridge corridor</li>\n  <li>Treasury interest in devolution to Scotland, Wales and Northern Ireland</li>\n  <li>women in the economy</li>\n  <li>skills, labour market policy and childcare policy, including tax free childcare</li>\n  <li>tax credits policy</li>\n  <li>housing and planning</li>\n  <li>legislative strategy</li>\n  <li>state pensions/ pensioner benefits</li>\n  <li>freeports – with support from <abbr title=\"Economic Secretary to the Treasury\">EST</abbr> on customs aspects\n.</li>\n</ul>\n\n",
+                      "role_payment_type": "Unpaid",
+                      "seniority": 1,
+                      "whip_organisation": {}
+                    },
+                    "links": {},
+                    "api_url": "https://www.gov.uk/api/content/government/ministers/chief-secretary-to-the-treasury",
+                    "web_url": "https://www.gov.uk/government/ministers/chief-secretary-to-the-treasury"
+                  }
+                ]
+              }
+            },
+            {
+              "content_id": "1d1682bd-c063-4ab5-92c2-4fdbf7be6c72",
+              "title": "The Rt Hon Greg Hands - Minister of State for Trade and Investment",
+              "locale": "en",
+              "document_type": "role_appointment",
+              "public_updated_at": "2019-11-06T00:11:00Z",
+              "schema_name": "role_appointment",
+              "withdrawn": false,
+              "details": {
+                "started_on": "2016-07-15T00:00:00+01:00",
+                "ended_on": "2017-09-03T00:00:00+01:00",
+                "current": false,
+                "person_appointment_order": 3573
+              },
+              "links": {
+                "role": [
+                  {
+                    "content_id": "846143a9-c0f1-11e4-8223-005056011aef",
+                    "title": "Minister of State for Trade and Investment",
+                    "locale": "en",
+                    "api_path": "/api/content/government/ministers/minister-of-state-for-trade-and-investment",
+                    "base_path": "/government/ministers/minister-of-state-for-trade-and-investment",
+                    "document_type": "ministerial_role",
+                    "public_updated_at": "2017-04-04T12:41:08Z",
+                    "schema_name": "role",
+                    "withdrawn": false,
+                    "details": {
+                      "body": "<p>The Minister of State for Trade and Investment leads on trade and investment promotion in the following sectors:</p>\n\n<ul>\n  <li>technology and smart cities</li>\n  <li>infrastructure</li>\n  <li>energy</li>\n  <li>healthcare</li>\n  <li>life sciences</li>\n</ul>\n\n<p>Additionally, he leads on areas including:</p>\n\n<ul>\n  <li>UK Export Finance (UKEF)</li>\n  <li>business planning and forecasting</li>\n  <li>outward direct investment</li>\n  <li>economic diplomacy and the Prosperity Fund</li>\n  <li>the GREAT Britain campaign</li>\n  <li>policy direction on topics such as mergers and acquisitions</li>\n</ul>\n\n",
+                      "role_payment_type": null,
+                      "seniority": 100,
+                      "whip_organisation": {}
+                    },
+                    "links": {},
+                    "api_url": "https://www.gov.uk/api/content/government/ministers/minister-of-state-for-trade-and-investment",
+                    "web_url": "https://www.gov.uk/government/ministers/minister-of-state-for-trade-and-investment"
+                  }
+                ]
+              }
+            },
+            {
+              "content_id": "fa4edca6-34a0-4830-8937-80c50653bade",
+              "title": "The Rt Hon Greg Hands - Minister for London",
+              "locale": "en",
+              "document_type": "role_appointment",
+              "public_updated_at": "2019-11-06T00:11:00Z",
+              "schema_name": "role_appointment",
+              "withdrawn": false,
+              "details": {
+                "started_on": "2017-06-13T00:00:00+01:00",
+                "ended_on": "2018-01-09T00:00:00+00:00",
+                "current": false,
+                "person_appointment_order": 4123
+              },
+              "links": {
+                "role": [
+                  {
+                    "content_id": "c29a26f0-941e-469e-840b-dfba55c5d9d7",
+                    "title": "Minister for London",
+                    "locale": "en",
+                    "api_path": "/api/content/government/ministers/minister-for-london",
+                    "base_path": "/government/ministers/minister-for-london",
+                    "document_type": "ministerial_role",
+                    "public_updated_at": "2018-01-24T09:44:08Z",
+                    "schema_name": "role",
+                    "withdrawn": false,
+                    "details": {
+                      "body": "<p>The minister is responsible for:</p>\n\n<ul>\n  <li>London</li>\n</ul>\n",
+                      "role_payment_type": null,
+                      "seniority": 100,
+                      "whip_organisation": {}
+                    },
+                    "links": {},
+                    "api_url": "https://www.gov.uk/api/content/government/ministers/minister-for-london",
+                    "web_url": "https://www.gov.uk/government/ministers/minister-for-london"
+                  }
+                ]
+              }
+            },
+            {
+              "content_id": "a78066c3-9ade-4b4c-b59c-e93219c6100e",
+              "title": "The Rt Hon Greg Hands - Minister of State for Trade Policy",
+              "locale": "en",
+              "document_type": "role_appointment",
+              "public_updated_at": "2019-11-06T00:11:00Z",
+              "schema_name": "role_appointment",
+              "withdrawn": false,
+              "details": {
+                "started_on": "2017-09-03T00:00:00+01:00",
+                "ended_on": "2018-06-21T00:00:00+01:00",
+                "current": false,
+                "person_appointment_order": 4308
+              },
+              "links": {
+                "role": [
+                  {
+                    "content_id": "f3324a7a-2ac9-4aaa-839b-01c640b6d961",
+                    "title": "Minister of State for Trade Policy",
+                    "locale": "en",
+                    "api_path": "/api/content/government/ministers/minister-of-state--37",
+                    "base_path": "/government/ministers/minister-of-state--37",
+                    "document_type": "ministerial_role",
+                    "public_updated_at": "2019-03-13T10:23:21Z",
+                    "schema_name": "role",
+                    "withdrawn": false,
+                    "details": {
+                      "body": "<p>The Minister of State for Trade Policy oversees the Trade Policy Group, which leads for the department on developing, coordinating and delivering a new trade policy. The minister also acts as deputy to the Secretary of State for International Trade.</p>\n\n<p>The minister’s responsibilities include:</p>\n\n<ul>\n  <li>trading agreements and arrangements with other countries</li>\n  <li>UK engagement with the World Trade Organization</li>\n  <li>ongoing EU trade business while the UK remains a member of the EU</li>\n  <li>trade remedies</li>\n</ul>\n\n<p>Additionally, the minister leads on:</p>\n\n<ul>\n  <li>bills for the Department for International Trade (<abbr title=\"Department for International Trade\">DIT</abbr>)</li>\n  <li>secondary legislation</li>\n  <li>economic diplomacy, Prosperity Fund, and economic horizons markets</li>\n</ul>\n\n",
+                      "role_payment_type": null,
+                      "seniority": 100,
+                      "whip_organisation": {}
+                    },
+                    "links": {},
+                    "api_url": "https://www.gov.uk/api/content/government/ministers/minister-of-state--37",
+                    "web_url": "https://www.gov.uk/government/ministers/minister-of-state--37"
+                  }
+                ]
+              }
+            },
+            {
+              "content_id": "321bdb6d-6b7b-4767-959e-cd0e22f4da54",
+              "title": "The Rt Hon Greg Hands MP - Minister of State (Minister for Trade Policy)",
+              "locale": "en",
+              "document_type": "role_appointment",
+              "public_updated_at": "2021-09-16T08:39:15Z",
+              "schema_name": "role_appointment",
+              "withdrawn": false,
+              "details": {
+                "started_on": "2020-02-13T00:00:00+00:00",
+                "ended_on": "2021-09-15T00:00:00+01:00",
+                "current": false,
+                "person_appointment_order": 6042
+              },
+              "links": {
+                "role": [
+                  {
+                    "content_id": "079d5ff0-bf3f-41dc-be88-6384b4a57d8f",
+                    "title": "Minister of State (Minister for Trade Policy)",
+                    "locale": "en",
+                    "api_path": "/api/content/government/ministers/minister-of-state--96",
+                    "base_path": "/government/ministers/minister-of-state--96",
+                    "document_type": "ministerial_role",
+                    "public_updated_at": "2022-11-21T15:38:44Z",
+                    "schema_name": "role",
+                    "withdrawn": false,
+                    "details": {
+                      "body": "<p>The Minister of State for Trade Policy supports the Secretary of State with:</p>\n\n<ul>\n  <li>support on all free trade agreements (FTAs)</li>\n  <li>support on World Trade Organization (WTO), G7, G20, OECD, Commonwealth and wider multilateral engagement</li>\n  <li>market access strategy</li>\n  <li>FTA implementation</li>\n  <li>the Board of Trade</li>\n  <li>union policy</li>\n  <li>chairing the XWH Inter-Ministerial Trade Advisory Group (IMTAG)</li>\n  <li>external engagement via the:\n    <ul>\n      <li>Strategic Trade Advisory Group</li>\n      <li>sectoral trade advisory groups</li>\n      <li>trade union advisory groups</li>\n      <li>civil society and think tank roundtables</li>\n    </ul>\n  </li>\n</ul>\n",
+                      "role_payment_type": null,
+                      "seniority": 100,
+                      "whip_organisation": {}
+                    },
+                    "links": {},
+                    "api_url": "https://www.gov.uk/api/content/government/ministers/minister-of-state--96",
+                    "web_url": "https://www.gov.uk/government/ministers/minister-of-state--96"
+                  }
+                ]
+              }
+            },
+            {
+              "content_id": "f2873972-2236-4de6-9948-4a9ad7853789",
+              "title": "The Rt Hon Greg Hands MP - Minister without Portfolio",
+              "locale": "en",
+              "document_type": "role_appointment",
+              "public_updated_at": "2023-02-07T11:51:57Z",
+              "schema_name": "role_appointment",
+              "withdrawn": false,
+              "details": {
+                "started_on": "2023-02-07T00:00:00+00:00",
+                "ended_on": null,
+                "current": true,
+                "person_appointment_order": 11
+              },
+              "links": {
+                "role": [
+                  {
+                    "content_id": "d7f7603e-ac5b-40cf-bafe-6765d6ffb53b",
+                    "title": "Minister without Portfolio",
+                    "locale": "en",
+                    "api_path": "/api/content/government/ministers/minister-without-portfolio--8",
+                    "base_path": "/government/ministers/minister-without-portfolio--8",
+                    "document_type": "ministerial_role",
+                    "public_updated_at": "2023-02-21T16:17:37Z",
+                    "schema_name": "role",
+                    "withdrawn": false,
+                    "details": {
+                      "body": "\n",
+                      "role_payment_type": "Unpaid",
+                      "seniority": 29,
+                      "whip_organisation": {}
+                    },
+                    "links": {},
+                    "api_url": "https://www.gov.uk/api/content/government/ministers/minister-without-portfolio--8",
+                    "web_url": "https://www.gov.uk/government/ministers/minister-without-portfolio--8"
+                  }
+                ]
+              }
+            },
+            {
+              "content_id": "2ccdada3-fe39-41ff-8a9b-2856027550ec",
+              "title": "The Rt Hon Greg Hands MP - Minister of State (Minister for Trade Policy)",
+              "locale": "en",
+              "document_type": "role_appointment",
+              "public_updated_at": "2023-02-07T11:52:52Z",
+              "schema_name": "role_appointment",
+              "withdrawn": false,
+              "details": {
+                "started_on": "2022-10-09T00:00:00+01:00",
+                "ended_on": "2023-02-07T00:00:00+00:00",
+                "current": false,
+                "person_appointment_order": 10
+              },
+              "links": {
+                "role": [
+                  {
+                    "content_id": "079d5ff0-bf3f-41dc-be88-6384b4a57d8f",
+                    "title": "Minister of State (Minister for Trade Policy)",
+                    "locale": "en",
+                    "api_path": "/api/content/government/ministers/minister-of-state--96",
+                    "base_path": "/government/ministers/minister-of-state--96",
+                    "document_type": "ministerial_role",
+                    "public_updated_at": "2022-11-21T15:38:44Z",
+                    "schema_name": "role",
+                    "withdrawn": false,
+                    "details": {
+                      "body": "<p>The Minister of State for Trade Policy supports the Secretary of State with:</p>\n\n<ul>\n  <li>support on all free trade agreements (FTAs)</li>\n  <li>support on World Trade Organization (WTO), G7, G20, OECD, Commonwealth and wider multilateral engagement</li>\n  <li>market access strategy</li>\n  <li>FTA implementation</li>\n  <li>the Board of Trade</li>\n  <li>union policy</li>\n  <li>chairing the XWH Inter-Ministerial Trade Advisory Group (IMTAG)</li>\n  <li>external engagement via the:\n    <ul>\n      <li>Strategic Trade Advisory Group</li>\n      <li>sectoral trade advisory groups</li>\n      <li>trade union advisory groups</li>\n      <li>civil society and think tank roundtables</li>\n    </ul>\n  </li>\n</ul>\n",
+                      "role_payment_type": null,
+                      "seniority": 100,
+                      "whip_organisation": {}
+                    },
+                    "links": {},
+                    "api_url": "https://www.gov.uk/api/content/government/ministers/minister-of-state--96",
+                    "web_url": "https://www.gov.uk/government/ministers/minister-of-state--96"
+                  }
+                ]
+              }
+            },
+            {
+              "content_id": "c898ced9-967c-4ce4-ac4f-2d132bfa99e9",
+              "title": "The Rt Hon Greg Hands MP - Minister of State (Minister for Energy, Clean Growth and Climate Change)",
+              "locale": "en",
+              "document_type": "role_appointment",
+              "public_updated_at": "2022-09-09T13:20:10Z",
+              "schema_name": "role_appointment",
+              "withdrawn": false,
+              "details": {
+                "started_on": "2021-09-16T00:00:00+01:00",
+                "ended_on": "2022-09-07T00:00:00+01:00",
+                "current": false,
+                "person_appointment_order": 7346
+              },
+              "links": {
+                "role": [
+                  {
+                    "content_id": "2dc8314c-67ef-4fab-913d-1305a0024e56",
+                    "title": "Minister of State (Minister for Energy, Clean Growth and Climate Change)",
+                    "locale": "en",
+                    "api_path": "/api/content/government/ministers/minister-of-state--75",
+                    "base_path": "/government/ministers/minister-of-state--75",
+                    "document_type": "ministerial_role",
+                    "public_updated_at": "2022-07-12T16:46:23Z",
+                    "schema_name": "role",
+                    "withdrawn": false,
+                    "details": {
+                      "body": "<p>Responsibilities include:</p>\n\n<ul>\n  <li>Net Zero Strategy</li>\n  <li>carbon budgets</li>\n  <li>low carbon generation</li>\n  <li>energy retail markets</li>\n  <li>oil and gas</li>\n  <li>security of supply</li>\n  <li>electricity and gas wholesale markets and networks</li>\n  <li>international energy, climate change and climate finance</li>\n  <li>energy security, including resilience</li>\n  <li>hydrogen</li>\n  <li>nuclear</li>\n  <li>fusion</li>\n  <li>industrial decarbonisation</li>\n</ul>\n",
+                      "role_payment_type": null,
+                      "seniority": 5,
+                      "whip_organisation": {}
+                    },
+                    "links": {},
+                    "api_url": "https://www.gov.uk/api/content/government/ministers/minister-of-state--75",
+                    "web_url": "https://www.gov.uk/government/ministers/minister-of-state--75"
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        "api_url": "https://www.gov.uk/api/content/government/people/greg-hands",
+        "web_url": "https://www.gov.uk/government/people/greg-hands"
+      }
+    ],
+    "ordered_house_lords_whips": [
+      {
+        "content_id": "853df657-c0f1-11e4-8223-005056011aef",
+        "title": "The Rt Hon Baroness Williams of Trafford",
+        "locale": "en",
+        "api_path": "/api/content/government/people/susan-williams-of-trafford",
+        "base_path": "/government/people/susan-williams-of-trafford",
+        "document_type": "person",
+        "public_updated_at": "2022-09-08T07:40:29Z",
+        "schema_name": "person",
+        "withdrawn": false,
+        "details": {
+          "image": {
+            "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/person/image/1552/s465_Baroness_Williams_-_Official_-_960_x_640.jpg",
+            "alt_text": "The Rt Hon Baroness Williams of Trafford"
+          },
+          "privy_counsellor": true
+        },
+        "links": {
+          "role_appointments": [
+            {
+              "content_id": "ff0992c3-1ef5-4446-9d8c-9fe23c7c4136",
+              "title": "Baroness Williams of Trafford - Baroness in Waiting (Government Whip)",
+              "locale": "en",
+              "document_type": "role_appointment",
+              "public_updated_at": "2019-08-02T09:35:59Z",
+              "schema_name": "role_appointment",
+              "withdrawn": false,
+              "details": {
+                "started_on": "2014-04-08T00:00:00+01:00",
+                "ended_on": "2015-05-13T00:00:00+01:00",
+                "current": false,
+                "person_appointment_order": 1811
+              },
+              "links": {
+                "role": [
+                  {
+                    "content_id": "8472bcaf-c0f1-11e4-8223-005056011aef",
+                    "title": "Baroness in Waiting (Government Whip)",
+                    "locale": "en",
+                    "api_path": "/api/content/government/ministers/government-whip-baroness-in-waiting--3",
+                    "base_path": "/government/ministers/government-whip-baroness-in-waiting--3",
+                    "document_type": "ministerial_role",
+                    "public_updated_at": "2015-06-12T13:23:00Z",
+                    "schema_name": "role",
+                    "withdrawn": false,
+                    "details": {
+                      "body": "<p>Lords Whips have the same constitutional position as departmental ministers. Their role in the House of Lords is different from that of Whips in the Commons, which is predominantly party management.</p>\n\n<p>A Lords Whip has an active role at the despatch box promoting and defending departmental policy which involves:</p>\n\n<ul>\n  <li>answering questions</li>\n  <li>responding to debates</li>\n  <li>taking through primary and secondary legislation</li>\n</ul>\n\n<p>If the department concerned does not have a departmental minister in the House of Lords, all of that department’s business will fall to a Whip.</p>\n",
+                      "role_payment_type": null,
+                      "seniority": 100,
+                      "whip_organisation": {
+                        "label": "Baronesses and Lords in Waiting",
+                        "sort_order": 5
+                      }
+                    },
+                    "links": {},
+                    "api_url": "https://www.gov.uk/api/content/government/ministers/government-whip-baroness-in-waiting--3",
+                    "web_url": "https://www.gov.uk/government/ministers/government-whip-baroness-in-waiting--3"
+                  }
+                ]
+              }
+            },
+            {
+              "content_id": "5bd455ee-3800-4521-b3c0-d523823118d4",
+              "title": "Baroness Williams of Trafford - Parliamentary Under Secretary of State (Minister for the Northern Powerhouse)",
+              "locale": "en",
+              "document_type": "role_appointment",
+              "public_updated_at": "2019-08-02T09:35:59Z",
+              "schema_name": "role_appointment",
+              "withdrawn": false,
+              "details": {
+                "started_on": "2015-05-13T00:00:00+01:00",
+                "ended_on": "2016-07-17T00:00:00+01:00",
+                "current": false,
+                "person_appointment_order": 2682
+              },
+              "links": {
+                "role": [
+                  {
+                    "content_id": "845e6d97-c0f1-11e4-8223-005056011aef",
+                    "title": "Parliamentary Under Secretary of State (Minister for the Northern Powerhouse)",
+                    "locale": "en",
+                    "api_path": "/api/content/government/ministers/parliamentary-under-secretary-of-state--17",
+                    "base_path": "/government/ministers/parliamentary-under-secretary-of-state--17",
+                    "document_type": "ministerial_role",
+                    "public_updated_at": "2016-11-22T14:13:07Z",
+                    "schema_name": "role",
+                    "withdrawn": false,
+                    "details": {
+                      "body": "<p>The minister is responsible for:</p>\n\n<ul>\n  <li>Northern Powerhouse</li>\n  <li>devolution deals</li>\n  <li>local growth</li>\n  <li>coastal communities</li>\n  <li>community rights (including pubs)</li>\n  <li>local enterprise partnership (LEP) policy</li>\n  <li>enterprise zones</li>\n  <li>high streets</li>\n  <li>inward investment and infrastructure (including High Speed 2)</li>\n  <li>European Regional Development Fund</li>\n  <li>resilience and emergencies</li>\n  <li>parks / green spaces</li>\n</ul>\n",
+                      "role_payment_type": null,
+                      "seniority": 100,
+                      "whip_organisation": {}
+                    },
+                    "links": {},
+                    "api_url": "https://www.gov.uk/api/content/government/ministers/parliamentary-under-secretary-of-state--17",
+                    "web_url": "https://www.gov.uk/government/ministers/parliamentary-under-secretary-of-state--17"
+                  }
+                ]
+              }
+            },
+            {
+              "content_id": "cb3ca8f1-6013-40d6-ba87-4d49e19cb259",
+              "title": "Baroness Williams of Trafford - Minister of State (Minister for Equalities)",
+              "locale": "en",
+              "document_type": "role_appointment",
+              "public_updated_at": "2020-02-14T19:29:18Z",
+              "schema_name": "role_appointment",
+              "withdrawn": false,
+              "details": {
+                "started_on": "2018-01-09T00:00:00+00:00",
+                "ended_on": "2020-02-14T00:00:00+00:00",
+                "current": false,
+                "person_appointment_order": 5434
+              },
+              "links": {
+                "role": [
+                  {
+                    "content_id": "f6679300-b226-4cbb-9de4-3b9f4378f5e9",
+                    "title": "Parliamentary Under-Secretary of State (Minister for Equalities) ",
+                    "locale": "en",
+                    "api_path": "/api/content/government/ministers/minister-of-state-for-equalities",
+                    "base_path": "/government/ministers/minister-of-state-for-equalities",
+                    "document_type": "ministerial_role",
+                    "public_updated_at": "2020-02-14T19:30:25Z",
+                    "schema_name": "role",
+                    "withdrawn": false,
+                    "details": {
+                      "body": "\n",
+                      "role_payment_type": null,
+                      "seniority": 100,
+                      "whip_organisation": {}
+                    },
+                    "links": {},
+                    "api_url": "https://www.gov.uk/api/content/government/ministers/minister-of-state-for-equalities",
+                    "web_url": "https://www.gov.uk/government/ministers/minister-of-state-for-equalities"
+                  }
+                ]
+              }
+            },
+            {
+              "content_id": "c9159b01-8de8-4085-b3a7-23b4d39d1ca3",
+              "title": "Baroness Williams of Trafford - Minister of State (Minister for Countering Extremism)",
+              "locale": "en",
+              "document_type": "role_appointment",
+              "public_updated_at": "2020-02-25T12:32:09Z",
+              "schema_name": "role_appointment",
+              "withdrawn": false,
+              "details": {
+                "started_on": "2016-07-17T00:00:00+01:00",
+                "ended_on": "2020-02-14T00:00:00+00:00",
+                "current": false,
+                "person_appointment_order": 3547
+              },
+              "links": {
+                "role": [
+                  {
+                    "content_id": "22de4e88-52da-4ab5-a27a-fd1ac6af7cce",
+                    "title": "Minister of State (Minister for Countering Extremism)",
+                    "locale": "en",
+                    "api_path": "/api/content/government/ministers/minister-of-state--46",
+                    "base_path": "/government/ministers/minister-of-state--46",
+                    "document_type": "ministerial_role",
+                    "public_updated_at": "2020-02-25T12:35:52Z",
+                    "schema_name": "role",
+                    "withdrawn": false,
+                    "details": {
+                      "body": "<p>The Minister of State is responsible for:</p>\n\n<ul>\n  <li>all Home Office business in the House of Lords</li>\n  <li>countering extremism</li>\n  <li>hate crime</li>\n  <li>integration</li>\n  <li>devolution</li>\n  <li>data strategy</li>\n  <li>identity and biometrics</li>\n  <li>Better Regulation</li>\n  <li>animals in science</li>\n</ul>\n",
+                      "role_payment_type": null,
+                      "seniority": 100,
+                      "whip_organisation": {}
+                    },
+                    "links": {},
+                    "api_url": "https://www.gov.uk/api/content/government/ministers/minister-of-state--46",
+                    "web_url": "https://www.gov.uk/government/ministers/minister-of-state--46"
+                  }
+                ]
+              }
+            },
+            {
+              "content_id": "6c1e7c6f-20fb-4ed5-9e68-c242aef0d4bc",
+              "title": "The Rt Hon Baroness Williams of Trafford - Minister of State",
+              "locale": "en",
+              "document_type": "role_appointment",
+              "public_updated_at": "2022-09-07T17:09:01Z",
+              "schema_name": "role_appointment",
+              "withdrawn": false,
+              "details": {
+                "started_on": "2020-02-14T00:00:00+00:00",
+                "ended_on": "2022-09-06T00:00:00+01:00",
+                "current": false,
+                "person_appointment_order": 6101
+              },
+              "links": {
+                "role": [
+                  {
+                    "content_id": "6ab10b53-d2c6-466d-a89e-8bb820166e88",
+                    "title": "Minister of State",
+                    "locale": "en",
+                    "api_path": "/api/content/government/ministers/lords-minister",
+                    "base_path": "/government/ministers/lords-minister",
+                    "document_type": "ministerial_role",
+                    "public_updated_at": "2021-04-07T11:30:17Z",
+                    "schema_name": "role",
+                    "withdrawn": false,
+                    "details": {
+                      "body": "<p>The Lords Minister has responsibility for:</p>\n\n<ul>\n  <li>overall corporate lead including Spending Review and Budget</li>\n  <li>data and identity</li>\n  <li>enablers</li>\n  <li>digital and technology</li>\n  <li>public appointments</li>\n  <li>sponsorship unit</li>\n  <li>countering extremism</li>\n  <li>hate crime</li>\n  <li>forensic science and DNA</li>\n</ul>\n",
+                      "role_payment_type": null,
+                      "seniority": 100,
+                      "whip_organisation": {}
+                    },
+                    "links": {},
+                    "api_url": "https://www.gov.uk/api/content/government/ministers/lords-minister",
+                    "web_url": "https://www.gov.uk/government/ministers/lords-minister"
+                  }
+                ]
+              }
+            },
+            {
+              "content_id": "0d0540c1-a098-41d3-bbfc-effcc6427f66",
+              "title": "The Rt Hon Baroness Williams of Trafford - Captain of the Honourable Corps of Gentlemen at Arms (Lords Chief Whip)",
+              "locale": "en",
+              "document_type": "role_appointment",
+              "public_updated_at": "2022-09-07T17:04:17Z",
+              "schema_name": "role_appointment",
+              "withdrawn": false,
+              "details": {
+                "started_on": "2022-09-07T00:00:00+01:00",
+                "ended_on": null,
+                "current": true,
+                "person_appointment_order": 7996
+              },
+              "links": {
+                "role": [
+                  {
+                    "content_id": "84619671-c0f1-11e4-8223-005056011aef",
+                    "title": "Captain of the Honourable Corps of Gentlemen at Arms (Lords Chief Whip)",
+                    "locale": "en",
+                    "api_path": "/api/content/government/ministers/lords-chief-whip-and-captain-of-the-honourable-corps-of-gentlemen-at-arms",
+                    "base_path": "/government/ministers/lords-chief-whip-and-captain-of-the-honourable-corps-of-gentlemen-at-arms",
+                    "document_type": "ministerial_role",
+                    "public_updated_at": "2019-08-12T13:39:17Z",
+                    "schema_name": "role",
+                    "withdrawn": false,
+                    "details": {
+                      "body": "<p>Lords Whips have the same constitutional position as departmental ministers. Their role in the House of Lords is different from that of Whips in the Commons, which is predominantly party management.</p>\n\n<p>A Lords Whip has an active role at the despatch box promoting and defending departmental policy which involves:</p>\n\n<ul>\n  <li>answering questions</li>\n  <li>responding to debates</li>\n  <li>taking through primary and secondary legislation</li>\n</ul>\n\n<p>If the department concerned does not have a departmental minister in the House of Lords, all of that department’s business will fall to a Whip.</p>\n",
+                      "role_payment_type": null,
+                      "seniority": 100,
+                      "whip_organisation": {
+                        "label": "House of Lords",
+                        "sort_order": 4
+                      }
+                    },
+                    "links": {},
+                    "api_url": "https://www.gov.uk/api/content/government/ministers/lords-chief-whip-and-captain-of-the-honourable-corps-of-gentlemen-at-arms",
+                    "web_url": "https://www.gov.uk/government/ministers/lords-chief-whip-and-captain-of-the-honourable-corps-of-gentlemen-at-arms"
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        "api_url": "https://www.gov.uk/api/content/government/people/susan-williams-of-trafford",
+        "web_url": "https://www.gov.uk/government/people/susan-williams-of-trafford"
+      },
+      {
+        "content_id": "7bf5ee92-238d-42fa-8bbe-69fd36a08912",
+        "title": "The Earl of Courtown",
+        "locale": "en",
+        "api_path": "/api/content/government/people/earl-of-courtown",
+        "base_path": "/government/people/earl-of-courtown",
+        "document_type": "person",
+        "public_updated_at": "2023-03-27T16:51:37Z",
+        "schema_name": "person",
+        "withdrawn": false,
+        "details": {
+          "image": {
+            "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/person/image/2284/s465_Earl_of_Courtown.jpg",
+            "alt_text": "The Earl of Courtown"
+          },
+          "privy_counsellor": false
+        },
+        "links": {
+          "role_appointments": [
+            {
+              "content_id": "609c62c9-5283-4bbb-a7b5-9bc12f3d032c",
+              "title": "Earl of Courtown - Lord in Waiting (Government Whip)",
+              "locale": "en",
+              "document_type": "role_appointment",
+              "public_updated_at": "2019-08-29T09:46:41Z",
+              "schema_name": "role_appointment",
+              "withdrawn": false,
+              "details": {
+                "started_on": "2015-05-13T00:00:00+01:00",
+                "ended_on": "2016-07-17T00:00:00+01:00",
+                "current": false,
+                "person_appointment_order": 2738
+              },
+              "links": {
+                "role": [
+                  {
+                    "content_id": "befc5a98-584b-40a3-af4f-98fad2d7729f",
+                    "title": "Lord in Waiting (Government Whip)",
+                    "locale": "en",
+                    "api_path": "/api/content/government/ministers/government-whip-lord-in-waiting--8",
+                    "base_path": "/government/ministers/government-whip-lord-in-waiting--8",
+                    "document_type": "ministerial_role",
+                    "public_updated_at": "2015-06-12T13:25:18Z",
+                    "schema_name": "role",
+                    "withdrawn": false,
+                    "details": {
+                      "body": "<p>Lords Whips have the same constitutional position as departmental ministers. Their role in the House of Lords is different from that of Whips in the Commons, which is predominantly party management.</p>\n\n<p>A Lords Whip has an active role at the despatch box promoting and defending departmental policy which involves:</p>\n\n<ul>\n  <li>answering questions</li>\n  <li>responding to debates</li>\n  <li>taking through primary and secondary legislation</li>\n</ul>\n\n<p>If the department concerned does not have a departmental minister in the House of Lords, all of that department’s business will fall to a Whip.</p>\n",
+                      "role_payment_type": null,
+                      "seniority": 100,
+                      "whip_organisation": {
+                        "label": "Baronesses and Lords in Waiting",
+                        "sort_order": 5
+                      }
+                    },
+                    "links": {},
+                    "api_url": "https://www.gov.uk/api/content/government/ministers/government-whip-lord-in-waiting--8",
+                    "web_url": "https://www.gov.uk/government/ministers/government-whip-lord-in-waiting--8"
+                  }
+                ]
+              }
+            },
+            {
+              "content_id": "ffe5bb50-29c5-4d57-b379-5fc91b4e5327",
+              "title": "Earl of Courtown - Captain of the Queen's Bodyguard of the Yeomen of the Guard (Lords Deputy Chief Whip)",
+              "locale": "en",
+              "document_type": "role_appointment",
+              "public_updated_at": "2019-08-13T07:12:23Z",
+              "schema_name": "role_appointment",
+              "withdrawn": false,
+              "details": {
+                "started_on": "2016-07-17T00:00:00+01:00",
+                "ended_on": null,
+                "current": true,
+                "person_appointment_order": 3505
+              },
+              "links": {
+                "role": [
+                  {
+                    "content_id": "84619907-c0f1-11e4-8223-005056011aef",
+                    "title": "Captain of the King's Bodyguard of the Yeomen of the Guard (Lords Deputy Chief Whip)",
+                    "locale": "en",
+                    "api_path": "/api/content/government/ministers/government-deputy-chief-whip-and-captain-of-the-kings-bodyguard-of-the-yeomen-of-the-guard",
+                    "base_path": "/government/ministers/government-deputy-chief-whip-and-captain-of-the-kings-bodyguard-of-the-yeomen-of-the-guard",
+                    "document_type": "ministerial_role",
+                    "public_updated_at": "2023-02-02T16:16:47Z",
+                    "schema_name": "role",
+                    "withdrawn": false,
+                    "details": {
+                      "body": "<p>Lords Whips have the same constitutional position as departmental ministers. Their role in the House of Lords is different from that of Whips in the Commons, which is predominantly party management.</p>\n\n<p>A Lords Whip has an active role at the despatch box promoting and defending departmental policy which involves:</p>\n\n<ul>\n  <li>answering questions</li>\n  <li>responding to debates</li>\n  <li>taking through primary and secondary legislation</li>\n</ul>\n\n<p>If the department concerned does not have a departmental minister in the House of Lords, all of that department’s business will fall to a Whip.</p>\n",
+                      "role_payment_type": null,
+                      "seniority": 100,
+                      "whip_organisation": {
+                        "label": "House of Lords",
+                        "sort_order": 4
+                      }
+                    },
+                    "links": {},
+                    "api_url": "https://www.gov.uk/api/content/government/ministers/government-deputy-chief-whip-and-captain-of-the-kings-bodyguard-of-the-yeomen-of-the-guard",
+                    "web_url": "https://www.gov.uk/government/ministers/government-deputy-chief-whip-and-captain-of-the-kings-bodyguard-of-the-yeomen-of-the-guard"
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        "api_url": "https://www.gov.uk/api/content/government/people/earl-of-courtown",
+        "web_url": "https://www.gov.uk/government/people/earl-of-courtown"
+      }
+    ],
+    "ordered_house_of_commons_whips": [
+      {
+        "content_id": "44f73b9f-58d3-493a-9d78-3f177e177cac",
+        "title": "The Rt Hon Simon Hart MP",
+        "locale": "en",
+        "api_path": "/api/content/government/people/simon-hart",
+        "base_path": "/government/people/simon-hart",
+        "document_type": "person",
+        "public_updated_at": "2022-10-25T15:43:50Z",
+        "schema_name": "person",
+        "withdrawn": false,
+        "details": {
+          "image": {
+            "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/person/image/3188/s465_Simon_Hart_960-640.jpg",
+            "alt_text": "The Rt Hon Simon Hart MP"
+          },
+          "privy_counsellor": true
+        },
+        "links": {
+          "role_appointments": [
+            {
+              "content_id": "8a982e70-4b8f-408b-9d8b-127e65059c6e",
+              "title": "Simon Hart - Member",
+              "locale": "en",
+              "document_type": "role_appointment",
+              "public_updated_at": "2019-11-06T16:37:00Z",
+              "schema_name": "role_appointment",
+              "withdrawn": false,
+              "details": {
+                "started_on": "2017-08-08T00:00:00+01:00",
+                "ended_on": "2019-07-28T00:00:00+01:00",
+                "current": false,
+                "person_appointment_order": 4264
+              },
+              "links": {
+                "role": [
+                  {
+                    "content_id": "f92922a3-1364-40eb-a0df-95d1c4b477da",
+                    "title": "Member, Committee on Standards in Public Life",
+                    "locale": "en",
+                    "document_type": "board_member_role",
+                    "public_updated_at": "2023-03-13T10:28:40Z",
+                    "schema_name": "role",
+                    "withdrawn": false,
+                    "details": {
+                      "body": "<p>See <a href=\"https://www.gov.uk/government/publications/cspl-latest-register-of-interests--2\">CSPL’s register of interests for Committee members</a></p>\n",
+                      "role_payment_type": null
+                    },
+                    "links": {}
+                  }
+                ]
+              }
+            },
+            {
+              "content_id": "7fdc5051-b0b3-468e-86aa-99095f79a870",
+              "title": "Simon Hart - Parliamentary Secretary (Minister for Implementation)",
+              "locale": "en",
+              "document_type": "role_appointment",
+              "public_updated_at": "2019-12-16T18:05:57Z",
+              "schema_name": "role_appointment",
+              "withdrawn": false,
+              "details": {
+                "started_on": "2019-07-27T00:00:00+01:00",
+                "ended_on": "2019-12-16T00:00:00+00:00",
+                "current": false,
+                "person_appointment_order": 5729
+              },
+              "links": {
+                "role": [
+                  {
+                    "content_id": "7a07c083-4faf-43d9-8eac-676855289d39",
+                    "title": "Parliamentary Secretary (Minister for Implementation)",
+                    "locale": "en",
+                    "api_path": "/api/content/government/ministers/parliamentary-under-secretary-of-state--86",
+                    "base_path": "/government/ministers/parliamentary-under-secretary-of-state--86",
+                    "document_type": "ministerial_role",
+                    "public_updated_at": "2019-08-27T13:17:40Z",
+                    "schema_name": "role",
+                    "withdrawn": false,
+                    "details": {
+                      "body": "<ul>\n  <li>Supporting MCO on cross-government delivery and implementation</li>\n  <li>Controls (commercial, digital, property)</li>\n  <li>Commercial models</li>\n  <li>Cyber and resilience</li>\n  <li>Civil Service HR and Shared Services</li>\n  <li>Fraud, Error, Debt and Grants</li>\n  <li>Geospatial Commission</li>\n  <li>Government Digital Service</li>\n  <li>Government Security Group</li>\n  <li>Infrastructure and Projects Authority</li>\n  <li>Government Property</li>\n  <li>Government Commercial Function</li>\n  <li>Public bodies and appointments policy</li>\n</ul>\n\n",
+                      "role_payment_type": null,
+                      "seniority": 100,
+                      "whip_organisation": {}
+                    },
+                    "links": {},
+                    "api_url": "https://www.gov.uk/api/content/government/ministers/parliamentary-under-secretary-of-state--86",
+                    "web_url": "https://www.gov.uk/government/ministers/parliamentary-under-secretary-of-state--86"
+                  }
+                ]
+              }
+            },
+            {
+              "content_id": "1aeb27cf-1be2-493d-ad32-214360295c6d",
+              "title": "The Rt Hon Simon Hart MP - Secretary of State for Wales",
+              "locale": "en",
+              "document_type": "role_appointment",
+              "public_updated_at": "2022-07-07T09:15:07Z",
+              "schema_name": "role_appointment",
+              "withdrawn": false,
+              "details": {
+                "started_on": "2019-12-16T00:00:00+00:00",
+                "ended_on": "2022-07-06T00:00:00+01:00",
+                "current": false,
+                "person_appointment_order": 5926
+              },
+              "links": {
+                "role": [
+                  {
+                    "content_id": "845e661b-c0f1-11e4-8223-005056011aef",
+                    "title": "Secretary of State for Wales",
+                    "locale": "en",
+                    "api_path": "/api/content/government/ministers/secretary-of-state-for-wales",
+                    "base_path": "/government/ministers/secretary-of-state-for-wales",
+                    "document_type": "ministerial_role",
+                    "public_updated_at": "2023-03-09T15:06:29Z",
+                    "schema_name": "role",
+                    "withdrawn": false,
+                    "details": {
+                      "body": "<p>The Secretary of State is responsible for the overall strategic direction of the UK Government in Wales.</p>\n\n<p>Responsibilities include:</p>\n\n<ul>\n  <li>Fiscal</li>\n  <li>Constitutional and Electoral issues</li>\n  <li>Cost of living</li>\n  <li>Welsh language</li>\n  <li>Investment Zones</li>\n  <li>Freeports</li>\n  <li>Steel</li>\n  <li>Funds (eg SPF, Levelling Up)</li>\n  <li>Home Affairs (policing, immigration, security)</li>\n  <li>Defence</li>\n  <li>Foreign Affairs</li>\n  <li>Major Growth Deal Announcements</li>\n  <li>Public Appointments</li>\n  <li>Honours</li>\n  <li>Places for Growth</li>\n</ul>\n\n<p>The Secretary of State shares responsibility with the Parliamentary Under Secretary of State in these areas:</p>\n\n<ul>\n  <li>Union</li>\n  <li>Welsh Government / Senedd / Assembly Liaison</li>\n  <li>Economy</li>\n  <li>Transport (partially devolved)</li>\n  <li>International Trade</li>\n  <li>Research and Development, Innovation</li>\n  <li>Agriculture</li>\n  <li>Global Britain</li>\n  <li>Western Gateway</li>\n  <li>Third Sector</li>\n  <li>Local Government</li>\n</ul>\n\n",
+                      "role_payment_type": null,
+                      "seniority": 32,
+                      "whip_organisation": {}
+                    },
+                    "links": {},
+                    "api_url": "https://www.gov.uk/api/content/government/ministers/secretary-of-state-for-wales",
+                    "web_url": "https://www.gov.uk/government/ministers/secretary-of-state-for-wales"
+                  }
+                ]
+              }
+            },
+            {
+              "content_id": "cf56d569-534d-4cfc-8db1-61115f87fca8",
+              "title": "The Rt Hon Simon Hart MP - Parliamentary Secretary to the Treasury (Chief Whip)",
+              "locale": "en",
+              "document_type": "role_appointment",
+              "public_updated_at": "2022-10-25T15:47:07Z",
+              "schema_name": "role_appointment",
+              "withdrawn": false,
+              "details": {
+                "started_on": "2022-10-25T00:00:00+01:00",
+                "ended_on": null,
+                "current": true,
+                "person_appointment_order": 8154
+              },
+              "links": {
+                "role": [
+                  {
+                    "content_id": "845e6a56-c0f1-11e4-8223-005056011aef",
+                    "title": "Parliamentary Secretary to the Treasury (Chief Whip)",
+                    "locale": "en",
+                    "api_path": "/api/content/government/ministers/parliamentary-secretary-to-the-treasury-and-chief-whip",
+                    "base_path": "/government/ministers/parliamentary-secretary-to-the-treasury-and-chief-whip",
+                    "document_type": "ministerial_role",
+                    "public_updated_at": "2018-01-10T10:54:33Z",
+                    "schema_name": "role",
+                    "withdrawn": false,
+                    "details": {
+                      "body": "<p>The Chief Whip is responsible for administering the whipping system that ensures that members of the party attend and vote in Parliament as the party leadership desires.</p>\n\n<p>Whips are MPs or Lords appointed by each party in Parliament to help organise their party’s contribution to parliamentary business. One of their responsibilities is making sure the maximum number of their party members vote, and vote the way their party wants.</p>\n\n<h2 id=\"other-whip-duties\">Other whip duties</h2>\n\n<p>Whips frequently act as tellers (counting votes in divisions). They also manage the pairing system whereby Members of opposing parties both agree not to vote when other business (such as a select committee visit) prevents them from being present at Westminster.</p>\n\n<p>Whips are also largely responsible (together with the Leader of the House in the Commons) for arranging the business of Parliament. In this role they are frequently referred to as ‘the usual channels’.</p>\n",
+                      "role_payment_type": null,
+                      "seniority": 0,
+                      "whip_organisation": {
+                        "label": "House of Commons",
+                        "sort_order": 1
+                      }
+                    },
+                    "links": {},
+                    "api_url": "https://www.gov.uk/api/content/government/ministers/parliamentary-secretary-to-the-treasury-and-chief-whip",
+                    "web_url": "https://www.gov.uk/government/ministers/parliamentary-secretary-to-the-treasury-and-chief-whip"
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        "api_url": "https://www.gov.uk/api/content/government/people/simon-hart",
+        "web_url": "https://www.gov.uk/government/people/simon-hart"
+      },
+      {
+        "content_id": "ad85f664-e99f-4408-88a8-1394e829d647",
+        "title": "The Rt Hon Marcus Jones MP",
+        "locale": "en",
+        "api_path": "/api/content/government/people/marcus-jones",
+        "base_path": "/government/people/marcus-jones",
+        "document_type": "person",
+        "public_updated_at": "2023-02-22T16:03:14Z",
+        "schema_name": "person",
+        "withdrawn": false,
+        "details": {
+          "image": {
+            "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/person/image/2268/s465_Marcus_Jones_-_Official_960x640.jpg",
+            "alt_text": "The Rt Hon Marcus Jones MP"
+          },
+          "privy_counsellor": true
+        },
+        "links": {
+          "role_appointments": [
+            {
+              "content_id": "ab986204-5e90-42a8-9fd2-b193a53f9849",
+              "title": "Marcus Jones MP - Treasurer of HM Household (Deputy Chief Whip)",
+              "locale": "en",
+              "document_type": "role_appointment",
+              "public_updated_at": "2022-10-27T14:14:27Z",
+              "schema_name": "role_appointment",
+              "withdrawn": false,
+              "details": {
+                "started_on": "2022-10-27T00:00:00+01:00",
+                "ended_on": null,
+                "current": true,
+                "person_appointment_order": 8202
+              },
+              "links": {
+                "role": [
+                  {
+                    "content_id": "84619b8e-c0f1-11e4-8223-005056011aef",
+                    "title": "Treasurer of HM Household (Deputy Chief Whip)",
+                    "locale": "en",
+                    "api_path": "/api/content/government/ministers/deputy-chief-whip-comptroller-of-hm-household--2",
+                    "base_path": "/government/ministers/deputy-chief-whip-comptroller-of-hm-household--2",
+                    "document_type": "ministerial_role",
+                    "public_updated_at": "2018-01-10T10:55:16Z",
+                    "schema_name": "role",
+                    "withdrawn": false,
+                    "details": {
+                      "body": "<p>Whips are MPs or Lords appointed by each party to help organise their party’s contribution to parliamentary business. They are responsible for making sure the maximum number of their party members vote, and vote the way their party wants.</p>\n",
+                      "role_payment_type": null,
+                      "seniority": 100,
+                      "whip_organisation": {
+                        "label": "House of Commons",
+                        "sort_order": 1
+                      }
+                    },
+                    "links": {},
+                    "api_url": "https://www.gov.uk/api/content/government/ministers/deputy-chief-whip-comptroller-of-hm-household--2",
+                    "web_url": "https://www.gov.uk/government/ministers/deputy-chief-whip-comptroller-of-hm-household--2"
+                  }
+                ]
+              }
+            },
+            {
+              "content_id": "3ecdce09-a655-4bd2-b3f7-279271471b7f",
+              "title": "Marcus Jones - Parliamentary Under Secretary of State (Minister for Local Government)",
+              "locale": "en",
+              "document_type": "role_appointment",
+              "public_updated_at": "2019-11-06T00:11:46Z",
+              "schema_name": "role_appointment",
+              "withdrawn": false,
+              "details": {
+                "started_on": "2015-05-12T00:00:00+01:00",
+                "ended_on": "2018-01-08T00:00:00+00:00",
+                "current": false,
+                "person_appointment_order": 2671
+              },
+              "links": {
+                "role": [
+                  {
+                    "content_id": "ab2b784f-97d5-44ce-9e8f-21e230b0c993",
+                    "title": "Parliamentary Under Secretary of State (Minister for Local Government)",
+                    "locale": "en",
+                    "api_path": "/api/content/government/ministers/parliamentary-under-secretary-of-state-minister-for-local-government",
+                    "base_path": "/government/ministers/parliamentary-under-secretary-of-state-minister-for-local-government",
+                    "document_type": "ministerial_role",
+                    "public_updated_at": "2017-07-21T09:05:40Z",
+                    "schema_name": "role",
+                    "withdrawn": false,
+                    "details": {
+                      "body": "<p>The minister is responsible for:</p>\n\n<ul>\n  <li>Local government policy, including local government reform</li>\n  <li>Local government finances (including local authority sustainability and business rates retention)</li>\n  <li>Adult social care</li>\n  <li>Local government interventions policy and oversight of existing interventions</li>\n  <li>Local government pensions</li>\n  <li>Troubled Families</li>\n  <li>Homelessness</li>\n  <li>Supported housing</li>\n  <li>Parks and green spaces</li>\n</ul>\n\n",
+                      "role_payment_type": null,
+                      "seniority": 100,
+                      "whip_organisation": {}
+                    },
+                    "links": {},
+                    "api_url": "https://www.gov.uk/api/content/government/ministers/parliamentary-under-secretary-of-state-minister-for-local-government",
+                    "web_url": "https://www.gov.uk/government/ministers/parliamentary-under-secretary-of-state-minister-for-local-government"
+                  }
+                ]
+              }
+            },
+            {
+              "content_id": "0e34d479-2420-48f4-a3d4-96b21890a30a",
+              "title": "Marcus Jones MP - Assistant Government Whip",
+              "locale": "en",
+              "document_type": "role_appointment",
+              "public_updated_at": "2020-02-13T20:53:55Z",
+              "schema_name": "role_appointment",
+              "withdrawn": false,
+              "details": {
+                "started_on": "2019-07-29T00:00:00+01:00",
+                "ended_on": "2020-02-13T00:00:00+00:00",
+                "current": false,
+                "person_appointment_order": 5652
+              },
+              "links": {
+                "role": [
+                  {
+                    "content_id": "84618e06-c0f1-11e4-8223-005056011aef",
+                    "title": "Assistant Government Whip",
+                    "locale": "en",
+                    "api_path": "/api/content/government/ministers/assistant-government-whip--7",
+                    "base_path": "/government/ministers/assistant-government-whip--7",
+                    "document_type": "ministerial_role",
+                    "public_updated_at": "2018-07-25T19:45:01Z",
+                    "schema_name": "role",
+                    "withdrawn": false,
+                    "details": {
+                      "body": "<p>Whips are MPs or Lords appointed by each party to help organise their party’s contribution to parliamentary business. They are responsible for making sure the maximum number of their party members vote, and vote the way their party wants.</p>\n",
+                      "role_payment_type": null,
+                      "seniority": 100,
+                      "whip_organisation": {
+                        "label": "Assistant Whips",
+                        "sort_order": 3
+                      }
+                    },
+                    "links": {},
+                    "api_url": "https://www.gov.uk/api/content/government/ministers/assistant-government-whip--7",
+                    "web_url": "https://www.gov.uk/government/ministers/assistant-government-whip--7"
+                  }
+                ]
+              }
+            },
+            {
+              "content_id": "f3c8c46a-1ba0-40dd-a69f-ad20dcd2f04e",
+              "title": "Marcus Jones MP - Comptroller of HM Household (Government Whip) ",
+              "locale": "en",
+              "document_type": "role_appointment",
+              "public_updated_at": "2022-07-07T20:11:09Z",
+              "schema_name": "role_appointment",
+              "withdrawn": false,
+              "details": {
+                "started_on": "2021-09-17T00:00:00+01:00",
+                "ended_on": "2022-07-07T00:00:00+01:00",
+                "current": false,
+                "person_appointment_order": 7165
+              },
+              "links": {
+                "role": [
+                  {
+                    "content_id": "dd4e6468-e7a9-4259-8524-29599794c2b7",
+                    "title": "Comptroller of HM Household (Government Whip) ",
+                    "locale": "en",
+                    "api_path": "/api/content/government/ministers/comptroller-of-hm-household-government-whip",
+                    "base_path": "/government/ministers/comptroller-of-hm-household-government-whip",
+                    "document_type": "ministerial_role",
+                    "public_updated_at": "2018-01-09T17:37:16Z",
+                    "schema_name": "role",
+                    "withdrawn": false,
+                    "details": {
+                      "body": "<p>Ministerial responsibilities will be confirmed in due course.</p>\n",
+                      "role_payment_type": null,
+                      "seniority": 100,
+                      "whip_organisation": {
+                        "label": "House of Commons",
+                        "sort_order": 1
+                      }
+                    },
+                    "links": {},
+                    "api_url": "https://www.gov.uk/api/content/government/ministers/comptroller-of-hm-household-government-whip",
+                    "web_url": "https://www.gov.uk/government/ministers/comptroller-of-hm-household-government-whip"
+                  }
+                ]
+              }
+            },
+            {
+              "content_id": "765ee5a7-e0a5-402c-b394-83bdb8426707",
+              "title": "Marcus Jones MP - Vice Chamberlain of HM Household (Government Whip)",
+              "locale": "en",
+              "document_type": "role_appointment",
+              "public_updated_at": "2021-09-17T16:00:46Z",
+              "schema_name": "role_appointment",
+              "withdrawn": false,
+              "details": {
+                "started_on": "2020-02-13T00:00:00+00:00",
+                "ended_on": "2021-09-17T00:00:00+01:00",
+                "current": false,
+                "person_appointment_order": 6051
+              },
+              "links": {
+                "role": [
+                  {
+                    "content_id": "52e6d6ec-0d95-414f-8947-ac0c5277ff72",
+                    "title": "Vice Chamberlain of HM Household (Government Whip)",
+                    "locale": "en",
+                    "api_path": "/api/content/government/ministers/government-whip--2",
+                    "base_path": "/government/ministers/government-whip--2",
+                    "document_type": "ministerial_role",
+                    "public_updated_at": "2020-02-13T20:44:11Z",
+                    "schema_name": "role",
+                    "withdrawn": false,
+                    "details": {
+                      "body": "\n",
+                      "role_payment_type": null,
+                      "seniority": 100,
+                      "whip_organisation": {
+                        "label": "House of Commons",
+                        "sort_order": 1
+                      }
+                    },
+                    "links": {},
+                    "api_url": "https://www.gov.uk/api/content/government/ministers/government-whip--2",
+                    "web_url": "https://www.gov.uk/government/ministers/government-whip--2"
+                  }
+                ]
+              }
+            },
+            {
+              "content_id": "4ee7668b-902b-4778-8dcc-58d98a31cf2f",
+              "title": "Marcus Jones MP - Minister of State",
+              "locale": "en",
+              "document_type": "role_appointment",
+              "public_updated_at": "2022-07-22T08:28:27Z",
+              "schema_name": "role_appointment",
+              "withdrawn": false,
+              "details": {
+                "started_on": "2022-07-07T00:00:00+01:00",
+                "ended_on": "2022-07-07T00:00:00+01:00",
+                "current": false,
+                "person_appointment_order": 7775
+              },
+              "links": {
+                "role": [
+                  {
+                    "content_id": "e5118e78-eb4c-4438-ba41-99532ad66f30",
+                    "title": "Minister of State",
+                    "locale": "en",
+                    "api_path": "/api/content/government/ministers/minister-of-state-at-the-department-for-levelling-up-housing-and-communities",
+                    "base_path": "/government/ministers/minister-of-state-at-the-department-for-levelling-up-housing-and-communities",
+                    "document_type": "ministerial_role",
+                    "public_updated_at": "2022-07-08T16:10:29Z",
+                    "schema_name": "role",
+                    "withdrawn": false,
+                    "details": {
+                      "body": "\n",
+                      "role_payment_type": null,
+                      "seniority": 100,
+                      "whip_organisation": {}
+                    },
+                    "links": {},
+                    "api_url": "https://www.gov.uk/api/content/government/ministers/minister-of-state-at-the-department-for-levelling-up-housing-and-communities",
+                    "web_url": "https://www.gov.uk/government/ministers/minister-of-state-at-the-department-for-levelling-up-housing-and-communities"
+                  }
+                ]
+              }
+            },
+            {
+              "content_id": "c2ccfc97-9629-47ba-8097-0ebf448861e1",
+              "title": "Marcus Jones MP - Minister of State (Minister for Housing)",
+              "locale": "en",
+              "document_type": "role_appointment",
+              "public_updated_at": "2022-09-12T14:44:08Z",
+              "schema_name": "role_appointment",
+              "withdrawn": false,
+              "details": {
+                "started_on": "2022-07-07T00:00:00+01:00",
+                "ended_on": "2022-09-07T00:00:00+01:00",
+                "current": false,
+                "person_appointment_order": 7839
+              },
+              "links": {
+                "role": [
+                  {
+                    "content_id": "6fd4647b-a9d1-48e6-84ee-d4c35807c6e0",
+                    "title": "Minister of State (Minister for Housing)",
+                    "locale": "en",
+                    "api_path": "/api/content/government/ministers/minister-of-state-minister-for-housing--2",
+                    "base_path": "/government/ministers/minister-of-state-minister-for-housing--2",
+                    "document_type": "ministerial_role",
+                    "public_updated_at": "2022-07-22T08:55:26Z",
+                    "schema_name": "role",
+                    "withdrawn": false,
+                    "details": {
+                      "body": "<ul>\n  <li>Planning casework</li>\n  <li>Tackling leasehold and freehold abuses</li>\n  <li>Housing Supply</li>\n  <li>Planning reform</li>\n  <li>Design</li>\n  <li>Homeownership</li>\n  <li>Homebuying and Selling</li>\n  <li>Voluntary Right to Buy</li>\n  <li>Affordable Housing Programme</li>\n  <li>Legislation: Levelling Up &amp; Regeneration Bill (together with Levelling Up Minister)</li>\n</ul>\n",
+                      "role_payment_type": null,
+                      "seniority": 100,
+                      "whip_organisation": {}
+                    },
+                    "links": {},
+                    "api_url": "https://www.gov.uk/api/content/government/ministers/minister-of-state-minister-for-housing--2",
+                    "web_url": "https://www.gov.uk/government/ministers/minister-of-state-minister-for-housing--2"
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        "api_url": "https://www.gov.uk/api/content/government/people/marcus-jones",
+        "web_url": "https://www.gov.uk/government/people/marcus-jones"
+      }
+    ],
+    "ordered_junior_lords_of_the_treasury_whips": [
+      {
+        "content_id": "fd04b002-083f-4b95-b78a-8e29184c3d53",
+        "title": "Amanda Solloway MP",
+        "locale": "en",
+        "api_path": "/api/content/government/people/amanda-solloway",
+        "base_path": "/government/people/amanda-solloway",
+        "document_type": "person",
+        "public_updated_at": "2023-02-28T12:13:47Z",
+        "schema_name": "person",
+        "withdrawn": false,
+        "details": {
+          "image": {
+            "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/person/image/4216/s465_amanda-solloway-cc-by-3.jpg",
+            "alt_text": "Amanda Solloway MP"
+          },
+          "privy_counsellor": false
+        },
+        "links": {
+          "role_appointments": [
+            {
+              "content_id": "f9813dd3-58ad-4127-a2d5-51b389549e6c",
+              "title": "Amanda Solloway MP - Parliamentary Under Secretary of State (Minister for Equalities)",
+              "locale": "en",
+              "document_type": "role_appointment",
+              "public_updated_at": "2022-09-21T10:44:37Z",
+              "schema_name": "role_appointment",
+              "withdrawn": false,
+              "details": {
+                "started_on": "2022-07-08T00:00:00+01:00",
+                "ended_on": "2022-09-20T00:00:00+01:00",
+                "current": false,
+                "person_appointment_order": 7801
+              },
+              "links": {
+                "role": [
+                  {
+                    "content_id": "ccea3444-4897-431d-b77e-a202a4d3a85c",
+                    "title": "Parliamentary Under Secretary of State (Minister for Equalities)",
+                    "locale": "en",
+                    "api_path": "/api/content/government/ministers/parliamentary-under-secretary-of-state-minister-for-equalities",
+                    "base_path": "/government/ministers/parliamentary-under-secretary-of-state-minister-for-equalities",
+                    "document_type": "ministerial_role",
+                    "public_updated_at": "2022-04-28T08:05:38Z",
+                    "schema_name": "role",
+                    "withdrawn": false,
+                    "details": {
+                      "body": "<p>The Minister for Equalities’ responsibilities include:</p>\n\n<ul>\n  <li>Equality for LGBT people in the UK (at home, work, health and wellbeing)</li>\n  <li>Banning conversion therapy in England and Wales</li>\n  <li>LGBT equality in the workplace</li>\n  <li>LGBT safety (including homelessness and domestic violence)</li>\n</ul>\n",
+                      "role_payment_type": null,
+                      "seniority": 100,
+                      "whip_organisation": {}
+                    },
+                    "links": {},
+                    "api_url": "https://www.gov.uk/api/content/government/ministers/parliamentary-under-secretary-of-state-minister-for-equalities",
+                    "web_url": "https://www.gov.uk/government/ministers/parliamentary-under-secretary-of-state-minister-for-equalities"
+                  }
+                ]
+              }
+            },
+            {
+              "content_id": "5fd68eae-ea93-4ef3-9a88-35e19eabbbd8",
+              "title": "Amanda Solloway MP - Government Whip (Lord Commissioner of HM Treasury)",
+              "locale": "en",
+              "document_type": "role_appointment",
+              "public_updated_at": "2022-09-21T10:45:30Z",
+              "schema_name": "role_appointment",
+              "withdrawn": false,
+              "details": {
+                "started_on": "2022-09-20T00:00:00+01:00",
+                "ended_on": null,
+                "current": true,
+                "person_appointment_order": 8053
+              },
+              "links": {
+                "role": [
+                  {
+                    "content_id": "4d415f0a-1c2e-4c11-9294-4838f756f509",
+                    "title": "Government Whip (Lord Commissioner of HM Treasury)",
+                    "locale": "en",
+                    "api_path": "/api/content/government/ministers/government-whip-lord-commissioner-of-hm-treasury--19",
+                    "base_path": "/government/ministers/government-whip-lord-commissioner-of-hm-treasury--19",
+                    "document_type": "ministerial_role",
+                    "public_updated_at": "2023-02-21T16:17:10Z",
+                    "schema_name": "role",
+                    "withdrawn": false,
+                    "details": {
+                      "body": "\n",
+                      "role_payment_type": "Paid as a whip",
+                      "seniority": 100,
+                      "whip_organisation": {
+                        "label": "Junior Lords of the Treasury",
+                        "sort_order": 2
+                      }
+                    },
+                    "links": {},
+                    "api_url": "https://www.gov.uk/api/content/government/ministers/government-whip-lord-commissioner-of-hm-treasury--19",
+                    "web_url": "https://www.gov.uk/government/ministers/government-whip-lord-commissioner-of-hm-treasury--19"
+                  }
+                ]
+              }
+            },
+            {
+              "content_id": "54b2bf72-cfe2-4c3f-9f0f-8658fed22c3c",
+              "title": "Amanda Solloway MP - Government Whip (Lord Commissioner of HM Treasury)",
+              "locale": "en",
+              "document_type": "role_appointment",
+              "public_updated_at": "2022-09-21T10:58:58Z",
+              "schema_name": "role_appointment",
+              "withdrawn": false,
+              "details": {
+                "started_on": "2021-09-16T00:00:00+01:00",
+                "ended_on": "2022-07-06T00:00:00+01:00",
+                "current": false,
+                "person_appointment_order": 7142
+              },
+              "links": {
+                "role": [
+                  {
+                    "content_id": "300ed612-1b9e-4115-a1ad-28b3651f5b88",
+                    "title": "Government Whip (Lord Commissioner of HM Treasury)",
+                    "locale": "en",
+                    "api_path": "/api/content/government/ministers/government-whip-lord-commissioner-of-hm-treasury--11",
+                    "base_path": "/government/ministers/government-whip-lord-commissioner-of-hm-treasury--11",
+                    "document_type": "ministerial_role",
+                    "public_updated_at": "2022-07-13T09:03:09Z",
+                    "schema_name": "role",
+                    "withdrawn": false,
+                    "details": {
+                      "body": "\n",
+                      "role_payment_type": null,
+                      "seniority": 100,
+                      "whip_organisation": {
+                        "label": "Junior Lords of the Treasury",
+                        "sort_order": 2
+                      }
+                    },
+                    "links": {},
+                    "api_url": "https://www.gov.uk/api/content/government/ministers/government-whip-lord-commissioner-of-hm-treasury--11",
+                    "web_url": "https://www.gov.uk/government/ministers/government-whip-lord-commissioner-of-hm-treasury--11"
+                  }
+                ]
+              }
+            },
+            {
+              "content_id": "92d5eeb5-b9d3-4e1f-914b-46fe57e6e592",
+              "title": "Amanda Solloway MP - Parliamentary Under Secretary of State (Minister for Science, Research and Innovation)",
+              "locale": "en",
+              "document_type": "role_appointment",
+              "public_updated_at": "2021-09-16T19:42:42Z",
+              "schema_name": "role_appointment",
+              "withdrawn": false,
+              "details": {
+                "started_on": "2020-02-14T00:00:00+00:00",
+                "ended_on": "2021-09-15T00:00:00+01:00",
+                "current": false,
+                "person_appointment_order": 6106
+              },
+              "links": {
+                "role": [
+                  {
+                    "content_id": "12077894-e086-4495-aafe-194bfcf6b974",
+                    "title": "Parliamentary Under Secretary of State (Minister for Science, Research and Innovation)",
+                    "locale": "en",
+                    "api_path": "/api/content/government/ministers/parliamentary-under-secretary-of-state-minister-for-science-research-and-innovation",
+                    "base_path": "/government/ministers/parliamentary-under-secretary-of-state-minister-for-science-research-and-innovation",
+                    "document_type": "ministerial_role",
+                    "public_updated_at": "2021-10-26T11:43:29Z",
+                    "schema_name": "role",
+                    "withdrawn": false,
+                    "details": {
+                      "body": "<p>Responsibilities include:</p>\n\n<ul>\n  <li>science and research (domestic and international)\n    <ul>\n      <li>UK Research and Innovation (UKRI) sponsorship</li>\n      <li>Advanced Research and Invention Agency (ARIA)</li>\n    </ul>\n  </li>\n  <li>fusion</li>\n  <li>artificial intelligence (Office for AI), joint with DCMS</li>\n  <li>innovation</li>\n  <li>intellectual property</li>\n  <li>space</li>\n  <li>technology (strategy and security)</li>\n  <li>life sciences (including vaccine production)</li>\n</ul>\n",
+                      "role_payment_type": null,
+                      "seniority": 100,
+                      "whip_organisation": {}
+                    },
+                    "links": {},
+                    "api_url": "https://www.gov.uk/api/content/government/ministers/parliamentary-under-secretary-of-state-minister-for-science-research-and-innovation",
+                    "web_url": "https://www.gov.uk/government/ministers/parliamentary-under-secretary-of-state-minister-for-science-research-and-innovation"
+                  }
+                ]
+              }
+            },
+            {
+              "content_id": "d8671f27-a361-40c7-ab72-59dd35c572b1",
+              "title": "Amanda Solloway MP - Parliamentary Under Secretary of State (Minister for Safeguarding)",
+              "locale": "en",
+              "document_type": "role_appointment",
+              "public_updated_at": "2022-09-26T14:29:48Z",
+              "schema_name": "role_appointment",
+              "withdrawn": false,
+              "details": {
+                "started_on": "2022-07-08T00:00:00+01:00",
+                "ended_on": "2022-09-20T00:00:00+01:00",
+                "current": false,
+                "person_appointment_order": 7802
+              },
+              "links": {
+                "role": [
+                  {
+                    "content_id": "352c7ffb-5c67-4bbd-9433-b96576028aad",
+                    "title": "Parliamentary Under Secretary of State (Minister for Safeguarding)",
+                    "locale": "en",
+                    "api_path": "/api/content/government/ministers/parliamentary-under-secretary-of-state--165",
+                    "base_path": "/government/ministers/parliamentary-under-secretary-of-state--165",
+                    "document_type": "ministerial_role",
+                    "public_updated_at": "2022-07-14T08:13:26Z",
+                    "schema_name": "role",
+                    "withdrawn": false,
+                    "details": {
+                      "body": "<p>At the Home Office, the Minister is responsible for:</p>\n\n<ul>\n  <li>modern slavery and the national referral mechanism</li>\n  <li>domestic abuse</li>\n  <li>violence against women and girls including female genital mutilation (FGM) and forced marriage</li>\n  <li>early youth intervention on serious violence</li>\n  <li>Disclosure and Barring Service (DBS)</li>\n  <li>victims</li>\n  <li>child sexual abuse and exploitation</li>\n  <li>Independent Inquiry into Child Sexual Abuse</li>\n  <li>Gangmasters and Labour Abuse Authority</li>\n  <li>sexual violence including the rape review</li>\n  <li>anti-social behaviour</li>\n  <li>prostitution</li>\n  <li>stalking</li>\n  <li>online internet safety/WeProtect</li>\n  <li>Security Industry Authority</li>\n  <li>safeguarding and DBS checks for COVID volunteers and community groups</li>\n</ul>\n",
+                      "role_payment_type": null,
+                      "seniority": 100,
+                      "whip_organisation": {}
+                    },
+                    "links": {},
+                    "api_url": "https://www.gov.uk/api/content/government/ministers/parliamentary-under-secretary-of-state--165",
+                    "web_url": "https://www.gov.uk/government/ministers/parliamentary-under-secretary-of-state--165"
+                  }
+                ]
+              }
+            },
+            {
+              "content_id": "b18a87f4-87e9-4d0e-af49-a5d8e498a66a",
+              "title": "Amanda Solloway MP - Parliamentary Under Secretary of State (Minister for Energy Consumers and Affordability)",
+              "locale": "en",
+              "document_type": "role_appointment",
+              "public_updated_at": "2023-02-28T11:59:23Z",
+              "schema_name": "role_appointment",
+              "withdrawn": false,
+              "details": {
+                "started_on": "2023-02-07T00:00:00+00:00",
+                "ended_on": null,
+                "current": true,
+                "person_appointment_order": 7
+              },
+              "links": {
+                "role": [
+                  {
+                    "content_id": "beb88ec6-58ea-4eec-ab83-4d5e80eabd11",
+                    "title": "Parliamentary Under Secretary of State (Minister for Energy Consumers and Affordability)",
+                    "locale": "en",
+                    "api_path": "/api/content/government/ministers/parliamentary-under-secretary-of-state-minister-for-energy-consumers-and-affordability",
+                    "base_path": "/government/ministers/parliamentary-under-secretary-of-state-minister-for-energy-consumers-and-affordability",
+                    "document_type": "ministerial_role",
+                    "public_updated_at": "2023-02-28T11:37:53Z",
+                    "schema_name": "role",
+                    "withdrawn": false,
+                    "details": {
+                      "body": "<p>The minister is responsible for:</p>\n\n<ul>\n  <li>energy affordability schemes, including the Energy Price Guarantee (EPG), Energy Bills Discount Scheme (EBSS) and Energy Bills Relief Scheme (EBRS)</li>\n  <li>energy consumer issues, including pre-payment meters (PPMs)</li>\n  <li>fuel poverty\n<br><br>\n</li>\n  <li>\n<a rel=\"external\" href=\"http://www.ofgem.gov.uk/\">Ofgem</a> consumer elements, including the energy price cap (shared with the Minister for Energy Security and Net Zero)</li>\n</ul>\n",
+                      "role_payment_type": null,
+                      "seniority": 100,
+                      "whip_organisation": {}
+                    },
+                    "links": {},
+                    "api_url": "https://www.gov.uk/api/content/government/ministers/parliamentary-under-secretary-of-state-minister-for-energy-consumers-and-affordability",
+                    "web_url": "https://www.gov.uk/government/ministers/parliamentary-under-secretary-of-state-minister-for-energy-consumers-and-affordability"
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        "api_url": "https://www.gov.uk/api/content/government/people/amanda-solloway",
+        "web_url": "https://www.gov.uk/government/people/amanda-solloway"
+      },
+      {
+        "content_id": "73cca05b-ead4-4e89-b573-49053476c013",
+        "title": "Steve Double MP",
+        "locale": "en",
+        "api_path": "/api/content/government/people/steve-double",
+        "base_path": "/government/people/steve-double",
+        "document_type": "person",
+        "public_updated_at": "2022-10-31T08:44:35Z",
+        "schema_name": "person",
+        "withdrawn": false,
+        "details": {
+          "image": {
+            "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/person/image/4847/s465_steve-double-960x640.jpg",
+            "alt_text": "Steve Double MP"
+          },
+          "privy_counsellor": false
+        },
+        "links": {
+          "role_appointments": [
+            {
+              "content_id": "a1b8a6dd-f0d0-45f9-9d7d-30cd7b090ce3",
+              "title": "Steve Double MP - Government Whip (Lord Commissioner of HM Treasury)",
+              "locale": "en",
+              "document_type": "role_appointment",
+              "public_updated_at": "2022-10-31T08:46:28Z",
+              "schema_name": "role_appointment",
+              "withdrawn": false,
+              "details": {
+                "started_on": "2022-10-28T00:00:00+01:00",
+                "ended_on": null,
+                "current": true,
+                "person_appointment_order": 8234
+              },
+              "links": {
+                "role": [
+                  {
+                    "content_id": "b5775e81-f891-4cef-8431-05e23e6339e4",
+                    "title": "Government Whip (Lord Commissioner of HM Treasury)",
+                    "locale": "en",
+                    "api_path": "/api/content/government/ministers/government-whip-lord-commissioner-of-hm-treasury--17",
+                    "base_path": "/government/ministers/government-whip-lord-commissioner-of-hm-treasury--17",
+                    "document_type": "ministerial_role",
+                    "public_updated_at": "2022-09-21T10:40:23Z",
+                    "schema_name": "role",
+                    "withdrawn": false,
+                    "details": {
+                      "body": "\n",
+                      "role_payment_type": null,
+                      "seniority": 100,
+                      "whip_organisation": {
+                        "label": "Junior Lords of the Treasury",
+                        "sort_order": 2
+                      }
+                    },
+                    "links": {},
+                    "api_url": "https://www.gov.uk/api/content/government/ministers/government-whip-lord-commissioner-of-hm-treasury--17",
+                    "web_url": "https://www.gov.uk/government/ministers/government-whip-lord-commissioner-of-hm-treasury--17"
+                  }
+                ]
+              }
+            },
+            {
+              "content_id": "08da458d-bb04-47cb-8662-fb54cd5983be",
+              "title": "Steve Double - Assistant government whip",
+              "locale": "en",
+              "document_type": "role_appointment",
+              "public_updated_at": "2022-07-08T18:14:10Z",
+              "schema_name": "role_appointment",
+              "withdrawn": false,
+              "details": {
+                "started_on": "2021-09-17T00:00:00+01:00",
+                "ended_on": "2022-07-08T00:00:00+01:00",
+                "current": false,
+                "person_appointment_order": 7176
+              },
+              "links": {
+                "role": [
+                  {
+                    "content_id": "7687cc88-520b-411a-9d08-c889a2ad2749",
+                    "title": "Assistant government whip",
+                    "locale": "en",
+                    "api_path": "/api/content/government/ministers/assistant-government-whip--24",
+                    "base_path": "/government/ministers/assistant-government-whip--24",
+                    "document_type": "ministerial_role",
+                    "public_updated_at": "2021-09-21T11:36:53Z",
+                    "schema_name": "role",
+                    "withdrawn": false,
+                    "details": {
+                      "body": "\n",
+                      "role_payment_type": null,
+                      "seniority": 100,
+                      "whip_organisation": {
+                        "label": "Assistant Whips",
+                        "sort_order": 3
+                      }
+                    },
+                    "links": {},
+                    "api_url": "https://www.gov.uk/api/content/government/ministers/assistant-government-whip--24",
+                    "web_url": "https://www.gov.uk/government/ministers/assistant-government-whip--24"
+                  }
+                ]
+              }
+            },
+            {
+              "content_id": "9f511c99-9ebf-4310-8702-3218e5e57cca",
+              "title": "Steve Double MP - Parliamentary Under Secretary of State",
+              "locale": "en",
+              "document_type": "role_appointment",
+              "public_updated_at": "2022-09-12T15:09:46Z",
+              "schema_name": "role_appointment",
+              "withdrawn": false,
+              "details": {
+                "started_on": "2022-07-08T00:00:00+01:00",
+                "ended_on": "2022-09-08T00:00:00+01:00",
+                "current": false,
+                "person_appointment_order": 7796
+              },
+              "links": {
+                "role": [
+                  {
+                    "content_id": "f33ab47b-292e-48c8-a6d7-8060c3b0e5e1",
+                    "title": "Parliamentary Under Secretary of State",
+                    "locale": "en",
+                    "api_path": "/api/content/government/ministers/parliamentary-under-secretary-of-state--162",
+                    "base_path": "/government/ministers/parliamentary-under-secretary-of-state--162",
+                    "document_type": "ministerial_role",
+                    "public_updated_at": "2022-07-15T10:00:37Z",
+                    "schema_name": "role",
+                    "withdrawn": false,
+                    "details": {
+                      "body": "<p>Responsibilities include:</p>\n\n<ul>\n  <li>floods and water</li>\n  <li>science and innovation, including gene editing and agri-food innovation</li>\n  <li>Defra delivery of Net Zero and climate change adaptation</li>\n  <li>domestic and international environmental management and regulation</li>\n  <li>commercial projects</li>\n  <li>lead for Environment Agency</li>\n</ul>\n",
+                      "role_payment_type": null,
+                      "seniority": 100,
+                      "whip_organisation": {}
+                    },
+                    "links": {},
+                    "api_url": "https://www.gov.uk/api/content/government/ministers/parliamentary-under-secretary-of-state--162",
+                    "web_url": "https://www.gov.uk/government/ministers/parliamentary-under-secretary-of-state--162"
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        "api_url": "https://www.gov.uk/api/content/government/people/steve-double",
+        "web_url": "https://www.gov.uk/government/people/steve-double"
+      }
+    ],
+    "ordered_ministerial_departments": [
+      {
+        "content_id": "96ae61d6-c2a1-48cb-8e67-da9d105ae381",
+        "title": "Cabinet Office",
+        "locale": "en",
+        "analytics_identifier": "D2",
+        "api_path": "/api/content/government/organisations/cabinet-office",
+        "base_path": "/government/organisations/cabinet-office",
+        "document_type": "organisation",
+        "schema_name": "organisation",
+        "withdrawn": false,
+        "details": {
+          "logo": {
+            "crest": "single-identity",
+            "formatted_title": "Cabinet Office"
+          },
+          "brand": "cabinet-office",
+          "default_news_image": {
+            "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/default_news_organisation_image_data/file/148/s300_cabinet-office.jpg",
+            "high_resolution_url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/default_news_organisation_image_data/file/148/s960_cabinet-office.jpg"
+          },
+          "organisation_govuk_status": {
+            "url": null,
+            "status": "live",
+            "updated_at": null
+          }
+        },
+        "links": {
+          "ordered_ministers": [
+            {
+              "content_id": "361b04ed-731a-4f55-82c0-14cdf129afac",
+              "title": "The Rt Hon Rishi Sunak MP",
+              "locale": "en",
+              "api_path": "/api/content/government/people/rishi-sunak",
+              "base_path": "/government/people/rishi-sunak",
+              "document_type": "person",
+              "public_updated_at": "2022-10-27T10:43:34Z",
+              "schema_name": "person",
+              "withdrawn": false,
+              "details": {
+                "image": {
+                  "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/person/image/3339/s465_Rishi_profile.jpg",
+                  "alt_text": "The Rt Hon Rishi Sunak MP"
+                },
+                "privy_counsellor": true
+              },
+              "links": {
+                "role_appointments": [
+                  {
+                    "content_id": "fa81796a-8b47-40b1-ab11-507aecae480f",
+                    "title": "The Rt Hon Rishi Sunak - Parliamentary Under Secretary of State (Minister for Local Government)",
+                    "locale": "en",
+                    "document_type": "role_appointment",
+                    "public_updated_at": "2019-11-06T16:37:58Z",
+                    "schema_name": "role_appointment",
+                    "withdrawn": false,
+                    "details": {
+                      "started_on": "2018-01-09T00:00:00+00:00",
+                      "ended_on": "2019-07-24T00:00:00+01:00",
+                      "current": false,
+                      "person_appointment_order": 4541
+                    },
+                    "links": {
+                      "role": [
+                        {
+                          "content_id": "8b9f67df-4acd-4c91-b48e-3635952fb4a7",
+                          "title": "Parliamentary Under Secretary of State (Minister for Local Government)",
+                          "locale": "en",
+                          "api_path": "/api/content/government/ministers/parliamentary-under-secretary-of-state--91",
+                          "base_path": "/government/ministers/parliamentary-under-secretary-of-state--91",
+                          "document_type": "ministerial_role",
+                          "public_updated_at": "2018-01-15T15:36:31Z",
+                          "schema_name": "role",
+                          "withdrawn": false,
+                          "details": {
+                            "body": "<p>The minister is responsible for:</p>\n\n<ul>\n  <li>Local government policy, including local government reform</li>\n  <li>Local government finances (including local authority sustainability and business rates retention)</li>\n  <li>Adult social care</li>\n  <li>Local government interventions policy and oversight of existing interventions</li>\n  <li>Local government pensions</li>\n  <li>Troubled Families</li>\n  <li>Parks / green space</li>\n</ul>\n",
+                            "role_payment_type": null,
+                            "seniority": 100,
+                            "whip_organisation": {}
+                          },
+                          "links": {},
+                          "api_url": "https://www.gov.uk/api/content/government/ministers/parliamentary-under-secretary-of-state--91",
+                          "web_url": "https://www.gov.uk/government/ministers/parliamentary-under-secretary-of-state--91"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "content_id": "d7d06a50-8250-4de9-b196-5c6b07a77229",
+                    "title": "The Rt Hon Rishi Sunak MP - Chief Secretary to the Treasury",
+                    "locale": "en",
+                    "document_type": "role_appointment",
+                    "public_updated_at": "2020-02-13T12:28:53Z",
+                    "schema_name": "role_appointment",
+                    "withdrawn": false,
+                    "details": {
+                      "started_on": "2019-07-24T00:00:00+01:00",
+                      "ended_on": "2020-02-13T00:00:00+00:00",
+                      "current": false,
+                      "person_appointment_order": 5594
+                    },
+                    "links": {
+                      "role": [
+                        {
+                          "content_id": "845e6667-c0f1-11e4-8223-005056011aef",
+                          "title": "Chief Secretary to the Treasury",
+                          "locale": "en",
+                          "api_path": "/api/content/government/ministers/chief-secretary-to-the-treasury",
+                          "base_path": "/government/ministers/chief-secretary-to-the-treasury",
+                          "document_type": "ministerial_role",
+                          "public_updated_at": "2022-11-22T15:30:28Z",
+                          "schema_name": "role",
+                          "withdrawn": false,
+                          "details": {
+                            "body": "<p>The Chief Secretary (<abbr title=\"Chief Secretary to the Treasury\">CST</abbr>) is responsible for public expenditure, including:</p>\n\n<ul>\n  <li>spending reviews and strategic planning</li>\n  <li>in-year spending control</li>\n  <li>public sector pay and pensions</li>\n  <li>Annually Managed Expenditure (<abbr title=\"Annually Managed Expenditure\">AME</abbr>) and welfare reform</li>\n  <li>efficiency and value for money in public service</li>\n  <li>procurement</li>\n  <li>capital investment</li>\n  <li>infrastructure spending</li>\n  <li>housing and planning</li>\n  <li>spending issues related to trade</li>\n  <li>transport policy, including HS2, Crossrail 2, Roads, Network Rail,\nOxford/Cambridge corridor</li>\n  <li>Treasury interest in devolution to Scotland, Wales and Northern Ireland</li>\n  <li>women in the economy</li>\n  <li>skills, labour market policy and childcare policy, including tax free childcare</li>\n  <li>tax credits policy</li>\n  <li>housing and planning</li>\n  <li>legislative strategy</li>\n  <li>state pensions/ pensioner benefits</li>\n  <li>freeports – with support from <abbr title=\"Economic Secretary to the Treasury\">EST</abbr> on customs aspects\n.</li>\n</ul>\n\n",
+                            "role_payment_type": "Unpaid",
+                            "seniority": 1,
+                            "whip_organisation": {}
+                          },
+                          "links": {},
+                          "api_url": "https://www.gov.uk/api/content/government/ministers/chief-secretary-to-the-treasury",
+                          "web_url": "https://www.gov.uk/government/ministers/chief-secretary-to-the-treasury"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "content_id": "e119bc68-d989-4243-802f-0486299c82ca",
+                    "title": "The Rt Hon Rishi Sunak MP - Chancellor of the Exchequer",
+                    "locale": "en",
+                    "document_type": "role_appointment",
+                    "public_updated_at": "2022-07-05T20:57:43Z",
+                    "schema_name": "role_appointment",
+                    "withdrawn": false,
+                    "details": {
+                      "started_on": "2020-02-13T00:00:00+00:00",
+                      "ended_on": "2022-07-05T00:00:00+01:00",
+                      "current": false,
+                      "person_appointment_order": 6018
+                    },
+                    "links": {
+                      "role": [
+                        {
+                          "content_id": "845e5c6b-c0f1-11e4-8223-005056011aef",
+                          "title": "Chancellor of the Exchequer",
+                          "locale": "en",
+                          "api_path": "/api/content/government/ministers/chancellor-of-the-exchequer",
+                          "base_path": "/government/ministers/chancellor-of-the-exchequer",
+                          "document_type": "ministerial_role",
+                          "public_updated_at": "2020-09-03T09:54:34Z",
+                          "schema_name": "role",
+                          "withdrawn": false,
+                          "details": {
+                            "body": "<p>The Chancellor of the Exchequer is the government’s chief financial minister and as such is responsible for raising revenue through taxation or borrowing and for controlling public spending. He has overall responsibility for the work of the Treasury.</p>\n\n<p>The Chancellor’s responsibilities cover:</p>\n\n<ul>\n  <li>fiscal policy (including the presenting of the annual Budget)</li>\n  <li>monetary policy, setting inflation targets</li>\n  <li>ministerial arrangements (in his role as Second Lord of the Treasury)</li>\n  <li>overall responsibility for the Treasury’s response to COVID-19</li>\n</ul>\n\n",
+                            "role_payment_type": null,
+                            "seniority": 6,
+                            "whip_organisation": {}
+                          },
+                          "links": {},
+                          "api_url": "https://www.gov.uk/api/content/government/ministers/chancellor-of-the-exchequer",
+                          "web_url": "https://www.gov.uk/government/ministers/chancellor-of-the-exchequer"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "content_id": "d4c7c6ae-5597-443a-88c0-e8770e162121",
+                    "title": "The Rt Hon Rishi Sunak MP - Prime Minister",
+                    "locale": "en",
+                    "document_type": "role_appointment",
+                    "public_updated_at": "2022-10-25T11:08:03Z",
+                    "schema_name": "role_appointment",
+                    "withdrawn": false,
+                    "details": {
+                      "started_on": "2022-10-25T00:00:00+01:00",
+                      "ended_on": null,
+                      "current": true,
+                      "person_appointment_order": 8145
+                    },
+                    "links": {
+                      "role": [
+                        {
+                          "content_id": "845e5811-c0f1-11e4-8223-005056011aef",
+                          "title": "Prime Minister",
+                          "locale": "en",
+                          "api_path": "/api/content/government/ministers/prime-minister",
+                          "base_path": "/government/ministers/prime-minister",
+                          "document_type": "ministerial_role",
+                          "public_updated_at": "2022-10-05T07:44:54Z",
+                          "schema_name": "role",
+                          "withdrawn": false,
+                          "details": {
+                            "body": "<p>The Prime Minister is the leader of His Majesty’s Government and is ultimately responsible for the policy and decisions of the government.</p>\n\n<p>As leader of the UK government the Prime Minister also:</p>\n\n<ul>\n  <li>oversees the <a href=\"https://www.gov.uk/government/ministers/minister-for-the-civil-service\">operation of the Civil Service</a> and government agencies</li>\n  <li>chooses members of the government</li>\n  <li>is the principal government figure in the House of Commons</li>\n</ul>\n\n<p>As <a href=\"https://www.gov.uk/government/ministers/minister-for-the-union\">Minister for the Union</a>, the Prime Minister works to ensure that all of government is acting on behalf of the entire United Kingdom: England, Northern Ireland, Scotland, and Wales.</p>\n",
+                            "role_payment_type": null,
+                            "seniority": 0,
+                            "whip_organisation": {}
+                          },
+                          "links": {},
+                          "api_url": "https://www.gov.uk/api/content/government/ministers/prime-minister",
+                          "web_url": "https://www.gov.uk/government/ministers/prime-minister"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "content_id": "78f96893-faa3-49f1-82ed-7bc2b4dde144",
+                    "title": "The Rt Hon Rishi Sunak MP - First Lord of the Treasury",
+                    "locale": "en",
+                    "document_type": "role_appointment",
+                    "public_updated_at": "2022-10-25T11:09:37Z",
+                    "schema_name": "role_appointment",
+                    "withdrawn": false,
+                    "details": {
+                      "started_on": "2022-10-25T00:00:00+01:00",
+                      "ended_on": null,
+                      "current": true,
+                      "person_appointment_order": 8146
+                    },
+                    "links": {
+                      "role": [
+                        {
+                          "content_id": "846a754c-c0f1-11e4-8223-005056011aef",
+                          "title": "First Lord of the Treasury",
+                          "locale": "en",
+                          "api_path": "/api/content/government/ministers/first-lord-of-the-treasury",
+                          "base_path": "/government/ministers/first-lord-of-the-treasury",
+                          "document_type": "ministerial_role",
+                          "public_updated_at": "2022-10-05T07:44:10Z",
+                          "schema_name": "role",
+                          "withdrawn": false,
+                          "details": {
+                            "body": "<p>The First Lord of the Treasury is one of the Lords Commissioners of the Treasury. This role is usually held by the <a href=\"https://www.gov.uk/government/ministers/prime-minister\">Prime Minister</a>.</p>\n\n<p>Since the 17th century, the Lords Commissioners of the Treasury have collectively carried out duties that were previously held by the Lord High Treasurer (head of His Majesty’s Treasury).</p>\n\n<p>The Lords Commissioners of the Treasury also include:</p>\n\n<ul>\n  <li>the Second Lord of the Treasury - the <a href=\"https://www.gov.uk/government/ministers/chancellor-of-the-exchequer\">Chancellor of the Exchequer</a>, who has most of the functional financial responsibilities</li>\n  <li>Junior Lords Commissioners of the Treasury - other members of the government, usually <a href=\"https://www.gov.uk/government/ministers#whips\">government whips in the House of Commons</a>\n</li>\n</ul>\n\n<p>10 Downing Street is the official residence of the First Lord of the Treasury, and not of the Prime Minister.</p>\n",
+                            "role_payment_type": null,
+                            "seniority": 1,
+                            "whip_organisation": {}
+                          },
+                          "links": {},
+                          "api_url": "https://www.gov.uk/api/content/government/ministers/first-lord-of-the-treasury",
+                          "web_url": "https://www.gov.uk/government/ministers/first-lord-of-the-treasury"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "content_id": "bfef43a3-4f05-4f2a-9b53-ef0810229eaf",
+                    "title": "The Rt Hon Rishi Sunak MP - Minister for the Union",
+                    "locale": "en",
+                    "document_type": "role_appointment",
+                    "public_updated_at": "2022-10-25T14:23:21Z",
+                    "schema_name": "role_appointment",
+                    "withdrawn": false,
+                    "details": {
+                      "started_on": "2022-10-25T00:00:00+01:00",
+                      "ended_on": null,
+                      "current": true,
+                      "person_appointment_order": 8148
+                    },
+                    "links": {
+                      "role": [
+                        {
+                          "content_id": "041f4e4c-45f8-44b0-a7d8-ae1eb11370a2",
+                          "title": "Minister for the Union",
+                          "locale": "en",
+                          "api_path": "/api/content/government/ministers/minister-for-the-union",
+                          "base_path": "/government/ministers/minister-for-the-union",
+                          "document_type": "ministerial_role",
+                          "public_updated_at": "2020-09-01T15:38:15Z",
+                          "schema_name": "role",
+                          "withdrawn": false,
+                          "details": {
+                            "body": "<p>As Minister for the Union, the Prime Minister works to ensure that all of government is acting on behalf of the entire United Kingdom: England, Northern Ireland, Scotland, and Wales.</p>\n",
+                            "role_payment_type": null,
+                            "seniority": 3,
+                            "whip_organisation": {}
+                          },
+                          "links": {},
+                          "api_url": "https://www.gov.uk/api/content/government/ministers/minister-for-the-union",
+                          "web_url": "https://www.gov.uk/government/ministers/minister-for-the-union"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "content_id": "dc7ea91a-0219-41e6-8891-83b47698349b",
+                    "title": "The Rt Hon Rishi Sunak MP - Minister for the Civil Service",
+                    "locale": "en",
+                    "document_type": "role_appointment",
+                    "public_updated_at": "2022-10-25T14:24:03Z",
+                    "schema_name": "role_appointment",
+                    "withdrawn": false,
+                    "details": {
+                      "started_on": "2022-10-25T00:00:00+01:00",
+                      "ended_on": null,
+                      "current": true,
+                      "person_appointment_order": 8149
+                    },
+                    "links": {
+                      "role": [
+                        {
+                          "content_id": "846a7351-c0f1-11e4-8223-005056011aef",
+                          "title": "Minister for the Civil Service",
+                          "locale": "en",
+                          "api_path": "/api/content/government/ministers/minister-for-the-civil-service",
+                          "base_path": "/government/ministers/minister-for-the-civil-service",
+                          "document_type": "ministerial_role",
+                          "public_updated_at": "2022-09-28T11:40:15Z",
+                          "schema_name": "role",
+                          "withdrawn": false,
+                          "details": {
+                            "body": "<p>The Minister for the Civil Service is responsible for regulating the <a rel=\"external\" href=\"http://www.civilservice.gov.uk/\">Civil Service</a>.</p>\n\n<p>The <a rel=\"external\" href=\"http://www.legislation.gov.uk/ukpga/1992/61/contents\">Civil Service (Management Functions) Act of 1992</a>, allows the Minister for the Civil Service to delegate power to other ministers and devolved administrations.</p>\n\n<p>This role was created in 1968 and is always held by the <a href=\"https://www.gov.uk/government/ministers/prime-minister\">Prime Minister</a>.</p>\n",
+                            "role_payment_type": null,
+                            "seniority": 2,
+                            "whip_organisation": {}
+                          },
+                          "links": {},
+                          "api_url": "https://www.gov.uk/api/content/government/ministers/minister-for-the-civil-service",
+                          "web_url": "https://www.gov.uk/government/ministers/minister-for-the-civil-service"
+                        }
+                      ]
+                    }
+                  }
+                ]
+              },
+              "api_url": "https://www.gov.uk/api/content/government/people/rishi-sunak",
+              "web_url": "https://www.gov.uk/government/people/rishi-sunak"
+            },
+            {
+              "content_id": "852e83e6-c0f1-11e4-8223-005056011aef",
+              "title": "The Rt Hon Greg Hands MP",
+              "locale": "en",
+              "api_path": "/api/content/government/people/greg-hands",
+              "base_path": "/government/people/greg-hands",
+              "document_type": "person",
+              "public_updated_at": "2023-02-07T11:54:39Z",
+              "schema_name": "person",
+              "withdrawn": false,
+              "details": {
+                "image": {
+                  "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/person/image/397/s465_Greg_Hands_May2015_GOVUK.jpg",
+                  "alt_text": "The Rt Hon Greg Hands MP"
+                },
+                "privy_counsellor": true
+              },
+              "links": {
+                "role_appointments": [
+                  {
+                    "content_id": "86968de6-3407-48ac-95fe-79b677644e1e",
+                    "title": "The Rt Hon Greg Hands MP - Minister of State",
+                    "locale": "en",
+                    "document_type": "role_appointment",
+                    "public_updated_at": "2021-11-19T13:57:56Z",
+                    "schema_name": "role_appointment",
+                    "withdrawn": false,
+                    "details": {
+                      "started_on": "2021-09-16T00:00:00+01:00",
+                      "ended_on": "2021-09-16T00:00:00+01:00",
+                      "current": false,
+                      "person_appointment_order": 7128
+                    },
+                    "links": {
+                      "role": [
+                        {
+                          "content_id": "385a8215-a8d3-4d45-9f38-3c74f79d9ea1",
+                          "title": "Minister of State",
+                          "locale": "en",
+                          "api_path": "/api/content/government/ministers/minister-of-state--110",
+                          "base_path": "/government/ministers/minister-of-state--110",
+                          "document_type": "ministerial_role",
+                          "public_updated_at": "2021-10-26T11:37:11Z",
+                          "schema_name": "role",
+                          "withdrawn": false,
+                          "details": {
+                            "body": "<p>Responsibilities include:</p>\n\n<ul>\n  <li>Net Zero Strategy</li>\n  <li>carbon budgets</li>\n  <li>green finance, joint with HMT</li>\n  <li>low carbon generation</li>\n  <li>energy retail markets</li>\n  <li>oil and gas</li>\n  <li>security of supply</li>\n  <li>electricity and gas wholesale markets and networks</li>\n  <li>international energy, climate change and climate finance</li>\n  <li>energy security, including resilience</li>\n  <li>hydrogen</li>\n  <li>industrial decarbonisation</li>\n  <li>nuclear</li>\n</ul>\n",
+                            "role_payment_type": null,
+                            "seniority": 100,
+                            "whip_organisation": {}
+                          },
+                          "links": {},
+                          "api_url": "https://www.gov.uk/api/content/government/ministers/minister-of-state--110",
+                          "web_url": "https://www.gov.uk/government/ministers/minister-of-state--110"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "content_id": "707fc660-b5dc-4b22-b078-2b960c2f1ee0",
+                    "title": "The Rt Hon Greg Hands - Assistant Whip",
+                    "locale": "en",
+                    "document_type": "role_appointment",
+                    "public_updated_at": "2019-11-06T00:11:00Z",
+                    "schema_name": "role_appointment",
+                    "withdrawn": false,
+                    "details": {
+                      "started_on": "2011-10-01T00:00:00+01:00",
+                      "ended_on": "2013-10-07T00:00:00+01:00",
+                      "current": false,
+                      "person_appointment_order": 485
+                    },
+                    "links": {
+                      "role": [
+                        {
+                          "content_id": "84618559-c0f1-11e4-8223-005056011aef",
+                          "title": "Assistant Whip",
+                          "locale": "en",
+                          "api_path": "/api/content/government/ministers/assistant-government-whip--4",
+                          "base_path": "/government/ministers/assistant-government-whip--4",
+                          "document_type": "ministerial_role",
+                          "public_updated_at": "2013-02-20T11:26:04Z",
+                          "schema_name": "role",
+                          "withdrawn": false,
+                          "details": {
+                            "body": "<p>Whips are MPs or Lords appointed by each party to help organise their party’s contribution to parliamentary business. They are responsible for making sure the maximum number of their party members vote, and vote the way their party wants.</p>\n",
+                            "role_payment_type": null,
+                            "seniority": 100,
+                            "whip_organisation": {
+                              "label": "Assistant Whips",
+                              "sort_order": 3
+                            }
+                          },
+                          "links": {},
+                          "api_url": "https://www.gov.uk/api/content/government/ministers/assistant-government-whip--4",
+                          "web_url": "https://www.gov.uk/government/ministers/assistant-government-whip--4"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "content_id": "4f452681-c7d7-4912-9a5b-13ef34ef21b3",
+                    "title": "The Rt Hon Greg Hands - Treasurer of HM Household (Deputy Chief Whip)",
+                    "locale": "en",
+                    "document_type": "role_appointment",
+                    "public_updated_at": "2019-11-06T00:11:00Z",
+                    "schema_name": "role_appointment",
+                    "withdrawn": false,
+                    "details": {
+                      "started_on": "2013-10-07T00:00:00+01:00",
+                      "ended_on": "2015-05-11T00:00:00+01:00",
+                      "current": false,
+                      "person_appointment_order": 1403
+                    },
+                    "links": {
+                      "role": [
+                        {
+                          "content_id": "84619b8e-c0f1-11e4-8223-005056011aef",
+                          "title": "Treasurer of HM Household (Deputy Chief Whip)",
+                          "locale": "en",
+                          "api_path": "/api/content/government/ministers/deputy-chief-whip-comptroller-of-hm-household--2",
+                          "base_path": "/government/ministers/deputy-chief-whip-comptroller-of-hm-household--2",
+                          "document_type": "ministerial_role",
+                          "public_updated_at": "2018-01-10T10:55:16Z",
+                          "schema_name": "role",
+                          "withdrawn": false,
+                          "details": {
+                            "body": "<p>Whips are MPs or Lords appointed by each party to help organise their party’s contribution to parliamentary business. They are responsible for making sure the maximum number of their party members vote, and vote the way their party wants.</p>\n",
+                            "role_payment_type": null,
+                            "seniority": 100,
+                            "whip_organisation": {
+                              "label": "House of Commons",
+                              "sort_order": 1
+                            }
+                          },
+                          "links": {},
+                          "api_url": "https://www.gov.uk/api/content/government/ministers/deputy-chief-whip-comptroller-of-hm-household--2",
+                          "web_url": "https://www.gov.uk/government/ministers/deputy-chief-whip-comptroller-of-hm-household--2"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "content_id": "94bb6277-5ab7-4fd9-84dd-e85fc753d952",
+                    "title": "The Rt Hon Greg Hands - Chief Secretary to the Treasury",
+                    "locale": "en",
+                    "document_type": "role_appointment",
+                    "public_updated_at": "2019-11-06T00:11:00Z",
+                    "schema_name": "role_appointment",
+                    "withdrawn": false,
+                    "details": {
+                      "started_on": "2015-05-11T00:00:00+01:00",
+                      "ended_on": "2016-07-14T00:00:00+01:00",
+                      "current": false,
+                      "person_appointment_order": 2640
+                    },
+                    "links": {
+                      "role": [
+                        {
+                          "content_id": "845e6667-c0f1-11e4-8223-005056011aef",
+                          "title": "Chief Secretary to the Treasury",
+                          "locale": "en",
+                          "api_path": "/api/content/government/ministers/chief-secretary-to-the-treasury",
+                          "base_path": "/government/ministers/chief-secretary-to-the-treasury",
+                          "document_type": "ministerial_role",
+                          "public_updated_at": "2022-11-22T15:30:28Z",
+                          "schema_name": "role",
+                          "withdrawn": false,
+                          "details": {
+                            "body": "<p>The Chief Secretary (<abbr title=\"Chief Secretary to the Treasury\">CST</abbr>) is responsible for public expenditure, including:</p>\n\n<ul>\n  <li>spending reviews and strategic planning</li>\n  <li>in-year spending control</li>\n  <li>public sector pay and pensions</li>\n  <li>Annually Managed Expenditure (<abbr title=\"Annually Managed Expenditure\">AME</abbr>) and welfare reform</li>\n  <li>efficiency and value for money in public service</li>\n  <li>procurement</li>\n  <li>capital investment</li>\n  <li>infrastructure spending</li>\n  <li>housing and planning</li>\n  <li>spending issues related to trade</li>\n  <li>transport policy, including HS2, Crossrail 2, Roads, Network Rail,\nOxford/Cambridge corridor</li>\n  <li>Treasury interest in devolution to Scotland, Wales and Northern Ireland</li>\n  <li>women in the economy</li>\n  <li>skills, labour market policy and childcare policy, including tax free childcare</li>\n  <li>tax credits policy</li>\n  <li>housing and planning</li>\n  <li>legislative strategy</li>\n  <li>state pensions/ pensioner benefits</li>\n  <li>freeports – with support from <abbr title=\"Economic Secretary to the Treasury\">EST</abbr> on customs aspects\n.</li>\n</ul>\n\n",
+                            "role_payment_type": "Unpaid",
+                            "seniority": 1,
+                            "whip_organisation": {}
+                          },
+                          "links": {},
+                          "api_url": "https://www.gov.uk/api/content/government/ministers/chief-secretary-to-the-treasury",
+                          "web_url": "https://www.gov.uk/government/ministers/chief-secretary-to-the-treasury"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "content_id": "1d1682bd-c063-4ab5-92c2-4fdbf7be6c72",
+                    "title": "The Rt Hon Greg Hands - Minister of State for Trade and Investment",
+                    "locale": "en",
+                    "document_type": "role_appointment",
+                    "public_updated_at": "2019-11-06T00:11:00Z",
+                    "schema_name": "role_appointment",
+                    "withdrawn": false,
+                    "details": {
+                      "started_on": "2016-07-15T00:00:00+01:00",
+                      "ended_on": "2017-09-03T00:00:00+01:00",
+                      "current": false,
+                      "person_appointment_order": 3573
+                    },
+                    "links": {
+                      "role": [
+                        {
+                          "content_id": "846143a9-c0f1-11e4-8223-005056011aef",
+                          "title": "Minister of State for Trade and Investment",
+                          "locale": "en",
+                          "api_path": "/api/content/government/ministers/minister-of-state-for-trade-and-investment",
+                          "base_path": "/government/ministers/minister-of-state-for-trade-and-investment",
+                          "document_type": "ministerial_role",
+                          "public_updated_at": "2017-04-04T12:41:08Z",
+                          "schema_name": "role",
+                          "withdrawn": false,
+                          "details": {
+                            "body": "<p>The Minister of State for Trade and Investment leads on trade and investment promotion in the following sectors:</p>\n\n<ul>\n  <li>technology and smart cities</li>\n  <li>infrastructure</li>\n  <li>energy</li>\n  <li>healthcare</li>\n  <li>life sciences</li>\n</ul>\n\n<p>Additionally, he leads on areas including:</p>\n\n<ul>\n  <li>UK Export Finance (UKEF)</li>\n  <li>business planning and forecasting</li>\n  <li>outward direct investment</li>\n  <li>economic diplomacy and the Prosperity Fund</li>\n  <li>the GREAT Britain campaign</li>\n  <li>policy direction on topics such as mergers and acquisitions</li>\n</ul>\n\n",
+                            "role_payment_type": null,
+                            "seniority": 100,
+                            "whip_organisation": {}
+                          },
+                          "links": {},
+                          "api_url": "https://www.gov.uk/api/content/government/ministers/minister-of-state-for-trade-and-investment",
+                          "web_url": "https://www.gov.uk/government/ministers/minister-of-state-for-trade-and-investment"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "content_id": "fa4edca6-34a0-4830-8937-80c50653bade",
+                    "title": "The Rt Hon Greg Hands - Minister for London",
+                    "locale": "en",
+                    "document_type": "role_appointment",
+                    "public_updated_at": "2019-11-06T00:11:00Z",
+                    "schema_name": "role_appointment",
+                    "withdrawn": false,
+                    "details": {
+                      "started_on": "2017-06-13T00:00:00+01:00",
+                      "ended_on": "2018-01-09T00:00:00+00:00",
+                      "current": false,
+                      "person_appointment_order": 4123
+                    },
+                    "links": {
+                      "role": [
+                        {
+                          "content_id": "c29a26f0-941e-469e-840b-dfba55c5d9d7",
+                          "title": "Minister for London",
+                          "locale": "en",
+                          "api_path": "/api/content/government/ministers/minister-for-london",
+                          "base_path": "/government/ministers/minister-for-london",
+                          "document_type": "ministerial_role",
+                          "public_updated_at": "2018-01-24T09:44:08Z",
+                          "schema_name": "role",
+                          "withdrawn": false,
+                          "details": {
+                            "body": "<p>The minister is responsible for:</p>\n\n<ul>\n  <li>London</li>\n</ul>\n",
+                            "role_payment_type": null,
+                            "seniority": 100,
+                            "whip_organisation": {}
+                          },
+                          "links": {},
+                          "api_url": "https://www.gov.uk/api/content/government/ministers/minister-for-london",
+                          "web_url": "https://www.gov.uk/government/ministers/minister-for-london"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "content_id": "a78066c3-9ade-4b4c-b59c-e93219c6100e",
+                    "title": "The Rt Hon Greg Hands - Minister of State for Trade Policy",
+                    "locale": "en",
+                    "document_type": "role_appointment",
+                    "public_updated_at": "2019-11-06T00:11:00Z",
+                    "schema_name": "role_appointment",
+                    "withdrawn": false,
+                    "details": {
+                      "started_on": "2017-09-03T00:00:00+01:00",
+                      "ended_on": "2018-06-21T00:00:00+01:00",
+                      "current": false,
+                      "person_appointment_order": 4308
+                    },
+                    "links": {
+                      "role": [
+                        {
+                          "content_id": "f3324a7a-2ac9-4aaa-839b-01c640b6d961",
+                          "title": "Minister of State for Trade Policy",
+                          "locale": "en",
+                          "api_path": "/api/content/government/ministers/minister-of-state--37",
+                          "base_path": "/government/ministers/minister-of-state--37",
+                          "document_type": "ministerial_role",
+                          "public_updated_at": "2019-03-13T10:23:21Z",
+                          "schema_name": "role",
+                          "withdrawn": false,
+                          "details": {
+                            "body": "<p>The Minister of State for Trade Policy oversees the Trade Policy Group, which leads for the department on developing, coordinating and delivering a new trade policy. The minister also acts as deputy to the Secretary of State for International Trade.</p>\n\n<p>The minister’s responsibilities include:</p>\n\n<ul>\n  <li>trading agreements and arrangements with other countries</li>\n  <li>UK engagement with the World Trade Organization</li>\n  <li>ongoing EU trade business while the UK remains a member of the EU</li>\n  <li>trade remedies</li>\n</ul>\n\n<p>Additionally, the minister leads on:</p>\n\n<ul>\n  <li>bills for the Department for International Trade (<abbr title=\"Department for International Trade\">DIT</abbr>)</li>\n  <li>secondary legislation</li>\n  <li>economic diplomacy, Prosperity Fund, and economic horizons markets</li>\n</ul>\n\n",
+                            "role_payment_type": null,
+                            "seniority": 100,
+                            "whip_organisation": {}
+                          },
+                          "links": {},
+                          "api_url": "https://www.gov.uk/api/content/government/ministers/minister-of-state--37",
+                          "web_url": "https://www.gov.uk/government/ministers/minister-of-state--37"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "content_id": "321bdb6d-6b7b-4767-959e-cd0e22f4da54",
+                    "title": "The Rt Hon Greg Hands MP - Minister of State (Minister for Trade Policy)",
+                    "locale": "en",
+                    "document_type": "role_appointment",
+                    "public_updated_at": "2021-09-16T08:39:15Z",
+                    "schema_name": "role_appointment",
+                    "withdrawn": false,
+                    "details": {
+                      "started_on": "2020-02-13T00:00:00+00:00",
+                      "ended_on": "2021-09-15T00:00:00+01:00",
+                      "current": false,
+                      "person_appointment_order": 6042
+                    },
+                    "links": {
+                      "role": [
+                        {
+                          "content_id": "079d5ff0-bf3f-41dc-be88-6384b4a57d8f",
+                          "title": "Minister of State (Minister for Trade Policy)",
+                          "locale": "en",
+                          "api_path": "/api/content/government/ministers/minister-of-state--96",
+                          "base_path": "/government/ministers/minister-of-state--96",
+                          "document_type": "ministerial_role",
+                          "public_updated_at": "2022-11-21T15:38:44Z",
+                          "schema_name": "role",
+                          "withdrawn": false,
+                          "details": {
+                            "body": "<p>The Minister of State for Trade Policy supports the Secretary of State with:</p>\n\n<ul>\n  <li>support on all free trade agreements (FTAs)</li>\n  <li>support on World Trade Organization (WTO), G7, G20, OECD, Commonwealth and wider multilateral engagement</li>\n  <li>market access strategy</li>\n  <li>FTA implementation</li>\n  <li>the Board of Trade</li>\n  <li>union policy</li>\n  <li>chairing the XWH Inter-Ministerial Trade Advisory Group (IMTAG)</li>\n  <li>external engagement via the:\n    <ul>\n      <li>Strategic Trade Advisory Group</li>\n      <li>sectoral trade advisory groups</li>\n      <li>trade union advisory groups</li>\n      <li>civil society and think tank roundtables</li>\n    </ul>\n  </li>\n</ul>\n",
+                            "role_payment_type": null,
+                            "seniority": 100,
+                            "whip_organisation": {}
+                          },
+                          "links": {},
+                          "api_url": "https://www.gov.uk/api/content/government/ministers/minister-of-state--96",
+                          "web_url": "https://www.gov.uk/government/ministers/minister-of-state--96"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "content_id": "f2873972-2236-4de6-9948-4a9ad7853789",
+                    "title": "The Rt Hon Greg Hands MP - Minister without Portfolio",
+                    "locale": "en",
+                    "document_type": "role_appointment",
+                    "public_updated_at": "2023-02-07T11:51:57Z",
+                    "schema_name": "role_appointment",
+                    "withdrawn": false,
+                    "details": {
+                      "started_on": "2023-02-07T00:00:00+00:00",
+                      "ended_on": null,
+                      "current": true,
+                      "person_appointment_order": 11
+                    },
+                    "links": {
+                      "role": [
+                        {
+                          "content_id": "d7f7603e-ac5b-40cf-bafe-6765d6ffb53b",
+                          "title": "Minister without Portfolio",
+                          "locale": "en",
+                          "api_path": "/api/content/government/ministers/minister-without-portfolio--8",
+                          "base_path": "/government/ministers/minister-without-portfolio--8",
+                          "document_type": "ministerial_role",
+                          "public_updated_at": "2023-02-21T16:17:37Z",
+                          "schema_name": "role",
+                          "withdrawn": false,
+                          "details": {
+                            "body": "\n",
+                            "role_payment_type": "Unpaid",
+                            "seniority": 29,
+                            "whip_organisation": {}
+                          },
+                          "links": {},
+                          "api_url": "https://www.gov.uk/api/content/government/ministers/minister-without-portfolio--8",
+                          "web_url": "https://www.gov.uk/government/ministers/minister-without-portfolio--8"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "content_id": "2ccdada3-fe39-41ff-8a9b-2856027550ec",
+                    "title": "The Rt Hon Greg Hands MP - Minister of State (Minister for Trade Policy)",
+                    "locale": "en",
+                    "document_type": "role_appointment",
+                    "public_updated_at": "2023-02-07T11:52:52Z",
+                    "schema_name": "role_appointment",
+                    "withdrawn": false,
+                    "details": {
+                      "started_on": "2022-10-09T00:00:00+01:00",
+                      "ended_on": "2023-02-07T00:00:00+00:00",
+                      "current": false,
+                      "person_appointment_order": 10
+                    },
+                    "links": {
+                      "role": [
+                        {
+                          "content_id": "079d5ff0-bf3f-41dc-be88-6384b4a57d8f",
+                          "title": "Minister of State (Minister for Trade Policy)",
+                          "locale": "en",
+                          "api_path": "/api/content/government/ministers/minister-of-state--96",
+                          "base_path": "/government/ministers/minister-of-state--96",
+                          "document_type": "ministerial_role",
+                          "public_updated_at": "2022-11-21T15:38:44Z",
+                          "schema_name": "role",
+                          "withdrawn": false,
+                          "details": {
+                            "body": "<p>The Minister of State for Trade Policy supports the Secretary of State with:</p>\n\n<ul>\n  <li>support on all free trade agreements (FTAs)</li>\n  <li>support on World Trade Organization (WTO), G7, G20, OECD, Commonwealth and wider multilateral engagement</li>\n  <li>market access strategy</li>\n  <li>FTA implementation</li>\n  <li>the Board of Trade</li>\n  <li>union policy</li>\n  <li>chairing the XWH Inter-Ministerial Trade Advisory Group (IMTAG)</li>\n  <li>external engagement via the:\n    <ul>\n      <li>Strategic Trade Advisory Group</li>\n      <li>sectoral trade advisory groups</li>\n      <li>trade union advisory groups</li>\n      <li>civil society and think tank roundtables</li>\n    </ul>\n  </li>\n</ul>\n",
+                            "role_payment_type": null,
+                            "seniority": 100,
+                            "whip_organisation": {}
+                          },
+                          "links": {},
+                          "api_url": "https://www.gov.uk/api/content/government/ministers/minister-of-state--96",
+                          "web_url": "https://www.gov.uk/government/ministers/minister-of-state--96"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "content_id": "c898ced9-967c-4ce4-ac4f-2d132bfa99e9",
+                    "title": "The Rt Hon Greg Hands MP - Minister of State (Minister for Energy, Clean Growth and Climate Change)",
+                    "locale": "en",
+                    "document_type": "role_appointment",
+                    "public_updated_at": "2022-09-09T13:20:10Z",
+                    "schema_name": "role_appointment",
+                    "withdrawn": false,
+                    "details": {
+                      "started_on": "2021-09-16T00:00:00+01:00",
+                      "ended_on": "2022-09-07T00:00:00+01:00",
+                      "current": false,
+                      "person_appointment_order": 7346
+                    },
+                    "links": {
+                      "role": [
+                        {
+                          "content_id": "2dc8314c-67ef-4fab-913d-1305a0024e56",
+                          "title": "Minister of State (Minister for Energy, Clean Growth and Climate Change)",
+                          "locale": "en",
+                          "api_path": "/api/content/government/ministers/minister-of-state--75",
+                          "base_path": "/government/ministers/minister-of-state--75",
+                          "document_type": "ministerial_role",
+                          "public_updated_at": "2022-07-12T16:46:23Z",
+                          "schema_name": "role",
+                          "withdrawn": false,
+                          "details": {
+                            "body": "<p>Responsibilities include:</p>\n\n<ul>\n  <li>Net Zero Strategy</li>\n  <li>carbon budgets</li>\n  <li>low carbon generation</li>\n  <li>energy retail markets</li>\n  <li>oil and gas</li>\n  <li>security of supply</li>\n  <li>electricity and gas wholesale markets and networks</li>\n  <li>international energy, climate change and climate finance</li>\n  <li>energy security, including resilience</li>\n  <li>hydrogen</li>\n  <li>nuclear</li>\n  <li>fusion</li>\n  <li>industrial decarbonisation</li>\n</ul>\n",
+                            "role_payment_type": null,
+                            "seniority": 5,
+                            "whip_organisation": {}
+                          },
+                          "links": {},
+                          "api_url": "https://www.gov.uk/api/content/government/ministers/minister-of-state--75",
+                          "web_url": "https://www.gov.uk/government/ministers/minister-of-state--75"
+                        }
+                      ]
+                    }
+                  }
+                ]
+              },
+              "api_url": "https://www.gov.uk/api/content/government/people/greg-hands",
+              "web_url": "https://www.gov.uk/government/people/greg-hands"
+            },
+            {
+              "content_id": "a448451c-ac3c-481b-a970-089b6f6a6046",
+              "title": "Nusrat Ghani MP",
+              "locale": "en",
+              "api_path": "/api/content/government/people/nusrat-ghani",
+              "base_path": "/government/people/nusrat-ghani",
+              "document_type": "person",
+              "public_updated_at": "2023-03-20T14:40:01Z",
+              "schema_name": "person",
+              "withdrawn": false,
+              "details": {
+                "image": {
+                  "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/person/image/3346/s465_nusrat-ghani.jpg",
+                  "alt_text": "Nusrat Ghani MP"
+                },
+                "privy_counsellor": false
+              },
+              "links": {
+                "role_appointments": [
+                  {
+                    "content_id": "c12605e6-63a4-43d4-9883-eac908984065",
+                    "title": "Nusrat Ghani - Assistant Government Whip",
+                    "locale": "en",
+                    "document_type": "role_appointment",
+                    "public_updated_at": "2019-11-08T17:10:20Z",
+                    "schema_name": "role_appointment",
+                    "withdrawn": false,
+                    "details": {
+                      "started_on": "2018-01-09T00:00:00+00:00",
+                      "ended_on": "2019-07-11T00:00:00+01:00",
+                      "current": false,
+                      "person_appointment_order": 4559
+                    },
+                    "links": {
+                      "role": [
+                        {
+                          "content_id": "7bb9a1ac-0a95-4825-8c5e-3027b50cec4a",
+                          "title": "Assistant Government Whip",
+                          "locale": "en",
+                          "api_path": "/api/content/government/ministers/assistant-government-whip--10",
+                          "base_path": "/government/ministers/assistant-government-whip--10",
+                          "document_type": "ministerial_role",
+                          "public_updated_at": "2018-01-29T10:55:26Z",
+                          "schema_name": "role",
+                          "withdrawn": false,
+                          "details": {
+                            "body": "<p>Whips are <abbr title=\"Members of Parliament\">MPs</abbr> or Lords appointed by each party to help organise their party’s contribution to parliamentary business. They are responsible for making sure the maximum number of their party members vote, and vote the way their party wants.</p>\n\n",
+                            "role_payment_type": null,
+                            "seniority": 100,
+                            "whip_organisation": {
+                              "label": "Assistant Whips",
+                              "sort_order": 3
+                            }
+                          },
+                          "links": {},
+                          "api_url": "https://www.gov.uk/api/content/government/ministers/assistant-government-whip--10",
+                          "web_url": "https://www.gov.uk/government/ministers/assistant-government-whip--10"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "content_id": "133a0399-f7e0-4773-90bb-49a4e6aa582b",
+                    "title": "Nusrat Ghani MP - Parliamentary Under Secretary of State",
+                    "locale": "en",
+                    "document_type": "role_appointment",
+                    "public_updated_at": "2020-02-14T12:04:43Z",
+                    "schema_name": "role_appointment",
+                    "withdrawn": false,
+                    "details": {
+                      "started_on": "2018-01-09T00:00:00+00:00",
+                      "ended_on": "2020-02-13T00:00:00+00:00",
+                      "current": false,
+                      "person_appointment_order": 4572
+                    },
+                    "links": {
+                      "role": [
+                        {
+                          "content_id": "2cdb3d54-ab83-44d0-934c-4585f9eb84e6",
+                          "title": "Parliamentary Under Secretary of State",
+                          "locale": "en",
+                          "api_path": "/api/content/government/ministers/parliamentary-under-secretary-of-state-for-transport--4",
+                          "base_path": "/government/ministers/parliamentary-under-secretary-of-state-for-transport--4",
+                          "document_type": "ministerial_role",
+                          "public_updated_at": "2022-07-08T06:05:22Z",
+                          "schema_name": "role",
+                          "withdrawn": false,
+                          "details": {
+                            "body": "<p>The Minister is responsible for:</p>\n\n<ul>\n  <li>rail</li>\n  <li>accessibility</li>\n</ul>\n\n",
+                            "role_payment_type": null,
+                            "seniority": 100,
+                            "whip_organisation": {}
+                          },
+                          "links": {},
+                          "api_url": "https://www.gov.uk/api/content/government/ministers/parliamentary-under-secretary-of-state-for-transport--4",
+                          "web_url": "https://www.gov.uk/government/ministers/parliamentary-under-secretary-of-state-for-transport--4"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "content_id": "8f72dcbf-bc80-4d16-b9e4-b8d2bd156623",
+                    "title": "Nusrat Ghani - Government Whip, Lord Commissioner of HM Treasury",
+                    "locale": "en",
+                    "document_type": "role_appointment",
+                    "public_updated_at": "2019-12-17T16:48:35Z",
+                    "schema_name": "role_appointment",
+                    "withdrawn": false,
+                    "details": {
+                      "started_on": "2019-07-11T00:00:00+01:00",
+                      "ended_on": "2019-12-17T00:00:00+00:00",
+                      "current": false,
+                      "person_appointment_order": 5550
+                    },
+                    "links": {
+                      "role": [
+                        {
+                          "content_id": "846193d2-c0f1-11e4-8223-005056011aef",
+                          "title": "Government Whip, Lord Commissioner of HM Treasury",
+                          "locale": "en",
+                          "api_path": "/api/content/government/ministers/government-whip-lord-commissioner-of-hm-treasury--2",
+                          "base_path": "/government/ministers/government-whip-lord-commissioner-of-hm-treasury--2",
+                          "document_type": "ministerial_role",
+                          "public_updated_at": "2021-04-21T10:17:00Z",
+                          "schema_name": "role",
+                          "withdrawn": false,
+                          "details": {
+                            "body": "<p>Whips are MPs or Lords appointed by each party to help organise their party’s contribution to parliamentary business. They are responsible for making sure the maximum number of their party members vote, and vote the way their party wants.</p>\n",
+                            "role_payment_type": "Unpaid",
+                            "seniority": 100,
+                            "whip_organisation": {
+                              "label": "Junior Lords of the Treasury",
+                              "sort_order": 2
+                            }
+                          },
+                          "links": {},
+                          "api_url": "https://www.gov.uk/api/content/government/ministers/government-whip-lord-commissioner-of-hm-treasury--2",
+                          "web_url": "https://www.gov.uk/government/ministers/government-whip-lord-commissioner-of-hm-treasury--2"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "content_id": "ce342d3e-2b61-4dc8-a558-c0701f3346e8",
+                    "title": "Nusrat Ghani MP - Minister of State",
+                    "locale": "en",
+                    "document_type": "role_appointment",
+                    "public_updated_at": "2023-02-07T15:54:14Z",
+                    "schema_name": "role_appointment",
+                    "withdrawn": false,
+                    "details": {
+                      "started_on": "2023-02-07T00:00:00+00:00",
+                      "ended_on": null,
+                      "current": true,
+                      "person_appointment_order": 6
+                    },
+                    "links": {
+                      "role": [
+                        {
+                          "content_id": "e901f3a3-b51c-4491-8667-6605155a3fcd",
+                          "title": "Minister of State at the Department for Business and Trade",
+                          "locale": "en",
+                          "api_path": "/api/content/government/ministers/minister-of-state--155",
+                          "base_path": "/government/ministers/minister-of-state--155",
+                          "document_type": "ministerial_role",
+                          "public_updated_at": "2023-03-20T14:45:02Z",
+                          "schema_name": "role",
+                          "withdrawn": false,
+                          "details": {
+                            "body": "\n",
+                            "role_payment_type": null,
+                            "seniority": 100,
+                            "whip_organisation": {}
+                          },
+                          "links": {},
+                          "api_url": "https://www.gov.uk/api/content/government/ministers/minister-of-state--155",
+                          "web_url": "https://www.gov.uk/government/ministers/minister-of-state--155"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "content_id": "fd63227b-4344-4a9a-9697-316e925bb45a",
+                    "title": "Nusrat Ghani MP - Minister of State (Minister for Industry and Investment Security)",
+                    "locale": "en",
+                    "document_type": "role_appointment",
+                    "public_updated_at": "2023-02-07T15:57:48Z",
+                    "schema_name": "role_appointment",
+                    "withdrawn": false,
+                    "details": {
+                      "started_on": "2022-10-27T00:00:00+01:00",
+                      "ended_on": "2023-02-07T00:00:00+00:00",
+                      "current": false,
+                      "person_appointment_order": 5
+                    },
+                    "links": {
+                      "role": [
+                        {
+                          "content_id": "3a445bfc-0d56-48f0-9a72-7c938b07199b",
+                          "title": "Minister of State (Minister for Industry and Investment Security)",
+                          "locale": "en",
+                          "api_path": "/api/content/government/ministers/minister-of-state-minister-for-industry-and-investment-security",
+                          "base_path": "/government/ministers/minister-of-state-minister-for-industry-and-investment-security",
+                          "document_type": "ministerial_role",
+                          "public_updated_at": "2022-11-21T15:15:09Z",
+                          "schema_name": "role",
+                          "withdrawn": false,
+                          "details": {
+                            "body": "<p>Responsibilities include:</p>\n\n<ul>\n  <li>advanced manufacturing, including aerospace, Made Smarter, defence</li>\n  <li>automotive, including the Office for Zero Emission Vehicles</li>\n  <li>infrastructure and materials, including steel, energy intensive industries, chemicals, construction</li>\n  <li>life sciences, including vaccine production</li>\n  <li>professional and business services</li>\n  <li>maritime and shipbuilding</li>\n  <li>critical minerals and critical mineral supply chains</li>\n  <li>industrial decarbonisation</li>\n  <li>economic shocks</li>\n  <li>supply chains</li>\n  <li>levelling up and regional growth</li>\n  <li>investment pipeline and opportunities</li>\n  <li>Investment Security Unit</li>\n  <li>skills</li>\n  <li>retained EU law and Brexit opportunities</li>\n  <li>better regulation</li>\n</ul>\n",
+                            "role_payment_type": null,
+                            "seniority": 100,
+                            "whip_organisation": {}
+                          },
+                          "links": {},
+                          "api_url": "https://www.gov.uk/api/content/government/ministers/minister-of-state-minister-for-industry-and-investment-security",
+                          "web_url": "https://www.gov.uk/government/ministers/minister-of-state-minister-for-industry-and-investment-security"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "content_id": "0225d5c1-5989-4d70-b4b8-cd07ded2fc7e",
+                    "title": "Nusrat Ghani MP - Minister of State",
+                    "locale": "en",
+                    "document_type": "role_appointment",
+                    "public_updated_at": "2023-02-07T15:55:04Z",
+                    "schema_name": "role_appointment",
+                    "withdrawn": false,
+                    "details": {
+                      "started_on": "2023-02-07T00:00:00+00:00",
+                      "ended_on": null,
+                      "current": true,
+                      "person_appointment_order": 7
+                    },
+                    "links": {
+                      "role": [
+                        {
+                          "content_id": "949c0326-a1ca-4fcd-8d0b-8d205ea8cbad",
+                          "title": "Minister of State for the Investment Security Unit",
+                          "locale": "en",
+                          "api_path": "/api/content/government/ministers/minister-of-state--156",
+                          "base_path": "/government/ministers/minister-of-state--156",
+                          "document_type": "ministerial_role",
+                          "public_updated_at": "2023-03-20T14:40:34Z",
+                          "schema_name": "role",
+                          "withdrawn": false,
+                          "details": {
+                            "body": "\n",
+                            "role_payment_type": null,
+                            "seniority": 100,
+                            "whip_organisation": {}
+                          },
+                          "links": {},
+                          "api_url": "https://www.gov.uk/api/content/government/ministers/minister-of-state--156",
+                          "web_url": "https://www.gov.uk/government/ministers/minister-of-state--156"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "content_id": "95238090-b755-4be3-99a6-e0a4b223c859",
+                    "title": "Nusrat Ghani MP - Minister of State (Minister for Science and Investment Security)",
+                    "locale": "en",
+                    "document_type": "role_appointment",
+                    "public_updated_at": "2022-11-18T16:34:44Z",
+                    "schema_name": "role_appointment",
+                    "withdrawn": false,
+                    "details": {
+                      "started_on": "2022-09-07T00:00:00+01:00",
+                      "ended_on": "2022-10-26T00:00:00+01:00",
+                      "current": false,
+                      "person_appointment_order": 8109
+                    },
+                    "links": {
+                      "role": [
+                        {
+                          "content_id": "06abd7d3-d0db-4bff-9f5f-054a4387c473",
+                          "title": "Minister of State (Minister for Science and Investment Security)",
+                          "locale": "en",
+                          "api_path": "/api/content/government/ministers/minister-of-state-minister-for-science-and-investment-security",
+                          "base_path": "/government/ministers/minister-of-state-minister-for-science-and-investment-security",
+                          "document_type": "ministerial_role",
+                          "public_updated_at": "2022-10-03T10:59:25Z",
+                          "schema_name": "role",
+                          "withdrawn": false,
+                          "details": {
+                            "body": "<p>Responsibilities include:</p>\n\n<ul>\n  <li>science and research (domestic and international) </li>\n  <li>Horizon Europe membership </li>\n  <li>innovation strategy / science superpower </li>\n  <li>critical minerals and critical mineral supply chains </li>\n  <li>maritime and shipbuilding </li>\n  <li>life sciences (including vaccine production) </li>\n  <li>space strategy (excluding OneWeb) </li>\n  <li>technology, strategy and security </li>\n  <li>artificial intelligence (including the Office for AI) </li>\n  <li>fusion </li>\n  <li>R&amp;D people and culture strategy </li>\n  <li>research approvals </li>\n</ul>\n\n<p>Supporting the Secretary of State on:</p>\n\n<ul>\n  <li>investment security</li>\n  <li>investment pipeline and opportunities</li>\n  <li>UK Research and Innovation (UKRI)</li>\n  <li>Advanced Research and Invention Agency (ARIA)</li>\n</ul>\n",
+                            "role_payment_type": null,
+                            "seniority": 100,
+                            "whip_organisation": {}
+                          },
+                          "links": {},
+                          "api_url": "https://www.gov.uk/api/content/government/ministers/minister-of-state-minister-for-science-and-investment-security",
+                          "web_url": "https://www.gov.uk/government/ministers/minister-of-state-minister-for-science-and-investment-security"
+                        }
+                      ]
+                    }
+                  }
+                ]
+              },
+              "api_url": "https://www.gov.uk/api/content/government/people/nusrat-ghani",
+              "web_url": "https://www.gov.uk/government/people/nusrat-ghani"
+            }
+          ],
+          "ordered_roles": [
+            {
+              "content_id": "845e5811-c0f1-11e4-8223-005056011aef",
+              "title": "Prime Minister",
+              "locale": "en",
+              "api_path": "/api/content/government/ministers/prime-minister",
+              "base_path": "/government/ministers/prime-minister",
+              "document_type": "ministerial_role",
+              "public_updated_at": "2022-10-05T07:44:54Z",
+              "schema_name": "role",
+              "withdrawn": false,
+              "details": {
+                "body": "<p>The Prime Minister is the leader of His Majesty’s Government and is ultimately responsible for the policy and decisions of the government.</p>\n\n<p>As leader of the UK government the Prime Minister also:</p>\n\n<ul>\n  <li>oversees the <a href=\"https://www.gov.uk/government/ministers/minister-for-the-civil-service\">operation of the Civil Service</a> and government agencies</li>\n  <li>chooses members of the government</li>\n  <li>is the principal government figure in the House of Commons</li>\n</ul>\n\n<p>As <a href=\"https://www.gov.uk/government/ministers/minister-for-the-union\">Minister for the Union</a>, the Prime Minister works to ensure that all of government is acting on behalf of the entire United Kingdom: England, Northern Ireland, Scotland, and Wales.</p>\n",
+                "role_payment_type": null,
+                "seniority": 0,
+                "whip_organisation": {}
+              },
+              "links": {},
+              "api_url": "https://www.gov.uk/api/content/government/ministers/prime-minister",
+              "web_url": "https://www.gov.uk/government/ministers/prime-minister"
+            },
+            {
+              "content_id": "846a7351-c0f1-11e4-8223-005056011aef",
+              "title": "Minister for the Civil Service",
+              "locale": "en",
+              "api_path": "/api/content/government/ministers/minister-for-the-civil-service",
+              "base_path": "/government/ministers/minister-for-the-civil-service",
+              "document_type": "ministerial_role",
+              "public_updated_at": "2022-09-28T11:40:15Z",
+              "schema_name": "role",
+              "withdrawn": false,
+              "details": {
+                "body": "<p>The Minister for the Civil Service is responsible for regulating the <a rel=\"external\" href=\"http://www.civilservice.gov.uk/\">Civil Service</a>.</p>\n\n<p>The <a rel=\"external\" href=\"http://www.legislation.gov.uk/ukpga/1992/61/contents\">Civil Service (Management Functions) Act of 1992</a>, allows the Minister for the Civil Service to delegate power to other ministers and devolved administrations.</p>\n\n<p>This role was created in 1968 and is always held by the <a href=\"https://www.gov.uk/government/ministers/prime-minister\">Prime Minister</a>.</p>\n",
+                "role_payment_type": null,
+                "seniority": 2,
+                "whip_organisation": {}
+              },
+              "links": {},
+              "api_url": "https://www.gov.uk/api/content/government/ministers/minister-for-the-civil-service",
+              "web_url": "https://www.gov.uk/government/ministers/minister-for-the-civil-service"
+            },
+            {
+              "content_id": "846a754c-c0f1-11e4-8223-005056011aef",
+              "title": "First Lord of the Treasury",
+              "locale": "en",
+              "api_path": "/api/content/government/ministers/first-lord-of-the-treasury",
+              "base_path": "/government/ministers/first-lord-of-the-treasury",
+              "document_type": "ministerial_role",
+              "public_updated_at": "2022-10-05T07:44:10Z",
+              "schema_name": "role",
+              "withdrawn": false,
+              "details": {
+                "body": "<p>The First Lord of the Treasury is one of the Lords Commissioners of the Treasury. This role is usually held by the <a href=\"https://www.gov.uk/government/ministers/prime-minister\">Prime Minister</a>.</p>\n\n<p>Since the 17th century, the Lords Commissioners of the Treasury have collectively carried out duties that were previously held by the Lord High Treasurer (head of His Majesty’s Treasury).</p>\n\n<p>The Lords Commissioners of the Treasury also include:</p>\n\n<ul>\n  <li>the Second Lord of the Treasury - the <a href=\"https://www.gov.uk/government/ministers/chancellor-of-the-exchequer\">Chancellor of the Exchequer</a>, who has most of the functional financial responsibilities</li>\n  <li>Junior Lords Commissioners of the Treasury - other members of the government, usually <a href=\"https://www.gov.uk/government/ministers#whips\">government whips in the House of Commons</a>\n</li>\n</ul>\n\n<p>10 Downing Street is the official residence of the First Lord of the Treasury, and not of the Prime Minister.</p>\n",
+                "role_payment_type": null,
+                "seniority": 1,
+                "whip_organisation": {}
+              },
+              "links": {},
+              "api_url": "https://www.gov.uk/api/content/government/ministers/first-lord-of-the-treasury",
+              "web_url": "https://www.gov.uk/government/ministers/first-lord-of-the-treasury"
+            },
+            {
+              "content_id": "041f4e4c-45f8-44b0-a7d8-ae1eb11370a2",
+              "title": "Minister for the Union",
+              "locale": "en",
+              "api_path": "/api/content/government/ministers/minister-for-the-union",
+              "base_path": "/government/ministers/minister-for-the-union",
+              "document_type": "ministerial_role",
+              "public_updated_at": "2020-09-01T15:38:15Z",
+              "schema_name": "role",
+              "withdrawn": false,
+              "details": {
+                "body": "<p>As Minister for the Union, the Prime Minister works to ensure that all of government is acting on behalf of the entire United Kingdom: England, Northern Ireland, Scotland, and Wales.</p>\n",
+                "role_payment_type": null,
+                "seniority": 3,
+                "whip_organisation": {}
+              },
+              "links": {},
+              "api_url": "https://www.gov.uk/api/content/government/ministers/minister-for-the-union",
+              "web_url": "https://www.gov.uk/government/ministers/minister-for-the-union"
+            }
+          ]
+        },
+        "api_url": "https://www.gov.uk/api/content/government/organisations/cabinet-office",
+        "web_url": "https://www.gov.uk/government/organisations/cabinet-office"
+      },
+      {
+        "content_id": "aa750cdf-7925-429d-a2b3-0d9fa47d2c48",
+        "title": "Department for Business and Trade",
+        "locale": "en",
+        "analytics_identifier": "D1382",
+        "api_path": "/api/content/government/organisations/department-for-business-and-trade",
+        "base_path": "/government/organisations/department-for-business-and-trade",
+        "document_type": "organisation",
+        "schema_name": "organisation",
+        "withdrawn": false,
+        "details": {
+          "logo": {
+            "crest": "dbt",
+            "formatted_title": "Department for<br/>Business &amp; Trade"
+          },
+          "brand": "department-for-business-and-trade",
+          "default_news_image": {
+            "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/default_news_organisation_image_data/file/575/s300_DBT_Plaque-2.jpg",
+            "high_resolution_url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/default_news_organisation_image_data/file/575/s960_DBT_Plaque-2.jpg"
+          },
+          "organisation_govuk_status": {
+            "url": null,
+            "status": "live",
+            "updated_at": null
+          }
+        },
+        "links": {
+          "ordered_ministers": [
+            {
+              "content_id": "b775b0fb-4a6c-40db-abc5-d8724e5d8ce4",
+              "title": "The Rt Hon Kemi Badenoch MP",
+              "locale": "en",
+              "api_path": "/api/content/government/people/kemi-badenoch",
+              "base_path": "/government/people/kemi-badenoch",
+              "document_type": "person",
+              "public_updated_at": "2023-02-28T12:42:04Z",
+              "schema_name": "person",
+              "withdrawn": false,
+              "details": {
+                "image": {
+                  "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/person/image/4010/s465_Kemi_gov.uk.png",
+                  "alt_text": "The Rt Hon Kemi Badenoch MP"
+                },
+                "privy_counsellor": true
+              },
+              "links": {
+                "role_appointments": [
+                  {
+                    "content_id": "c27b7fea-20a3-4b21-b51c-e2828880e1d9",
+                    "title": "Kemi Badenoch MP - Parliamentary Under Secretary of State (Minister for Children and Families)",
+                    "locale": "en",
+                    "document_type": "role_appointment",
+                    "public_updated_at": "2020-02-13T20:12:56Z",
+                    "schema_name": "role_appointment",
+                    "withdrawn": false,
+                    "details": {
+                      "started_on": "2019-07-27T00:00:00+01:00",
+                      "ended_on": "2020-02-13T00:00:00+00:00",
+                      "current": false,
+                      "person_appointment_order": 5641
+                    },
+                    "links": {
+                      "role": [
+                        {
+                          "content_id": "845e7222-c0f1-11e4-8223-005056011aef",
+                          "title": "Parliamentary Under Secretary of State (Minister for Children and Families)",
+                          "locale": "en",
+                          "api_path": "/api/content/government/ministers/parliamentary-under-secretary-of-state-children-and-young-families",
+                          "base_path": "/government/ministers/parliamentary-under-secretary-of-state-children-and-young-families",
+                          "document_type": "ministerial_role",
+                          "public_updated_at": "2022-07-13T10:05:06Z",
+                          "schema_name": "role",
+                          "withdrawn": false,
+                          "details": {
+                            "body": "<p>The minister’s responsibilities include:</p>\n\n<ul>\n  <li>children’s social care</li>\n  <li>families</li>\n  <li>children in care, children in need, child protection, adoption and care leavers</li>\n  <li>early years and childcare</li>\n  <li>disadvantaged and vulnerable children</li>\n  <li>school sport</li>\n  <li>alternative provision</li>\n  <li>behaviour, attendance and exclusions</li>\n  <li>children and young people’s mental health, online safety and preventing bullying in schools</li>\n  <li>policy to protect against serious violence</li>\n  <li>coronavirus (COVID-19) recovery for children’s services and early years</li>\n</ul>\n\n",
+                            "role_payment_type": null,
+                            "seniority": 100,
+                            "whip_organisation": {}
+                          },
+                          "links": {},
+                          "api_url": "https://www.gov.uk/api/content/government/ministers/parliamentary-under-secretary-of-state-children-and-young-families",
+                          "web_url": "https://www.gov.uk/government/ministers/parliamentary-under-secretary-of-state-children-and-young-families"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "content_id": "e839feff-a7f9-48c0-bcac-39fccb92c896",
+                    "title": "Kemi Badenoch MP - Minister of State (Minister for Local Government, Faith and Communities)",
+                    "locale": "en",
+                    "document_type": "role_appointment",
+                    "public_updated_at": "2022-07-08T08:50:43Z",
+                    "schema_name": "role_appointment",
+                    "withdrawn": false,
+                    "details": {
+                      "started_on": "2021-09-19T00:00:00+01:00",
+                      "ended_on": "2022-07-06T00:00:00+01:00",
+                      "current": false,
+                      "person_appointment_order": 7189
+                    },
+                    "links": {
+                      "role": [
+                        {
+                          "content_id": "ac67fbb9-3c4f-4c26-959d-b9a2dc5ebe22",
+                          "title": "Minister of State (Minister for Local Government, Faith and Communities)",
+                          "locale": "en",
+                          "api_path": "/api/content/government/ministers/minister-of-state--113",
+                          "base_path": "/government/ministers/minister-of-state--113",
+                          "document_type": "ministerial_role",
+                          "public_updated_at": "2022-06-16T12:06:12Z",
+                          "schema_name": "role",
+                          "withdrawn": false,
+                          "details": {
+                            "body": "<ul>\n  <li>Local government policy, finance and improvement in England</li>\n  <li>Electoral Integrity Programme</li>\n  <li>Integration, anti-extremism, and religious hatred policy</li>\n  <li>Faith community engagement</li>\n  <li>Foreign Affairs (Economic activity of publicly funded bodies) Bill and policy oversight</li>\n  <li>Holocaust Memorial Learning Centre</li>\n</ul>\n",
+                            "role_payment_type": null,
+                            "seniority": 100,
+                            "whip_organisation": {}
+                          },
+                          "links": {},
+                          "api_url": "https://www.gov.uk/api/content/government/ministers/minister-of-state--113",
+                          "web_url": "https://www.gov.uk/government/ministers/minister-of-state--113"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "content_id": "931d990c-5ebb-4930-8360-58f452325508",
+                    "title": "Kemi Badenoch MP - Minister of State (Minister for Equalities)",
+                    "locale": "en",
+                    "document_type": "role_appointment",
+                    "public_updated_at": "2022-07-08T10:11:37Z",
+                    "schema_name": "role_appointment",
+                    "withdrawn": false,
+                    "details": {
+                      "started_on": "2021-09-15T00:00:00+01:00",
+                      "ended_on": "2022-07-06T00:00:00+01:00",
+                      "current": false,
+                      "person_appointment_order": 7202
+                    },
+                    "links": {
+                      "role": [
+                        {
+                          "content_id": "871a9d80-d9ec-4219-bccb-28afa271bd9e",
+                          "title": "Minister of State (Minister for Equalities)",
+                          "locale": "en",
+                          "api_path": "/api/content/government/ministers/minister-of-state-minister-for-equalities",
+                          "base_path": "/government/ministers/minister-of-state-minister-for-equalities",
+                          "document_type": "ministerial_role",
+                          "public_updated_at": "2022-06-16T12:07:21Z",
+                          "schema_name": "role",
+                          "withdrawn": false,
+                          "details": {
+                            "body": "<ul>\n  <li>Racial and ethnic disparities</li>\n  <li>Inclusive Britain Strategy</li>\n  <li>Inclusion at Work Panel oversight</li>\n  <li>Equality Act and Public Sector Equality Duty oversight</li>\n  <li>Sponsoring minister for the Social Mobility Commission and the Equality and Human Rights Commission</li>\n</ul>\n",
+                            "role_payment_type": null,
+                            "seniority": 100,
+                            "whip_organisation": {}
+                          },
+                          "links": {},
+                          "api_url": "https://www.gov.uk/api/content/government/ministers/minister-of-state-minister-for-equalities",
+                          "web_url": "https://www.gov.uk/government/ministers/minister-of-state-minister-for-equalities"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "content_id": "2b33f51e-ddb1-401f-966d-17160c7dfd5c",
+                    "title": "Kemi Badenoch MP - Exchequer Secretary to the Treasury",
+                    "locale": "en",
+                    "document_type": "role_appointment",
+                    "public_updated_at": "2021-09-16T10:15:14Z",
+                    "schema_name": "role_appointment",
+                    "withdrawn": false,
+                    "details": {
+                      "started_on": "2020-02-13T00:00:00+00:00",
+                      "ended_on": "2021-09-15T00:00:00+01:00",
+                      "current": false,
+                      "person_appointment_order": 6045
+                    },
+                    "links": {
+                      "role": [
+                        {
+                          "content_id": "845e88c6-c0f1-11e4-8223-005056011aef",
+                          "title": "Exchequer Secretary to the Treasury",
+                          "locale": "en",
+                          "api_path": "/api/content/government/ministers/exchequer-secretary-to-the-treasury",
+                          "base_path": "/government/ministers/exchequer-secretary-to-the-treasury",
+                          "document_type": "ministerial_role",
+                          "public_updated_at": "2023-02-06T13:18:17Z",
+                          "schema_name": "role",
+                          "withdrawn": false,
+                          "details": {
+                            "body": "<h3 id=\"the-exchequer-secretary-xst-is-responsible-for\">The Exchequer Secretary (<abbr title=\"Exchequer Secretary to the Treasury\">XST</abbr>) is responsible for:</h3>\n\n<ul>\n  <li>\n    <p>Growth and productivity, including skills, migration, infrastructure (physical &amp; digital), digital economy, economic regulation, business regulation, competition, corporate governance, foreign direct investment (non-FS), and the Levelling Up White Paper living standards mission.</p>\n  </li>\n  <li>\n    <p>Energy, environment and climate policy and taxes (including transport taxes)</p>\n  </li>\n  <li>\n    <p>The following indirect taxes, including stakeholder engagement:</p>\n\n    <ul>\n      <li>Excise duties (alcohol, tobacco, gambling, and SDIL), including excise fraud and law enforcement</li>\n      <li>Charities, the voluntary sector, and gift aid</li>\n    </ul>\n  </li>\n  <li>\n    <p>Departmental minister for HM Treasury Group (including responsibility for the Darlington campus)</p>\n  </li>\n  <li>\n    <p>Crown Estate and the Royal Household</p>\n  </li>\n  <li>\n    <p>Energy Profits Levy</p>\n  </li>\n</ul>\n\n",
+                            "role_payment_type": null,
+                            "seniority": 100,
+                            "whip_organisation": {}
+                          },
+                          "links": {},
+                          "api_url": "https://www.gov.uk/api/content/government/ministers/exchequer-secretary-to-the-treasury",
+                          "web_url": "https://www.gov.uk/government/ministers/exchequer-secretary-to-the-treasury"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "content_id": "00e090ae-f8af-493b-be0b-5c1282a02c09",
+                    "title": "Kemi Badenoch MP - Minister of State",
+                    "locale": "en",
+                    "document_type": "role_appointment",
+                    "public_updated_at": "2021-09-21T12:53:22Z",
+                    "schema_name": "role_appointment",
+                    "withdrawn": false,
+                    "details": {
+                      "started_on": "2021-09-16T00:00:00+01:00",
+                      "ended_on": "2021-09-19T00:00:00+01:00",
+                      "current": false,
+                      "person_appointment_order": 7132
+                    },
+                    "links": {
+                      "role": [
+                        {
+                          "content_id": "a47c2d17-f940-47ac-bc4a-d4ecdc5f3bcd",
+                          "title": "Minister of State",
+                          "locale": "en",
+                          "api_path": "/api/content/government/ministers/minister-of-state--112",
+                          "base_path": "/government/ministers/minister-of-state--112",
+                          "document_type": "ministerial_role",
+                          "public_updated_at": "2021-09-16T10:14:04Z",
+                          "schema_name": "role",
+                          "withdrawn": false,
+                          "details": {
+                            "body": "\n",
+                            "role_payment_type": null,
+                            "seniority": 100,
+                            "whip_organisation": {}
+                          },
+                          "links": {},
+                          "api_url": "https://www.gov.uk/api/content/government/ministers/minister-of-state--112",
+                          "web_url": "https://www.gov.uk/government/ministers/minister-of-state--112"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "content_id": "efdf98a0-fbe6-4256-bf40-ffd13cb967a5",
+                    "title": "Kemi Badenoch MP - Parliamentary Under-Secretary of State (Minister for Equalities) ",
+                    "locale": "en",
+                    "document_type": "role_appointment",
+                    "public_updated_at": "2021-09-22T17:20:04Z",
+                    "schema_name": "role_appointment",
+                    "withdrawn": false,
+                    "details": {
+                      "started_on": "2020-02-14T00:00:00+00:00",
+                      "ended_on": "2021-09-15T00:00:00+01:00",
+                      "current": false,
+                      "person_appointment_order": 6079
+                    },
+                    "links": {
+                      "role": [
+                        {
+                          "content_id": "f6679300-b226-4cbb-9de4-3b9f4378f5e9",
+                          "title": "Parliamentary Under-Secretary of State (Minister for Equalities) ",
+                          "locale": "en",
+                          "api_path": "/api/content/government/ministers/minister-of-state-for-equalities",
+                          "base_path": "/government/ministers/minister-of-state-for-equalities",
+                          "document_type": "ministerial_role",
+                          "public_updated_at": "2020-02-14T19:30:25Z",
+                          "schema_name": "role",
+                          "withdrawn": false,
+                          "details": {
+                            "body": "\n",
+                            "role_payment_type": null,
+                            "seniority": 100,
+                            "whip_organisation": {}
+                          },
+                          "links": {},
+                          "api_url": "https://www.gov.uk/api/content/government/ministers/minister-of-state-for-equalities",
+                          "web_url": "https://www.gov.uk/government/ministers/minister-of-state-for-equalities"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "content_id": "5e2284cd-8e2d-4563-9e4d-784b2ec0a490",
+                    "title": "The Rt Hon Kemi Badenoch MP - Secretary of State",
+                    "locale": "en",
+                    "document_type": "role_appointment",
+                    "public_updated_at": "2023-02-07T13:10:49Z",
+                    "schema_name": "role_appointment",
+                    "withdrawn": false,
+                    "details": {
+                      "started_on": "2023-02-07T00:00:00+00:00",
+                      "ended_on": null,
+                      "current": true,
+                      "person_appointment_order": 9
+                    },
+                    "links": {
+                      "role": [
+                        {
+                          "content_id": "5cb74a2c-7e9f-444a-8347-d944cc05b606",
+                          "title": "Secretary of State for Business and Trade",
+                          "locale": "en",
+                          "api_path": "/api/content/government/ministers/secretary-of-state--2",
+                          "base_path": "/government/ministers/secretary-of-state--2",
+                          "document_type": "ministerial_role",
+                          "public_updated_at": "2023-02-10T16:52:51Z",
+                          "schema_name": "role",
+                          "withdrawn": false,
+                          "details": {
+                            "body": "\n",
+                            "role_payment_type": null,
+                            "seniority": 21,
+                            "whip_organisation": {}
+                          },
+                          "links": {},
+                          "api_url": "https://www.gov.uk/api/content/government/ministers/secretary-of-state--2",
+                          "web_url": "https://www.gov.uk/government/ministers/secretary-of-state--2"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "content_id": "32169de2-b1de-4f00-ab75-647a2a77bde1",
+                    "title": "The Rt Hon Kemi Badenoch MP -  Secretary of State for International Trade and President of the Board of Trade",
+                    "locale": "en",
+                    "document_type": "role_appointment",
+                    "public_updated_at": "2023-02-10T14:19:25Z",
+                    "schema_name": "role_appointment",
+                    "withdrawn": false,
+                    "details": {
+                      "started_on": "2022-09-06T00:00:00+01:00",
+                      "ended_on": "2023-02-07T00:00:00+00:00",
+                      "current": false,
+                      "person_appointment_order": 7
+                    },
+                    "links": {
+                      "role": [
+                        {
+                          "content_id": "30371bc0-0c68-4146-b5a1-2ba89b15516c",
+                          "title": " Secretary of State for International Trade and President of the Board of Trade",
+                          "locale": "en",
+                          "api_path": "/api/content/government/ministers/secretary-of-state-for-international-trade",
+                          "base_path": "/government/ministers/secretary-of-state-for-international-trade",
+                          "document_type": "ministerial_role",
+                          "public_updated_at": "2021-11-26T11:18:19Z",
+                          "schema_name": "role",
+                          "withdrawn": false,
+                          "details": {
+                            "body": "<p>The Secretary of State’s principal responsibility is delivering the department’s priority outcomes:</p>\n\n<ul>\n  <li>securing world-class free trade agreements and reducing market access barriers, ensuring that consumers and businesses can benefit from both</li>\n  <li>encouraging economic growth and a green industrial revolution across all parts of the UK through attracting and retaining inward investment</li>\n  <li>supporting UK business to take full advantage of trade opportunities, including those arising from delivering free trade agreements (FTAs), facilitating UK exports</li>\n  <li>championing the rules-based international trading system and operating the UK’s new trading system, including protecting UK businesses from unfair trade practices</li>\n</ul>\n\n",
+                            "role_payment_type": null,
+                            "seniority": 20,
+                            "whip_organisation": {}
+                          },
+                          "links": {},
+                          "api_url": "https://www.gov.uk/api/content/government/ministers/secretary-of-state-for-international-trade",
+                          "web_url": "https://www.gov.uk/government/ministers/secretary-of-state-for-international-trade"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "content_id": "e46bb014-9601-4c75-acc9-72da173a7eb6",
+                    "title": "The Rt Hon Kemi Badenoch MP - President of the Board of Trade",
+                    "locale": "en",
+                    "document_type": "role_appointment",
+                    "public_updated_at": "2023-02-10T14:25:46Z",
+                    "schema_name": "role_appointment",
+                    "withdrawn": false,
+                    "details": {
+                      "started_on": "2023-02-07T00:00:00+00:00",
+                      "ended_on": null,
+                      "current": true,
+                      "person_appointment_order": 10
+                    },
+                    "links": {
+                      "role": [
+                        {
+                          "content_id": "de3d5e37-ff1c-4111-b029-fc926da764e9",
+                          "title": "President of the Board of Trade",
+                          "locale": "en",
+                          "api_path": "/api/content/government/ministers/president-of-the-board-of-trade",
+                          "base_path": "/government/ministers/president-of-the-board-of-trade",
+                          "document_type": "ministerial_role",
+                          "public_updated_at": "2023-02-10T14:25:34Z",
+                          "schema_name": "role",
+                          "withdrawn": false,
+                          "details": {
+                            "body": "\n",
+                            "role_payment_type": null,
+                            "seniority": 22,
+                            "whip_organisation": {}
+                          },
+                          "links": {},
+                          "api_url": "https://www.gov.uk/api/content/government/ministers/president-of-the-board-of-trade",
+                          "web_url": "https://www.gov.uk/government/ministers/president-of-the-board-of-trade"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "content_id": "5dc41e8a-8302-4437-9a3e-3ecf2c76ccc7",
+                    "title": "The Rt Hon Kemi Badenoch MP - Minister for Women and Equalities ",
+                    "locale": "en",
+                    "document_type": "role_appointment",
+                    "public_updated_at": "2022-10-25T18:15:43Z",
+                    "schema_name": "role_appointment",
+                    "withdrawn": false,
+                    "details": {
+                      "started_on": "2022-10-25T00:00:00+01:00",
+                      "ended_on": null,
+                      "current": true,
+                      "person_appointment_order": 8166
+                    },
+                    "links": {
+                      "role": [
+                        {
+                          "content_id": "84753907-c0f1-11e4-8223-005056011aef",
+                          "title": "Minister for Women and Equalities",
+                          "locale": "en",
+                          "api_path": "/api/content/government/ministers/minister-for-women-and-equalities--3",
+                          "base_path": "/government/ministers/minister-for-women-and-equalities--3",
+                          "document_type": "ministerial_role",
+                          "public_updated_at": "2023-03-03T11:10:06Z",
+                          "schema_name": "role",
+                          "withdrawn": false,
+                          "details": {
+                            "body": "<p>The Minister for Women and Equalities has responsibility for:</p>\n\n<ul>\n  <li>promoting equality of opportunity for everyone, and reducing negative disparities</li>\n  <li>strategic oversight of Government’s equality policy, for women, ethnicity and LGBT</li>\n  <li>sponsorship of the Social Mobility Commission and Equality and Human Rights Commission</li>\n  <li>overview of the overarching equalities legislative framework, including the Equality Act</li>\n</ul>\n\n<p>Before July 2014, this role was covered by the <a href=\"https://www.gov.uk/government/ministers/minister-for-women\">Minister for Women</a> and the <a href=\"https://www.gov.uk/government/ministers/minister-for-equality\">Minister for Equalities</a>.</p>\n",
+                            "role_payment_type": null,
+                            "seniority": 23,
+                            "whip_organisation": {}
+                          },
+                          "links": {},
+                          "api_url": "https://www.gov.uk/api/content/government/ministers/minister-for-women-and-equalities--3",
+                          "web_url": "https://www.gov.uk/government/ministers/minister-for-women-and-equalities--3"
+                        }
+                      ]
+                    }
+                  }
+                ]
+              },
+              "api_url": "https://www.gov.uk/api/content/government/people/kemi-badenoch",
+              "web_url": "https://www.gov.uk/government/people/kemi-badenoch"
+            },
+            {
+              "content_id": "a448451c-ac3c-481b-a970-089b6f6a6046",
+              "title": "Nusrat Ghani MP",
+              "locale": "en",
+              "api_path": "/api/content/government/people/nusrat-ghani",
+              "base_path": "/government/people/nusrat-ghani",
+              "document_type": "person",
+              "public_updated_at": "2023-03-20T14:40:01Z",
+              "schema_name": "person",
+              "withdrawn": false,
+              "details": {
+                "image": {
+                  "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/person/image/3346/s465_nusrat-ghani.jpg",
+                  "alt_text": "Nusrat Ghani MP"
+                },
+                "privy_counsellor": false
+              },
+              "links": {
+                "role_appointments": [
+                  {
+                    "content_id": "c12605e6-63a4-43d4-9883-eac908984065",
+                    "title": "Nusrat Ghani - Assistant Government Whip",
+                    "locale": "en",
+                    "document_type": "role_appointment",
+                    "public_updated_at": "2019-11-08T17:10:20Z",
+                    "schema_name": "role_appointment",
+                    "withdrawn": false,
+                    "details": {
+                      "started_on": "2018-01-09T00:00:00+00:00",
+                      "ended_on": "2019-07-11T00:00:00+01:00",
+                      "current": false,
+                      "person_appointment_order": 4559
+                    },
+                    "links": {
+                      "role": [
+                        {
+                          "content_id": "7bb9a1ac-0a95-4825-8c5e-3027b50cec4a",
+                          "title": "Assistant Government Whip",
+                          "locale": "en",
+                          "api_path": "/api/content/government/ministers/assistant-government-whip--10",
+                          "base_path": "/government/ministers/assistant-government-whip--10",
+                          "document_type": "ministerial_role",
+                          "public_updated_at": "2018-01-29T10:55:26Z",
+                          "schema_name": "role",
+                          "withdrawn": false,
+                          "details": {
+                            "body": "<p>Whips are <abbr title=\"Members of Parliament\">MPs</abbr> or Lords appointed by each party to help organise their party’s contribution to parliamentary business. They are responsible for making sure the maximum number of their party members vote, and vote the way their party wants.</p>\n\n",
+                            "role_payment_type": null,
+                            "seniority": 100,
+                            "whip_organisation": {
+                              "label": "Assistant Whips",
+                              "sort_order": 3
+                            }
+                          },
+                          "links": {},
+                          "api_url": "https://www.gov.uk/api/content/government/ministers/assistant-government-whip--10",
+                          "web_url": "https://www.gov.uk/government/ministers/assistant-government-whip--10"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "content_id": "133a0399-f7e0-4773-90bb-49a4e6aa582b",
+                    "title": "Nusrat Ghani MP - Parliamentary Under Secretary of State",
+                    "locale": "en",
+                    "document_type": "role_appointment",
+                    "public_updated_at": "2020-02-14T12:04:43Z",
+                    "schema_name": "role_appointment",
+                    "withdrawn": false,
+                    "details": {
+                      "started_on": "2018-01-09T00:00:00+00:00",
+                      "ended_on": "2020-02-13T00:00:00+00:00",
+                      "current": false,
+                      "person_appointment_order": 4572
+                    },
+                    "links": {
+                      "role": [
+                        {
+                          "content_id": "2cdb3d54-ab83-44d0-934c-4585f9eb84e6",
+                          "title": "Parliamentary Under Secretary of State",
+                          "locale": "en",
+                          "api_path": "/api/content/government/ministers/parliamentary-under-secretary-of-state-for-transport--4",
+                          "base_path": "/government/ministers/parliamentary-under-secretary-of-state-for-transport--4",
+                          "document_type": "ministerial_role",
+                          "public_updated_at": "2022-07-08T06:05:22Z",
+                          "schema_name": "role",
+                          "withdrawn": false,
+                          "details": {
+                            "body": "<p>The Minister is responsible for:</p>\n\n<ul>\n  <li>rail</li>\n  <li>accessibility</li>\n</ul>\n\n",
+                            "role_payment_type": null,
+                            "seniority": 100,
+                            "whip_organisation": {}
+                          },
+                          "links": {},
+                          "api_url": "https://www.gov.uk/api/content/government/ministers/parliamentary-under-secretary-of-state-for-transport--4",
+                          "web_url": "https://www.gov.uk/government/ministers/parliamentary-under-secretary-of-state-for-transport--4"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "content_id": "8f72dcbf-bc80-4d16-b9e4-b8d2bd156623",
+                    "title": "Nusrat Ghani - Government Whip, Lord Commissioner of HM Treasury",
+                    "locale": "en",
+                    "document_type": "role_appointment",
+                    "public_updated_at": "2019-12-17T16:48:35Z",
+                    "schema_name": "role_appointment",
+                    "withdrawn": false,
+                    "details": {
+                      "started_on": "2019-07-11T00:00:00+01:00",
+                      "ended_on": "2019-12-17T00:00:00+00:00",
+                      "current": false,
+                      "person_appointment_order": 5550
+                    },
+                    "links": {
+                      "role": [
+                        {
+                          "content_id": "846193d2-c0f1-11e4-8223-005056011aef",
+                          "title": "Government Whip, Lord Commissioner of HM Treasury",
+                          "locale": "en",
+                          "api_path": "/api/content/government/ministers/government-whip-lord-commissioner-of-hm-treasury--2",
+                          "base_path": "/government/ministers/government-whip-lord-commissioner-of-hm-treasury--2",
+                          "document_type": "ministerial_role",
+                          "public_updated_at": "2021-04-21T10:17:00Z",
+                          "schema_name": "role",
+                          "withdrawn": false,
+                          "details": {
+                            "body": "<p>Whips are MPs or Lords appointed by each party to help organise their party’s contribution to parliamentary business. They are responsible for making sure the maximum number of their party members vote, and vote the way their party wants.</p>\n",
+                            "role_payment_type": "Unpaid",
+                            "seniority": 100,
+                            "whip_organisation": {
+                              "label": "Junior Lords of the Treasury",
+                              "sort_order": 2
+                            }
+                          },
+                          "links": {},
+                          "api_url": "https://www.gov.uk/api/content/government/ministers/government-whip-lord-commissioner-of-hm-treasury--2",
+                          "web_url": "https://www.gov.uk/government/ministers/government-whip-lord-commissioner-of-hm-treasury--2"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "content_id": "ce342d3e-2b61-4dc8-a558-c0701f3346e8",
+                    "title": "Nusrat Ghani MP - Minister of State",
+                    "locale": "en",
+                    "document_type": "role_appointment",
+                    "public_updated_at": "2023-02-07T15:54:14Z",
+                    "schema_name": "role_appointment",
+                    "withdrawn": false,
+                    "details": {
+                      "started_on": "2023-02-07T00:00:00+00:00",
+                      "ended_on": null,
+                      "current": true,
+                      "person_appointment_order": 6
+                    },
+                    "links": {
+                      "role": [
+                        {
+                          "content_id": "e901f3a3-b51c-4491-8667-6605155a3fcd",
+                          "title": "Minister of State at the Department for Business and Trade",
+                          "locale": "en",
+                          "api_path": "/api/content/government/ministers/minister-of-state--155",
+                          "base_path": "/government/ministers/minister-of-state--155",
+                          "document_type": "ministerial_role",
+                          "public_updated_at": "2023-03-20T14:45:02Z",
+                          "schema_name": "role",
+                          "withdrawn": false,
+                          "details": {
+                            "body": "\n",
+                            "role_payment_type": null,
+                            "seniority": 100,
+                            "whip_organisation": {}
+                          },
+                          "links": {},
+                          "api_url": "https://www.gov.uk/api/content/government/ministers/minister-of-state--155",
+                          "web_url": "https://www.gov.uk/government/ministers/minister-of-state--155"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "content_id": "fd63227b-4344-4a9a-9697-316e925bb45a",
+                    "title": "Nusrat Ghani MP - Minister of State (Minister for Industry and Investment Security)",
+                    "locale": "en",
+                    "document_type": "role_appointment",
+                    "public_updated_at": "2023-02-07T15:57:48Z",
+                    "schema_name": "role_appointment",
+                    "withdrawn": false,
+                    "details": {
+                      "started_on": "2022-10-27T00:00:00+01:00",
+                      "ended_on": "2023-02-07T00:00:00+00:00",
+                      "current": false,
+                      "person_appointment_order": 5
+                    },
+                    "links": {
+                      "role": [
+                        {
+                          "content_id": "3a445bfc-0d56-48f0-9a72-7c938b07199b",
+                          "title": "Minister of State (Minister for Industry and Investment Security)",
+                          "locale": "en",
+                          "api_path": "/api/content/government/ministers/minister-of-state-minister-for-industry-and-investment-security",
+                          "base_path": "/government/ministers/minister-of-state-minister-for-industry-and-investment-security",
+                          "document_type": "ministerial_role",
+                          "public_updated_at": "2022-11-21T15:15:09Z",
+                          "schema_name": "role",
+                          "withdrawn": false,
+                          "details": {
+                            "body": "<p>Responsibilities include:</p>\n\n<ul>\n  <li>advanced manufacturing, including aerospace, Made Smarter, defence</li>\n  <li>automotive, including the Office for Zero Emission Vehicles</li>\n  <li>infrastructure and materials, including steel, energy intensive industries, chemicals, construction</li>\n  <li>life sciences, including vaccine production</li>\n  <li>professional and business services</li>\n  <li>maritime and shipbuilding</li>\n  <li>critical minerals and critical mineral supply chains</li>\n  <li>industrial decarbonisation</li>\n  <li>economic shocks</li>\n  <li>supply chains</li>\n  <li>levelling up and regional growth</li>\n  <li>investment pipeline and opportunities</li>\n  <li>Investment Security Unit</li>\n  <li>skills</li>\n  <li>retained EU law and Brexit opportunities</li>\n  <li>better regulation</li>\n</ul>\n",
+                            "role_payment_type": null,
+                            "seniority": 100,
+                            "whip_organisation": {}
+                          },
+                          "links": {},
+                          "api_url": "https://www.gov.uk/api/content/government/ministers/minister-of-state-minister-for-industry-and-investment-security",
+                          "web_url": "https://www.gov.uk/government/ministers/minister-of-state-minister-for-industry-and-investment-security"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "content_id": "0225d5c1-5989-4d70-b4b8-cd07ded2fc7e",
+                    "title": "Nusrat Ghani MP - Minister of State",
+                    "locale": "en",
+                    "document_type": "role_appointment",
+                    "public_updated_at": "2023-02-07T15:55:04Z",
+                    "schema_name": "role_appointment",
+                    "withdrawn": false,
+                    "details": {
+                      "started_on": "2023-02-07T00:00:00+00:00",
+                      "ended_on": null,
+                      "current": true,
+                      "person_appointment_order": 7
+                    },
+                    "links": {
+                      "role": [
+                        {
+                          "content_id": "949c0326-a1ca-4fcd-8d0b-8d205ea8cbad",
+                          "title": "Minister of State for the Investment Security Unit",
+                          "locale": "en",
+                          "api_path": "/api/content/government/ministers/minister-of-state--156",
+                          "base_path": "/government/ministers/minister-of-state--156",
+                          "document_type": "ministerial_role",
+                          "public_updated_at": "2023-03-20T14:40:34Z",
+                          "schema_name": "role",
+                          "withdrawn": false,
+                          "details": {
+                            "body": "\n",
+                            "role_payment_type": null,
+                            "seniority": 100,
+                            "whip_organisation": {}
+                          },
+                          "links": {},
+                          "api_url": "https://www.gov.uk/api/content/government/ministers/minister-of-state--156",
+                          "web_url": "https://www.gov.uk/government/ministers/minister-of-state--156"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "content_id": "95238090-b755-4be3-99a6-e0a4b223c859",
+                    "title": "Nusrat Ghani MP - Minister of State (Minister for Science and Investment Security)",
+                    "locale": "en",
+                    "document_type": "role_appointment",
+                    "public_updated_at": "2022-11-18T16:34:44Z",
+                    "schema_name": "role_appointment",
+                    "withdrawn": false,
+                    "details": {
+                      "started_on": "2022-09-07T00:00:00+01:00",
+                      "ended_on": "2022-10-26T00:00:00+01:00",
+                      "current": false,
+                      "person_appointment_order": 8109
+                    },
+                    "links": {
+                      "role": [
+                        {
+                          "content_id": "06abd7d3-d0db-4bff-9f5f-054a4387c473",
+                          "title": "Minister of State (Minister for Science and Investment Security)",
+                          "locale": "en",
+                          "api_path": "/api/content/government/ministers/minister-of-state-minister-for-science-and-investment-security",
+                          "base_path": "/government/ministers/minister-of-state-minister-for-science-and-investment-security",
+                          "document_type": "ministerial_role",
+                          "public_updated_at": "2022-10-03T10:59:25Z",
+                          "schema_name": "role",
+                          "withdrawn": false,
+                          "details": {
+                            "body": "<p>Responsibilities include:</p>\n\n<ul>\n  <li>science and research (domestic and international) </li>\n  <li>Horizon Europe membership </li>\n  <li>innovation strategy / science superpower </li>\n  <li>critical minerals and critical mineral supply chains </li>\n  <li>maritime and shipbuilding </li>\n  <li>life sciences (including vaccine production) </li>\n  <li>space strategy (excluding OneWeb) </li>\n  <li>technology, strategy and security </li>\n  <li>artificial intelligence (including the Office for AI) </li>\n  <li>fusion </li>\n  <li>R&amp;D people and culture strategy </li>\n  <li>research approvals </li>\n</ul>\n\n<p>Supporting the Secretary of State on:</p>\n\n<ul>\n  <li>investment security</li>\n  <li>investment pipeline and opportunities</li>\n  <li>UK Research and Innovation (UKRI)</li>\n  <li>Advanced Research and Invention Agency (ARIA)</li>\n</ul>\n",
+                            "role_payment_type": null,
+                            "seniority": 100,
+                            "whip_organisation": {}
+                          },
+                          "links": {},
+                          "api_url": "https://www.gov.uk/api/content/government/ministers/minister-of-state-minister-for-science-and-investment-security",
+                          "web_url": "https://www.gov.uk/government/ministers/minister-of-state-minister-for-science-and-investment-security"
+                        }
+                      ]
+                    }
+                  }
+                ]
+              },
+              "api_url": "https://www.gov.uk/api/content/government/people/nusrat-ghani",
+              "web_url": "https://www.gov.uk/government/people/nusrat-ghani"
+            }
+          ],
+          "ordered_roles": [
+            {
+              "content_id": "5cb74a2c-7e9f-444a-8347-d944cc05b606",
+              "title": "Secretary of State for Business and Trade",
+              "locale": "en",
+              "api_path": "/api/content/government/ministers/secretary-of-state--2",
+              "base_path": "/government/ministers/secretary-of-state--2",
+              "document_type": "ministerial_role",
+              "public_updated_at": "2023-02-10T16:52:51Z",
+              "schema_name": "role",
+              "withdrawn": false,
+              "details": {
+                "body": "\n",
+                "role_payment_type": null,
+                "seniority": 21,
+                "whip_organisation": {}
+              },
+              "links": {},
+              "api_url": "https://www.gov.uk/api/content/government/ministers/secretary-of-state--2",
+              "web_url": "https://www.gov.uk/government/ministers/secretary-of-state--2"
+            },
+            {
+              "content_id": "de3d5e37-ff1c-4111-b029-fc926da764e9",
+              "title": "President of the Board of Trade",
+              "locale": "en",
+              "api_path": "/api/content/government/ministers/president-of-the-board-of-trade",
+              "base_path": "/government/ministers/president-of-the-board-of-trade",
+              "document_type": "ministerial_role",
+              "public_updated_at": "2023-02-10T14:25:34Z",
+              "schema_name": "role",
+              "withdrawn": false,
+              "details": {
+                "body": "\n",
+                "role_payment_type": null,
+                "seniority": 22,
+                "whip_organisation": {}
+              },
+              "links": {},
+              "api_url": "https://www.gov.uk/api/content/government/ministers/president-of-the-board-of-trade",
+              "web_url": "https://www.gov.uk/government/ministers/president-of-the-board-of-trade"
+            }
+          ]
+        },
+        "api_url": "https://www.gov.uk/api/content/government/organisations/department-for-business-and-trade",
+        "web_url": "https://www.gov.uk/government/organisations/department-for-business-and-trade"
+      },
+      {
+        "content_id": "c4e41647-ad69-4e96-843b-05fa7867bbc0",
+        "title": "UK Export Finance",
+        "locale": "en",
+        "analytics_identifier": "D241",
+        "api_path": "/api/content/government/organisations/uk-export-finance",
+        "base_path": "/government/organisations/uk-export-finance",
+        "document_type": "organisation",
+        "schema_name": "organisation",
+        "withdrawn": false,
+        "details": {
+          "logo": {
+            "crest": "dbt",
+            "formatted_title": "UK Export <br/>Finance"
+          },
+          "brand": "department-for-business-and-trade",
+          "default_news_image": {
+            "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/default_news_organisation_image_data/file/242/s300_istock487495098_960x640px.jpg",
+            "high_resolution_url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/default_news_organisation_image_data/file/242/s960_istock487495098_960x640px.jpg"
+          },
+          "organisation_govuk_status": {
+            "url": null,
+            "status": "live",
+            "updated_at": null
+          }
+        },
+        "links": {
+          "ordered_ministers": [
+            {
+              "content_id": "b775b0fb-4a6c-40db-abc5-d8724e5d8ce4",
+              "title": "The Rt Hon Kemi Badenoch MP",
+              "locale": "en",
+              "api_path": "/api/content/government/people/kemi-badenoch",
+              "base_path": "/government/people/kemi-badenoch",
+              "document_type": "person",
+              "public_updated_at": "2023-02-28T12:42:04Z",
+              "schema_name": "person",
+              "withdrawn": false,
+              "details": {
+                "image": {
+                  "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/person/image/4010/s465_Kemi_gov.uk.png",
+                  "alt_text": "The Rt Hon Kemi Badenoch MP"
+                },
+                "privy_counsellor": true
+              },
+              "links": {
+                "role_appointments": [
+                  {
+                    "content_id": "c27b7fea-20a3-4b21-b51c-e2828880e1d9",
+                    "title": "Kemi Badenoch MP - Parliamentary Under Secretary of State (Minister for Children and Families)",
+                    "locale": "en",
+                    "document_type": "role_appointment",
+                    "public_updated_at": "2020-02-13T20:12:56Z",
+                    "schema_name": "role_appointment",
+                    "withdrawn": false,
+                    "details": {
+                      "started_on": "2019-07-27T00:00:00+01:00",
+                      "ended_on": "2020-02-13T00:00:00+00:00",
+                      "current": false,
+                      "person_appointment_order": 5641
+                    },
+                    "links": {
+                      "role": [
+                        {
+                          "content_id": "845e7222-c0f1-11e4-8223-005056011aef",
+                          "title": "Parliamentary Under Secretary of State (Minister for Children and Families)",
+                          "locale": "en",
+                          "api_path": "/api/content/government/ministers/parliamentary-under-secretary-of-state-children-and-young-families",
+                          "base_path": "/government/ministers/parliamentary-under-secretary-of-state-children-and-young-families",
+                          "document_type": "ministerial_role",
+                          "public_updated_at": "2022-07-13T10:05:06Z",
+                          "schema_name": "role",
+                          "withdrawn": false,
+                          "details": {
+                            "body": "<p>The minister’s responsibilities include:</p>\n\n<ul>\n  <li>children’s social care</li>\n  <li>families</li>\n  <li>children in care, children in need, child protection, adoption and care leavers</li>\n  <li>early years and childcare</li>\n  <li>disadvantaged and vulnerable children</li>\n  <li>school sport</li>\n  <li>alternative provision</li>\n  <li>behaviour, attendance and exclusions</li>\n  <li>children and young people’s mental health, online safety and preventing bullying in schools</li>\n  <li>policy to protect against serious violence</li>\n  <li>coronavirus (COVID-19) recovery for children’s services and early years</li>\n</ul>\n\n",
+                            "role_payment_type": null,
+                            "seniority": 100,
+                            "whip_organisation": {}
+                          },
+                          "links": {},
+                          "api_url": "https://www.gov.uk/api/content/government/ministers/parliamentary-under-secretary-of-state-children-and-young-families",
+                          "web_url": "https://www.gov.uk/government/ministers/parliamentary-under-secretary-of-state-children-and-young-families"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "content_id": "e839feff-a7f9-48c0-bcac-39fccb92c896",
+                    "title": "Kemi Badenoch MP - Minister of State (Minister for Local Government, Faith and Communities)",
+                    "locale": "en",
+                    "document_type": "role_appointment",
+                    "public_updated_at": "2022-07-08T08:50:43Z",
+                    "schema_name": "role_appointment",
+                    "withdrawn": false,
+                    "details": {
+                      "started_on": "2021-09-19T00:00:00+01:00",
+                      "ended_on": "2022-07-06T00:00:00+01:00",
+                      "current": false,
+                      "person_appointment_order": 7189
+                    },
+                    "links": {
+                      "role": [
+                        {
+                          "content_id": "ac67fbb9-3c4f-4c26-959d-b9a2dc5ebe22",
+                          "title": "Minister of State (Minister for Local Government, Faith and Communities)",
+                          "locale": "en",
+                          "api_path": "/api/content/government/ministers/minister-of-state--113",
+                          "base_path": "/government/ministers/minister-of-state--113",
+                          "document_type": "ministerial_role",
+                          "public_updated_at": "2022-06-16T12:06:12Z",
+                          "schema_name": "role",
+                          "withdrawn": false,
+                          "details": {
+                            "body": "<ul>\n  <li>Local government policy, finance and improvement in England</li>\n  <li>Electoral Integrity Programme</li>\n  <li>Integration, anti-extremism, and religious hatred policy</li>\n  <li>Faith community engagement</li>\n  <li>Foreign Affairs (Economic activity of publicly funded bodies) Bill and policy oversight</li>\n  <li>Holocaust Memorial Learning Centre</li>\n</ul>\n",
+                            "role_payment_type": null,
+                            "seniority": 100,
+                            "whip_organisation": {}
+                          },
+                          "links": {},
+                          "api_url": "https://www.gov.uk/api/content/government/ministers/minister-of-state--113",
+                          "web_url": "https://www.gov.uk/government/ministers/minister-of-state--113"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "content_id": "931d990c-5ebb-4930-8360-58f452325508",
+                    "title": "Kemi Badenoch MP - Minister of State (Minister for Equalities)",
+                    "locale": "en",
+                    "document_type": "role_appointment",
+                    "public_updated_at": "2022-07-08T10:11:37Z",
+                    "schema_name": "role_appointment",
+                    "withdrawn": false,
+                    "details": {
+                      "started_on": "2021-09-15T00:00:00+01:00",
+                      "ended_on": "2022-07-06T00:00:00+01:00",
+                      "current": false,
+                      "person_appointment_order": 7202
+                    },
+                    "links": {
+                      "role": [
+                        {
+                          "content_id": "871a9d80-d9ec-4219-bccb-28afa271bd9e",
+                          "title": "Minister of State (Minister for Equalities)",
+                          "locale": "en",
+                          "api_path": "/api/content/government/ministers/minister-of-state-minister-for-equalities",
+                          "base_path": "/government/ministers/minister-of-state-minister-for-equalities",
+                          "document_type": "ministerial_role",
+                          "public_updated_at": "2022-06-16T12:07:21Z",
+                          "schema_name": "role",
+                          "withdrawn": false,
+                          "details": {
+                            "body": "<ul>\n  <li>Racial and ethnic disparities</li>\n  <li>Inclusive Britain Strategy</li>\n  <li>Inclusion at Work Panel oversight</li>\n  <li>Equality Act and Public Sector Equality Duty oversight</li>\n  <li>Sponsoring minister for the Social Mobility Commission and the Equality and Human Rights Commission</li>\n</ul>\n",
+                            "role_payment_type": null,
+                            "seniority": 100,
+                            "whip_organisation": {}
+                          },
+                          "links": {},
+                          "api_url": "https://www.gov.uk/api/content/government/ministers/minister-of-state-minister-for-equalities",
+                          "web_url": "https://www.gov.uk/government/ministers/minister-of-state-minister-for-equalities"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "content_id": "2b33f51e-ddb1-401f-966d-17160c7dfd5c",
+                    "title": "Kemi Badenoch MP - Exchequer Secretary to the Treasury",
+                    "locale": "en",
+                    "document_type": "role_appointment",
+                    "public_updated_at": "2021-09-16T10:15:14Z",
+                    "schema_name": "role_appointment",
+                    "withdrawn": false,
+                    "details": {
+                      "started_on": "2020-02-13T00:00:00+00:00",
+                      "ended_on": "2021-09-15T00:00:00+01:00",
+                      "current": false,
+                      "person_appointment_order": 6045
+                    },
+                    "links": {
+                      "role": [
+                        {
+                          "content_id": "845e88c6-c0f1-11e4-8223-005056011aef",
+                          "title": "Exchequer Secretary to the Treasury",
+                          "locale": "en",
+                          "api_path": "/api/content/government/ministers/exchequer-secretary-to-the-treasury",
+                          "base_path": "/government/ministers/exchequer-secretary-to-the-treasury",
+                          "document_type": "ministerial_role",
+                          "public_updated_at": "2023-02-06T13:18:17Z",
+                          "schema_name": "role",
+                          "withdrawn": false,
+                          "details": {
+                            "body": "<h3 id=\"the-exchequer-secretary-xst-is-responsible-for\">The Exchequer Secretary (<abbr title=\"Exchequer Secretary to the Treasury\">XST</abbr>) is responsible for:</h3>\n\n<ul>\n  <li>\n    <p>Growth and productivity, including skills, migration, infrastructure (physical &amp; digital), digital economy, economic regulation, business regulation, competition, corporate governance, foreign direct investment (non-FS), and the Levelling Up White Paper living standards mission.</p>\n  </li>\n  <li>\n    <p>Energy, environment and climate policy and taxes (including transport taxes)</p>\n  </li>\n  <li>\n    <p>The following indirect taxes, including stakeholder engagement:</p>\n\n    <ul>\n      <li>Excise duties (alcohol, tobacco, gambling, and SDIL), including excise fraud and law enforcement</li>\n      <li>Charities, the voluntary sector, and gift aid</li>\n    </ul>\n  </li>\n  <li>\n    <p>Departmental minister for HM Treasury Group (including responsibility for the Darlington campus)</p>\n  </li>\n  <li>\n    <p>Crown Estate and the Royal Household</p>\n  </li>\n  <li>\n    <p>Energy Profits Levy</p>\n  </li>\n</ul>\n\n",
+                            "role_payment_type": null,
+                            "seniority": 100,
+                            "whip_organisation": {}
+                          },
+                          "links": {},
+                          "api_url": "https://www.gov.uk/api/content/government/ministers/exchequer-secretary-to-the-treasury",
+                          "web_url": "https://www.gov.uk/government/ministers/exchequer-secretary-to-the-treasury"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "content_id": "00e090ae-f8af-493b-be0b-5c1282a02c09",
+                    "title": "Kemi Badenoch MP - Minister of State",
+                    "locale": "en",
+                    "document_type": "role_appointment",
+                    "public_updated_at": "2021-09-21T12:53:22Z",
+                    "schema_name": "role_appointment",
+                    "withdrawn": false,
+                    "details": {
+                      "started_on": "2021-09-16T00:00:00+01:00",
+                      "ended_on": "2021-09-19T00:00:00+01:00",
+                      "current": false,
+                      "person_appointment_order": 7132
+                    },
+                    "links": {
+                      "role": [
+                        {
+                          "content_id": "a47c2d17-f940-47ac-bc4a-d4ecdc5f3bcd",
+                          "title": "Minister of State",
+                          "locale": "en",
+                          "api_path": "/api/content/government/ministers/minister-of-state--112",
+                          "base_path": "/government/ministers/minister-of-state--112",
+                          "document_type": "ministerial_role",
+                          "public_updated_at": "2021-09-16T10:14:04Z",
+                          "schema_name": "role",
+                          "withdrawn": false,
+                          "details": {
+                            "body": "\n",
+                            "role_payment_type": null,
+                            "seniority": 100,
+                            "whip_organisation": {}
+                          },
+                          "links": {},
+                          "api_url": "https://www.gov.uk/api/content/government/ministers/minister-of-state--112",
+                          "web_url": "https://www.gov.uk/government/ministers/minister-of-state--112"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "content_id": "efdf98a0-fbe6-4256-bf40-ffd13cb967a5",
+                    "title": "Kemi Badenoch MP - Parliamentary Under-Secretary of State (Minister for Equalities) ",
+                    "locale": "en",
+                    "document_type": "role_appointment",
+                    "public_updated_at": "2021-09-22T17:20:04Z",
+                    "schema_name": "role_appointment",
+                    "withdrawn": false,
+                    "details": {
+                      "started_on": "2020-02-14T00:00:00+00:00",
+                      "ended_on": "2021-09-15T00:00:00+01:00",
+                      "current": false,
+                      "person_appointment_order": 6079
+                    },
+                    "links": {
+                      "role": [
+                        {
+                          "content_id": "f6679300-b226-4cbb-9de4-3b9f4378f5e9",
+                          "title": "Parliamentary Under-Secretary of State (Minister for Equalities) ",
+                          "locale": "en",
+                          "api_path": "/api/content/government/ministers/minister-of-state-for-equalities",
+                          "base_path": "/government/ministers/minister-of-state-for-equalities",
+                          "document_type": "ministerial_role",
+                          "public_updated_at": "2020-02-14T19:30:25Z",
+                          "schema_name": "role",
+                          "withdrawn": false,
+                          "details": {
+                            "body": "\n",
+                            "role_payment_type": null,
+                            "seniority": 100,
+                            "whip_organisation": {}
+                          },
+                          "links": {},
+                          "api_url": "https://www.gov.uk/api/content/government/ministers/minister-of-state-for-equalities",
+                          "web_url": "https://www.gov.uk/government/ministers/minister-of-state-for-equalities"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "content_id": "5e2284cd-8e2d-4563-9e4d-784b2ec0a490",
+                    "title": "The Rt Hon Kemi Badenoch MP - Secretary of State",
+                    "locale": "en",
+                    "document_type": "role_appointment",
+                    "public_updated_at": "2023-02-07T13:10:49Z",
+                    "schema_name": "role_appointment",
+                    "withdrawn": false,
+                    "details": {
+                      "started_on": "2023-02-07T00:00:00+00:00",
+                      "ended_on": null,
+                      "current": true,
+                      "person_appointment_order": 9
+                    },
+                    "links": {
+                      "role": [
+                        {
+                          "content_id": "5cb74a2c-7e9f-444a-8347-d944cc05b606",
+                          "title": "Secretary of State for Business and Trade",
+                          "locale": "en",
+                          "api_path": "/api/content/government/ministers/secretary-of-state--2",
+                          "base_path": "/government/ministers/secretary-of-state--2",
+                          "document_type": "ministerial_role",
+                          "public_updated_at": "2023-02-10T16:52:51Z",
+                          "schema_name": "role",
+                          "withdrawn": false,
+                          "details": {
+                            "body": "\n",
+                            "role_payment_type": null,
+                            "seniority": 21,
+                            "whip_organisation": {}
+                          },
+                          "links": {},
+                          "api_url": "https://www.gov.uk/api/content/government/ministers/secretary-of-state--2",
+                          "web_url": "https://www.gov.uk/government/ministers/secretary-of-state--2"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "content_id": "32169de2-b1de-4f00-ab75-647a2a77bde1",
+                    "title": "The Rt Hon Kemi Badenoch MP -  Secretary of State for International Trade and President of the Board of Trade",
+                    "locale": "en",
+                    "document_type": "role_appointment",
+                    "public_updated_at": "2023-02-10T14:19:25Z",
+                    "schema_name": "role_appointment",
+                    "withdrawn": false,
+                    "details": {
+                      "started_on": "2022-09-06T00:00:00+01:00",
+                      "ended_on": "2023-02-07T00:00:00+00:00",
+                      "current": false,
+                      "person_appointment_order": 7
+                    },
+                    "links": {
+                      "role": [
+                        {
+                          "content_id": "30371bc0-0c68-4146-b5a1-2ba89b15516c",
+                          "title": " Secretary of State for International Trade and President of the Board of Trade",
+                          "locale": "en",
+                          "api_path": "/api/content/government/ministers/secretary-of-state-for-international-trade",
+                          "base_path": "/government/ministers/secretary-of-state-for-international-trade",
+                          "document_type": "ministerial_role",
+                          "public_updated_at": "2021-11-26T11:18:19Z",
+                          "schema_name": "role",
+                          "withdrawn": false,
+                          "details": {
+                            "body": "<p>The Secretary of State’s principal responsibility is delivering the department’s priority outcomes:</p>\n\n<ul>\n  <li>securing world-class free trade agreements and reducing market access barriers, ensuring that consumers and businesses can benefit from both</li>\n  <li>encouraging economic growth and a green industrial revolution across all parts of the UK through attracting and retaining inward investment</li>\n  <li>supporting UK business to take full advantage of trade opportunities, including those arising from delivering free trade agreements (FTAs), facilitating UK exports</li>\n  <li>championing the rules-based international trading system and operating the UK’s new trading system, including protecting UK businesses from unfair trade practices</li>\n</ul>\n\n",
+                            "role_payment_type": null,
+                            "seniority": 20,
+                            "whip_organisation": {}
+                          },
+                          "links": {},
+                          "api_url": "https://www.gov.uk/api/content/government/ministers/secretary-of-state-for-international-trade",
+                          "web_url": "https://www.gov.uk/government/ministers/secretary-of-state-for-international-trade"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "content_id": "e46bb014-9601-4c75-acc9-72da173a7eb6",
+                    "title": "The Rt Hon Kemi Badenoch MP - President of the Board of Trade",
+                    "locale": "en",
+                    "document_type": "role_appointment",
+                    "public_updated_at": "2023-02-10T14:25:46Z",
+                    "schema_name": "role_appointment",
+                    "withdrawn": false,
+                    "details": {
+                      "started_on": "2023-02-07T00:00:00+00:00",
+                      "ended_on": null,
+                      "current": true,
+                      "person_appointment_order": 10
+                    },
+                    "links": {
+                      "role": [
+                        {
+                          "content_id": "de3d5e37-ff1c-4111-b029-fc926da764e9",
+                          "title": "President of the Board of Trade",
+                          "locale": "en",
+                          "api_path": "/api/content/government/ministers/president-of-the-board-of-trade",
+                          "base_path": "/government/ministers/president-of-the-board-of-trade",
+                          "document_type": "ministerial_role",
+                          "public_updated_at": "2023-02-10T14:25:34Z",
+                          "schema_name": "role",
+                          "withdrawn": false,
+                          "details": {
+                            "body": "\n",
+                            "role_payment_type": null,
+                            "seniority": 22,
+                            "whip_organisation": {}
+                          },
+                          "links": {},
+                          "api_url": "https://www.gov.uk/api/content/government/ministers/president-of-the-board-of-trade",
+                          "web_url": "https://www.gov.uk/government/ministers/president-of-the-board-of-trade"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "content_id": "5dc41e8a-8302-4437-9a3e-3ecf2c76ccc7",
+                    "title": "The Rt Hon Kemi Badenoch MP - Minister for Women and Equalities ",
+                    "locale": "en",
+                    "document_type": "role_appointment",
+                    "public_updated_at": "2022-10-25T18:15:43Z",
+                    "schema_name": "role_appointment",
+                    "withdrawn": false,
+                    "details": {
+                      "started_on": "2022-10-25T00:00:00+01:00",
+                      "ended_on": null,
+                      "current": true,
+                      "person_appointment_order": 8166
+                    },
+                    "links": {
+                      "role": [
+                        {
+                          "content_id": "84753907-c0f1-11e4-8223-005056011aef",
+                          "title": "Minister for Women and Equalities",
+                          "locale": "en",
+                          "api_path": "/api/content/government/ministers/minister-for-women-and-equalities--3",
+                          "base_path": "/government/ministers/minister-for-women-and-equalities--3",
+                          "document_type": "ministerial_role",
+                          "public_updated_at": "2023-03-03T11:10:06Z",
+                          "schema_name": "role",
+                          "withdrawn": false,
+                          "details": {
+                            "body": "<p>The Minister for Women and Equalities has responsibility for:</p>\n\n<ul>\n  <li>promoting equality of opportunity for everyone, and reducing negative disparities</li>\n  <li>strategic oversight of Government’s equality policy, for women, ethnicity and LGBT</li>\n  <li>sponsorship of the Social Mobility Commission and Equality and Human Rights Commission</li>\n  <li>overview of the overarching equalities legislative framework, including the Equality Act</li>\n</ul>\n\n<p>Before July 2014, this role was covered by the <a href=\"https://www.gov.uk/government/ministers/minister-for-women\">Minister for Women</a> and the <a href=\"https://www.gov.uk/government/ministers/minister-for-equality\">Minister for Equalities</a>.</p>\n",
+                            "role_payment_type": null,
+                            "seniority": 23,
+                            "whip_organisation": {}
+                          },
+                          "links": {},
+                          "api_url": "https://www.gov.uk/api/content/government/ministers/minister-for-women-and-equalities--3",
+                          "web_url": "https://www.gov.uk/government/ministers/minister-for-women-and-equalities--3"
+                        }
+                      ]
+                    }
+                  }
+                ]
+              },
+              "api_url": "https://www.gov.uk/api/content/government/people/kemi-badenoch",
+              "web_url": "https://www.gov.uk/government/people/kemi-badenoch"
+            }
+          ],
+          "ordered_roles": [
+            {
+              "content_id": "845e61e9-c0f1-11e4-8223-005056011aef",
+              "title": "Secretary of State for Business, Innovation and Skills and President of the Board of Trade",
+              "locale": "en",
+              "api_path": "/api/content/government/ministers/secretary-of-state-for-business-innovation-and-skills",
+              "base_path": "/government/ministers/secretary-of-state-for-business-innovation-and-skills",
+              "document_type": "ministerial_role",
+              "public_updated_at": "2020-06-30T10:19:16Z",
+              "schema_name": "role",
+              "withdrawn": false,
+              "details": {
+                "body": "<p>The Secretary of State is responsible for strategy and policy across the Department for Business, Innovation &amp; Skills (<abbr title=\"Department for Business, Innovation &amp; Skills\">BIS</abbr>). The department’s main policy areas are:</p>\n\n<ul>\n  <li>business law</li>\n  <li>consumer issues</li>\n  <li>employment relations</li>\n  <li>enterprise and business support</li>\n  <li>trade policy</li>\n  <li>higher education</li>\n  <li>further education and skills</li>\n  <li>science</li>\n  <li>innovation</li>\n</ul>\n\n<div class=\"call-to-action\">\n<p>BIS was replaced by the <a href=\"https://www.gov.uk/government/organisations/department-for-business-energy-and-industrial-strategy\">Department for Business, Energy &amp; Industrial Strategy</a> in July 2016.</p>\n</div>\n\n<p>The Secretary of State responsibilities:</p>\n\n<ul>\n  <li>overall responsibility for the department, strategy and all policies</li>\n  <li>overall responsibility for the <abbr title=\"Department for Business, Innovation &amp; Skills\">BIS</abbr> budget</li>\n  <li>President of the Board of Trade</li>\n  <li>lead Cabinet minister for reducing regulatory burdens across government</li>\n</ul>\n\n",
+                "role_payment_type": null,
+                "seniority": 51,
+                "whip_organisation": {}
+              },
+              "links": {},
+              "api_url": "https://www.gov.uk/api/content/government/ministers/secretary-of-state-for-business-innovation-and-skills",
+              "web_url": "https://www.gov.uk/government/ministers/secretary-of-state-for-business-innovation-and-skills"
+            },
+            {
+              "content_id": "846a61ea-c0f1-11e4-8223-005056011aef",
+              "title": "Chief Executive",
+              "locale": "en",
+              "document_type": "board_member_role",
+              "public_updated_at": "2023-04-11T15:04:58Z",
+              "schema_name": "role",
+              "withdrawn": false,
+              "details": {
+                "body": "<p>The UK Export Finance (UKEF) Chief Executive Officer is responsible for management of the department as a whole. As Principal Accounting Officer, the CEO is responsible to ministers and Parliament for the management of UKEF’s operations. UKEF is the UK’s Export Credit Agency, supporting business of all sizes to invest and export overseas. It is a unique ministerial department reporting to the Secretary of State for Business and Trade. The Chief Executive’s responsibilities include:</p>\n\n<ul>\n  <li>setting the strategic vision for the department</li>\n  <li>facilitating growth of UK exports in line with the government’s export strategy</li>\n  <li>supporting UKEF to provide guarantees to UK exporters to win contracts, fulfil orders and get paid</li>\n</ul>\n",
+                "role_payment_type": null
+              },
+              "links": {}
+            },
+            {
+              "content_id": "30371bc0-0c68-4146-b5a1-2ba89b15516c",
+              "title": " Secretary of State for International Trade and President of the Board of Trade",
+              "locale": "en",
+              "api_path": "/api/content/government/ministers/secretary-of-state-for-international-trade",
+              "base_path": "/government/ministers/secretary-of-state-for-international-trade",
+              "document_type": "ministerial_role",
+              "public_updated_at": "2021-11-26T11:18:19Z",
+              "schema_name": "role",
+              "withdrawn": false,
+              "details": {
+                "body": "<p>The Secretary of State’s principal responsibility is delivering the department’s priority outcomes:</p>\n\n<ul>\n  <li>securing world-class free trade agreements and reducing market access barriers, ensuring that consumers and businesses can benefit from both</li>\n  <li>encouraging economic growth and a green industrial revolution across all parts of the UK through attracting and retaining inward investment</li>\n  <li>supporting UK business to take full advantage of trade opportunities, including those arising from delivering free trade agreements (FTAs), facilitating UK exports</li>\n  <li>championing the rules-based international trading system and operating the UK’s new trading system, including protecting UK businesses from unfair trade practices</li>\n</ul>\n\n",
+                "role_payment_type": null,
+                "seniority": 20,
+                "whip_organisation": {}
+              },
+              "links": {},
+              "api_url": "https://www.gov.uk/api/content/government/ministers/secretary-of-state-for-international-trade",
+              "web_url": "https://www.gov.uk/government/ministers/secretary-of-state-for-international-trade"
+            },
+            {
+              "content_id": "de3d5e37-ff1c-4111-b029-fc926da764e9",
+              "title": "President of the Board of Trade",
+              "locale": "en",
+              "api_path": "/api/content/government/ministers/president-of-the-board-of-trade",
+              "base_path": "/government/ministers/president-of-the-board-of-trade",
+              "document_type": "ministerial_role",
+              "public_updated_at": "2023-02-10T14:25:34Z",
+              "schema_name": "role",
+              "withdrawn": false,
+              "details": {
+                "body": "\n",
+                "role_payment_type": null,
+                "seniority": 22,
+                "whip_organisation": {}
+              },
+              "links": {},
+              "api_url": "https://www.gov.uk/api/content/government/ministers/president-of-the-board-of-trade",
+              "web_url": "https://www.gov.uk/government/ministers/president-of-the-board-of-trade"
+            }
+          ]
+        },
+        "api_url": "https://www.gov.uk/api/content/government/organisations/uk-export-finance",
+        "web_url": "https://www.gov.uk/government/organisations/uk-export-finance"
+      }
+    ],
+    "suggested_ordered_related_items": [
+      {
+        "content_id": "7176a989-9e44-4105-9bee-58ed6e0dc8eb",
+        "title": "Election 2015: Prime Minister's speech",
+        "locale": "en",
+        "api_path": "/api/content/government/speeches/election-2015-prime-ministers-speech",
+        "base_path": "/government/speeches/election-2015-prime-ministers-speech",
+        "document_type": "speech",
+        "public_updated_at": "2015-05-08T16:52:00Z",
+        "schema_name": "speech",
+        "withdrawn": false,
+        "links": {},
+        "api_url": "https://www.gov.uk/api/content/government/speeches/election-2015-prime-ministers-speech",
+        "web_url": "https://www.gov.uk/government/speeches/election-2015-prime-ministers-speech"
+      },
+      {
+        "content_id": "91879a11-9f4c-4a15-bc0f-7c4ae3de8cb0",
+        "title": "PM speech on opportunity",
+        "locale": "en",
+        "api_path": "/api/content/government/speeches/pm-speech-on-opportunity",
+        "base_path": "/government/speeches/pm-speech-on-opportunity",
+        "document_type": "speech",
+        "public_updated_at": "2015-06-22T12:08:00Z",
+        "schema_name": "speech",
+        "withdrawn": false,
+        "links": {},
+        "api_url": "https://www.gov.uk/api/content/government/speeches/pm-speech-on-opportunity",
+        "web_url": "https://www.gov.uk/government/speeches/pm-speech-on-opportunity"
+      },
+      {
+        "content_id": "1990fccc-e67e-42fd-b6af-bed5bb146ed5",
+        "title": "Mystery Shopper results: 2016",
+        "locale": "en",
+        "api_path": "/api/content/government/publications/mystery-shopper-results-2016",
+        "base_path": "/government/publications/mystery-shopper-results-2016",
+        "document_type": "research",
+        "public_updated_at": "2017-03-15T11:02:45Z",
+        "schema_name": "publication",
+        "withdrawn": false,
+        "links": {},
+        "api_url": "https://www.gov.uk/api/content/government/publications/mystery-shopper-results-2016",
+        "web_url": "https://www.gov.uk/government/publications/mystery-shopper-results-2016"
+      },
+      {
+        "content_id": "0f89d6bd-b3be-4d81-917a-3928b60c4824",
+        "title": "Mystery Shopper results: 2015",
+        "locale": "en",
+        "api_path": "/api/content/government/publications/mystery-shopper-results-2015",
+        "base_path": "/government/publications/mystery-shopper-results-2015",
+        "document_type": "research",
+        "public_updated_at": "2015-12-01T13:56:17Z",
+        "schema_name": "publication",
+        "withdrawn": false,
+        "links": {},
+        "api_url": "https://www.gov.uk/api/content/government/publications/mystery-shopper-results-2015",
+        "web_url": "https://www.gov.uk/government/publications/mystery-shopper-results-2015"
+      },
+      {
+        "content_id": "5d31c99e-7631-11e4-a3cb-005056011aef",
+        "title": "Mystery Shopper results: 2011 to 2014",
+        "locale": "en",
+        "api_path": "/api/content/government/publications/mystery-shopper-results",
+        "base_path": "/government/publications/mystery-shopper-results",
+        "document_type": "research",
+        "public_updated_at": "2015-01-05T15:33:15Z",
+        "schema_name": "publication",
+        "withdrawn": false,
+        "links": {},
+        "api_url": "https://www.gov.uk/api/content/government/publications/mystery-shopper-results",
+        "web_url": "https://www.gov.uk/government/publications/mystery-shopper-results"
+      }
+    ],
+    "available_translations": [
+      {
+        "title": "Ministers",
+        "public_updated_at": "2023-05-16T16:32:31Z",
+        "document_type": "ministers_index",
+        "schema_name": "ministers_index",
+        "base_path": "/government/ministers",
+        "api_path": "/api/content/government/ministers",
+        "withdrawn": false,
+        "content_id": "324e4708-2285-40a0-b3aa-cb13af14ec5f",
+        "locale": "en",
+        "api_url": "https://www.gov.uk/api/content/government/ministers",
+        "web_url": "https://www.gov.uk/government/ministers",
+        "links": {}
+      }
+    ]
+  },
+  "description": null,
+  "details": {
+    "body": "Read biographies and responsibilities of <a href=\"#cabinet-ministers\" class=\"govuk-link\">Cabinet ministers</a> and all <a href=\"#ministers-by-department\" class=\"govuk-link\">ministers by department</a>, as well as the <a href=\"#whips\" class=\"govuk-link\">whips</a> who help co-ordinate parliamentary business."
+  }
+}

--- a/content_schemas/examples/ministers_index/frontend/ministers_index-reshuffle-mode-on.json
+++ b/content_schemas/examples/ministers_index/frontend/ministers_index-reshuffle-mode-on.json
@@ -1,0 +1,26 @@
+{
+  "analytics_identifier": null,
+  "base_path": "/government/ministers",
+  "content_id": "324e4708-2285-40a0-b3aa-cb13af14ec5f",
+  "document_type": "ministers_index",
+  "first_published_at": "2016-11-14T16:28:54.000+00:00",
+  "locale": "en",
+  "phase": "live",
+  "public_updated_at": "2023-05-16T16:32:31.000+00:00",
+  "publishing_app": "whitehall",
+  "publishing_scheduled_at": null,
+  "rendering_app": "whitehall-frontend",
+  "scheduled_publishing_delay_seconds": null,
+  "schema_name": "ministers_index",
+  "title": "Ministers",
+  "updated_at": "2023-05-16T16:33:12.247Z",
+  "withdrawn_notice": {},
+  "publishing_request_id": "21-1684254751.844-10.1.28.61-389",
+  "links": {},
+  "description": null,
+  "details": {
+    "reshuffle": {
+      "message": "Reshuffle in progress"
+    }
+  }
+}

--- a/lib/schema_generator/format.rb
+++ b/lib/schema_generator/format.rb
@@ -269,11 +269,19 @@ module SchemaGenerator
       ALLOWED_KEYS = %w[description required minItems maxItems].freeze
       LINKS_WITHOUT_BASE_PATHS = %w[
         facets
+        ordered_also_attends_cabinet
+        ordered_assistant_whips
+        ordered_baronesses_and_lords_in_waiting_whips
         ordered_board_members
+        ordered_cabinet_ministers
         ordered_chief_professional_officers
         ordered_contacts
         ordered_foi_contacts
+        ordered_house_lords_whips
+        ordered_house_of_commons_whips
+        ordered_junior_lords_of_the_treasury_whips
         ordered_military_personnel
+        ordered_ministerial_departments
         ordered_ministers
         ordered_roles
         ordered_special_representatives


### PR DESCRIPTION
This is an already edited version of the real content item. I've kept enough items to have all the interesting test cases that we have discovered in the process of rendering the Ministers index page in collections.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
