### PR TITLE
Fix bug when filtering by org and all locales

### DIFF
--- a/app/queries/get_content_collection.rb
+++ b/app/queries/get_content_collection.rb
@@ -46,10 +46,10 @@ module Queries
     )
 
     def editions
-      scope = Edition.all
+      scope = Edition.with_document
       scope = scope.where(document_type: document_types) if document_types.any?
       scope = scope.where(publishing_app:) if publishing_app
-      scope = scope.with_document.where("documents.locale": locale) unless locale == "all"
+      scope = scope.where("documents.locale": locale) unless locale == "all"
       scope = Link.filter_editions(scope, link_filters) if link_filters.present?
       scope
     end

--- a/spec/queries/get_content_collection_spec.rb
+++ b/spec/queries/get_content_collection_spec.rb
@@ -19,11 +19,16 @@ RSpec.describe Queries::GetContentCollection do
         document_type: "mainstream_browse_page",
         schema_name: "mainstream_browse_page",
       )
-      create(
+      draft_d = create(
         :draft_edition,
         base_path: "/d",
         document_type: "another_type",
         schema_name: "another_type",
+      )
+      create(
+        :link_set,
+        content_id: draft_d.content_id,
+        links_hash: { organisations: %w[af07d5a5-df63-4ddc-9383-6a666845ebe9] },
       )
     end
 
@@ -34,6 +39,15 @@ RSpec.describe Queries::GetContentCollection do
         hash_including("base_path" => "/a"),
         hash_including("base_path" => "/b"),
         hash_including("base_path" => "/c"),
+        hash_including("base_path" => "/d"),
+      ])
+    end
+
+    it "returns editions for an organisation for all locales" do
+      expect(Queries::GetContentCollection.new(
+        fields: %w[base_path],
+        filters: { locale: "all", links: { organisations: "af07d5a5-df63-4ddc-9383-6a666845ebe9" } },
+      ).call).to match_array([
         hash_including("base_path" => "/d"),
       ])
     end


### PR DESCRIPTION
Previously, if the query included `locales: all` and contained link_filters then we'd receive an SQL error:

```
PG::UndefinedTable: ERROR:  missing FROM-clause entry for table "documents"
LINE 1: ...s" INNER JOIN link_sets ON link_sets.content_id = documents....
```

This only occurred when using the `all` value for a locale due to the `documents` join being skipped [1] and so then the link_sets join failed [2] due to missing the `documents` table declaration.

[1]: https://github.com/alphagov/publishing-api/blob/ff491b745bf7cfdd3ff8fba6dabbdabbe40c9150/app/queries/get_content_collection.rb#L52
[2]: https://github.com/alphagov/publishing-api/blob/ff491b745bf7cfdd3ff8fba6dabbdabbe40c9150/app/models/link.rb#L13

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
