### PR TITLE
Resolve issue when unpublishing redirect content items

### DIFF
--- a/app/downstream_payload.rb
+++ b/app/downstream_payload.rb
@@ -61,14 +61,14 @@ private
   end
 
   def content_store_presenter
-    return redirect_presenter if edition.document_type == "redirect"
-    return content_presenter unless unpublished?
-
-    case unpublishing.type
-    when "redirect" then redirect_presenter
-    when "gone" then gone_presenter
-    else content_presenter
+    if unpublishing
+      return redirect_presenter if unpublishing.type == "redirect"
+      return gone_presenter if unpublishing.type == "gone"
     end
+
+    return redirect_presenter if edition.document_type == "redirect"
+
+    content_presenter
   end
 
   def message_queue_presenter

--- a/spec/downstream_payload_spec.rb
+++ b/spec/downstream_payload_spec.rb
@@ -157,6 +157,22 @@ RSpec.describe DownstreamPayload do
         end
       end
 
+      context "redirect type with unpublishing type of gone" do
+        let(:edition) do
+          create_edition(:redirect_edition, unpublishing: create(
+            :unpublishing,
+            type: "gone",
+          ))
+        end
+
+        it "returns a gone payload" do
+          expect(downstream_payload.content_store_payload).to include(
+            document_type: "gone",
+            base_path: edition.base_path,
+          )
+        end
+      end
+
       context "gone type" do
         let(:edition) { create_edition(:gone_unpublished_edition) }
 


### PR DESCRIPTION
When a content item with document type of `redirect` was being unpublished as `gone`, we were still presenting it to Content Store with the redirect presenter (instead of the gone presenter). This meant that the redirect remained in place and the gone response was never handled.

This was because the `content_store_presenter` method prioritised the redirect over the unpublishing, which is not correct. The unpublishing should take priority over the document's existing type.

Therefore updating to ensure we handle unpublishing first.

Also added a test to cover the scenario, which was failing before this fix was implemented.

[Trello card](https://trello.com/c/04oigyvM)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
