### PR TITLE
Remove public feedback from call for evidence

### DIFF
--- a/content_schemas/dist/formats/call_for_evidence/frontend/schema.json
+++ b/content_schemas/dist/formats/call_for_evidence/frontend/schema.json
@@ -392,23 +392,6 @@
         "political": {
           "$ref": "#/definitions/political"
         },
-        "public_feedback_attachments": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "uniqueItems": true
-        },
-        "public_feedback_detail": {
-          "type": "string"
-        },
-        "public_feedback_documents": {
-          "$ref": "#/definitions/attachments_with_thumbnails"
-        },
-        "public_feedback_publication_date": {
-          "type": "string",
-          "format": "date-time"
-        },
         "tags": {
           "$ref": "#/definitions/tags"
         },

--- a/content_schemas/dist/formats/call_for_evidence/notification/schema.json
+++ b/content_schemas/dist/formats/call_for_evidence/notification/schema.json
@@ -498,23 +498,6 @@
         "political": {
           "$ref": "#/definitions/political"
         },
-        "public_feedback_attachments": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "uniqueItems": true
-        },
-        "public_feedback_detail": {
-          "type": "string"
-        },
-        "public_feedback_documents": {
-          "$ref": "#/definitions/attachments_with_thumbnails"
-        },
-        "public_feedback_publication_date": {
-          "type": "string",
-          "format": "date-time"
-        },
         "tags": {
           "$ref": "#/definitions/tags"
         },

--- a/content_schemas/dist/formats/call_for_evidence/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/call_for_evidence/publisher_v2/schema.json
@@ -317,23 +317,6 @@
         "political": {
           "$ref": "#/definitions/political"
         },
-        "public_feedback_attachments": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "uniqueItems": true
-        },
-        "public_feedback_detail": {
-          "type": "string"
-        },
-        "public_feedback_documents": {
-          "$ref": "#/definitions/attachments_with_thumbnails"
-        },
-        "public_feedback_publication_date": {
-          "type": "string",
-          "format": "date-time"
-        },
         "tags": {
           "$ref": "#/definitions/tags"
         },

--- a/content_schemas/formats/call_for_evidence.jsonnet
+++ b/content_schemas/formats/call_for_evidence.jsonnet
@@ -85,23 +85,6 @@
             },
           },
         },
-        public_feedback_publication_date: {
-          type: "string",
-          format: "date-time",
-        },
-        public_feedback_detail: {
-          type: "string",
-        },
-        public_feedback_documents: {
-          "$ref": "#/definitions/attachments_with_thumbnails",
-        },
-        public_feedback_attachments: {
-          type: "array",
-          uniqueItems: true,
-          items: {
-            type: "string",
-          },
-        },
         final_outcome_publication_date: {
           type: "string",
           format: "date-time",


### PR DESCRIPTION
When a closed call for evidence has results published to it, we only upload an outcome, therefore the public feedback options can be removed from the content_schemas.

trello card: https://trello.com/c/LVOk25hB/1476-remove-public-feedback-from-call-for-evidence-in-publishing-api