### PR TITLE
Remove `remove_invalid_worldorg_drafts` rake task

### DIFF
--- a/lib/tasks/data_hygiene.rake
+++ b/lib/tasks/data_hygiene.rake
@@ -38,25 +38,6 @@ namespace :data_hygiene do
     end
   end
 
-  desc "Removes invalid about page drafts from world organisations that can prevent editing"
-  task remove_invalid_worldorg_drafts: :environment do
-    about_pages = Edition
-                    .where(document_type: "about", state: "draft")
-                    .select { |edition| edition.base_path =~ /\A\/world\/organisations\/[^\/]+\z/ }
-                    .map { |edition| [edition.document.content_id, edition.document.locale] }
-
-    puts "Found #{about_pages.size} invalid draft Worldwide Organisation editions to remove"
-    about_pages.each do |content_id, locale|
-      puts "Removing draft edition #{content_id}"
-      Commands::V2::DiscardDraft.call(
-        {
-          content_id:,
-          locale:,
-        },
-      )
-    end
-  end
-
   desc "Bulk update the organisations associated with documents."
   task :bulk_update_organisation, %i[csv_filename] => :environment do |_, args|
     DataHygiene::BulkOrganisationUpdater.call(args[:csv_filename])


### PR DESCRIPTION
This was used to remove draft placeholder Worldwide Organisations, that were caused by Whitehall publishing two different documents (the Worldwide Organisation and it's associated 'About Us' Corporate Information Page) to the same path.

We have removed the publishing of placeholder Worldwide Organisation pages and resolved the issue that caused them to be published.

Therefore the rake task can be removed.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
