### PR TITLE
Allow external redirects to caa.co.uk

### DIFF
--- a/app/validators/routes_and_redirects_validator.rb
+++ b/app/validators/routes_and_redirects_validator.rb
@@ -1,5 +1,6 @@
 class RoutesAndRedirectsValidator < ActiveModel::Validator
   EXTERNAL_HOST_ALLOW_LIST = %w[
+    .caa.co.uk
     .gov.uk
     .judiciary.uk
     .nationalhighways.co.uk

--- a/app/validators/routes_and_redirects_validator.rb
+++ b/app/validators/routes_and_redirects_validator.rb
@@ -198,7 +198,7 @@ private
         return
       end
 
-      errors.add(:redirects, "external redirects only accepted within the gov.uk, judiciary.uk, nhs.uk or ukri.org domains") unless
+      errors.add(:redirects, "external redirects only accepted for the domains #{EXTERNAL_HOST_ALLOW_LIST.to_sentence}") unless
         government_domain?(uri.host)
 
       errors.add(:redirects, "internal redirect should not be specified with full url") if


### PR DESCRIPTION
This allows users to unpublish documents and redirect it to URLs on the Civil Aviation Authority (CAA) website.

Requested in Zendesk ticket:
https://govuk.zendesk.com/agent/tickets/4994883

And agreed in Slack thread:
https://gds.slack.com/archives/CACV3TACU/p1694690016148749

I originally added this to Whitehall in PR alphagov/whitehall#8290 before realising that the document to be unpublished & redirected is actually published via Specialist Publisher, and therefore this is actually where the list needs updating. 🙈

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
