### PR TITLE
Correct document type on call for evidence examples

### DIFF
--- a/content_schemas/examples/call_for_evidence/frontend/closed_call_for_evidence.json
+++ b/content_schemas/examples/call_for_evidence/frontend/closed_call_for_evidence.json
@@ -6,7 +6,7 @@
   "title": "Review of Net Zero",
   "updated_at": "2016-09-05T15:00:00Z",
   "schema_name": "call_for_evidence",
-  "document_type": "call_for_evidence",
+  "document_type": "closed_call_for_evidence",
   "locale": "en",
   "details": {
     "body": "<div class=\"govspeak\"><p>The BEIS Secretary of State has commissioned a review to ensure that delivering the net zero target does not place undue burdens on businesses or consumers. The review will report at the end of 2022.</p>\n</div>",

--- a/content_schemas/examples/call_for_evidence/frontend/open_call_for_evidence.json
+++ b/content_schemas/examples/call_for_evidence/frontend/open_call_for_evidence.json
@@ -7,7 +7,7 @@
   "updated_at": "2023-05-24T22:45:10.294Z",
   "first_published_at": "2023-04-11T13:01:57.000+00:00",
   "schema_name": "call_for_evidence",
-  "document_type": "call_for_evidence",
+  "document_type": "open_call_for_evidence",
   "locale": "en",
   "details": {
     "body": "<div class=\"govspeak\"><p>The government is holding this call for evidence to identify opportunities to reduce the number of children (people aged under 18) accessing and using vape products, while ensuring they are still easily available as a quit aid for adult smokers.</p>\n</div>",


### PR DESCRIPTION
We have two fields on call for evidence one is called schema and one is called document_type. We need document_type to reflect the state of the call for evidence so it can be correctly rendered.

This corrects where the document_type has been put as the schema so we could work on the code in another app.

Trello card: https://trello.com/c/hxD7EECb/1467-update-document-types-for-call-for-evidence-in-publishing-api
