### PR TITLE
Add logging for `SidekiqUniqueJobs`

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -23,3 +23,37 @@ Sidekiq.strict_args!
 
 # SidekiqUniqueJobs recommends not testing this behaviour https://github.com/mhenrixon/sidekiq-unique-jobs#uniqueness
 SidekiqUniqueJobs.config.enabled = !Rails.env.test?
+
+# Logging for SidekiqUniqueJobs
+# Somewhat copied from https://github.com/mhenrixon/sidekiq-unique-jobs/blob/36ffe8f95b01ab059a34c8093c2410a64ca191b9/UPGRADING.md?plain=1
+SidekiqUniqueJobs.reflect do |on|
+  on.duplicate do |job_hash|
+    logger.warn(job_hash.merge(message: "Duplicate Job"))
+  end
+
+  on.execution_failed do |job_hash, exception = nil|
+    message = "Execution failed"
+    message += " (#{exception.message})" if exception
+    logger.warn(job_hash.merge(message:))
+  end
+
+  on.lock_failed do |job_hash|
+    logger.warn(job_hash.merge(message: "Lock failed to be acquired"))
+  end
+
+  on.reschedule_failed do |job_hash|
+    logger.debug(job_hash.merge(message: "Reschedule failed"))
+  end
+
+  on.timeout do |job_hash|
+    logger.warn(job_hash.merge(message: "Lock acquisition timed out"))
+  end
+
+  on.unknown_sidekiq_worker do |job_hash|
+    logger.warn(job_hash.merge(message: "Unknown Sidekiq worker"))
+  end
+
+  on.unlock_failed do |job_hash|
+    logger.warn(job_hash.merge(message: "Unlock failed"))
+  end
+end


### PR DESCRIPTION
As of version 7.1.0 of `sidekiq-unique-jobs`, [there is no logging by default](https://github.com/mhenrixon/sidekiq-unique-jobs/blob/36ffe8f95b01ab059a34c8093c2410a64ca191b9/UPGRADING.md).

Therefore adding some logging to help us debug events that occur when publishers are unable to see a preview.

[Trello card](https://trello.com/c/IUj0VRw8)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
