### PR TITLE
Remove legacy taxons from taxon schema

### DIFF
--- a/content_schemas/dist/formats/taxon/frontend/schema.json
+++ b/content_schemas/dist/formats/taxon/frontend/schema.json
@@ -79,10 +79,6 @@
           "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "legacy_taxons": {
-          "description": "Prior taxons (such as mainstream_browse_page, topic, policy_area, policy) before the single site-wide Topic Taxonomy was introduced",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "level_one_taxons": {
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/content_schemas/dist/formats/taxon/notification/schema.json
+++ b/content_schemas/dist/formats/taxon/notification/schema.json
@@ -97,10 +97,6 @@
           "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "legacy_taxons": {
-          "description": "Prior taxons (such as mainstream_browse_page, topic, policy_area, policy) before the single site-wide Topic Taxonomy was introduced",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "level_one_taxons": {
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -217,10 +213,6 @@
         },
         "lead_organisations": {
           "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "legacy_taxons": {
-          "description": "Prior taxons (such as mainstream_browse_page, topic, policy_area, policy) before the single site-wide Topic Taxonomy was introduced",
           "$ref": "#/definitions/guid_list"
         },
         "mainstream_browse_pages": {

--- a/content_schemas/dist/formats/taxon/publisher_v2/links.json
+++ b/content_schemas/dist/formats/taxon/publisher_v2/links.json
@@ -18,10 +18,6 @@
           "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
           "$ref": "#/definitions/guid_list"
         },
-        "legacy_taxons": {
-          "description": "Prior taxons (such as mainstream_browse_page, topic, policy_area, policy) before the single site-wide Topic Taxonomy was introduced",
-          "$ref": "#/definitions/guid_list"
-        },
         "mainstream_browse_pages": {
           "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/formats/taxon.jsonnet
+++ b/content_schemas/formats/taxon.jsonnet
@@ -33,8 +33,5 @@
     root_taxon: {
       description: "Set to the root taxon (homepage) if this is a level one taxon.",
     },
-    legacy_taxons: {
-      description: "Prior taxons (such as mainstream_browse_page, topic, policy_area, policy) before the single site-wide Topic Taxonomy was introduced",
-    },
   },
 }


### PR DESCRIPTION
These links are deprecated and no longer in use. They have been removed from all items in the content store so can now be removed from the schema.

Depends on [rake task to clear out the last set of these from publishing api](https://github.com/alphagov/content-tagger/pull/1513), and confirmation that this has been successful. ✅ 

[Trello](https://trello.com/c/r9c2kyDA/1450-remove-legacytaxon-from-govuk-content-schemas-so-adding-a-legacy-taxon-to-new-content-items-is-no-longer-possible-m)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
