### PR TITLE
Add 'open_filter_on_load' property to finder

### DIFF
--- a/content_schemas/dist/formats/finder/frontend/schema.json
+++ b/content_schemas/dist/formats/finder/frontend/schema.json
@@ -347,6 +347,9 @@
         "no_index": {
           "type": "boolean"
         },
+        "open_filter_on_load": {
+          "type": "boolean"
+        },
         "reject": {
           "$ref": "#/definitions/finder_reject_filter"
         },

--- a/content_schemas/dist/formats/finder/notification/schema.json
+++ b/content_schemas/dist/formats/finder/notification/schema.json
@@ -447,6 +447,9 @@
         "no_index": {
           "type": "boolean"
         },
+        "open_filter_on_load": {
+          "type": "boolean"
+        },
         "reject": {
           "$ref": "#/definitions/finder_reject_filter"
         },

--- a/content_schemas/dist/formats/finder/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/finder/publisher_v2/schema.json
@@ -221,6 +221,9 @@
         "no_index": {
           "type": "boolean"
         },
+        "open_filter_on_load": {
+          "type": "boolean"
+        },
         "reject": {
           "$ref": "#/definitions/finder_reject_filter"
         },

--- a/content_schemas/formats/finder.jsonnet
+++ b/content_schemas/formats/finder.jsonnet
@@ -49,6 +49,9 @@
         filter: {
           "$ref": "#/definitions/finder_filter",
         },
+        open_filter_on_load: {
+          type: "boolean",
+        },
         reject: {
           "$ref": "#/definitions/finder_reject_filter",
         },


### PR DESCRIPTION
## What

https://trello.com/c/p6FCqlHs/2042-expand-filter-and-location-facets-by-default-on-mobile

Add `open_filter_on_load` property to open filters, on page load, on mobile. Configured for **Find a licence** (specialist finder) only.

## Why

During user research, a common observation has emerged that mobile users do not interact with the 'Filter' button.

## Anything else

https://github.com/alphagov/finder-frontend/pull/3131
https://github.com/alphagov/specialist-publisher/pull/2369