### PR TITLE
Include world location name translations in Worldwide Office

### DIFF
--- a/content_schemas/examples/worldwide_office/frontend/worldwide_office.json
+++ b/content_schemas/examples/worldwide_office/frontend/worldwide_office.json
@@ -148,6 +148,18 @@
             }
           ]
         },
+        "details": {
+          "world_location_names": [
+            {
+              "content_id": "5e9f1506-7706-11e4-a3cb-005056011aef",
+              "name": "Philippines with translation"
+            },
+            {
+              "content_id": "5e9f33e4-7706-11e4-a3cb-005056011aef",
+              "name": "Palau with translation"
+            }
+          ]
+        },
         "api_url": "https://www.integration.publishing.service.gov.uk/api/content/world/organisations/british-embassy-manila",
         "web_url": "https://www.integration.publishing.service.gov.uk/world/organisations/british-embassy-manila"
       }

--- a/lib/expansion_rules.rb
+++ b/lib/expansion_rules.rb
@@ -113,6 +113,7 @@ module_function
   TRAVEL_ADVICE_FIELDS = (DEFAULT_FIELDS + details_fields(:country, :change_description)).freeze
   WORLD_LOCATION_FIELDS = %i[content_id title schema_name locale analytics_identifier].freeze
   WORLDWIDE_OFFICE_FIELDS = (DEFAULT_FIELDS + details_fields(:access_and_opening_times)).freeze
+  WORLDWIDE_ORGANISATION_FIELDS = (DEFAULT_FIELDS_AND_DESCRIPTION + details_fields(:world_location_names)).freeze
 
   CUSTOM_EXPANSION_FIELDS_FOR_PEOPLE = (
     %i[
@@ -208,7 +209,7 @@ module_function
       { document_type: :worldwide_office,
         fields: WORLDWIDE_OFFICE_FIELDS },
       { document_type: :worldwide_organisation,
-        fields: DEFAULT_FIELDS_AND_DESCRIPTION },
+        fields: WORLDWIDE_ORGANISATION_FIELDS },
       { document_type: :government,
         fields: GOVERNMENT_FIELDS },
       { document_type: :coronavirus_landing_page,

--- a/spec/lib/expansion_rules_spec.rb
+++ b/spec/lib/expansion_rules_spec.rb
@@ -58,6 +58,7 @@ RSpec.describe ExpansionRules do
     let(:travel_advice_fields) { default_fields + [%i[details country], %i[details change_description]] }
     let(:world_location_fields) { %i[content_id title schema_name locale analytics_identifier] }
     let(:worldwide_office_fields) { default_fields + [%i[details access_and_opening_times]] }
+    let(:worldwide_organisation_fields) { default_fields_and_description + [%i[details world_location_names]] }
 
     specify { expect(rules.expansion_fields(:redirect)).to eq([]) }
     specify { expect(rules.expansion_fields(:gone)).to eq([]) }
@@ -119,7 +120,7 @@ RSpec.describe ExpansionRules do
     specify { expect(rules.expansion_fields(:taxon)).to eq(taxon_fields) }
     specify { expect(rules.expansion_fields(:travel_advice)).to eq(travel_advice_fields) }
     specify { expect(rules.expansion_fields(:world_location)).to eq(world_location_fields) }
-    specify { expect(rules.expansion_fields(:worldwide_organisation)).to eq(default_fields_and_description) }
+    specify { expect(rules.expansion_fields(:worldwide_organisation)).to eq(worldwide_organisation_fields) }
     specify { expect(rules.expansion_fields(:worldwide_office)).to eq(worldwide_office_fields) }
 
     specify { expect(rules.expansion_fields(:finder, link_type: :finder)).to eq(finder_fields) }


### PR DESCRIPTION
We need to display the translated names of World Locations for the related Worldwide Organisation on the Worldwide Office pages.

Therefore updating the expansion rules to include this.

Follows on from https://github.com/alphagov/publishing-api/pull/2405.

[Trello card](https://trello.com/c/lzp59ynE)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
