### PR TITLE
Update ministers index example for reshuffle mode

### DIFF
--- a/content_schemas/examples/ministers_index/frontend/ministers_index-reshuffle-mode-on.json
+++ b/content_schemas/examples/ministers_index/frontend/ministers_index-reshuffle-mode-on.json
@@ -20,7 +20,7 @@
   "description": null,
   "details": {
     "reshuffle": {
-      "message": "Reshuffle in progress"
+      "message": "<p>Check <a href=\"/government/news/ministerial-appointments-february-2023\" class=\"govuk-link\">latest appointments</a>.</p>\n"
     }
   }
 }


### PR DESCRIPTION
Add a more realistic reshuffle message example, consisting of [HTML rendered by whitehall out of govspeak](https://github.com/alphagov/whitehall/pull/7712).

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
