### PR TITLE
Add label text property to finder

### DIFF
--- a/content_schemas/dist/formats/finder/frontend/schema.json
+++ b/content_schemas/dist/formats/finder/frontend/schema.json
@@ -338,6 +338,9 @@
         "generic_description": {
           "type": "boolean"
         },
+        "label_text": {
+          "type": "string"
+        },
         "logo_path": {
           "type": "string"
         },

--- a/content_schemas/dist/formats/finder/notification/schema.json
+++ b/content_schemas/dist/formats/finder/notification/schema.json
@@ -438,6 +438,9 @@
         "generic_description": {
           "type": "boolean"
         },
+        "label_text": {
+          "type": "string"
+        },
         "logo_path": {
           "type": "string"
         },

--- a/content_schemas/dist/formats/finder/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/finder/publisher_v2/schema.json
@@ -212,6 +212,9 @@
         "generic_description": {
           "type": "boolean"
         },
+        "label_text": {
+          "type": "string"
+        },
         "logo_path": {
           "type": "string"
         },

--- a/content_schemas/formats/finder.jsonnet
+++ b/content_schemas/formats/finder.jsonnet
@@ -58,6 +58,9 @@
         format_name: {
           type: "string",
         },
+        label_text: {
+          type: "string",
+        },
         show_summaries: {
           "$ref": "#/definitions/finder_show_summaries",
         },


### PR DESCRIPTION
## What

https://trello.com/c/UwVqYJjP/2065-change-frontend-text-for-search-boxes

Add label text (`label_text`) property to change the word **Search** to **Keywords**, for licence finder (specialist finder) only, which may help users with entering keywords and not treating it like a Google search box.

## Why

There were examples in user research of users confusing the main search and the industry filter box, both on mobile and desktop, but particularly on mobile. A successful iteration will improve the usability of the tool.

## Anything else

- https://github.com/alphagov/finder-frontend/pull/3091
- https://github.com/alphagov/specialist-publisher/pull/2315