### PR TITLE
Add new field to edition links

### DIFF
--- a/content_schemas/dist/formats/document_collection/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/document_collection/publisher_v2/schema.json
@@ -89,6 +89,11 @@
         "related_policies": {
           "$ref": "#/definitions/guid_list"
         },
+        "taxonomy_topic_email_override": {
+          "description": "The taxonomy topic that email subscriptions for this document collection should go to - only for document collections converted from specialist topics",
+          "$ref": "#/definitions/guid_list",
+          "maxItems": 1
+        },
         "topical_events": {
           "$ref": "#/definitions/guid_list"
         },

--- a/content_schemas/formats/document_collection.jsonnet
+++ b/content_schemas/formats/document_collection.jsonnet
@@ -69,6 +69,10 @@
   },
   edition_links: (import "shared/whitehall_edition_links.jsonnet") + {
     documents: "",
+    taxonomy_topic_email_override: {
+        description: "The taxonomy topic that email subscriptions for this document collection should go to - only for document collections converted from specialist topics",
+        maxItems: 1
+    },
   },
   links: (import "shared/base_links.jsonnet") + {
     government: {


### PR DESCRIPTION
When trying to publish document collections that have a `taxonomy_topic_email_override` we are seeing schema validation errors: `#/links contains additional properties [\"taxonomy_topic_email_override\"] outside of the schema when none are allowed.`

This is because the field is only present in the [publisher_v2/links.json](https://github.com/alphagov/publishing-api/blob/main/content_schemas/dist/formats/document_collection/publisher_v2/links.json#L80-L83) file, and is not yet defined in [publisher_v2/schema.json](https://github.com/alphagov/publishing-api/blob/main/content_schemas/dist/formats/document_collection/publisher_v2/schema.json).

When the schemas are regenerated, [publisher_content_schema_generator.rb](https://github.com/alphagov/publishing-api/blob/main/lib/schema_generator/publisher_content_schema_generator.rb#L64) fetches the `edition_links`. It does not fetch the `base_links`, which is where this field had previously been added. 

This PR adds the field to `edition_links` (in addition to it being present in `base_links`).This duplication is needed so that both `links.json` and `schema.json` contain the field. Not sure I fully understand why, but hopefully this will allow us to publish!

Follows original PR: https://github.com/alphagov/publishing-api/pull/2440
Related PR in Whitehall: https://github.com/alphagov/whitehall/pull/8203

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
