### PR TITLE
Add links to all roles to worldwide organisation content item

### DIFF
--- a/content_schemas/dist/formats/worldwide_organisation/frontend/schema.json
+++ b/content_schemas/dist/formats/worldwide_organisation/frontend/schema.json
@@ -335,6 +335,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
+        "roles": {
+          "description": "All roles associated with this Worldwide Organisation",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "secondary_role_person": {
           "description": "The person currently appointed to a secondary role in this Worldwide Organisation",
           "$ref": "#/definitions/frontend_links"

--- a/content_schemas/dist/formats/worldwide_organisation/notification/schema.json
+++ b/content_schemas/dist/formats/worldwide_organisation/notification/schema.json
@@ -353,6 +353,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
+        "roles": {
+          "description": "All roles associated with this Worldwide Organisation",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "secondary_role_person": {
           "description": "The person currently appointed to a secondary role in this Worldwide Organisation",
           "$ref": "#/definitions/frontend_links"
@@ -465,6 +469,10 @@
         },
         "primary_role_person": {
           "description": "The person currently appointed to a primary role in this Worldwide Organisation",
+          "$ref": "#/definitions/guid_list"
+        },
+        "roles": {
+          "description": "All roles associated with this Worldwide Organisation",
           "$ref": "#/definitions/guid_list"
         },
         "secondary_role_person": {

--- a/content_schemas/dist/formats/worldwide_organisation/publisher_v2/links.json
+++ b/content_schemas/dist/formats/worldwide_organisation/publisher_v2/links.json
@@ -76,6 +76,10 @@
           "description": "The person currently appointed to a primary role in this Worldwide Organisation",
           "$ref": "#/definitions/guid_list"
         },
+        "roles": {
+          "description": "All roles associated with this Worldwide Organisation",
+          "$ref": "#/definitions/guid_list"
+        },
         "secondary_role_person": {
           "description": "The person currently appointed to a secondary role in this Worldwide Organisation",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/formats/worldwide_organisation.jsonnet
+++ b/content_schemas/formats/worldwide_organisation.jsonnet
@@ -64,6 +64,7 @@
     secondary_role_person: "The person currently appointed to a secondary role in this Worldwide Organisation",
     office_staff: "People currently appointed to office staff roles in this Worldwide Organisation",
     sponsoring_organisations: "Sponsoring organisations for this Worldwide Organisation",
-    world_locations: "World Locations associated with this Worldwide Organisation"
+    world_locations: "World Locations associated with this Worldwide Organisation",
+    roles: "All roles associated with this Worldwide Organisation",
   },
 }


### PR DESCRIPTION
https://trello.com/c/54I3mDxr

People linked to a worldwide organisation may have multiple roles, some of which are related to other organsaitions. Currently, we are incorrectly displaying these roles on the world wide organisation pages.

This copies the approach taken in alphagov/collections#1719. We link to all roles from the worldwide organisation, then filter out the incorrect ones in the rendering app.

See also alphagov/whitehall#8162 and alphagov/government-frontend#2906.

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
