### PR TITLE
Add the field held on another site to example call for evidence

### DIFF
--- a/content_schemas/examples/call_for_evidence/frontend/open_call_for_evidence.json
+++ b/content_schemas/examples/call_for_evidence/frontend/open_call_for_evidence.json
@@ -20,6 +20,7 @@
         "note": "Added sub-topic tag."
       }
     ],
+    "held_on_another_website_url": "https://consult.education.gov.uk/part-time-maintenance-loans/post-graduate-doctoral-loans/",
     "tags": {
       "browse_pages": [
 


### PR DESCRIPTION
We have added the field `held_on_another_website` to the example open_call_for_evidence so that it can be used to test in the frontend rendering.

https://trello.com/c/ur96Ex4v/1466-add-the-field-held-on-another-website-to-open-call-for-evidence-example-in-publishing-api