### PR TITLE
Include secondary corporate info pages separately

### DIFF
--- a/content_schemas/dist/formats/worldwide_organisation/frontend/schema.json
+++ b/content_schemas/dist/formats/worldwide_organisation/frontend/schema.json
@@ -551,6 +551,10 @@
             }
           }
         },
+        "secondary_corporate_information_pages": {
+          "description": "A string containing sentences and links to corporate information pages that are not included in ordered_corporate_information_pages.",
+          "type": "string"
+        },
         "social_media_links": {
           "description": "A set of links to social media profiles for the object.",
           "type": "array",

--- a/content_schemas/dist/formats/worldwide_organisation/notification/schema.json
+++ b/content_schemas/dist/formats/worldwide_organisation/notification/schema.json
@@ -670,6 +670,10 @@
             }
           }
         },
+        "secondary_corporate_information_pages": {
+          "description": "A string containing sentences and links to corporate information pages that are not included in ordered_corporate_information_pages.",
+          "type": "string"
+        },
         "social_media_links": {
           "description": "A set of links to social media profiles for the object.",
           "type": "array",

--- a/content_schemas/dist/formats/worldwide_organisation/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/worldwide_organisation/publisher_v2/schema.json
@@ -402,6 +402,10 @@
             }
           }
         },
+        "secondary_corporate_information_pages": {
+          "description": "A string containing sentences and links to corporate information pages that are not included in ordered_corporate_information_pages.",
+          "type": "string"
+        },
         "social_media_links": {
           "description": "A set of links to social media profiles for the object.",
           "type": "array",

--- a/content_schemas/formats/worldwide_organisation.jsonnet
+++ b/content_schemas/formats/worldwide_organisation.jsonnet
@@ -28,6 +28,10 @@
           },
           description: "A set of links to corporate information pages to display for the worldwide organisation.",
         },
+        secondary_corporate_information_pages: {
+          type: "string",
+          description: "A string containing sentences and links to corporate information pages that are not included in ordered_corporate_information_pages.",
+        },
         social_media_links: (import "shared/definitions/_social_media_links.jsonnet"),
       },
     },


### PR DESCRIPTION
This replicates what has been done with non-worldwide org page content items, where the secondary corporate info pages are assembled as entire HTML-enriched phrases and stored in the content item to be rendered as such by collections.

We are doing the same, but to be rendered by government-frontend.

The advantages:
- consistency between organisation and worldwide organisation
- government-frontend doesn't need to know about the business logic of this special category of pages
- government-frontend doesn't need to import all the translations that are required to generate the links

Disadvantages:
- relies on keeping what is arguably rendering logic within whitehall

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
