### PR TITLE
Remove ordered_contacts from worldwide org

### DIFF
--- a/content_schemas/dist/formats/worldwide_organisation/frontend/schema.json
+++ b/content_schemas/dist/formats/worldwide_organisation/frontend/schema.json
@@ -285,10 +285,6 @@
           "description": "People currently appointed to office staff roles in this Worldwide Organisation",
           "$ref": "#/definitions/frontend_links"
         },
-        "ordered_contacts": {
-          "description": "Contact details for this Worldwide Organisation",
-          "$ref": "#/definitions/frontend_links"
-        },
         "ordered_related_items": {
           "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/content_schemas/dist/formats/worldwide_organisation/notification/schema.json
+++ b/content_schemas/dist/formats/worldwide_organisation/notification/schema.json
@@ -303,10 +303,6 @@
           "description": "People currently appointed to office staff roles in this Worldwide Organisation",
           "$ref": "#/definitions/frontend_links"
         },
-        "ordered_contacts": {
-          "description": "Contact details for this Worldwide Organisation",
-          "$ref": "#/definitions/frontend_links"
-        },
         "ordered_related_items": {
           "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -435,10 +431,6 @@
         },
         "office_staff": {
           "description": "People currently appointed to office staff roles in this Worldwide Organisation",
-          "$ref": "#/definitions/guid_list"
-        },
-        "ordered_contacts": {
-          "description": "Contact details for this Worldwide Organisation",
           "$ref": "#/definitions/guid_list"
         },
         "ordered_related_items": {

--- a/content_schemas/dist/formats/worldwide_organisation/publisher_v2/links.json
+++ b/content_schemas/dist/formats/worldwide_organisation/publisher_v2/links.json
@@ -42,10 +42,6 @@
           "description": "People currently appointed to office staff roles in this Worldwide Organisation",
           "$ref": "#/definitions/guid_list"
         },
-        "ordered_contacts": {
-          "description": "Contact details for this Worldwide Organisation",
-          "$ref": "#/definitions/guid_list"
-        },
         "ordered_related_items": {
           "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/formats/worldwide_organisation.jsonnet
+++ b/content_schemas/formats/worldwide_organisation.jsonnet
@@ -38,7 +38,6 @@
   },
   links: (import "shared/base_links.jsonnet") + {
     corporate_information_pages: "Corporate information pages for this Worldwide Organisation",
-    ordered_contacts: "Contact details for this Worldwide Organisation",
     main_office: "The main office for this Worldwide Organisation",
     home_page_offices: "The offices, other than the main office, to be shown on the home page of this Worldwide Organisation",
     primary_role_person: "The person currently appointed to a primary role in this Worldwide Organisation",


### PR DESCRIPTION
Now that we've removed `ordered_contacts` from the worldwide org presenter in whitehall, we can remove it from the schema as well.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
