### PR TITLE
Add taxonomy_topic_email_override to document collection schema

### DIFF
--- a/content_schemas/dist/formats/document_collection/frontend/schema.json
+++ b/content_schemas/dist/formats/document_collection/frontend/schema.json
@@ -159,6 +159,11 @@
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "taxonomy_topic_email_override": {
+          "description": "The taxonomy topic that email subscriptions for this document collection should go to - only for document collections converted from specialist topics",
+          "$ref": "#/definitions/frontend_links_with_base_path",
+          "maxItems": 1
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/content_schemas/dist/formats/document_collection/notification/schema.json
+++ b/content_schemas/dist/formats/document_collection/notification/schema.json
@@ -177,6 +177,11 @@
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "taxonomy_topic_email_override": {
+          "description": "The taxonomy topic that email subscriptions for this document collection should go to - only for document collections converted from specialist topics",
+          "$ref": "#/definitions/frontend_links_with_base_path",
+          "maxItems": 1
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -270,6 +275,11 @@
         "suggested_ordered_related_items": {
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/guid_list"
+        },
+        "taxonomy_topic_email_override": {
+          "description": "The taxonomy topic that email subscriptions for this document collection should go to - only for document collections converted from specialist topics",
+          "$ref": "#/definitions/guid_list",
+          "maxItems": 1
         },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",

--- a/content_schemas/dist/formats/document_collection/publisher_v2/links.json
+++ b/content_schemas/dist/formats/document_collection/publisher_v2/links.json
@@ -77,6 +77,11 @@
           "description": "New A/B test suggestions for related items. Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms included in this A/B test.",
           "$ref": "#/definitions/guid_list"
         },
+        "taxonomy_topic_email_override": {
+          "description": "The taxonomy topic that email subscriptions for this document collection should go to - only for document collections converted from specialist topics",
+          "$ref": "#/definitions/guid_list",
+          "maxItems": 1
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/formats/document_collection.jsonnet
+++ b/content_schemas/formats/document_collection.jsonnet
@@ -80,5 +80,9 @@
     related_mainstream_content: "",
     documents: "",
     topical_events: "The topical events that are part of this document collection.",
+    taxonomy_topic_email_override: {
+        description: "The taxonomy topic that email subscriptions for this document collection should go to - only for document collections converted from specialist topics",
+        maxItems: 1
+    },
   },
 }


### PR DESCRIPTION
This is an optional field that, if present, will contain the base path of the taxonomy that the document collection's email signup button should instead be used as the url to signup a user for email subscriptions.

This is part of work to retire specialist topics, and is being implemented specifically to support behaviour requested by HMRC for a small number of document collections that have been created to replace specialist topics. This field will not be present for the vast majority of document collections

[Trello](https://trello.com/c/YVmmF0Yz/1889-add-emailsignupoverride-to-document-collection-content-schema-s)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
