### PR TITLE
Add `lock_ttl` to downstream workers

### DIFF
--- a/app/workers/downstream_draft_worker.rb
+++ b/app/workers/downstream_draft_worker.rb
@@ -8,7 +8,8 @@ class DownstreamDraftWorker
   sidekiq_options queue: HIGH_QUEUE,
                   lock: :until_executing,
                   lock_args_method: :uniq_args,
-                  on_conflict: :log
+                  on_conflict: :log,
+                  lock_ttl: 1.day
 
   def self.uniq_args(args)
     [

--- a/app/workers/downstream_draft_worker.rb
+++ b/app/workers/downstream_draft_worker.rb
@@ -5,10 +5,10 @@ class DownstreamDraftWorker
   include Sidekiq::Worker
   include PerformAsyncInQueue
 
-  sidekiq_options "queue" => HIGH_QUEUE,
-                  "lock" => :until_executing,
-                  "lock_args_method" => :uniq_args,
-                  "on_conflict" => :log
+  sidekiq_options queue: HIGH_QUEUE,
+                  lock: :until_executing,
+                  lock_args_method: :uniq_args,
+                  on_conflict: :log
 
   def self.uniq_args(args)
     [

--- a/app/workers/downstream_live_worker.rb
+++ b/app/workers/downstream_live_worker.rb
@@ -8,7 +8,8 @@ class DownstreamLiveWorker
   sidekiq_options queue: HIGH_QUEUE,
                   lock: :until_executing,
                   lock_args_method: :uniq_args,
-                  on_conflict: :log
+                  on_conflict: :log,
+                  lock_ttl: 1.day
 
   def self.uniq_args(args)
     [


### PR DESCRIPTION
This adds an expiry time to the worker locks. This means that if a lock fails to be unset, we will automatically expire it after one day.

We know that locks sometimes remain on jobs after they have executed but have yet to identify the cause.

This should alleviate the issue by expiring these locks after one day, meaning the document preview can be generated again after that day.

We will separately identify and fix the issue causing the locks to not be removed.

[Trello card](https://trello.com/c/IUj0VRw8)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
