### PR TITLE
Disallow a conflicting draft editions

### DIFF
--- a/app/queries/base_path_for_state.rb
+++ b/app/queries/base_path_for_state.rb
@@ -36,7 +36,7 @@ module Queries
     end
 
     def allowed_states(state)
-      state == "draft" ? %w[draft] : %w[published unpublished]
+      state == "draft" ? %w[draft published] : %w[published unpublished]
     end
 
     def limit_scope_to_unpublishing(scope, state)

--- a/spec/queries/base_path_for_state_spec.rb
+++ b/spec/queries/base_path_for_state_spec.rb
@@ -36,7 +36,17 @@ RSpec.describe Queries::BasePathForState do
           is_expected.to match(collision_hash)
         end
 
-        %w[published unpublished superseded].each do |state|
+        context "when the editin is published" do
+          before do
+            conflict_edition.update(state: "published")
+          end
+
+          it "should be a collision" do
+            is_expected.to match(collision_hash)
+          end
+        end
+
+        %w[unpublished superseded].each do |state|
           context "when the edition is #{state}" do
             before do
               conflict_edition.update(state:)

--- a/spec/validators/base_path_for_state_validator_spec.rb
+++ b/spec/validators/base_path_for_state_validator_spec.rb
@@ -63,6 +63,19 @@ RSpec.describe BasePathForStateValidator do
             expect(edition.errors[:base]).to eq([expected_error])
           end
         end
+
+        context "when there is a live item at the base path" do
+          let(:conflict_state_name) { "published" }
+          let(:expected_error) do
+            "base path=#{conflict_base_path} conflicts with content_id=" \
+              "#{conflict_content_id} and locale=#{conflict_locale}"
+          end
+          before { validate }
+
+          it "adds the error to edition attribute" do
+            expect(edition.errors[:base]).to eq([expected_error])
+          end
+        end
       end
 
       %w[published unpublished].each do |name|


### PR DESCRIPTION
Currently, a publishing application can send a draft edition to Publishing API, which has the same base path as a live edition but with a different content ID.

This results in a valid draft edition being created in Publishing API.

However after this occurs, neither the original live edition with the original content ID or the draft edition can have a new edition created, as there will be a conflict in content IDs.

This updates the validation to disallow a draft edition with a different content ID if there is already a published edition at that base path.

[Trello card](https://trello.com/c/QRFqcMKd)