### PR TITLE
Reduce `lock_ttl` and make the value global

### DIFF
--- a/app/workers/downstream_draft_worker.rb
+++ b/app/workers/downstream_draft_worker.rb
@@ -8,8 +8,7 @@ class DownstreamDraftWorker
   sidekiq_options queue: HIGH_QUEUE,
                   lock: :until_executing,
                   lock_args_method: :uniq_args,
-                  on_conflict: :log,
-                  lock_ttl: 1.day
+                  on_conflict: :log
 
   def self.uniq_args(args)
     [

--- a/app/workers/downstream_live_worker.rb
+++ b/app/workers/downstream_live_worker.rb
@@ -8,8 +8,7 @@ class DownstreamLiveWorker
   sidekiq_options queue: HIGH_QUEUE,
                   lock: :until_executing,
                   lock_args_method: :uniq_args,
-                  on_conflict: :log,
-                  lock_ttl: 1.day
+                  on_conflict: :log
 
   def self.uniq_args(args)
     [

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,3 +1,8 @@
+SidekiqUniqueJobs.configure do |config|
+  config.enabled = !Rails.env.test? # SidekiqUniqueJobs recommends not testing this behaviour https://github.com/mhenrixon/sidekiq-unique-jobs#uniqueness
+  config.lock_ttl = 1.hour
+end
+
 Sidekiq.configure_client do |config|
   config.client_middleware do |chain|
     chain.add SidekiqLoggerMiddleware
@@ -20,9 +25,6 @@ end
 
 # Use Sidekiq strict args to force Sidekiq 6 deprecations to error ahead of upgrade to Sidekiq 7
 Sidekiq.strict_args!
-
-# SidekiqUniqueJobs recommends not testing this behaviour https://github.com/mhenrixon/sidekiq-unique-jobs#uniqueness
-SidekiqUniqueJobs.config.enabled = !Rails.env.test?
 
 # Logging for SidekiqUniqueJobs
 # Somewhat copied from https://github.com/mhenrixon/sidekiq-unique-jobs/blob/36ffe8f95b01ab059a34c8093c2410a64ca191b9/UPGRADING.md?plain=1


### PR DESCRIPTION
In https://github.com/alphagov/publishing-api/pull/2515, we added an expiry time to the locking of downstream workers, as some locks are not being removed when the job executes. We are still unsure of the reason for this.

Having examined the logs further, this affects all types of worker, not just the downstream workers.

Therefore making the `lock_ttl` value global for all Sidekiq workers.

Also reducing the expiry time to one hour, as all the workers we have should complete within that timescale.

[Trello card](https://trello.com/c/IUj0VRw8)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
