### PR TITLE
Remove expansion rules for legacy taxons

### DIFF
--- a/lib/expansion_rules.rb
+++ b/lib/expansion_rules.rb
@@ -18,7 +18,6 @@ module_function
   MULTI_LEVEL_LINK_PATHS = [
     [:associated_taxons.recurring],
     [:child_taxons, :associated_taxons.recurring],
-    [:child_taxons.recurring, :legacy_taxons],
     [:child_taxons.recurring],
     [:parent.recurring],
     [:parent_taxons.recurring],
@@ -65,7 +64,6 @@ module_function
     root_taxon: :level_one_taxons,
     pages_part_of_step_nav: :part_of_step_navs,
     pages_related_to_step_nav: :related_to_step_navs,
-    legacy_taxons: :topic_taxonomy_taxons,
     pages_secondary_to_step_nav: :secondary_to_step_navs,
     person: :role_appointments,
     role: :role_appointments,


### PR DESCRIPTION
Legacy taxons are now deprected, and these links have now been removed from all content items, and from the schema, so we can remove expansion rules relating to them.

[Trello](https://trello.com/c/r9c2kyDA/1450-remove-legacytaxon-from-govuk-content-schemas-so-adding-a-legacy-taxon-to-new-content-items-is-no-longer-possible-m)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
