### PR TITLE
Added the "not applicable" market sector option to CMA case definitions

### DIFF
--- a/content_schemas/dist/formats/specialist_document/frontend/schema.json
+++ b/content_schemas/dist/formats/specialist_document/frontend/schema.json
@@ -854,6 +854,7 @@
               "household-goods-furniture-and-furnishings",
               "mineral-extraction-mining-and-quarrying",
               "motor-industry",
+              "not-applicable",
               "oil-and-gas-refining-and-petrochemicals",
               "paper-printing-and-packaging",
               "pharmaceuticals",

--- a/content_schemas/dist/formats/specialist_document/notification/schema.json
+++ b/content_schemas/dist/formats/specialist_document/notification/schema.json
@@ -946,6 +946,7 @@
               "household-goods-furniture-and-furnishings",
               "mineral-extraction-mining-and-quarrying",
               "motor-industry",
+              "not-applicable",
               "oil-and-gas-refining-and-petrochemicals",
               "paper-printing-and-packaging",
               "pharmaceuticals",

--- a/content_schemas/dist/formats/specialist_document/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/specialist_document/publisher_v2/schema.json
@@ -770,6 +770,7 @@
               "household-goods-furniture-and-furnishings",
               "mineral-extraction-mining-and-quarrying",
               "motor-industry",
+              "not-applicable",
               "oil-and-gas-refining-and-petrochemicals",
               "paper-printing-and-packaging",
               "pharmaceuticals",

--- a/content_schemas/examples/specialist_document/frontend/cma-cases.json
+++ b/content_schemas/examples/specialist_document/frontend/cma-cases.json
@@ -274,6 +274,10 @@
                   "value": "motor-industry"
                 },
                 {
+                  "label": "Not applicable",
+                  "value": "not-applicable"
+                },
+                {
                   "label": "Oil and gas refining and petrochemicals",
                   "value": "oil-and-gas-refining-and-petrochemicals"
                 },

--- a/content_schemas/formats/shared/definitions/_specialist_document.jsonnet
+++ b/content_schemas/formats/shared/definitions/_specialist_document.jsonnet
@@ -563,6 +563,7 @@
             "household-goods-furniture-and-furnishings",
             "mineral-extraction-mining-and-quarrying",
             "motor-industry",
+            "not-applicable",
             "oil-and-gas-refining-and-petrochemicals",
             "paper-printing-and-packaging",
             "pharmaceuticals",


### PR DESCRIPTION
The Competition and Markets authority have recently started including Office for the Internal Market projects and Subsidy Advice Unit referrals in their CMA case specialist finder. However, the market sector field in the CMA case data type does not apply to these new types. Therefore, we are adding a new "not applicable" option to the CMA case market sector field.

Trello ticket: https://trello.com/c/SdjSO9PB