### PR TITLE
Add case type options to cma case schema

### DIFF
--- a/content_schemas/dist/formats/specialist_document/frontend/schema.json
+++ b/content_schemas/dist/formats/specialist_document/frontend/schema.json
@@ -814,13 +814,15 @@
           "enum": [
             "ca98-and-civil-cartels",
             "competition-disqualification",
+            "consumer-enforcement",
             "criminal-cartels",
             "information-and-advice-to-government",
             "markets",
             "mergers",
-            "consumer-enforcement",
+            "oim-project",
             "regulatory-references-and-appeals",
             "review-of-orders-and-undertakings",
+            "sau-referral",
             "state-aid"
           ]
         },

--- a/content_schemas/dist/formats/specialist_document/notification/schema.json
+++ b/content_schemas/dist/formats/specialist_document/notification/schema.json
@@ -906,13 +906,15 @@
           "enum": [
             "ca98-and-civil-cartels",
             "competition-disqualification",
+            "consumer-enforcement",
             "criminal-cartels",
             "information-and-advice-to-government",
             "markets",
             "mergers",
-            "consumer-enforcement",
+            "oim-project",
             "regulatory-references-and-appeals",
             "review-of-orders-and-undertakings",
+            "sau-referral",
             "state-aid"
           ]
         },

--- a/content_schemas/dist/formats/specialist_document/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/specialist_document/publisher_v2/schema.json
@@ -730,13 +730,15 @@
           "enum": [
             "ca98-and-civil-cartels",
             "competition-disqualification",
+            "consumer-enforcement",
             "criminal-cartels",
             "information-and-advice-to-government",
             "markets",
             "mergers",
-            "consumer-enforcement",
+            "oim-project",
             "regulatory-references-and-appeals",
             "review-of-orders-and-undertakings",
+            "sau-referral",
             "state-aid"
           ]
         },

--- a/content_schemas/examples/specialist_document/frontend/cma-cases.json
+++ b/content_schemas/examples/specialist_document/frontend/cma-cases.json
@@ -150,6 +150,10 @@
                   "value": "mergers"
                 },
                 {
+                  "label": "OIM Project",
+                  "value": "oim-project"
+                },
+                {
                   "label": "Consumer enforcement",
                   "value": "consumer-enforcement"
                 },
@@ -160,6 +164,10 @@
                 {
                   "label": "Reviews of orders and undertakings",
                   "value": "review-of-orders-and-undertakings"
+                },
+                {
+                  "label": "SAU Referral",
+                  "value": "sau-referral"
                 }
               ]
             },

--- a/content_schemas/formats/shared/definitions/_specialist_document.jsonnet
+++ b/content_schemas/formats/shared/definitions/_specialist_document.jsonnet
@@ -520,14 +520,16 @@
         enum: [
           "ca98-and-civil-cartels",
           "competition-disqualification",
+          "consumer-enforcement",
           "criminal-cartels",
           "information-and-advice-to-government",
           "markets",
           "mergers",
-          "consumer-enforcement",
+          "oim-project",
           "regulatory-references-and-appeals",
           "review-of-orders-and-undertakings",
-          "state-aid",
+          "sau-referral",
+          "state-aid"
         ],
       },
       case_state: {


### PR DESCRIPTION
I have recently added two new case type options to the Competition and Markets Authority case specialist content type. I was unaware at the time that the case types options were enumerated in the Publishing API content schema, resulting in the CMA raising a ticket when they encountered a rather unpleasant looking JSON Schema validation error message. I'm hopeful this will resolve the issue.

Trello ticket from Zendesk report: https://trello.com/c/UD22Wsh0
Original CMA request Trello ticket: https://trello.com/c/r7sZCKI4