### PR TITLE
Add multi level links Worldwide Organisations 

### DIFF
--- a/content_schemas/dist/formats/worldwide_office/frontend/schema.json
+++ b/content_schemas/dist/formats/worldwide_office/frontend/schema.json
@@ -347,6 +347,10 @@
         "topics": {
           "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/frontend_links_with_base_path"
+        },
+        "worldwide_organisation": {
+          "description": "The Worldwide Organisation that this Worldwide Office belongs to",
+          "$ref": "#/definitions/frontend_links_with_base_path"
         }
       }
     },

--- a/content_schemas/dist/formats/worldwide_office/notification/schema.json
+++ b/content_schemas/dist/formats/worldwide_office/notification/schema.json
@@ -365,6 +365,10 @@
         "topics": {
           "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/frontend_links_with_base_path"
+        },
+        "worldwide_organisation": {
+          "description": "The Worldwide Organisation that this Worldwide Office belongs to",
+          "$ref": "#/definitions/frontend_links_with_base_path"
         }
       }
     },
@@ -442,6 +446,10 @@
         },
         "topics": {
           "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "worldwide_organisation": {
+          "description": "The Worldwide Organisation that this Worldwide Office belongs to",
           "$ref": "#/definitions/guid_list"
         }
       }

--- a/content_schemas/dist/formats/worldwide_office/publisher_v2/links.json
+++ b/content_schemas/dist/formats/worldwide_office/publisher_v2/links.json
@@ -71,6 +71,10 @@
         "topics": {
           "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/guid_list"
+        },
+        "worldwide_organisation": {
+          "description": "The Worldwide Organisation that this Worldwide Office belongs to",
+          "$ref": "#/definitions/guid_list"
         }
       }
     },

--- a/content_schemas/formats/worldwide_office.jsonnet
+++ b/content_schemas/formats/worldwide_office.jsonnet
@@ -16,5 +16,6 @@
   },
   links: (import "shared/base_links.jsonnet") + {
     contact: "Contact details for this Worldwide Office",
+    worldwide_organisation: "The Worldwide Organisation that this Worldwide Office belongs to",
   },
 }

--- a/lib/expansion_rules.rb
+++ b/lib/expansion_rules.rb
@@ -48,6 +48,8 @@ module_function
     %i[ordered_special_representatives role_appointments role],
     %i[ordered_traffic_commissioners role_appointments role],
     %i[historical_accounts person],
+    %i[worldwide_organisation sponsoring_organisations],
+    %i[worldwide_organisation world_locations],
   ].freeze
 
   REVERSE_LINKS = {


### PR DESCRIPTION
We are currently retrieving the Worldwide Organisation that a Worldwide Office
belongs to through the `parent` link.

However, we now also need to be able to retrieve the Sponsored Organisations
and World Locations that are linked to the parent Worldwide Organisation.

In order to define multi level links, we need the link to be named (instead of
just being a `parent` link).

This adds the required named link to Worldwide Offices, and defines multi
level links so that links to Worldwide Organisations include Sponsored
Organisations and World Locations.

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
