### PR TITLE
Add assurance technique approach field to AI assurance technique specialist document metadata

### DIFF
--- a/content_schemas/dist/formats/specialist_document/frontend/schema.json
+++ b/content_schemas/dist/formats/specialist_document/frontend/schema.json
@@ -346,6 +346,17 @@
             ]
           }
         },
+        "assurance_technique_approach": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "technical",
+              "procedural",
+              "educational"
+            ]
+          }
+        },
         "bulk_published": {
           "type": "boolean"
         },

--- a/content_schemas/dist/formats/specialist_document/notification/schema.json
+++ b/content_schemas/dist/formats/specialist_document/notification/schema.json
@@ -438,6 +438,17 @@
             ]
           }
         },
+        "assurance_technique_approach": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "technical",
+              "procedural",
+              "educational"
+            ]
+          }
+        },
         "bulk_published": {
           "type": "boolean"
         },

--- a/content_schemas/dist/formats/specialist_document/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/specialist_document/publisher_v2/schema.json
@@ -262,6 +262,17 @@
             ]
           }
         },
+        "assurance_technique_approach": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "technical",
+              "procedural",
+              "educational"
+            ]
+          }
+        },
         "bulk_published": {
           "type": "boolean"
         },

--- a/content_schemas/formats/shared/definitions/_specialist_document.jsonnet
+++ b/content_schemas/formats/shared/definitions/_specialist_document.jsonnet
@@ -277,6 +277,17 @@
           ],
         },
       },
+      assurance_technique_approach: {
+        type: "array",
+        items: {
+          type: "string",
+          enum: [
+            "technical",
+            "procedural",
+            "educational"
+          ],
+        },
+      },
     },
   }, 
   animal_disease_case_metadata: {


### PR DESCRIPTION
Required as part of addition of new assurance technique approach facet to AI Assurance technique specialist finder

Trello: https://trello.com/c/dk6wY8nD
Zendesk: https://govuk.zendesk.com/agent/tickets/5444446

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
