### PR TITLE
Make `rendering_app` optional for `world_location` schema

### DIFF
--- a/content_schemas/dist/formats/world_location/frontend/schema.json
+++ b/content_schemas/dist/formats/world_location/frontend/schema.json
@@ -208,7 +208,7 @@
       ]
     },
     "rendering_app": {
-      "$ref": "#/definitions/rendering_app"
+      "$ref": "#/definitions/rendering_app_optional"
     },
     "scheduled_publishing_delay_seconds": {
       "anyOf": [
@@ -638,6 +638,16 @@
         "tariff",
         "whitehall-admin",
         "whitehall-frontend"
+      ]
+    },
+    "rendering_app_optional": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/rendering_app"
+        },
+        {
+          "type": "null"
+        }
       ]
     },
     "scheduled_publishing_delay_seconds": {

--- a/content_schemas/dist/formats/world_location/notification/schema.json
+++ b/content_schemas/dist/formats/world_location/notification/schema.json
@@ -299,7 +299,7 @@
       "items": {}
     },
     "rendering_app": {
-      "$ref": "#/definitions/rendering_app"
+      "$ref": "#/definitions/rendering_app_optional"
     },
     "routes": {
       "$ref": "#/definitions/routes_optional"
@@ -755,6 +755,16 @@
         "tariff",
         "whitehall-admin",
         "whitehall-frontend"
+      ]
+    },
+    "rendering_app_optional": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/rendering_app"
+        },
+        {
+          "type": "null"
+        }
       ]
     },
     "routes_optional": {

--- a/content_schemas/dist/formats/world_location/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/world_location/publisher_v2/schema.json
@@ -5,7 +5,6 @@
     "details",
     "document_type",
     "publishing_app",
-    "rendering_app",
     "schema_name",
     "title"
   ],
@@ -100,7 +99,7 @@
       "items": {}
     },
     "rendering_app": {
-      "$ref": "#/definitions/rendering_app"
+      "$ref": "#/definitions/rendering_app_optional"
     },
     "routes": {
       "$ref": "#/definitions/routes_optional"
@@ -383,6 +382,16 @@
         "tariff",
         "whitehall-admin",
         "whitehall-frontend"
+      ]
+    },
+    "rendering_app_optional": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/rendering_app"
+        },
+        {
+          "type": "null"
+        }
       ]
     },
     "routes_optional": {

--- a/content_schemas/formats/world_location.jsonnet
+++ b/content_schemas/formats/world_location.jsonnet
@@ -25,4 +25,5 @@
   edition_links: (import "shared/base_edition_links.jsonnet") + {
     featured_policies: "Featured policies primarily for use with Whitehall organisations",
   },
+  rendering_app: "optional",
 }


### PR DESCRIPTION
World Locations are not rendered by any application, as they have no base path and no routes.

The content item exists solely for use in link expansion.

We currently set the `rendering_app` to `whitehall-frontend`, which is incorrect as these pages are not rendered.

Therefore making the field optional so we can remove the rendering app completely.

[Trello card](https://trello.com/c/QWJnPXYf)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
