### PR TITLE
Delete placeholder translations

### DIFF
--- a/db/migrate/20230711131421_delete_placeholder_published_translations.rb
+++ b/db/migrate/20230711131421_delete_placeholder_published_translations.rb
@@ -1,0 +1,42 @@
+require_relative "helpers/delete_content"
+
+class DeletePlaceholderPublishedTranslations < ActiveRecord::Migration[7.0]
+  class NotPlaceholderTranslationError < StandardError; end
+
+  def up
+    base_paths = %w[
+      /world/organisations/british-embassy-riga/about/complaints-procedure.lv
+      /world/organisations/british-embassy-in-costa-rica.es
+      /world/organisations/department-for-international-trade-argentina.es-419
+      /world/organisations/department-for-international-trade-czech-republic.cs
+      /world/organisations/department-for-international-trade-ecuador.es-419
+      /world/organisations/department-for-international-trade-kazakhstan.ru
+      /world/organisations/department-for-international-trade-latvia.lv
+      /world/organisations/department-for-international-trade-morocco.ar
+      /world/organisations/department-for-international-trade-pakistan.ur
+      /world/organisations/department-for-international-trade-portugal.pt
+      /world/organisations/department-for-international-trade-south-korea.ar
+      /world/organisations/department-for-international-trade-taiwan.zh-tw
+      /world/organisations/department-for-international-trade-thailand.th
+      /world/organisations/department-for-international-trade-united-arab-emirates.ar
+      /world/organisations/uk-science-and-innovation-network.hi
+      /world/organisations/uk-science-innovation-network-in-chile.es-419
+      /government/world/organisations/british-embassy-colombia.es
+      /government/world/organisations/dfid-china.zh-tw
+      /world/organisations/dfid-china.zh
+      /world/organisations/dfid-middle-east-and-north-africa.ar
+      /world/organisations/dfid-bangladesh.bn
+      /world/organisations/dfid-pakistan.ur
+      /world/organisations/dfid-drc.fr
+      /world/organisations/dfid-india.hi
+    ]
+
+    editions = Edition.where(base_path: base_paths, state: "published")
+
+    raise NotPlaceholderTranslationError if editions.any? { |edition| !edition.schema_name.include?("placeholder") }
+
+    Helpers::DeleteContent.destroy_edition_supporting_objects(editions)
+
+    editions.destroy_all
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_03_28_161842) do
+ActiveRecord::Schema[7.0].define(version: 2023_07_11_131421) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 

--- a/docs/deleting-content.md
+++ b/docs/deleting-content.md
@@ -25,7 +25,7 @@ class RemoveYourEdition < ActiveRecord::Migration
   def up
     editions = Edition.where(id: 123)
 
-    Helpers::DeleteContent.destroy_supporting_objects(editions)
+    Helpers::DeleteContent.destroy_edition_supporting_objects(editions)
 
     editions.destroy_all
   end


### PR DESCRIPTION
https://trello.com/c/xxdiO4lZ

> **Note**
> In order to test this I have:
> - deployed this branch to integration to run the migration
> - republished the WW Orgs rendered by "government-frontend" (by deploying this branch https://github.com/alphagov/whitehall/pull/7937)
> - clicked down the list of suspects in [the CSV](https://trello.com/c/xxdiO4lZ/732-delete-placeholder-translations) to see that everything is rendered okay

### Delete placeholder translations
These placeholder translations get automatically expanded into the
`available_translations` for their content item, but they are not valid for
display, so they cause errors when using government-frontend to render
worldwide organisations.

### Fix method name in outdated documentation
This method was renamed in the past (#683), but the relevant documentation
still has the old method name.

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
