### PR TITLE
Add additional fields for Worldwide Offices

### DIFF
--- a/content_schemas/dist/formats/worldwide_office/frontend/schema.json
+++ b/content_schemas/dist/formats/worldwide_office/frontend/schema.json
@@ -483,6 +483,37 @@
         },
         "change_history": {
           "$ref": "#/definitions/change_history"
+        },
+        "services": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "title": {
+                "description": "The name of the service provided by this Worldwide Office.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "type": {
+                "description": "The type of service provided by this Worldwide Office.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            }
+          },
+          "uniqueItems": true
+        },
+        "type": {
+          "description": "The type of Worldwide Office.",
+          "type": [
+            "string",
+            "null"
+          ]
         }
       }
     },

--- a/content_schemas/dist/formats/worldwide_office/notification/schema.json
+++ b/content_schemas/dist/formats/worldwide_office/notification/schema.json
@@ -582,6 +582,37 @@
         },
         "change_history": {
           "$ref": "#/definitions/change_history"
+        },
+        "services": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "title": {
+                "description": "The name of the service provided by this Worldwide Office.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "type": {
+                "description": "The type of service provided by this Worldwide Office.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            }
+          },
+          "uniqueItems": true
+        },
+        "type": {
+          "description": "The type of Worldwide Office.",
+          "type": [
+            "string",
+            "null"
+          ]
         }
       }
     },

--- a/content_schemas/dist/formats/worldwide_office/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/worldwide_office/publisher_v2/schema.json
@@ -354,6 +354,37 @@
             "string",
             "null"
           ]
+        },
+        "services": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "title": {
+                "description": "The name of the service provided by this Worldwide Office.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "type": {
+                "description": "The type of service provided by this Worldwide Office.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            }
+          },
+          "uniqueItems": true
+        },
+        "type": {
+          "description": "The type of Worldwide Office.",
+          "type": [
+            "string",
+            "null"
+          ]
         }
       }
     },

--- a/content_schemas/formats/worldwide_office.jsonnet
+++ b/content_schemas/formats/worldwide_office.jsonnet
@@ -10,7 +10,38 @@
              "null",
            ],
            description: "The access and opening times for this Worldwide Office.",
-         },
+        },
+        type: {
+          type: [
+            "string",
+            "null",
+          ],
+          description: "The type of Worldwide Office.",
+        },
+        services: {
+          type: "array",
+          uniqueItems: true,
+          items: {
+            type: "object",
+            additionalProperties: false,
+            properties: {
+              title: {
+                type: [
+                  "string",
+                  "null",
+                ],
+                description: "The name of the service provided by this Worldwide Office.",
+              },
+              type: {
+                type: [
+                  "string",
+                  "null",
+                ],
+                description: "The type of service provided by this Worldwide Office.",
+              }
+            }
+          }
+        },
       },
     },
   },

--- a/lib/expansion_rules.rb
+++ b/lib/expansion_rules.rb
@@ -94,7 +94,7 @@ module_function
 
   CONTACT_FIELDS = (DEFAULT_FIELDS + details_fields(:description, :title, :contact_form_links, :post_addresses, :email_addresses, :phone_numbers)).freeze
   GOVERNMENT_FIELDS = (MANDATORY_FIELDS + %i[api_path base_path document_type] + details_fields(:started_on, :ended_on, :current)).freeze
-  ORGANISATION_FIELDS = (DEFAULT_FIELDS - [:public_updated_at] + details_fields(:logo, :brand, :default_news_image, :organisation_govuk_status)).freeze
+  ORGANISATION_FIELDS = (DEFAULT_FIELDS - [:public_updated_at] + details_fields(:acronym, :logo, :brand, :default_news_image, :organisation_govuk_status)).freeze
   TAXON_FIELDS = (DEFAULT_FIELDS + %i[description details phase]).freeze
   NEED_FIELDS = (DEFAULT_FIELDS + details_fields(:role, :goal, :benefit, :met_when, :justifications)).freeze
   FINDER_FIELDS = (DEFAULT_FIELDS + details_fields(:facets)).freeze

--- a/spec/lib/expansion_rules_spec.rb
+++ b/spec/lib/expansion_rules_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe ExpansionRules do
   describe ".expansion_fields" do
     let(:default_fields) { rules::DEFAULT_FIELDS }
     let(:contact_fields) { default_fields + [%i[details description], %i[details title], %i[details contact_form_links], %i[details post_addresses], %i[details email_addresses], %i[details phone_numbers]] }
-    let(:organisation_fields) { default_fields - [:public_updated_at] + [%i[details logo], %i[details brand], %i[details default_news_image], %i[details organisation_govuk_status]] }
+    let(:organisation_fields) { default_fields - [:public_updated_at] + [%i[details acronym], %i[details logo], %i[details brand], %i[details default_news_image], %i[details organisation_govuk_status]] }
     let(:taxon_fields) { default_fields + %i[description details phase] }
     let(:default_fields_and_description) { default_fields + %i[description] }
     let(:need_fields) { default_fields + [%i[details role], %i[details goal], %i[details benefit], %i[details met_when], %i[details justifications]] }


### PR DESCRIPTION
These are required in the content item, so we can serve the Worldwide Organisations API from the content item, instead of Whitehall's database.

[Trello card](https://trello.com/c/jJ0SH0N3)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
