### PR TITLE
Add current prime minister to example

### DIFF
--- a/content_schemas/examples/how_government_works/frontend/reshuffle-mode-off.json
+++ b/content_schemas/examples/how_government_works/frontend/reshuffle-mode-off.json
@@ -17,7 +17,31 @@
     "reshuffle_in_progress": false
   },
   "document_type": "how_government_works",
-  "links": {},
+  "links": {
+    "current_prime_minister": [
+      {
+        "content_id": "361b04ed-731a-4f55-82c0-14cdf129afac",
+        "title": "The Rt Hon Rishi Sunak MP",
+        "locale": "en",
+        "api_path": "/api/content/government/people/rishi-sunak",
+        "base_path": "/government/people/rishi-sunak",
+        "document_type": "person",
+        "public_updated_at": "2022-10-27T10:43:34Z",
+        "schema_name": "person",
+        "withdrawn": false,
+        "details": {
+          "image": {
+            "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/person/image/3339/s465_Rishi_profile.jpg",
+            "alt_text": "The Rt Hon Rishi Sunak MP"
+          },
+          "privy_counsellor": true
+        },
+        "links": {},
+        "api_url": "https://www.gov.uk/api/content/government/people/rishi-sunak",
+        "web_url": "https://www.gov.uk/government/people/rishi-sunak"
+      }
+    ]
+  },
   "locale": "en",
   "public_updated_at": "2023-03-06T11:01:01+00:00",
   "rendering_app": "whitehall-frontend",


### PR DESCRIPTION
We [fixed an incorrect assertion in government-frontend](https://github.com/alphagov/government-frontend/pull/2816), but the test is still passing by coincidence, because it is comparing that `nil` equals `nil`. Add a non-nil item so that the test is meaningful.

This will also fix a deprecation warning from minitest:

```
HowGovernmentWorksPresenterTest
DEPRECATED: Use assert_nil if expecting nil from
test/presenters/how_government_works_presenter_test.rb:14. This will
fail in Minitest 6.
```

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
