### PR TITLE
Update document collection schema

### DIFF
--- a/content_schemas/dist/formats/document_collection/frontend/schema.json
+++ b/content_schemas/dist/formats/document_collection/frontend/schema.json
@@ -378,6 +378,9 @@
         "government": {
           "$ref": "#/definitions/government"
         },
+        "mapped_specialist_topic_content_id": {
+          "type": "string"
+        },
         "political": {
           "$ref": "#/definitions/political"
         },

--- a/content_schemas/dist/formats/document_collection/notification/schema.json
+++ b/content_schemas/dist/formats/document_collection/notification/schema.json
@@ -485,6 +485,9 @@
         "government": {
           "$ref": "#/definitions/government"
         },
+        "mapped_specialist_topic_content_id": {
+          "type": "string"
+        },
         "political": {
           "$ref": "#/definitions/political"
         },

--- a/content_schemas/dist/formats/document_collection/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/document_collection/publisher_v2/schema.json
@@ -297,6 +297,9 @@
         "government": {
           "$ref": "#/definitions/government"
         },
+        "mapped_specialist_topic_content_id": {
+          "type": "string"
+        },
         "political": {
           "$ref": "#/definitions/political"
         },

--- a/content_schemas/formats/document_collection.jsonnet
+++ b/content_schemas/formats/document_collection.jsonnet
@@ -60,6 +60,9 @@
         },
         brexit_no_deal_notice: {
           "$ref": "#/definitions/brexit_no_deal_notice",
+        },
+        mapped_specialist_topic_content_id: {
+          type: "string",
         }
       },
     },


### PR DESCRIPTION
This field will be used as part of retiring specialist topics, some of which will be redirected to document collections that have been created to replace them. These document collections will have a `mapped_specialist_topic_content_id` thatrefers to the specialist topic they are intended to replace.

Having this field present on the document collection means that we will be able to pick out document collections where we can automatically migrate all email subscribers of the specialist topic over to the document collection.

We can remove this field once all specialist topics have been retired.

[Trello](https://trello.com/c/GVCkZIDl/1822-update-document-collection-content-schema-in-publishing-api-to-accept-mappedspecialisttopiccontentid-in-the-details-field-s)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
