### PR TITLE
Remove topical events from travel advice schema

### DIFF
--- a/content_schemas/dist/formats/travel_advice/frontend/schema.json
+++ b/content_schemas/dist/formats/travel_advice/frontend/schema.json
@@ -156,9 +156,6 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "topical_events": {
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "topics": {
           "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/content_schemas/dist/formats/travel_advice/notification/schema.json
+++ b/content_schemas/dist/formats/travel_advice/notification/schema.json
@@ -174,9 +174,6 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "topical_events": {
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "topics": {
           "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -252,9 +249,6 @@
         },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/guid_list"
-        },
-        "topical_events": {
           "$ref": "#/definitions/guid_list"
         },
         "topics": {

--- a/content_schemas/dist/formats/travel_advice/publisher_v2/links.json
+++ b/content_schemas/dist/formats/travel_advice/publisher_v2/links.json
@@ -67,9 +67,6 @@
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
         },
-        "topical_events": {
-          "$ref": "#/definitions/guid_list"
-        },
         "topics": {
           "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/formats/travel_advice.jsonnet
+++ b/content_schemas/formats/travel_advice.jsonnet
@@ -79,6 +79,5 @@
   },
   links: (import "shared/base_links.jsonnet") + {
     related: "",
-    topical_events: "",
   },
 }


### PR DESCRIPTION
Remove tech debt: Hacks introduced to support travel advice on https://www.gov.uk/government/topical-events/afghanistan-uk-government-response are now no longer needed (confirmed with FCDO)

https://trello.com/c/YZLEOB8w/6-august-2021-afghanistan-topical-event-is-augmented-with-hacks

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
