### PR TITLE
Add task to create code-snippet for email-alert-api queries

### DIFF
--- a/lib/tasks/email_reports.rake
+++ b/lib/tasks/email_reports.rake
@@ -1,0 +1,54 @@
+namespace :email_reports do
+  desc "Given a path, creates a chunk of code that can be pasted into email-alert-api to get subscriber lists that would be alerted by a change to that path"
+  task :get_subscriber_list_code, %i[govuk_path] => :environment do |_, _args|
+    puts_subscriber_list_query(govuk_path)
+  end
+end
+
+def puts_subscriber_list_query(govuk_path)
+  edition = Edition.live.where(base_path: govuk_path).last
+  ds_payload = DownstreamPayload.new(edition, 1, draft: false)
+  payload = ds_payload.message_queue_payload
+
+  puts("To use: Copy everything between the start and end block markers, and")
+  puts("paste into an email-alert-api console")
+  puts("")
+  puts("=== START BLOCK ===")
+  puts("lists = SubscriberListQuery.new(")
+  puts("  content_id: \"#{payload[:content_id]}\",")
+  puts("  tags: #{(payload[:tags] || {}).merge(additional_items(payload))},")
+  puts("  links: #{(payload[:links] || {}).merge(additional_items(payload).merge(taxon_tree: taxon_tree(payload)))},")
+  puts("  document_type: \"#{payload[:document_type]}\",")
+  puts("  email_document_supertype:  \"#{payload['email_document_supertype']}\",")
+  puts("  government_document_supertype:  \"#{payload['government_document_supertype']}\",")
+  puts(").lists")
+  puts("=== END BLOCK ===")
+end
+
+def additional_items(payload)
+  {
+    user_journey_document_supertype: payload["user_journey_document_supertype"],
+    email_document_supertype: payload["email_document_supertype"],
+    government_document_supertype: payload["government_document_supertype"],
+    content_purpose_subgroup: payload["content_purpose_subgroup"],
+    content_purpose_supergroup: payload["content_purpose_supergroup"],
+    content_store_document_type: payload[:document_type],
+  }
+end
+
+def taxon_tree(payload)
+  [payload[:expanded_links][:taxons].first[:content_id]] + get_parent_links(payload[:expanded_links][:taxons].first)
+end
+
+def get_parent_links(taxon_struct)
+  return [] unless taxon_struct[:links].key?(:parent_taxons)
+  return [] unless taxon_struct[:links][:parent_taxons].any?
+
+  tree = []
+  taxon_struct[:links][:parent_taxons].each do |parent_taxon|
+    tree += [parent_taxon[:content_id]]
+    tree += get_parent_links(parent_taxon)
+  end
+
+  tree
+end


### PR DESCRIPTION
It's currently awkward to find out how many people would be notified via email-alert-api if a particular content item is updated. The information flows one way (down the message queue) to email alert service and is stored in email-alert-api as a ContentChange. A [recent PR](https://github.com/alphagov/email-alert-api/pull/1976) added a rake task to easily query Email Alert API for the numbers of people in subscriber lists for changes that had already gone out, but we have no way of answering the number of people affected by a hypothetical change (a question asked occasionally on second line).

Since Publishing API and email-alert-api can't talk directly, I've added a rake task which will generate a code snippet to paste into the email-alert-api console, which then gives you a list of affected subscriber lists.

Example usage: You want to know how many people would be notified about a change to "/government/news/ifrs-17-gad-helps-develop-new-guidance"

On **publishing-api**, run the rake task:
```
rails email_reports:get_subscriber_list_code[/government/news/ifrs-17-gad-helps-develop-new-guidance]
```

this will output code similar to this:

```
To use: Copy everything between the start and end block markers, and
paste into an email-alert-api console

=== START BLOCK ===
lists = SubscriberListQuery.new(
  content_id: "70379c1a-4ed3-4296-b0ad-3afcf310d52e",
  tags: {:user_journey_document_supertype=>"thing", :email_document_supertype=>"announcements", :government_document_supertype=>"news-stories", :content_purpose_subgroup=>"news", :content_purpose_supergroup=>"news_and_communications", :content_store_document_type=>"news_story"},
  links: {:government=>["d4fbc1b9-d47d-4386-af04-ac909f868f92"], :organisations=>["02e01dc9-a4c4-46d9-b496-a618c89afe62"], :original_primary_publishing_organisation=>["02e01dc9-a4c4-46d9-b496-a618c89afe62"], :primary_publishing_organisation=>["02e01dc9-a4c4-46d9-b496-a618c89afe62"], :taxons=>["f3caf326-fe33-410f-b7f4-553f4011c81e"], :user_journey_document_supertype=>"thing", :email_document_supertype=>"announcements", :government_document_supertype=>"news-stories", :content_purpose_subgroup=>"news", :content_purpose_supergroup=>"news_and_communications", :content_store_document_type=>"news_story", :taxon_tree=>["f3caf326-fe33-410f-b7f4-553f4011c81e", "f3f4b5d3-49c4-487b-bd5b-be75f11ec8c5", "e48ab80a-de80-4e83-bf59-26316856a5f9"]},
  document_type: "news_story",
  email_document_supertype:  "announcements",
  government_document_supertype:  "news-stories",
).lists
=== END BLOCK ===
```

...copy and paste this into the application console of **email-alert-api**. lists will now contain a list of subscriber lists that would be notified, which can be manipulated to (eg) give you the breakdown of number of emails that would be sent:

```
        total_subs = lists.sum { |l| l.subscriptions.active.count }
        immediately_subs = lists.sum { |l| l.subscriptions.active.immediately.count }
        daily_subs = lists.sum { |l| l.subscriptions.active.daily.count }
        weekly_subs = lists.sum { |l| l.subscriptions.active.weekly.count }
```

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.
