### PR TITLE
Link main and home page offices for worlwide orgs

### DIFF
--- a/content_schemas/dist/formats/worldwide_organisation/frontend/schema.json
+++ b/content_schemas/dist/formats/worldwide_organisation/frontend/schema.json
@@ -249,12 +249,20 @@
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "home_page_offices": {
+          "description": "The offices, other than the main office, to be shown on the home page of this Worldwide Organisation",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "lead_organisations": {
           "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "level_one_taxons": {
           "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
+        "main_office": {
+          "description": "The main office for this Worldwide Organisation",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "mainstream_browse_pages": {

--- a/content_schemas/dist/formats/worldwide_organisation/notification/schema.json
+++ b/content_schemas/dist/formats/worldwide_organisation/notification/schema.json
@@ -267,12 +267,20 @@
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "home_page_offices": {
+          "description": "The offices, other than the main office, to be shown on the home page of this Worldwide Organisation",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "lead_organisations": {
           "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "level_one_taxons": {
           "description": "Link type automatically added by Publishing API",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
+        "main_office": {
+          "description": "The main office for this Worldwide Organisation",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "mainstream_browse_pages": {
@@ -401,8 +409,16 @@
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"
         },
+        "home_page_offices": {
+          "description": "The offices, other than the main office, to be shown on the home page of this Worldwide Organisation",
+          "$ref": "#/definitions/guid_list"
+        },
         "lead_organisations": {
           "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "main_office": {
+          "description": "The main office for this Worldwide Organisation",
           "$ref": "#/definitions/guid_list"
         },
         "mainstream_browse_pages": {

--- a/content_schemas/dist/formats/worldwide_organisation/publisher_v2/links.json
+++ b/content_schemas/dist/formats/worldwide_organisation/publisher_v2/links.json
@@ -18,8 +18,16 @@
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"
         },
+        "home_page_offices": {
+          "description": "The offices, other than the main office, to be shown on the home page of this Worldwide Organisation",
+          "$ref": "#/definitions/guid_list"
+        },
         "lead_organisations": {
           "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "main_office": {
+          "description": "The main office for this Worldwide Organisation",
           "$ref": "#/definitions/guid_list"
         },
         "mainstream_browse_pages": {

--- a/content_schemas/formats/worldwide_organisation.jsonnet
+++ b/content_schemas/formats/worldwide_organisation.jsonnet
@@ -39,6 +39,8 @@
   links: (import "shared/base_links.jsonnet") + {
     corporate_information_pages: "Corporate information pages for this Worldwide Organisation",
     ordered_contacts: "Contact details for this Worldwide Organisation",
+    main_office: "The main office for this Worldwide Organisation",
+    home_page_offices: "The offices, other than the main office, to be shown on the home page of this Worldwide Organisation",
     primary_role_person: "The person currently appointed to a primary role in this Worldwide Organisation",
     secondary_role_person: "The person currently appointed to a secondary role in this Worldwide Organisation",
     office_staff: "People currently appointed to office staff roles in this Worldwide Organisation",

--- a/lib/expansion_rules.rb
+++ b/lib/expansion_rules.rb
@@ -51,6 +51,8 @@ module_function
     %i[ordered_special_representatives role_appointments role],
     %i[ordered_traffic_commissioners role_appointments role],
     %i[historical_accounts person],
+    %i[main_office contact],
+    %i[home_page_offices contact],
     %i[worldwide_organisation sponsoring_organisations],
     %i[worldwide_organisation world_locations],
   ].freeze


### PR DESCRIPTION
In order to keep the current behaviour from whitehall, we need the worldwide organisation content item to have the information about which office, if any, is the main office, and which offices to show on the home page of the organisation.

Worldwide offices have their own content item, and some of the data (such as the `public_url` of the office to be shown when the main office has access and opening times) belong to the office rather than to its contact. So we have linked the offices rather than skipping directly to the contacts' `content_id`.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
