### PR TITLE
Add additional world location information to /world content item

### DIFF
--- a/content_schemas/dist/formats/world_index/frontend/schema.json
+++ b/content_schemas/dist/formats/world_index/frontend/schema.json
@@ -307,15 +307,32 @@
           "items": {
             "type": "object",
             "required": [
+              "active",
+              "content_id",
               "name",
               "slug",
-              "active"
+              "updated_at"
             ],
             "additionalProperties": false,
             "properties": {
               "active": {
                 "description": "Whether the location is currently active",
                 "type": "boolean"
+              },
+              "analytics_identifier": {
+                "description": "The analytics identifier for the international delegation",
+                "type": "string"
+              },
+              "content_id": {
+                "description": "The content ID for the international delegation",
+                "$ref": "#/definitions/guid"
+              },
+              "iso2": {
+                "description": "The two-letter code for the international delegation in ISO2 format",
+                "type": [
+                  "string",
+                  "null"
+                ]
               },
               "name": {
                 "description": "The name of the international delegation",
@@ -324,6 +341,11 @@
               "slug": {
                 "description": "The slug of the international delegation",
                 "type": "string"
+              },
+              "updated_at": {
+                "description": "The timestamp for the last update to the international delegation",
+                "type": "string",
+                "format": "date-time"
               }
             }
           }
@@ -333,15 +355,32 @@
           "items": {
             "type": "object",
             "required": [
+              "active",
+              "content_id",
               "name",
               "slug",
-              "active"
+              "updated_at"
             ],
             "additionalProperties": false,
             "properties": {
               "active": {
                 "description": "Whether the location is currently active",
                 "type": "boolean"
+              },
+              "analytics_identifier": {
+                "description": "The analytics identifier for the world location",
+                "type": "string"
+              },
+              "content_id": {
+                "description": "The content ID for the world location",
+                "$ref": "#/definitions/guid"
+              },
+              "iso2": {
+                "description": "The two-letter code for the world location in ISO2 format",
+                "type": [
+                  "string",
+                  "null"
+                ]
               },
               "name": {
                 "description": "The name of the world location",
@@ -350,6 +389,11 @@
               "slug": {
                 "description": "The slug of the world location",
                 "type": "string"
+              },
+              "updated_at": {
+                "description": "The timestamp for the last update to the world location",
+                "type": "string",
+                "format": "date-time"
               }
             }
           }

--- a/content_schemas/dist/formats/world_index/notification/schema.json
+++ b/content_schemas/dist/formats/world_index/notification/schema.json
@@ -398,15 +398,32 @@
           "items": {
             "type": "object",
             "required": [
+              "active",
+              "content_id",
               "name",
               "slug",
-              "active"
+              "updated_at"
             ],
             "additionalProperties": false,
             "properties": {
               "active": {
                 "description": "Whether the location is currently active",
                 "type": "boolean"
+              },
+              "analytics_identifier": {
+                "description": "The analytics identifier for the international delegation",
+                "type": "string"
+              },
+              "content_id": {
+                "description": "The content ID for the international delegation",
+                "$ref": "#/definitions/guid"
+              },
+              "iso2": {
+                "description": "The two-letter code for the international delegation in ISO2 format",
+                "type": [
+                  "string",
+                  "null"
+                ]
               },
               "name": {
                 "description": "The name of the international delegation",
@@ -415,6 +432,11 @@
               "slug": {
                 "description": "The slug of the international delegation",
                 "type": "string"
+              },
+              "updated_at": {
+                "description": "The timestamp for the last update to the international delegation",
+                "type": "string",
+                "format": "date-time"
               }
             }
           }
@@ -424,15 +446,32 @@
           "items": {
             "type": "object",
             "required": [
+              "active",
+              "content_id",
               "name",
               "slug",
-              "active"
+              "updated_at"
             ],
             "additionalProperties": false,
             "properties": {
               "active": {
                 "description": "Whether the location is currently active",
                 "type": "boolean"
+              },
+              "analytics_identifier": {
+                "description": "The analytics identifier for the world location",
+                "type": "string"
+              },
+              "content_id": {
+                "description": "The content ID for the world location",
+                "$ref": "#/definitions/guid"
+              },
+              "iso2": {
+                "description": "The two-letter code for the world location in ISO2 format",
+                "type": [
+                  "string",
+                  "null"
+                ]
               },
               "name": {
                 "description": "The name of the world location",
@@ -441,6 +480,11 @@
               "slug": {
                 "description": "The slug of the world location",
                 "type": "string"
+              },
+              "updated_at": {
+                "description": "The timestamp for the last update to the world location",
+                "type": "string",
+                "format": "date-time"
               }
             }
           }

--- a/content_schemas/dist/formats/world_index/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/world_index/publisher_v2/schema.json
@@ -186,15 +186,32 @@
           "items": {
             "type": "object",
             "required": [
+              "active",
+              "content_id",
               "name",
               "slug",
-              "active"
+              "updated_at"
             ],
             "additionalProperties": false,
             "properties": {
               "active": {
                 "description": "Whether the location is currently active",
                 "type": "boolean"
+              },
+              "analytics_identifier": {
+                "description": "The analytics identifier for the international delegation",
+                "type": "string"
+              },
+              "content_id": {
+                "description": "The content ID for the international delegation",
+                "$ref": "#/definitions/guid"
+              },
+              "iso2": {
+                "description": "The two-letter code for the international delegation in ISO2 format",
+                "type": [
+                  "string",
+                  "null"
+                ]
               },
               "name": {
                 "description": "The name of the international delegation",
@@ -203,6 +220,11 @@
               "slug": {
                 "description": "The slug of the international delegation",
                 "type": "string"
+              },
+              "updated_at": {
+                "description": "The timestamp for the last update to the international delegation",
+                "type": "string",
+                "format": "date-time"
               }
             }
           }
@@ -212,15 +234,32 @@
           "items": {
             "type": "object",
             "required": [
+              "active",
+              "content_id",
               "name",
               "slug",
-              "active"
+              "updated_at"
             ],
             "additionalProperties": false,
             "properties": {
               "active": {
                 "description": "Whether the location is currently active",
                 "type": "boolean"
+              },
+              "analytics_identifier": {
+                "description": "The analytics identifier for the world location",
+                "type": "string"
+              },
+              "content_id": {
+                "description": "The content ID for the world location",
+                "$ref": "#/definitions/guid"
+              },
+              "iso2": {
+                "description": "The two-letter code for the world location in ISO2 format",
+                "type": [
+                  "string",
+                  "null"
+                ]
               },
               "name": {
                 "description": "The name of the world location",
@@ -229,6 +268,11 @@
               "slug": {
                 "description": "The slug of the world location",
                 "type": "string"
+              },
+              "updated_at": {
+                "description": "The timestamp for the last update to the world location",
+                "type": "string",
+                "format": "date-time"
               }
             }
           }

--- a/content_schemas/examples/world_index/frontend/world_index.json
+++ b/content_schemas/examples/world_index/frontend/world_index.json
@@ -35,1200 +35,2157 @@
   "description": null,
   "details": {
     "world_locations": [{
+        "active": true,
+        "analytics_identifier": "WL1",
+        "content_id": "5e9ecbce-7706-11e4-a3cb-005056011aef",
+        "iso2": "AF",
         "name": "Afghanistan",
         "slug": "afghanistan",
-        "active": true
+        "updated_at": "2021-08-31T21:15:56.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL2",
+        "content_id": "5e9ece18-7706-11e4-a3cb-005056011aef",
+        "iso2": "AL",
         "name": "Albania",
         "slug": "albania",
-        "active": true
+        "updated_at": "2020-09-02T08:27:15.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL3",
+        "content_id": "5e9ece9b-7706-11e4-a3cb-005056011aef",
+        "iso2": "DZ",
         "name": "Algeria",
         "slug": "algeria",
-        "active": true
+        "updated_at": "2017-08-15T15:41:21.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL4",
+        "content_id": "5e9ecefc-7706-11e4-a3cb-005056011aef",
+        "iso2": "AO",
         "name": "Angola",
         "slug": "angola",
-        "active": true
+        "updated_at": "2017-08-15T15:41:21.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL5",
+        "content_id": "5e9ecf58-7706-11e4-a3cb-005056011aef",
+        "iso2": "AI",
         "name": "Anguilla",
         "slug": "anguilla",
-        "active": true
+        "updated_at": "2017-08-15T15:41:21.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL6",
+        "content_id": "5e9ecfba-7706-11e4-a3cb-005056011aef",
+        "iso2": "AR",
         "name": "Argentina",
         "slug": "argentina",
-        "active": true
+        "updated_at": "2017-08-15T15:41:22.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL7",
+        "content_id": "5e9ed016-7706-11e4-a3cb-005056011aef",
+        "iso2": "AM",
         "name": "Armenia",
         "slug": "armenia",
-        "active": true
+        "updated_at": "2017-12-06T13:04:22.000+00:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL8",
+        "content_id": "5e9ed06a-7706-11e4-a3cb-005056011aef",
+        "iso2": "AU",
         "name": "Australia",
         "slug": "australia",
-        "active": true
+        "updated_at": "2017-08-15T15:41:22.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL9",
+        "content_id": "5e9ed0c6-7706-11e4-a3cb-005056011aef",
+        "iso2": "AT",
         "name": "Austria",
         "slug": "austria",
-        "active": true
+        "updated_at": "2017-08-15T15:41:23.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL10",
+        "content_id": "5e9ed112-7706-11e4-a3cb-005056011aef",
+        "iso2": "AZ",
         "name": "Azerbaijan",
         "slug": "azerbaijan",
-        "active": true
+        "updated_at": "2017-08-15T15:41:23.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL11",
+        "content_id": "5e9ed163-7706-11e4-a3cb-005056011aef",
+        "iso2": "BH",
         "name": "Bahrain",
         "slug": "bahrain",
-        "active": true
+        "updated_at": "2022-07-18T06:23:04.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL12",
+        "content_id": "5e9ed1b2-7706-11e4-a3cb-005056011aef",
+        "iso2": "BD",
         "name": "Bangladesh",
         "slug": "bangladesh",
-        "active": true
+        "updated_at": "2020-09-02T06:49:33.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL13",
+        "content_id": "5e9eda90-7706-11e4-a3cb-005056011aef",
+        "iso2": "BB",
         "name": "Barbados",
         "slug": "barbados",
-        "active": true
+        "updated_at": "2020-09-02T07:41:48.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL14",
+        "content_id": "5e9edb00-7706-11e4-a3cb-005056011aef",
+        "iso2": "BY",
         "name": "Belarus",
         "slug": "belarus",
-        "active": true
+        "updated_at": "2022-01-06T10:03:44.000+00:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL15",
+        "content_id": "5e9edb47-7706-11e4-a3cb-005056011aef",
+        "iso2": "BE",
         "name": "Belgium",
         "slug": "belgium",
-        "active": true
+        "updated_at": "2017-08-25T11:35:19.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL16",
+        "content_id": "5e9edb8b-7706-11e4-a3cb-005056011aef",
+        "iso2": "BZ",
         "name": "Belize",
         "slug": "belize",
-        "active": true
+        "updated_at": "2020-09-02T06:50:44.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL17",
+        "content_id": "5e9edbcf-7706-11e4-a3cb-005056011aef",
+        "iso2": "BO",
         "name": "Bolivia",
         "slug": "bolivia",
-        "active": true
+        "updated_at": "2017-08-31T09:22:42.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL18",
+        "content_id": "5e9edc11-7706-11e4-a3cb-005056011aef",
+        "iso2": "BA",
         "name": "Bosnia and Herzegovina",
         "slug": "bosnia-and-herzegovina",
-        "active": true
+        "updated_at": "2019-08-14T14:06:30.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL19",
+        "content_id": "5e9edc56-7706-11e4-a3cb-005056011aef",
+        "iso2": "BW",
         "name": "Botswana",
         "slug": "botswana",
-        "active": true
+        "updated_at": "2017-08-15T15:41:25.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL20",
+        "content_id": "5e9edfc1-7706-11e4-a3cb-005056011aef",
+        "iso2": "BR",
         "name": "Brazil",
         "slug": "brazil",
-        "active": true
+        "updated_at": "2017-08-30T10:12:12.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL21",
+        "content_id": "5e9ee03f-7706-11e4-a3cb-005056011aef",
+        "iso2": null,
         "name": "British Antarctic Territory",
         "slug": "british-antarctic-territory",
-        "active": true
+        "updated_at": "2019-11-18T13:04:30.000+00:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL22",
+        "content_id": "5e9ee0a7-7706-11e4-a3cb-005056011aef",
+        "iso2": "VG",
         "name": "British Virgin Islands",
         "slug": "british-virgin-islands",
-        "active": true
+        "updated_at": "2017-08-15T15:41:26.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL23",
+        "content_id": "5e9ee108-7706-11e4-a3cb-005056011aef",
+        "iso2": "BN",
         "name": "Brunei",
         "slug": "brunei",
-        "active": true
+        "updated_at": "2017-08-15T15:41:27.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL24",
+        "content_id": "5e9ee4d4-7706-11e4-a3cb-005056011aef",
+        "iso2": "BG",
         "name": "Bulgaria",
         "slug": "bulgaria",
-        "active": true
+        "updated_at": "2017-08-30T14:30:24.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL25",
+        "content_id": "5e9ee557-7706-11e4-a3cb-005056011aef",
+        "iso2": "MM",
         "name": "Myanmar",
         "slug": "myanmar",
-        "active": true
+        "updated_at": "2020-09-02T07:19:38.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL26",
+        "content_id": "5e9ee5ba-7706-11e4-a3cb-005056011aef",
+        "iso2": "KH",
         "name": "Cambodia",
         "slug": "cambodia",
-        "active": true
+        "updated_at": "2017-08-15T15:41:27.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL27",
+        "content_id": "5e9ee834-7706-11e4-a3cb-005056011aef",
+        "iso2": "CM",
         "name": "Cameroon",
         "slug": "cameroon",
-        "active": true
+        "updated_at": "2017-08-15T15:41:28.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL28",
+        "content_id": "5e9ee897-7706-11e4-a3cb-005056011aef",
+        "iso2": "CA",
         "name": "Canada",
         "slug": "canada",
-        "active": true
+        "updated_at": "2017-08-15T15:41:28.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL29",
+        "content_id": "5e9eeb55-7706-11e4-a3cb-005056011aef",
+        "iso2": "KY",
         "name": "Cayman Islands",
         "slug": "cayman-islands",
-        "active": true
+        "updated_at": "2020-09-02T08:37:53.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL30",
+        "content_id": "5e9eedd1-7706-11e4-a3cb-005056011aef",
+        "iso2": "CL",
         "name": "Chile",
         "slug": "chile",
-        "active": true
+        "updated_at": "2020-09-02T11:14:15.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL31",
+        "content_id": "5e9ef857-7706-11e4-a3cb-005056011aef",
+        "iso2": "CN",
         "name": "China",
         "slug": "china",
-        "active": true
+        "updated_at": "2020-09-02T06:54:55.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL32",
+        "content_id": "5e9ef8c7-7706-11e4-a3cb-005056011aef",
+        "iso2": "CO",
         "name": "Colombia",
         "slug": "colombia",
-        "active": true
+        "updated_at": "2017-08-31T09:44:50.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL33",
+        "content_id": "5e9ef90e-7706-11e4-a3cb-005056011aef",
+        "iso2": "CR",
         "name": "Costa Rica",
         "slug": "costa-rica",
-        "active": true
+        "updated_at": "2017-08-30T10:32:12.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL34",
+        "content_id": "5e9ef952-7706-11e4-a3cb-005056011aef",
+        "iso2": "HR",
         "name": "Croatia",
         "slug": "croatia",
-        "active": true
+        "updated_at": "2017-08-30T10:53:45.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL35",
+        "content_id": "5e9ef997-7706-11e4-a3cb-005056011aef",
+        "iso2": "CU",
         "name": "Cuba",
         "slug": "cuba",
-        "active": true
+        "updated_at": "2017-08-30T11:03:18.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL36",
+        "content_id": "5e9efa29-7706-11e4-a3cb-005056011aef",
+        "iso2": "CY",
         "name": "Cyprus",
         "slug": "cyprus",
-        "active": true
+        "updated_at": "2017-08-15T15:41:30.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL37",
+        "content_id": "5e9efa75-7706-11e4-a3cb-005056011aef",
+        "iso2": "CZ",
         "name": "Czech Republic",
         "slug": "czech-republic",
-        "active": true
+        "updated_at": "2020-09-02T09:27:33.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL38",
+        "content_id": "5e9efab9-7706-11e4-a3cb-005056011aef",
+        "iso2": "CD",
         "name": "Democratic Republic of the Congo",
         "slug": "democratic-republic-of-the-congo",
-        "active": true
+        "updated_at": "2020-09-02T06:55:27.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL39",
+        "content_id": "5e9efafc-7706-11e4-a3cb-005056011aef",
+        "iso2": "DK",
         "name": "Denmark",
         "slug": "denmark",
-        "active": true
+        "updated_at": "2017-08-30T11:10:05.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL40",
+        "content_id": "5e9efb41-7706-11e4-a3cb-005056011aef",
+        "iso2": "DO",
         "name": "Dominican Republic",
         "slug": "dominican-republic",
-        "active": true
+        "updated_at": "2017-10-10T15:31:35.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL41",
+        "content_id": "5e9efb82-7706-11e4-a3cb-005056011aef",
+        "iso2": "EC",
         "name": "Ecuador",
         "slug": "ecuador",
-        "active": true
+        "updated_at": "2017-08-30T11:20:43.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL42",
+        "content_id": "5e9efbc4-7706-11e4-a3cb-005056011aef",
+        "iso2": "EG",
         "name": "Egypt",
         "slug": "egypt",
-        "active": true
+        "updated_at": "2022-01-10T13:59:12.000+00:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL43",
+        "content_id": "5e9efc06-7706-11e4-a3cb-005056011aef",
+        "iso2": "ER",
         "name": "Eritrea",
         "slug": "eritrea",
-        "active": true
+        "updated_at": "2017-08-15T15:41:32.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL44",
+        "content_id": "5e9eff2c-7706-11e4-a3cb-005056011aef",
+        "iso2": "EE",
         "name": "Estonia",
         "slug": "estonia",
-        "active": true
+        "updated_at": "2017-08-15T15:41:32.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL45",
+        "content_id": "5e9f0000-7706-11e4-a3cb-005056011aef",
+        "iso2": "ET",
         "name": "Ethiopia",
         "slug": "ethiopia",
-        "active": true
+        "updated_at": "2021-05-26T15:26:20.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL46",
+        "content_id": "5e9f0046-7706-11e4-a3cb-005056011aef",
+        "iso2": "FJ",
         "name": "Fiji",
         "slug": "fiji",
-        "active": true
+        "updated_at": "2021-05-14T12:53:31.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL47",
+        "content_id": "5e9f008b-7706-11e4-a3cb-005056011aef",
+        "iso2": "FI",
         "name": "Finland",
         "slug": "finland",
-        "active": true
+        "updated_at": "2017-08-30T11:31:31.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL48",
+        "content_id": "5e9f00ce-7706-11e4-a3cb-005056011aef",
+        "iso2": "FR",
         "name": "France",
         "slug": "france",
-        "active": true
+        "updated_at": "2017-08-28T09:40:55.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL49",
+        "content_id": "5e9f010f-7706-11e4-a3cb-005056011aef",
+        "iso2": "GM",
         "name": "The Gambia",
         "slug": "the-gambia",
-        "active": true
+        "updated_at": "2018-08-03T13:22:48.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL50",
+        "content_id": "5e9f0155-7706-11e4-a3cb-005056011aef",
+        "iso2": "GE",
         "name": "Georgia",
         "slug": "georgia",
-        "active": true
+        "updated_at": "2017-09-06T15:39:56.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL51",
+        "content_id": "5e9f0197-7706-11e4-a3cb-005056011aef",
+        "iso2": "DE",
         "name": "Germany",
         "slug": "germany",
-        "active": true
+        "updated_at": "2017-08-15T15:41:34.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL52",
+        "content_id": "5e9f01da-7706-11e4-a3cb-005056011aef",
+        "iso2": "GH",
         "name": "Ghana",
         "slug": "ghana",
-        "active": true
+        "updated_at": "2020-09-02T06:57:33.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL53",
+        "content_id": "5e9f021d-7706-11e4-a3cb-005056011aef",
+        "iso2": "GR",
         "name": "Greece",
         "slug": "greece",
-        "active": true
+        "updated_at": "2020-09-02T08:35:11.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL54",
+        "content_id": "5e9f025d-7706-11e4-a3cb-005056011aef",
+        "iso2": "GT",
         "name": "Guatemala",
         "slug": "guatemala",
-        "active": true
+        "updated_at": "2017-08-15T15:41:35.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL55",
+        "content_id": "5e9f02a1-7706-11e4-a3cb-005056011aef",
+        "iso2": "GY",
         "name": "Guyana",
         "slug": "guyana",
-        "active": true
+        "updated_at": "2020-09-02T06:58:41.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL56",
+        "content_id": "5e9f02e3-7706-11e4-a3cb-005056011aef",
+        "iso2": "VA",
         "name": "Holy See",
         "slug": "holy-see",
-        "active": true
+        "updated_at": "2021-08-03T13:12:18.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL57",
+        "content_id": "5e9f0326-7706-11e4-a3cb-005056011aef",
+        "iso2": "HN",
         "name": "Honduras",
         "slug": "honduras",
-        "active": true
+        "updated_at": "2017-08-15T15:41:36.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL58",
+        "content_id": "5e9f0369-7706-11e4-a3cb-005056011aef",
+        "iso2": "HK",
         "name": "Hong Kong",
         "slug": "hong-kong",
-        "active": true
+        "updated_at": "2017-08-15T15:41:36.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL59",
+        "content_id": "5e9f03ad-7706-11e4-a3cb-005056011aef",
+        "iso2": "HU",
         "name": "Hungary",
         "slug": "hungary",
-        "active": true
+        "updated_at": "2022-08-08T08:01:13.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL60",
+        "content_id": "5e9f0435-7706-11e4-a3cb-005056011aef",
+        "iso2": "IS",
         "name": "Iceland",
         "slug": "iceland",
-        "active": true
+        "updated_at": "2017-08-30T11:36:22.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL61",
+        "content_id": "5e9f047a-7706-11e4-a3cb-005056011aef",
+        "iso2": "IN",
         "name": "India",
         "slug": "india",
-        "active": true
+        "updated_at": "2020-09-02T06:59:51.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL62",
+        "content_id": "5e9f04bd-7706-11e4-a3cb-005056011aef",
+        "iso2": "ID",
         "name": "Indonesia",
         "slug": "indonesia",
-        "active": true
+        "updated_at": "2020-09-02T07:01:49.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL63",
+        "content_id": "5e9f05e7-7706-11e4-a3cb-005056011aef",
+        "iso2": "IR",
         "name": "Iran",
         "slug": "iran",
-        "active": true
+        "updated_at": "2020-04-30T16:14:02.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL64",
+        "content_id": "5e9f0663-7706-11e4-a3cb-005056011aef",
+        "iso2": "IQ",
         "name": "Iraq",
         "slug": "iraq",
-        "active": true
+        "updated_at": "2022-07-25T18:25:55.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL65",
+        "content_id": "5e9f06a8-7706-11e4-a3cb-005056011aef",
+        "iso2": "IE",
         "name": "Ireland",
         "slug": "ireland",
-        "active": true
+        "updated_at": "2017-09-14T10:53:54.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL66",
+        "content_id": "5e9f06ed-7706-11e4-a3cb-005056011aef",
+        "iso2": "IL",
         "name": "Israel",
         "slug": "israel",
-        "active": true
+        "updated_at": "2017-08-15T15:41:39.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL67",
+        "content_id": "5e9f0730-7706-11e4-a3cb-005056011aef",
+        "iso2": "IT",
         "name": "Italy",
         "slug": "italy",
-        "active": true
+        "updated_at": "2017-08-15T15:41:39.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL68",
+        "content_id": "5e9f0774-7706-11e4-a3cb-005056011aef",
+        "iso2": "JM",
         "name": "Jamaica",
         "slug": "jamaica",
-        "active": true
+        "updated_at": "2020-09-02T07:39:03.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL69",
+        "content_id": "5e9f07b7-7706-11e4-a3cb-005056011aef",
+        "iso2": "JP",
         "name": "Japan",
         "slug": "japan",
-        "active": true
+        "updated_at": "2017-08-15T15:41:39.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL71",
+        "content_id": "5e9f07fa-7706-11e4-a3cb-005056011aef",
+        "iso2": "JO",
         "name": "Jordan",
         "slug": "jordan",
-        "active": true
+        "updated_at": "2020-09-02T07:03:12.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL72",
+        "content_id": "5e9f083d-7706-11e4-a3cb-005056011aef",
+        "iso2": "KZ",
         "name": "Kazakhstan",
         "slug": "kazakhstan",
-        "active": true
+        "updated_at": "2020-10-30T09:13:10.000+00:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL73",
+        "content_id": "5e9f0880-7706-11e4-a3cb-005056011aef",
+        "iso2": "KE",
         "name": "Kenya",
         "slug": "kenya",
-        "active": true
+        "updated_at": "2020-09-02T07:03:40.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL74",
+        "content_id": "5e9f08c4-7706-11e4-a3cb-005056011aef",
+        "iso2": null,
         "name": "Kosovo",
         "slug": "kosovo",
-        "active": true
+        "updated_at": "2017-08-15T15:41:41.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL75",
+        "content_id": "5e9f0908-7706-11e4-a3cb-005056011aef",
+        "iso2": "KW",
         "name": "Kuwait",
         "slug": "kuwait",
-        "active": true
+        "updated_at": "2017-08-15T15:41:41.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL76",
+        "content_id": "5e9f094e-7706-11e4-a3cb-005056011aef",
+        "iso2": "LA",
         "name": "Laos",
         "slug": "laos",
-        "active": true
+        "updated_at": "2017-08-15T15:41:41.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL77",
+        "content_id": "5e9f099e-7706-11e4-a3cb-005056011aef",
+        "iso2": "LV",
         "name": "Latvia",
         "slug": "latvia",
-        "active": true
+        "updated_at": "2017-08-15T15:41:42.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL78",
+        "content_id": "5e9f0a28-7706-11e4-a3cb-005056011aef",
+        "iso2": "LB",
         "name": "Lebanon",
         "slug": "lebanon",
-        "active": true
+        "updated_at": "2020-09-02T07:04:39.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL79",
+        "content_id": "5e9f0ab6-7706-11e4-a3cb-005056011aef",
+        "iso2": "LY",
         "name": "Libya",
         "slug": "libya",
-        "active": true
+        "updated_at": "2020-09-02T07:07:31.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL80",
+        "content_id": "5e9f0c3a-7706-11e4-a3cb-005056011aef",
+        "iso2": "LT",
         "name": "Lithuania",
         "slug": "lithuania",
-        "active": true
+        "updated_at": "2017-08-15T15:41:42.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL81",
+        "content_id": "5e9f0cb0-7706-11e4-a3cb-005056011aef",
+        "iso2": "LU",
         "name": "Luxembourg",
         "slug": "luxembourg",
-        "active": true
+        "updated_at": "2017-08-15T15:41:43.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL82",
+        "content_id": "5e9f0cf4-7706-11e4-a3cb-005056011aef",
+        "iso2": "MK",
         "name": "North Macedonia",
         "slug": "north-macedonia",
-        "active": true
+        "updated_at": "2020-12-30T07:58:32.000+00:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL83",
+        "content_id": "5e9f0d38-7706-11e4-a3cb-005056011aef",
+        "iso2": "MG",
         "name": "Madagascar",
         "slug": "madagascar",
-        "active": true
+        "updated_at": "2017-08-15T15:41:43.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL84",
+        "content_id": "5e9f0d7c-7706-11e4-a3cb-005056011aef",
+        "iso2": "MW",
         "name": "Malawi",
         "slug": "malawi",
-        "active": true
+        "updated_at": "2020-09-02T06:46:48.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL85",
+        "content_id": "5e9f0dbf-7706-11e4-a3cb-005056011aef",
+        "iso2": "MY",
         "name": "Malaysia",
         "slug": "malaysia",
-        "active": true
+        "updated_at": "2017-08-15T15:41:44.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL86",
+        "content_id": "5e9f0e04-7706-11e4-a3cb-005056011aef",
+        "iso2": "MV",
         "name": "Maldives",
         "slug": "maldives",
-        "active": true
+        "updated_at": "2017-08-15T15:41:44.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL87",
+        "content_id": "5e9f0e45-7706-11e4-a3cb-005056011aef",
+        "iso2": "ML",
         "name": "Mali",
         "slug": "mali",
-        "active": true
+        "updated_at": "2020-09-02T07:08:34.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL88",
+        "content_id": "5e9f0e88-7706-11e4-a3cb-005056011aef",
+        "iso2": "MT",
         "name": "Malta",
         "slug": "malta",
-        "active": true
+        "updated_at": "2017-08-30T11:55:21.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL89",
+        "content_id": "5e9f0ecb-7706-11e4-a3cb-005056011aef",
+        "iso2": "MU",
         "name": "Mauritius",
         "slug": "mauritius",
-        "active": true
+        "updated_at": "2017-08-15T15:41:45.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL90",
+        "content_id": "5e9f0f0c-7706-11e4-a3cb-005056011aef",
+        "iso2": "MX",
         "name": "Mexico",
         "slug": "mexico",
-        "active": true
+        "updated_at": "2022-08-30T18:08:04.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL91",
+        "content_id": "5e9f0f4f-7706-11e4-a3cb-005056011aef",
+        "iso2": "MD",
         "name": "Moldova",
         "slug": "moldova",
-        "active": true
+        "updated_at": "2017-08-31T11:41:22.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL92",
+        "content_id": "5e9f0f90-7706-11e4-a3cb-005056011aef",
+        "iso2": "MN",
         "name": "Mongolia",
         "slug": "mongolia",
-        "active": true
+        "updated_at": "2017-08-15T15:41:46.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL93",
+        "content_id": "5e9f0fd3-7706-11e4-a3cb-005056011aef",
+        "iso2": "ME",
         "name": "Montenegro",
         "slug": "montenegro",
-        "active": true
+        "updated_at": "2017-08-15T15:41:46.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL94",
+        "content_id": "5e9f1016-7706-11e4-a3cb-005056011aef",
+        "iso2": "MS",
         "name": "Montserrat",
         "slug": "montserrat",
-        "active": true
+        "updated_at": "2020-09-02T07:09:38.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL95",
+        "content_id": "5e9f1057-7706-11e4-a3cb-005056011aef",
+        "iso2": "MA",
         "name": "Morocco",
         "slug": "morocco",
-        "active": true
+        "updated_at": "2020-09-02T07:41:56.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL96",
+        "content_id": "5e9f109a-7706-11e4-a3cb-005056011aef",
+        "iso2": "MZ",
         "name": "Mozambique",
         "slug": "mozambique",
-        "active": true
+        "updated_at": "2020-09-02T07:10:04.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL97",
+        "content_id": "5e9f10de-7706-11e4-a3cb-005056011aef",
+        "iso2": "NA",
         "name": "Namibia",
         "slug": "namibia",
-        "active": true
+        "updated_at": "2017-08-15T15:41:47.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL98",
+        "content_id": "5e9f111f-7706-11e4-a3cb-005056011aef",
+        "iso2": "NP",
         "name": "Nepal",
         "slug": "nepal",
-        "active": true
+        "updated_at": "2020-09-02T07:14:35.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL99",
+        "content_id": "5e9f1161-7706-11e4-a3cb-005056011aef",
+        "iso2": "NL",
         "name": "Netherlands",
         "slug": "netherlands",
-        "active": true
+        "updated_at": "2017-08-15T15:41:48.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL100",
+        "content_id": "5e9f11a2-7706-11e4-a3cb-005056011aef",
+        "iso2": "NZ",
         "name": "New Zealand",
         "slug": "new-zealand",
-        "active": true
+        "updated_at": "2017-08-15T15:41:48.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL101",
+        "content_id": "5e9f11e5-7706-11e4-a3cb-005056011aef",
+        "iso2": "NG",
         "name": "Nigeria",
         "slug": "nigeria",
-        "active": true
+        "updated_at": "2020-09-02T07:20:47.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL102",
+        "content_id": "5e9f1228-7706-11e4-a3cb-005056011aef",
+        "iso2": "KP",
         "name": "North Korea",
         "slug": "north-korea",
-        "active": true
+        "updated_at": "2018-02-27T06:24:21.000+00:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL103",
+        "content_id": "5e9f12bb-7706-11e4-a3cb-005056011aef",
+        "iso2": "NO",
         "name": "Norway",
         "slug": "norway",
-        "active": true
+        "updated_at": "2017-08-15T15:41:49.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL104",
+        "content_id": "5e9f130c-7706-11e4-a3cb-005056011aef",
+        "iso2": "OM",
         "name": "Oman",
         "slug": "oman",
-        "active": true
+        "updated_at": "2022-07-25T18:27:20.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL105",
+        "content_id": "5e9f134e-7706-11e4-a3cb-005056011aef",
+        "iso2": "PK",
         "name": "Pakistan",
         "slug": "pakistan",
-        "active": true
+        "updated_at": "2020-09-02T07:21:48.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL106",
+        "content_id": "5e9f141d-7706-11e4-a3cb-005056011aef",
+        "iso2": "PA",
         "name": "Panama",
         "slug": "panama",
-        "active": true
+        "updated_at": "2018-05-15T10:40:16.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL107",
+        "content_id": "5e9f146e-7706-11e4-a3cb-005056011aef",
+        "iso2": "PG",
         "name": "Papua New Guinea",
         "slug": "papua-new-guinea",
-        "active": true
+        "updated_at": "2017-08-15T15:41:50.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL108",
+        "content_id": "5e9f14b4-7706-11e4-a3cb-005056011aef",
+        "iso2": "PE",
         "name": "Peru",
         "slug": "peru",
-        "active": true
+        "updated_at": "2017-08-31T11:46:37.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL109",
+        "content_id": "5e9f1506-7706-11e4-a3cb-005056011aef",
+        "iso2": "PH",
         "name": "Philippines",
         "slug": "philippines",
-        "active": true
+        "updated_at": "2022-01-06T09:40:52.000+00:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL110",
+        "content_id": "5e9f1551-7706-11e4-a3cb-005056011aef",
+        "iso2": "PL",
         "name": "Poland",
         "slug": "poland",
-        "active": true
+        "updated_at": "2017-08-15T15:41:51.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL111",
+        "content_id": "5e9f159e-7706-11e4-a3cb-005056011aef",
+        "iso2": "PT",
         "name": "Portugal",
         "slug": "portugal",
-        "active": true
+        "updated_at": "2019-08-01T14:38:24.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL112",
+        "content_id": "5e9f15e9-7706-11e4-a3cb-005056011aef",
+        "iso2": "QA",
         "name": "Qatar",
         "slug": "qatar",
-        "active": true
+        "updated_at": "2022-07-18T06:23:39.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL113",
+        "content_id": "5e9f185e-7706-11e4-a3cb-005056011aef",
+        "iso2": "RO",
         "name": "Romania",
         "slug": "romania",
-        "active": true
+        "updated_at": "2020-02-24T12:11:54.000+00:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL114",
+        "content_id": "5e9f1919-7706-11e4-a3cb-005056011aef",
+        "iso2": "RU",
         "name": "Russia",
         "slug": "russia",
-        "active": true
+        "updated_at": "2022-05-04T17:56:12.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL115",
+        "content_id": "5e9f1969-7706-11e4-a3cb-005056011aef",
+        "iso2": "RW",
         "name": "Rwanda",
         "slug": "rwanda",
-        "active": true
+        "updated_at": "2020-09-02T07:22:38.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL116",
+        "content_id": "5e9f19b0-7706-11e4-a3cb-005056011aef",
+        "iso2": "SA",
         "name": "Saudi Arabia",
         "slug": "saudi-arabia",
-        "active": true
+        "updated_at": "2017-08-15T15:41:52.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL117",
+        "content_id": "5e9f1ac3-7706-11e4-a3cb-005056011aef",
+        "iso2": "SN",
         "name": "Senegal",
         "slug": "senegal",
-        "active": true
+        "updated_at": "2020-09-02T07:23:02.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL118",
+        "content_id": "5e9f1b3b-7706-11e4-a3cb-005056011aef",
+        "iso2": "RS",
         "name": "Serbia",
         "slug": "serbia",
-        "active": true
+        "updated_at": "2017-08-15T15:41:53.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL119",
+        "content_id": "5e9f1b89-7706-11e4-a3cb-005056011aef",
+        "iso2": "SC",
         "name": "Seychelles",
         "slug": "seychelles",
-        "active": true
+        "updated_at": "2017-08-15T15:41:53.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL120",
+        "content_id": "5e9f1bdb-7706-11e4-a3cb-005056011aef",
+        "iso2": "SL",
         "name": "Sierra Leone",
         "slug": "sierra-leone",
-        "active": true
+        "updated_at": "2020-09-02T07:23:29.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL121",
+        "content_id": "5e9f1c6d-7706-11e4-a3cb-005056011aef",
+        "iso2": "SG",
         "name": "Singapore",
         "slug": "singapore",
-        "active": true
+        "updated_at": "2017-08-15T15:41:54.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL122",
+        "content_id": "5e9f1cda-7706-11e4-a3cb-005056011aef",
+        "iso2": "SK",
         "name": "Slovakia",
         "slug": "slovakia",
-        "active": true
+        "updated_at": "2017-08-15T15:41:54.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL123",
+        "content_id": "5e9f1d43-7706-11e4-a3cb-005056011aef",
+        "iso2": "SI",
         "name": "Slovenia",
         "slug": "slovenia",
-        "active": true
+        "updated_at": "2017-08-30T13:03:34.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL124",
+        "content_id": "5e9f1e19-7706-11e4-a3cb-005056011aef",
+        "iso2": "SB",
         "name": "Solomon Islands",
         "slug": "solomon-islands",
-        "active": true
+        "updated_at": "2019-08-09T08:54:16.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL125",
+        "content_id": "5e9f1e8d-7706-11e4-a3cb-005056011aef",
+        "iso2": "SO",
         "name": "Somalia",
         "slug": "somalia",
-        "active": true
+        "updated_at": "2020-09-02T07:23:56.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL126",
+        "content_id": "5e9f1f02-7706-11e4-a3cb-005056011aef",
+        "iso2": "ZA",
         "name": "South Africa",
         "slug": "south-africa",
-        "active": true
+        "updated_at": "2020-09-02T07:24:30.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL127",
+        "content_id": "5e9f1f74-7706-11e4-a3cb-005056011aef",
+        "iso2": "KR",
         "name": "South Korea",
         "slug": "south-korea",
-        "active": true
+        "updated_at": "2017-08-15T15:41:55.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL128",
+        "content_id": "5e9f1fe3-7706-11e4-a3cb-005056011aef",
+        "iso2": "SS",
         "name": "South Sudan",
         "slug": "south-sudan",
-        "active": true
+        "updated_at": "2020-09-02T07:24:52.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL129",
+        "content_id": "5e9f204e-7706-11e4-a3cb-005056011aef",
+        "iso2": "ES",
         "name": "Spain",
         "slug": "spain",
-        "active": true
+        "updated_at": "2017-08-15T15:41:56.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL130",
+        "content_id": "5e9f209b-7706-11e4-a3cb-005056011aef",
+        "iso2": "LK",
         "name": "Sri Lanka",
         "slug": "sri-lanka",
-        "active": true
+        "updated_at": "2017-08-15T15:41:56.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL131",
+        "content_id": "5e9f2132-7706-11e4-a3cb-005056011aef",
+        "iso2": "SD",
         "name": "Sudan",
         "slug": "sudan",
-        "active": true
+        "updated_at": "2020-09-02T07:30:00.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL132",
+        "content_id": "5e9f2182-7706-11e4-a3cb-005056011aef",
+        "iso2": "SE",
         "name": "Sweden",
         "slug": "sweden",
-        "active": true
+        "updated_at": "2017-08-15T15:41:57.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL133",
+        "content_id": "5e9f21ce-7706-11e4-a3cb-005056011aef",
+        "iso2": "CH",
         "name": "Switzerland",
         "slug": "switzerland",
-        "active": true
+        "updated_at": "2020-09-15T09:03:57.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL134",
+        "content_id": "5e9f2218-7706-11e4-a3cb-005056011aef",
+        "iso2": "SY",
         "name": "Syria",
         "slug": "syria",
-        "active": true
+        "updated_at": "2020-09-02T07:30:58.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL135",
+        "content_id": "5e9f2264-7706-11e4-a3cb-005056011aef",
+        "iso2": "TW",
         "name": "Taiwan",
         "slug": "taiwan",
-        "active": true
+        "updated_at": "2020-09-02T08:00:08.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL136",
+        "content_id": "5e9f22ae-7706-11e4-a3cb-005056011aef",
+        "iso2": "TJ",
         "name": "Tajikistan",
         "slug": "tajikistan",
-        "active": true
+        "updated_at": "2020-09-02T07:33:16.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL137",
+        "content_id": "5e9f22f8-7706-11e4-a3cb-005056011aef",
+        "iso2": "TZ",
         "name": "Tanzania",
         "slug": "tanzania",
-        "active": true
+        "updated_at": "2020-09-02T07:33:45.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL138",
+        "content_id": "5e9f2342-7706-11e4-a3cb-005056011aef",
+        "iso2": "TH",
         "name": "Thailand",
         "slug": "thailand",
-        "active": true
+        "updated_at": "2017-08-15T15:41:58.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL139",
+        "content_id": "5e9f238b-7706-11e4-a3cb-005056011aef",
+        "iso2": "TL",
         "name": "Timor Leste",
         "slug": "timor-leste",
-        "active": true
+        "updated_at": "2017-08-15T15:41:59.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL140",
+        "content_id": "5e9f23d4-7706-11e4-a3cb-005056011aef",
+        "iso2": "TT",
         "name": "Trinidad and Tobago",
         "slug": "trinidad-and-tobago",
-        "active": true
+        "updated_at": "2017-08-15T15:41:59.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL141",
+        "content_id": "5e9f2420-7706-11e4-a3cb-005056011aef",
+        "iso2": "TN",
         "name": "Tunisia",
         "slug": "tunisia",
-        "active": true
+        "updated_at": "2020-09-02T13:21:24.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL142",
+        "content_id": "5e9f246a-7706-11e4-a3cb-005056011aef",
+        "iso2": "TR",
         "name": "Turkey",
         "slug": "turkey",
-        "active": true
+        "updated_at": "2020-09-02T07:34:14.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL143",
+        "content_id": "5e9f24b4-7706-11e4-a3cb-005056011aef",
+        "iso2": "TM",
         "name": "Turkmenistan",
         "slug": "turkmenistan",
-        "active": true
+        "updated_at": "2017-08-15T15:42:00.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL144",
+        "content_id": "5e9f24fc-7706-11e4-a3cb-005056011aef",
+        "iso2": "TC",
         "name": "Turks and Caicos Islands",
         "slug": "turks-and-caicos-islands",
-        "active": true
+        "updated_at": "2017-08-15T15:42:00.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL145",
+        "content_id": "5e9f2546-7706-11e4-a3cb-005056011aef",
+        "iso2": "UG",
         "name": "Uganda",
         "slug": "uganda",
-        "active": true
+        "updated_at": "2020-09-02T07:34:42.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL154",
+        "content_id": "5e9f274b-7706-11e4-a3cb-005056011aef",
+        "iso2": "UA",
         "name": "Ukraine",
         "slug": "ukraine",
-        "active": true
+        "updated_at": "2022-02-23T11:37:06.000+00:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL155",
+        "content_id": "5e9f2795-7706-11e4-a3cb-005056011aef",
+        "iso2": "AE",
         "name": "United Arab Emirates",
         "slug": "united-arab-emirates",
-        "active": true
+        "updated_at": "2022-07-14T13:02:55.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL156",
+        "content_id": "5e9f27dd-7706-11e4-a3cb-005056011aef",
+        "iso2": "UY",
         "name": "Uruguay",
         "slug": "uruguay",
-        "active": true
+        "updated_at": "2017-08-15T15:42:01.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL157",
+        "content_id": "5e9f2825-7706-11e4-a3cb-005056011aef",
+        "iso2": "US",
         "name": "USA",
         "slug": "usa",
-        "active": true
+        "updated_at": "2017-08-15T15:42:01.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL158",
+        "content_id": "5e9f286d-7706-11e4-a3cb-005056011aef",
+        "iso2": "UZ",
         "name": "Uzbekistan",
         "slug": "uzbekistan",
-        "active": true
+        "updated_at": "2017-08-31T11:19:40.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL159",
+        "content_id": "5e9f28b7-7706-11e4-a3cb-005056011aef",
+        "iso2": "VE",
         "name": "Venezuela",
         "slug": "venezuela",
-        "active": true
+        "updated_at": "2017-08-15T15:42:02.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL160",
+        "content_id": "5e9f2900-7706-11e4-a3cb-005056011aef",
+        "iso2": "VN",
         "name": "Vietnam",
         "slug": "vietnam",
-        "active": true
+        "updated_at": "2017-08-18T04:47:23.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL161",
+        "content_id": "5e9f294a-7706-11e4-a3cb-005056011aef",
+        "iso2": "YE",
         "name": "Yemen",
         "slug": "yemen",
-        "active": true
+        "updated_at": "2020-09-02T07:37:15.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL162",
+        "content_id": "5e9f2993-7706-11e4-a3cb-005056011aef",
+        "iso2": "ZM",
         "name": "Zambia",
         "slug": "zambia",
-        "active": true
+        "updated_at": "2020-09-02T07:38:14.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL163",
+        "content_id": "5e9f29db-7706-11e4-a3cb-005056011aef",
+        "iso2": "ZW",
         "name": "Zimbabwe",
         "slug": "zimbabwe",
-        "active": true
+        "updated_at": "2020-09-02T07:38:38.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL164",
+        "content_id": "5e9f2a26-7706-11e4-a3cb-005056011aef",
+        "iso2": "AD",
         "name": "Andorra",
         "slug": "andorra",
-        "active": true
+        "updated_at": "2017-08-15T15:42:03.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL165",
+        "content_id": "5e9f2a6f-7706-11e4-a3cb-005056011aef",
+        "iso2": "AG",
         "name": "Antigua and Barbuda",
         "slug": "antigua-and-barbuda",
-        "active": true
+        "updated_at": "2020-09-02T06:50:05.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL166",
+        "content_id": "5e9f2ab8-7706-11e4-a3cb-005056011aef",
+        "iso2": "BS",
         "name": "Bahamas",
         "slug": "bahamas",
-        "active": true
+        "updated_at": "2019-08-20T15:03:46.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL167",
+        "content_id": "5e9f2aff-7706-11e4-a3cb-005056011aef",
+        "iso2": "BJ",
         "name": "Benin",
         "slug": "benin",
-        "active": true
+        "updated_at": "2017-08-15T15:42:04.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL168",
+        "content_id": "5e9f2b45-7706-11e4-a3cb-005056011aef",
+        "iso2": "BT",
         "name": "Bhutan",
         "slug": "bhutan",
-        "active": true
+        "updated_at": "2017-08-15T15:42:05.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL169",
+        "content_id": "5e9f2b8d-7706-11e4-a3cb-005056011aef",
+        "iso2": "BF",
         "name": "Burkina Faso",
         "slug": "burkina-faso",
-        "active": true
+        "updated_at": "2020-09-02T06:53:27.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL170",
+        "content_id": "5e9f2bd5-7706-11e4-a3cb-005056011aef",
+        "iso2": "CV",
         "name": "Cape Verde",
         "slug": "cape-verde",
-        "active": true
+        "updated_at": "2017-08-15T15:42:05.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL171",
+        "content_id": "5e9f2c1c-7706-11e4-a3cb-005056011aef",
+        "iso2": "KM",
         "name": "Comoros",
         "slug": "comoros",
-        "active": true
+        "updated_at": "2019-08-29T13:39:31.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL172",
+        "content_id": "5e9f2c65-7706-11e4-a3cb-005056011aef",
+        "iso2": "CG",
         "name": "Congo",
         "slug": "congo",
-        "active": true
+        "updated_at": "2017-08-15T15:42:06.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL173",
+        "content_id": "5e9f2cae-7706-11e4-a3cb-005056011aef",
+        "iso2": "CI",
         "name": "Cote d’Ivoire",
         "slug": "cote-d-ivoire",
-        "active": true
+        "updated_at": "2017-08-15T15:42:06.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL174",
+        "content_id": "5e9f2cf5-7706-11e4-a3cb-005056011aef",
+        "iso2": "DJ",
         "name": "Djibouti",
         "slug": "djibouti",
-        "active": true
+        "updated_at": "2021-06-11T13:55:47.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL175",
+        "content_id": "5e9f2d3b-7706-11e4-a3cb-005056011aef",
+        "iso2": "DM",
         "name": "Dominica",
         "slug": "dominica",
-        "active": true
+        "updated_at": "2020-09-02T06:56:02.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL176",
+        "content_id": "5e9f2dc7-7706-11e4-a3cb-005056011aef",
+        "iso2": "GQ",
         "name": "Equatorial Guinea",
         "slug": "equatorial-guinea",
-        "active": true
+        "updated_at": "2017-08-15T15:42:07.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL177",
+        "content_id": "5e9f2e16-7706-11e4-a3cb-005056011aef",
+        "iso2": "GD",
         "name": "Grenada",
         "slug": "grenada",
-        "active": true
+        "updated_at": "2020-09-02T06:58:02.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL178",
+        "content_id": "5e9f2e61-7706-11e4-a3cb-005056011aef",
+        "iso2": "GW",
         "name": "Guinea-Bissau",
         "slug": "guinea-bissau",
-        "active": true
+        "updated_at": "2017-08-15T15:42:07.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL179",
+        "content_id": "5e9f2eab-7706-11e4-a3cb-005056011aef",
+        "iso2": "HT",
         "name": "Haiti",
         "slug": "haiti",
-        "active": true
+        "updated_at": "2020-09-02T06:59:18.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL180",
+        "content_id": "5e9f2ef2-7706-11e4-a3cb-005056011aef",
+        "iso2": "KI",
         "name": "Kiribati",
         "slug": "kiribati",
-        "active": true
+        "updated_at": "2017-08-15T15:42:08.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL181",
+        "content_id": "5e9f2f3c-7706-11e4-a3cb-005056011aef",
+        "iso2": "LS",
         "name": "Lesotho",
         "slug": "lesotho",
-        "active": true
+        "updated_at": "2020-09-02T07:05:06.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL182",
+        "content_id": "5e9f2f85-7706-11e4-a3cb-005056011aef",
+        "iso2": "LR",
         "name": "Liberia",
         "slug": "liberia",
-        "active": true
+        "updated_at": "2020-09-02T07:06:15.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL183",
+        "content_id": "5e9f2fcc-7706-11e4-a3cb-005056011aef",
+        "iso2": "LI",
         "name": "Liechtenstein",
         "slug": "liechtenstein",
-        "active": true
+        "updated_at": "2020-09-15T09:02:32.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL184",
+        "content_id": "5e9f3016-7706-11e4-a3cb-005056011aef",
+        "iso2": "MO",
         "name": "Macao",
         "slug": "macao",
-        "active": true
+        "updated_at": "2017-08-15T15:42:09.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL185",
+        "content_id": "5e9f3062-7706-11e4-a3cb-005056011aef",
+        "iso2": "MH",
         "name": "Marshall Islands",
         "slug": "marshall-islands",
-        "active": true
+        "updated_at": "2017-08-15T15:42:09.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL186",
+        "content_id": "5e9f30c8-7706-11e4-a3cb-005056011aef",
+        "iso2": "FM",
         "name": "Micronesia",
         "slug": "micronesia",
-        "active": true
+        "updated_at": "2017-08-15T15:42:10.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL187",
+        "content_id": "5e9f3167-7706-11e4-a3cb-005056011aef",
+        "iso2": "NR",
         "name": "Nauru",
         "slug": "nauru",
-        "active": true
+        "updated_at": "2017-08-15T15:42:10.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL188",
+        "content_id": "5e9f3210-7706-11e4-a3cb-005056011aef",
+        "iso2": "NI",
         "name": "Nicaragua",
         "slug": "nicaragua",
-        "active": true
+        "updated_at": "2017-08-15T15:42:10.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL189",
+        "content_id": "5e9f3337-7706-11e4-a3cb-005056011aef",
+        "iso2": "NE",
         "name": "Niger",
         "slug": "niger",
-        "active": true
+        "updated_at": "2021-04-12T07:36:47.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL190",
+        "content_id": "5e9f3393-7706-11e4-a3cb-005056011aef",
+        "iso2": "PS",
         "name": "The Occupied Palestinian Territories",
         "slug": "the-occupied-palestinian-territories",
-        "active": true
+        "updated_at": "2020-09-02T07:21:25.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL191",
+        "content_id": "5e9f33e4-7706-11e4-a3cb-005056011aef",
+        "iso2": "PW",
         "name": "Palau",
         "slug": "palau",
-        "active": true
+        "updated_at": "2017-08-15T15:42:11.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL192",
+        "content_id": "5e9f342f-7706-11e4-a3cb-005056011aef",
+        "iso2": "PY",
         "name": "Paraguay",
         "slug": "paraguay",
-        "active": true
+        "updated_at": "2020-05-27T23:21:06.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL193",
+        "content_id": "5e9f347c-7706-11e4-a3cb-005056011aef",
+        "iso2": "WS",
         "name": "Samoa",
         "slug": "samoa",
-        "active": true
+        "updated_at": "2019-12-19T04:47:23.000+00:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL194",
+        "content_id": "5e9f34c5-7706-11e4-a3cb-005056011aef",
+        "iso2": "ST",
         "name": "São Tomé and Principe",
         "slug": "sao-tome-and-principe",
-        "active": true
+        "updated_at": "2017-08-15T15:42:12.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL195",
+        "content_id": "5e9f3511-7706-11e4-a3cb-005056011aef",
+        "iso2": "KN",
         "name": "St Kitts and Nevis",
         "slug": "st-kitts-and-nevis",
-        "active": true
+        "updated_at": "2020-09-02T07:25:17.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL196",
+        "content_id": "5e9f355a-7706-11e4-a3cb-005056011aef",
+        "iso2": "VC",
         "name": "St Vincent and The Grenadines",
         "slug": "st-vincent-and-the-grenadines",
-        "active": true
+        "updated_at": "2020-09-02T07:28:39.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL197",
+        "content_id": "5e9f35a2-7706-11e4-a3cb-005056011aef",
+        "iso2": "SR",
         "name": "Suriname",
         "slug": "suriname",
-        "active": true
+        "updated_at": "2017-08-15T15:42:13.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL198",
+        "content_id": "5e9f35ee-7706-11e4-a3cb-005056011aef",
+        "iso2": "SZ",
         "name": "Eswatini",
         "slug": "eswatini",
-        "active": true
+        "updated_at": "2019-08-02T07:14:39.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL199",
+        "content_id": "5e9f363b-7706-11e4-a3cb-005056011aef",
+        "iso2": "TG",
         "name": "Togo",
         "slug": "togo",
-        "active": true
+        "updated_at": "2017-08-15T15:42:14.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL200",
+        "content_id": "5e9f3687-7706-11e4-a3cb-005056011aef",
+        "iso2": "TV",
         "name": "Tuvalu",
         "slug": "tuvalu",
-        "active": true
+        "updated_at": "2017-08-15T15:42:14.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL201",
+        "content_id": "5e9f36d1-7706-11e4-a3cb-005056011aef",
+        "iso2": "VU",
         "name": "Vanuatu",
         "slug": "vanuatu",
-        "active": true
+        "updated_at": "2019-08-09T08:56:41.000+01:00"
       },
       {
+        "active": false,
+        "analytics_identifier": "WL202",
+        "content_id": "5e9f371a-7706-11e4-a3cb-005056011aef",
+        "iso2": "GB",
         "name": "United Kingdom",
         "slug": "united-kingdom",
-        "active": false
+        "updated_at": "2017-08-15T15:42:15.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL203",
+        "content_id": "5e9f37a5-7706-11e4-a3cb-005056011aef",
+        "iso2": "bm",
         "name": "Bermuda",
         "slug": "bermuda",
-        "active": true
+        "updated_at": "2020-09-02T08:38:21.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL204",
+        "content_id": "5e9f3a5b-7706-11e4-a3cb-005056011aef",
+        "iso2": "bi",
         "name": "Burundi",
         "slug": "burundi",
-        "active": true
+        "updated_at": "2017-08-15T15:42:15.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL205",
+        "content_id": "5e9f3ab4-7706-11e4-a3cb-005056011aef",
+        "iso2": "sv",
         "name": "El Salvador",
         "slug": "el-salvador",
-        "active": true
+        "updated_at": "2017-08-31T10:59:24.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL206",
+        "content_id": "5e9f3aff-7706-11e4-a3cb-005056011aef",
+        "iso2": "fk",
         "name": "Falkland Islands",
         "slug": "falkland-islands",
-        "active": true
+        "updated_at": "2017-08-15T15:42:16.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL207",
+        "content_id": "5e9f3b4d-7706-11e4-a3cb-005056011aef",
+        "iso2": "gn",
         "name": "Guinea",
         "slug": "guinea",
-        "active": true
+        "updated_at": "2017-08-15T15:42:16.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL216",
+        "content_id": "5e9f3c6b-7706-11e4-a3cb-005056011aef",
+        "iso2": "sh",
         "name": "St Helena, Ascension and Tristan da Cunha",
         "slug": "st-helena-ascension-and-tristan-da-cunha",
-        "active": true
+        "updated_at": "2020-09-02T09:52:33.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL217",
+        "content_id": "5e9f3cba-7706-11e4-a3cb-005056011aef",
+        "iso2": "lc",
         "name": "St Lucia",
         "slug": "st-lucia",
-        "active": true
+        "updated_at": "2020-09-02T07:26:35.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL218",
+        "content_id": "5e9f3d03-7706-11e4-a3cb-005056011aef",
+        "iso2": "kg",
         "name": "Kyrgyzstan",
         "slug": "kyrgyzstan",
-        "active": true
+        "updated_at": "2020-09-02T07:04:13.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL219",
+        "content_id": "5e9f3d4a-7706-11e4-a3cb-005056011aef",
+        "iso2": "pn",
         "name": "Pitcairn Island",
         "slug": "pitcairn-island",
-        "active": true
+        "updated_at": "2020-09-02T07:22:12.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL220",
+        "content_id": "5e9f3d94-7706-11e4-a3cb-005056011aef",
+        "iso2": "td",
         "name": "Chad",
         "slug": "chad",
-        "active": true
+        "updated_at": "2022-03-24T12:07:01.000+00:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL221",
+        "content_id": "5e9f3ddb-7706-11e4-a3cb-005056011aef",
+        "iso2": "mr",
         "name": "Mauritania",
         "slug": "mauritania",
-        "active": true
+        "updated_at": "2021-03-08T11:23:20.000+00:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL222",
+        "content_id": "5e9f4140-7706-11e4-a3cb-005056011aef",
+        "iso2": "AS",
         "name": "American Samoa",
         "slug": "american-samoa",
-        "active": true
+        "updated_at": "2017-08-15T15:42:18.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL223",
+        "content_id": "5e9f41c0-7706-11e4-a3cb-005056011aef",
+        "iso2": "AW",
         "name": "Aruba",
         "slug": "aruba",
-        "active": true
+        "updated_at": "2020-10-16T12:23:05.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL224",
+        "content_id": "5e9f420d-7706-11e4-a3cb-005056011aef",
+        "iso2": "BQ",
         "name": "Bonaire/St Eustatius/Saba",
         "slug": "bonaire-st-eustatius-saba",
-        "active": true
+        "updated_at": "2020-10-16T12:23:22.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL225",
+        "content_id": "5e9f425a-7706-11e4-a3cb-005056011aef",
+        "iso2": "IO",
         "name": "British Indian Ocean Territory",
         "slug": "british-indian-ocean-territory",
-        "active": true
+        "updated_at": "2020-10-13T15:54:56.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL226",
+        "content_id": "5e9f42a8-7706-11e4-a3cb-005056011aef",
+        "iso2": "CF",
         "name": "Central African Republic",
         "slug": "central-african-republic",
-        "active": true
+        "updated_at": "2020-09-02T06:51:47.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL227",
+        "content_id": "5e9f42f7-7706-11e4-a3cb-005056011aef",
+        "iso2": "CW",
         "name": "Curaçao",
         "slug": "curacao",
-        "active": true
+        "updated_at": "2020-10-16T12:23:41.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL228",
+        "content_id": "5e9f4343-7706-11e4-a3cb-005056011aef",
+        "iso2": "GF",
         "name": "French Guiana",
         "slug": "french-guiana",
-        "active": true
+        "updated_at": "2017-08-15T15:42:20.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL229",
+        "content_id": "5e9f438e-7706-11e4-a3cb-005056011aef",
+        "iso2": "PF",
         "name": "French Polynesia",
         "slug": "french-polynesia",
-        "active": true
+        "updated_at": "2017-08-15T15:42:20.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL230",
+        "content_id": "5e9f43d8-7706-11e4-a3cb-005056011aef",
+        "iso2": "GA",
         "name": "Gabon",
         "slug": "gabon",
-        "active": true
+        "updated_at": "2017-08-15T15:42:20.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL231",
+        "content_id": "5e9f4422-7706-11e4-a3cb-005056011aef",
+        "iso2": "GI",
         "name": "Gibraltar",
         "slug": "gibraltar",
-        "active": true
+        "updated_at": "2017-11-15T11:18:09.000+00:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL232",
+        "content_id": "5e9f446c-7706-11e4-a3cb-005056011aef",
+        "iso2": "GP",
         "name": "Guadeloupe",
         "slug": "guadeloupe",
-        "active": true
+        "updated_at": "2017-08-15T15:42:21.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL233",
+        "content_id": "5e9f44b5-7706-11e4-a3cb-005056011aef",
+        "iso2": "MQ",
         "name": "Martinique",
         "slug": "martinique",
-        "active": true
+        "updated_at": "2017-08-15T15:42:21.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL234",
+        "content_id": "5e9f44fe-7706-11e4-a3cb-005056011aef",
+        "iso2": "YT",
         "name": "Mayotte",
         "slug": "mayotte",
-        "active": true
+        "updated_at": "2017-08-15T15:42:21.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL235",
+        "content_id": "5e9f4548-7706-11e4-a3cb-005056011aef",
+        "iso2": "MC",
         "name": "Monaco",
         "slug": "monaco",
-        "active": true
+        "updated_at": "2017-08-15T15:42:22.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL236",
+        "content_id": "5e9f4593-7706-11e4-a3cb-005056011aef",
+        "iso2": "NC",
         "name": "New Caledonia",
         "slug": "new-caledonia",
-        "active": true
+        "updated_at": "2017-08-15T15:42:22.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL237",
+        "content_id": "5e9f45e0-7706-11e4-a3cb-005056011aef",
+        "iso2": "RE",
         "name": "Réunion",
         "slug": "reunion",
-        "active": true
+        "updated_at": "2017-08-15T15:42:22.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL238",
+        "content_id": "5e9f462d-7706-11e4-a3cb-005056011aef",
+        "iso2": "SM",
         "name": "San Marino",
         "slug": "san-marino",
-        "active": true
+        "updated_at": "2017-08-15T15:42:22.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL239",
+        "content_id": "5e9f4678-7706-11e4-a3cb-005056011aef",
+        "iso2": "GS",
         "name": "South Georgia and the South Sandwich Islands",
         "slug": "south-georgia-and-the-south-sandwich-islands",
-        "active": true
+        "updated_at": "2018-08-29T12:29:17.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL240",
+        "content_id": "5e9f46c2-7706-11e4-a3cb-005056011aef",
+        "iso2": "MF",
         "name": "St Maarten",
         "slug": "st-maarten",
-        "active": true
+        "updated_at": "2020-10-16T12:23:56.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL241",
+        "content_id": "5e9f470e-7706-11e4-a3cb-005056011aef",
+        "iso2": "PM",
         "name": "St Pierre & Miquelon",
         "slug": "st-pierre-and-miquelon",
-        "active": true
+        "updated_at": "2017-08-15T15:42:23.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL242",
+        "content_id": "5e9f4755-7706-11e4-a3cb-005056011aef",
+        "iso2": "TO",
         "name": "Tonga",
         "slug": "tonga",
-        "active": true
+        "updated_at": "2021-05-14T12:47:03.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL243",
+        "content_id": "5e9f479e-7706-11e4-a3cb-005056011aef",
+        "iso2": "WF",
         "name": "Wallis and Futuna",
         "slug": "wallis-and-futuna",
-        "active": true
+        "updated_at": "2017-08-15T15:42:24.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL244",
+        "content_id": "5e9f47ea-7706-11e4-a3cb-005056011aef",
+        "iso2": "EH",
         "name": "Western Sahara",
         "slug": "western-sahara",
-        "active": true
+        "updated_at": "2017-08-15T15:42:24.000+01:00"
       },
       {
+        "active": false,
+        "analytics_identifier": "WL246",
+        "content_id": "7a11b56c-819d-4e85-a7b9-506319cb655b",
+        "iso2": null,
         "name": "St Martin",
         "slug": "st-martin",
-        "active": false
+        "updated_at": "2017-08-15T15:42:24.000+01:00"
       },
       {
+        "active": false,
+        "analytics_identifier": "WL247",
+        "content_id": "dc258e77-8731-4c7f-9a6f-df508b991298",
+        "iso2": null,
         "name": "Saint-Barthélemy",
         "slug": "saint-barthelemy",
-        "active": false
+        "updated_at": "2017-08-15T15:42:25.000+01:00"
       }
     ],
-    "international_delegations": [{
+    "international_delegations": [
+      {
+        "active": true,
+        "analytics_identifier": "WL146",
+        "content_id": "5e9f258d-7706-11e4-a3cb-005056011aef",
+        "iso2": null,
         "name": "UK Delegation to Council of Europe",
         "slug": "uk-delegation-to-council-of-europe",
-        "active": true
+        "updated_at": "2013-03-22T19:03:28.000+00:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL147",
+        "content_id": "5e9f25d7-7706-11e4-a3cb-005056011aef",
+        "iso2": null,
         "name": "UK Delegation to Organization for Security and Co-operation in Europe",
         "slug": "uk-delegation-to-organization-for-security-and-co-operation-in-europe",
-        "active": true
+        "updated_at": "2016-04-25T14:43:18.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL149",
+        "content_id": "5e9f2626-7706-11e4-a3cb-005056011aef",
+        "iso2": null,
         "name": "UK Joint Delegation to NATO",
         "slug": "uk-joint-delegation-to-nato",
-        "active": true
+        "updated_at": "2013-03-24T20:16:58.000+00:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL150",
+        "content_id": "5e9f266d-7706-11e4-a3cb-005056011aef",
+        "iso2": null,
         "name": "UK Mission to the WTO, UN and Other International Organisations (Geneva)",
         "slug": "uk-mission-to-the-wto-un-and-other-international-organisations-geneva",
-        "active": true
+        "updated_at": "2020-02-01T16:53:14.000+00:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL151",
+        "content_id": "5e9f26b8-7706-11e4-a3cb-005056011aef",
+        "iso2": null,
         "name": "UK Mission to the United Nations",
         "slug": "uk-mission-to-the-united-nations",
-        "active": true
+        "updated_at": "2013-03-22T19:03:08.000+00:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL152",
+        "content_id": "5e9f2704-7706-11e4-a3cb-005056011aef",
+        "iso2": null,
         "name": "UK Mission to the European Union",
         "slug": "uk-mission-to-the-eu",
-        "active": true
+        "updated_at": "2020-02-01T16:51:30.000+00:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL208",
+        "content_id": "5e9f3bc0-7706-11e4-a3cb-005056011aef",
+        "iso2": null,
         "name": "UK Mission to the United Nations, New York",
         "slug": "uk-mission-to-the-united-nations-new-york",
-        "active": true
+        "updated_at": "2013-03-25T23:11:41.000+00:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL210",
+        "content_id": "5e9f3c18-7706-11e4-a3cb-005056011aef",
+        "iso2": null,
         "name": "The UK Permanent Delegation to the OECD (Organisation for Economic Co-operation and Development)",
         "slug": "the-uk-permanent-delegation-to-the-oecd-organisation-for-economic-co-operation-and-development",
-        "active": true
+        "updated_at": "2013-03-22T19:08:14.000+00:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL245",
+        "content_id": "ecfd1704-e72c-4e1c-989b-1e39c9982c91",
+        "iso2": null,
         "name": "UK and the Commonwealth",
         "slug": "uk-and-the-commonwealth",
-        "active": true
+        "updated_at": "2016-10-14T12:27:01.000+01:00"
       },
       {
+        "active": true,
+        "analytics_identifier": "WL248",
+        "content_id": "cb2f986d-82e9-4145-8319-51bf991ef860",
+        "iso2": null,
         "name": "UK Mission to ASEAN",
         "slug": "uk-mission-to-asean",
-        "active": true
+        "updated_at": "2019-12-09T16:57:33.000+00:00"
       }
     ]
   }

--- a/content_schemas/formats/world_index.jsonnet
+++ b/content_schemas/formats/world_index.jsonnet
@@ -20,12 +20,33 @@
           "items": {
             "type": "object",
             "required": [
+              "active",
+              "content_id",
               "name",
               "slug",
-              "active"
+              "updated_at"
             ],
             "additionalProperties": false,
             "properties": {
+              "active": {
+                "description": "Whether the location is currently active",
+                "type": "boolean",
+              },
+              "analytics_identifier": {
+                "description": "The analytics identifier for the international delegation",
+                "type": "string"
+              },
+              "content_id": {
+                "description": "The content ID for the international delegation",
+                "$ref": "#/definitions/guid",
+              },
+              "iso2": {
+                "description": "The two-letter code for the international delegation in ISO2 format",
+                "type": [
+                  "string",
+                  "null",
+                ]
+              },
               "name": {
                 "description": "The name of the international delegation",
                 "type": "string"
@@ -34,9 +55,10 @@
                 "description": "The slug of the international delegation",
                 "type": "string",
               },
-              "active": {
-                "description": "Whether the location is currently active",
-                "type": "boolean",
+              "updated_at": {
+                "description": "The timestamp for the last update to the international delegation",
+                type: "string",
+                format: "date-time",
               }
             }
           },
@@ -46,12 +68,33 @@
           "items": {
             "type": "object",
             "required": [
+              "active",
+              "content_id",
               "name",
               "slug",
-              "active"
+              "updated_at"
             ],
             "additionalProperties": false,
             "properties": {
+              "active": {
+                "description": "Whether the location is currently active",
+                "type": "boolean",
+              },
+              "analytics_identifier": {
+                "description": "The analytics identifier for the world location",
+                "type": "string"
+              },
+              "content_id": {
+                "description": "The content ID for the world location",
+                "$ref": "#/definitions/guid",
+              },
+              "iso2": {
+                "description": "The two-letter code for the world location in ISO2 format",
+                "type": [
+                  "string",
+                  "null",
+                ]
+              },
               "name": {
                 "description": "The name of the world location",
                 "type": "string"
@@ -60,9 +103,10 @@
                 "description": "The slug of the world location",
                 "type": "string",
               },
-              "active": {
-                "description": "Whether the location is currently active",
-                "type": "boolean",
+              "updated_at": {
+                "description": "The timestamp for the last update to the world location",
+                type: "string",
+                format: "date-time",
               }
             }
           },


### PR DESCRIPTION
We are replacing the Whitehall World Location API with the content item for `/world`.

Therefore adding the additional information needed that is currently supplied by the API.

[Trello card](https://trello.com/c/g4ypLS8V)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
