### PR TITLE
Present all redirects consistently

### DIFF
--- a/app/downstream_payload.rb
+++ b/app/downstream_payload.rb
@@ -45,7 +45,11 @@ private
   end
 
   def redirect_presenter
-    Presenters::RedirectPresenter.from_unpublished_edition(edition)
+    if unpublishing
+      Presenters::RedirectPresenter.from_unpublished_edition(edition)
+    else
+      Presenters::RedirectPresenter.from_published_edition(edition)
+    end
   end
 
   def gone_presenter
@@ -67,6 +71,7 @@ private
   end
 
   def message_queue_presenter
+    return redirect_presenter if edition.document_type == "redirect"
     return content_presenter unless unpublished?
 
     case unpublishing.type

--- a/app/downstream_payload.rb
+++ b/app/downstream_payload.rb
@@ -61,6 +61,7 @@ private
   end
 
   def content_store_presenter
+    return redirect_presenter if edition.document_type == "redirect"
     return content_presenter unless unpublished?
 
     case unpublishing.type

--- a/app/downstream_payload.rb
+++ b/app/downstream_payload.rb
@@ -45,7 +45,7 @@ private
   end
 
   def redirect_presenter
-    Presenters::RedirectPresenter.from_edition(edition)
+    Presenters::RedirectPresenter.from_unpublished_edition(edition)
   end
 
   def gone_presenter

--- a/app/presenters/redirect_presenter.rb
+++ b/app/presenters/redirect_presenter.rb
@@ -1,11 +1,12 @@
 class Presenters::RedirectPresenter
-  def initialize(base_path:, content_id:, publishing_app:, redirects:, locale:, public_updated_at: nil)
+  def initialize(base_path:, content_id:, publishing_app:, redirects:, locale:, public_updated_at: nil, first_published_at: nil)
     @base_path = base_path
     @content_id = content_id
     @publishing_app = publishing_app
     @public_updated_at = public_updated_at
     @redirects = redirects
     @locale = locale
+    @first_published_at = first_published_at
   end
 
   def self.from_unpublished_edition(edition)
@@ -14,6 +15,7 @@ class Presenters::RedirectPresenter
       content_id: edition.content_id,
       publishing_app: edition.publishing_app,
       public_updated_at: edition.unpublishing.unpublished_at || edition.unpublishing.created_at,
+      first_published_at: edition.first_published_at,
       redirects: edition.unpublishing.redirects,
       locale: edition.locale,
     )
@@ -25,6 +27,7 @@ class Presenters::RedirectPresenter
       content_id: edition.content_id,
       publishing_app: edition.publishing_app,
       public_updated_at: edition.public_updated_at,
+      first_published_at: edition.first_published_at,
       redirects: edition.redirects,
       locale: edition.locale,
     )
@@ -51,6 +54,7 @@ private
   attr_reader :base_path,
               :publishing_app,
               :public_updated_at,
+              :first_published_at,
               :redirects,
               :content_id,
               :locale
@@ -64,9 +68,14 @@ private
       publishing_app:,
       redirects:,
     }
-    if public_updated_at.present?
-      attributes[:public_updated_at] = public_updated_at.iso8601
-    end
-    attributes
+    attributes.merge(formatted_dates)
+  end
+
+  def formatted_dates
+    {
+      public_updated_at:,
+      first_published_at:,
+    }.compact
+     .transform_values(&:iso8601)
   end
 end

--- a/app/presenters/redirect_presenter.rb
+++ b/app/presenters/redirect_presenter.rb
@@ -19,6 +19,17 @@ class Presenters::RedirectPresenter
     )
   end
 
+  def self.from_published_edition(edition)
+    new(
+      base_path: edition.base_path,
+      content_id: edition.content_id,
+      publishing_app: edition.publishing_app,
+      public_updated_at: edition.public_updated_at,
+      redirects: edition.redirects,
+      locale: edition.locale,
+    )
+  end
+
   def for_content_store(payload_version)
     present.merge(payload_version:)
   end

--- a/app/presenters/redirect_presenter.rb
+++ b/app/presenters/redirect_presenter.rb
@@ -8,7 +8,7 @@ class Presenters::RedirectPresenter
     @locale = locale
   end
 
-  def self.from_edition(edition)
+  def self.from_unpublished_edition(edition)
     new(
       base_path: edition.base_path,
       content_id: edition.content_id,

--- a/spec/downstream_payload_spec.rb
+++ b/spec/downstream_payload_spec.rb
@@ -158,17 +158,53 @@ RSpec.describe DownstreamPayload do
   end
 
   describe "#message_queue_payload" do
-    let(:edition) do
-      create_edition(:live_edition, update_type: "major")
+    context "a published edition" do
+      let(:edition) { create_edition(:live_edition, update_type: "major") }
+
+      it "uses the edition presenter" do
+        expect_any_instance_of(Presenters::EditionPresenter).to receive(:for_message_queue).with(payload_version)
+        downstream_payload.message_queue_payload
+      end
     end
 
-    it "returns a message queue payload" do
-      expect(downstream_payload.message_queue_payload).to include(
-        base_path: edition.base_path,
-        title: edition.title,
-        update_type: edition.update_type,
-        govuk_request_id: anything,
-      )
+    context "a gone edition" do
+      let(:edition) { create_edition(:gone_unpublished_edition, update_type: "major") }
+
+      it "uses the gone presenter" do
+        expect_any_instance_of(Presenters::GonePresenter).to receive(:for_message_queue).with(payload_version)
+        downstream_payload.message_queue_payload
+      end
+    end
+
+    context "a vanish edition" do
+      let(:edition) { create_edition(:vanish_unpublished_edition, update_type: "major") }
+
+      it "uses the vanish presenter" do
+        expect_any_instance_of(Presenters::VanishPresenter).to receive(:for_message_queue).with(payload_version)
+        downstream_payload.message_queue_payload
+      end
+    end
+
+    context "an unpublished redirect" do
+      let(:edition) { create_edition(:redirect_unpublished_edition, update_type: "major") }
+      let(:redirect_presenter_double) { instance_double(Presenters::RedirectPresenter) }
+
+      it "uses the redirect presenter" do
+        expect(Presenters::RedirectPresenter).to receive(:from_unpublished_edition).and_return(redirect_presenter_double)
+        expect(redirect_presenter_double).to receive(:for_message_queue).with(payload_version)
+        downstream_payload.message_queue_payload
+      end
+    end
+
+    context "a published redirect" do
+      let(:edition) { create_edition(:redirect_live_edition, update_type: "major") }
+      let(:redirect_presenter_double) { instance_double(Presenters::RedirectPresenter) }
+
+      it "uses the redirect presenter" do
+        expect(Presenters::RedirectPresenter).to receive(:from_published_edition).and_return(redirect_presenter_double)
+        expect(redirect_presenter_double).to receive(:for_message_queue).with(payload_version)
+        downstream_payload.message_queue_payload
+      end
     end
   end
 end

--- a/spec/downstream_payload_spec.rb
+++ b/spec/downstream_payload_spec.rb
@@ -109,10 +109,23 @@ RSpec.describe DownstreamPayload do
     end
 
     context "published item" do
-      let(:edition) { create_edition(:live_edition) }
+      context "standard edition" do
+        let(:edition) { create_edition(:live_edition) }
 
-      it "returns a content store payload" do
-        expect(downstream_payload.content_store_payload).to include(content_store_payload_hash)
+        it "returns a content store payload" do
+          expect(downstream_payload.content_store_payload).to include(content_store_payload_hash)
+        end
+      end
+
+      context "redirect edition" do
+        let(:edition) { create_edition(:redirect_live_edition) }
+        let(:redirect_presenter_double) { instance_double(Presenters::RedirectPresenter) }
+
+        it "returns a content store payload" do
+          expect(Presenters::RedirectPresenter).to receive(:from_published_edition).and_return(redirect_presenter_double)
+          expect(redirect_presenter_double).to receive(:for_content_store).with(payload_version)
+          downstream_payload.content_store_payload
+        end
       end
     end
 

--- a/spec/presenters/redirect_presenter_spec.rb
+++ b/spec/presenters/redirect_presenter_spec.rb
@@ -1,14 +1,29 @@
 RSpec.describe Presenters::RedirectPresenter do
   describe "#for_message_queue" do
     let(:payload_version) { 1 }
-    let(:edition) { create(:unpublishing, type: "redirect").edition }
 
-    subject(:result) do
-      described_class.from_unpublished_edition(edition).for_message_queue(payload_version)
+    context "when the edition is an unpublished redirect" do
+      let(:edition) { create(:unpublishing, type: "redirect").edition }
+
+      subject(:result) do
+        described_class.from_unpublished_edition(edition).for_message_queue(payload_version)
+      end
+
+      it "matches the notification schema" do
+        expect(subject).to be_valid_against_notification_schema("redirect")
+      end
     end
 
-    it "matches the notification schema" do
-      expect(subject).to be_valid_against_notification_schema("redirect")
+    context "when the edition is a published redirect" do
+      let(:edition) { create(:redirect_live_edition) }
+
+      subject(:result) do
+        described_class.from_published_edition(edition).for_message_queue(payload_version)
+      end
+
+      it "matches the notification schema" do
+        expect(subject).to be_valid_against_notification_schema("redirect")
+      end
     end
   end
 end

--- a/spec/presenters/redirect_presenter_spec.rb
+++ b/spec/presenters/redirect_presenter_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Presenters::RedirectPresenter do
     let(:edition) { create(:unpublishing, type: "redirect").edition }
 
     subject(:result) do
-      described_class.from_edition(edition).for_message_queue(payload_version)
+      described_class.from_unpublished_edition(edition).for_message_queue(payload_version)
     end
 
     it "matches the notification schema" do

--- a/spec/presenters/redirect_presenter_spec.rb
+++ b/spec/presenters/redirect_presenter_spec.rb
@@ -12,6 +12,14 @@ RSpec.describe Presenters::RedirectPresenter do
       it "matches the notification schema" do
         expect(subject).to be_valid_against_notification_schema("redirect")
       end
+
+      it "does not include first published at when it does not exist" do
+        expect(subject.key?(:first_published_at)).to be false
+      end
+
+      it "includes the public updated at" do
+        expect(subject[:public_updated_at]).to eq(edition.unpublishing.created_at.iso8601)
+      end
     end
 
     context "when the edition is a published redirect" do
@@ -23,6 +31,14 @@ RSpec.describe Presenters::RedirectPresenter do
 
       it "matches the notification schema" do
         expect(subject).to be_valid_against_notification_schema("redirect")
+      end
+
+      it "includes the first published at" do
+        expect(subject[:first_published_at]).to eq(edition.first_published_at.iso8601)
+      end
+
+      it "includes the public updated at" do
+        expect(subject[:public_updated_at]).to eq(edition.public_updated_at.iso8601)
       end
     end
   end

--- a/spec/requests/unpublishing_spec.rb
+++ b/spec/requests/unpublishing_spec.rb
@@ -108,6 +108,7 @@ RSpec.describe "POST /v2/content/:content_id/unpublish", type: :request do
           locale: edition.locale,
           publishing_app: edition.publishing_app,
           public_updated_at: Time.zone.now.iso8601,
+          first_published_at: edition.first_published_at.iso8601,
           redirects: [
             {
               path: base_path,


### PR DESCRIPTION
This PR ensures that all redirects in publishing api are treat consistently in terms of how they are presented downstream.

### Context

Redirects can be represented in publishing api in one of two ways:

1. As an unpublished edition, with an unpublishing record with a type of 'redirect'. These result from an 'unpublish' request to publishing api.
2. As a published edition, with a schema name and document type of 'redirect'. These result from a 'put content' request to publishing api.

We think that there is a use case for both, with 1) primarily being for pieces of content that were previously live on gov.uk and now redirected, and 2) being for urls that were never pieces of content on gov.uk, but where we want to ensure a redirect occurs. In practice, we think we have a lot of cases of 2) which should in fact be 1), because publishing apps call publishing api inconsistently in the case of redirects.

While both result in the same behaviour on gov.uk i.e. a redirected page, they are treated inconsistently in publishing api, which determines the presenter to use to represent the edition downstream (to content store and to the rabbit mq queues) based on whether it is unpublished or not. This means that for redirects that fall into the second category, we treat them as normal bits of live content. This ends up writing content which fails schema validation.

### What's the impact of the current situation / what are we fixing

This schema validation does not stop anything from being published, but it does result in us logging errors (this is how this was originally noticed) - see [this example](https://kibana.logit.io/s/13d1a0b1-f54f-407b-a4e5-f53ba653fac3/app/discover#/doc/8ac115c0-aac1-11e8-88ea-0383c11b333a/filebeat-2023.06.12?id=yyi_rogB4AU214aYzl9d). Additionally, having content in a state that doesn't match what we say about it in schemas is confusing.

### Considerations with this PR for the reviewer

I think this change will not cause issues. One thing I did think about was whether we'd lose any important information from switching some content items from the edition presenter to the more sparse redirect presenter. 

Here's an example of a published redirect content item: https://www.gov.uk/api/content/topic/immigration-operational-guidance
Here's an example of an unpublished redirect content item:
https://www.gov.uk/api/content/guidance/apply-to-join-the-physics-itt-for-engineers-pilot

Looking at these two specific examples, it looks like we're not going to be losing any useful information by switching the presenter - we lose links, but this is good since they don't exist in the schema and don't make sense for a redirect. I've added in the first published at date in this PR in case useful for metadata on the redirect, but it's not strictly necessary.

So I think this is all OK, but would welcome any thoughts about unintended consequences.

[Trello](https://trello.com/c/RbFmTlla/1834-investigate-why-redirects-from-collections-publisher-results-in-notification-schema-errors)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
