### PR TITLE
Provide a medium size image in whitehall image definitions

### DIFF
--- a/content_schemas/dist/formats/call_for_evidence/frontend/schema.json
+++ b/content_schemas/dist/formats/call_for_evidence/frontend/schema.json
@@ -628,6 +628,11 @@
           "type": "string",
           "format": "uri"
         },
+        "medium_resolution_url": {
+          "description": "URL to a medium resolution version of the image, for use by devices that have high pixel density such as iphone.",
+          "type": "string",
+          "format": "uri"
+        },
         "url": {
           "description": "URL to the image. The image should be in a suitable resolution for display on the page.",
           "type": "string",

--- a/content_schemas/dist/formats/call_for_evidence/notification/schema.json
+++ b/content_schemas/dist/formats/call_for_evidence/notification/schema.json
@@ -747,6 +747,11 @@
           "type": "string",
           "format": "uri"
         },
+        "medium_resolution_url": {
+          "description": "URL to a medium resolution version of the image, for use by devices that have high pixel density such as iphone.",
+          "type": "string",
+          "format": "uri"
+        },
         "url": {
           "description": "URL to the image. The image should be in a suitable resolution for display on the page.",
           "type": "string",

--- a/content_schemas/dist/formats/call_for_evidence/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/call_for_evidence/publisher_v2/schema.json
@@ -427,6 +427,11 @@
           "type": "string",
           "format": "uri"
         },
+        "medium_resolution_url": {
+          "description": "URL to a medium resolution version of the image, for use by devices that have high pixel density such as iphone.",
+          "type": "string",
+          "format": "uri"
+        },
         "url": {
           "description": "URL to the image. The image should be in a suitable resolution for display on the page.",
           "type": "string",

--- a/content_schemas/dist/formats/case_study/frontend/schema.json
+++ b/content_schemas/dist/formats/case_study/frontend/schema.json
@@ -559,6 +559,11 @@
           "type": "string",
           "format": "uri"
         },
+        "medium_resolution_url": {
+          "description": "URL to a medium resolution version of the image, for use by devices that have high pixel density such as iphone.",
+          "type": "string",
+          "format": "uri"
+        },
         "url": {
           "description": "URL to the image. The image should be in a suitable resolution for display on the page.",
           "type": "string",

--- a/content_schemas/dist/formats/case_study/notification/schema.json
+++ b/content_schemas/dist/formats/case_study/notification/schema.json
@@ -677,6 +677,11 @@
           "type": "string",
           "format": "uri"
         },
+        "medium_resolution_url": {
+          "description": "URL to a medium resolution version of the image, for use by devices that have high pixel density such as iphone.",
+          "type": "string",
+          "format": "uri"
+        },
         "url": {
           "description": "URL to the image. The image should be in a suitable resolution for display on the page.",
           "type": "string",

--- a/content_schemas/dist/formats/case_study/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/case_study/publisher_v2/schema.json
@@ -322,6 +322,11 @@
           "type": "string",
           "format": "uri"
         },
+        "medium_resolution_url": {
+          "description": "URL to a medium resolution version of the image, for use by devices that have high pixel density such as iphone.",
+          "type": "string",
+          "format": "uri"
+        },
         "url": {
           "description": "URL to the image. The image should be in a suitable resolution for display on the page.",
           "type": "string",

--- a/content_schemas/dist/formats/consultation/frontend/schema.json
+++ b/content_schemas/dist/formats/consultation/frontend/schema.json
@@ -645,6 +645,11 @@
           "type": "string",
           "format": "uri"
         },
+        "medium_resolution_url": {
+          "description": "URL to a medium resolution version of the image, for use by devices that have high pixel density such as iphone.",
+          "type": "string",
+          "format": "uri"
+        },
         "url": {
           "description": "URL to the image. The image should be in a suitable resolution for display on the page.",
           "type": "string",

--- a/content_schemas/dist/formats/consultation/notification/schema.json
+++ b/content_schemas/dist/formats/consultation/notification/schema.json
@@ -764,6 +764,11 @@
           "type": "string",
           "format": "uri"
         },
+        "medium_resolution_url": {
+          "description": "URL to a medium resolution version of the image, for use by devices that have high pixel density such as iphone.",
+          "type": "string",
+          "format": "uri"
+        },
         "url": {
           "description": "URL to the image. The image should be in a suitable resolution for display on the page.",
           "type": "string",

--- a/content_schemas/dist/formats/consultation/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/consultation/publisher_v2/schema.json
@@ -444,6 +444,11 @@
           "type": "string",
           "format": "uri"
         },
+        "medium_resolution_url": {
+          "description": "URL to a medium resolution version of the image, for use by devices that have high pixel density such as iphone.",
+          "type": "string",
+          "format": "uri"
+        },
         "url": {
           "description": "URL to the image. The image should be in a suitable resolution for display on the page.",
           "type": "string",

--- a/content_schemas/dist/formats/detailed_guide/frontend/schema.json
+++ b/content_schemas/dist/formats/detailed_guide/frontend/schema.json
@@ -650,6 +650,11 @@
           "type": "string",
           "format": "uri"
         },
+        "medium_resolution_url": {
+          "description": "URL to a medium resolution version of the image, for use by devices that have high pixel density such as iphone.",
+          "type": "string",
+          "format": "uri"
+        },
         "url": {
           "description": "URL to the image. The image should be in a suitable resolution for display on the page.",
           "type": "string",

--- a/content_schemas/dist/formats/detailed_guide/notification/schema.json
+++ b/content_schemas/dist/formats/detailed_guide/notification/schema.json
@@ -767,6 +767,11 @@
           "type": "string",
           "format": "uri"
         },
+        "medium_resolution_url": {
+          "description": "URL to a medium resolution version of the image, for use by devices that have high pixel density such as iphone.",
+          "type": "string",
+          "format": "uri"
+        },
         "url": {
           "description": "URL to the image. The image should be in a suitable resolution for display on the page.",
           "type": "string",

--- a/content_schemas/dist/formats/detailed_guide/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/detailed_guide/publisher_v2/schema.json
@@ -449,6 +449,11 @@
           "type": "string",
           "format": "uri"
         },
+        "medium_resolution_url": {
+          "description": "URL to a medium resolution version of the image, for use by devices that have high pixel density such as iphone.",
+          "type": "string",
+          "format": "uri"
+        },
         "url": {
           "description": "URL to the image. The image should be in a suitable resolution for display on the page.",
           "type": "string",

--- a/content_schemas/dist/formats/get_involved/frontend/schema.json
+++ b/content_schemas/dist/formats/get_involved/frontend/schema.json
@@ -517,6 +517,11 @@
           "type": "string",
           "format": "uri"
         },
+        "medium_resolution_url": {
+          "description": "URL to a medium resolution version of the image, for use by devices that have high pixel density such as iphone.",
+          "type": "string",
+          "format": "uri"
+        },
         "url": {
           "description": "URL to the image. The image should be in a suitable resolution for display on the page.",
           "type": "string",

--- a/content_schemas/dist/formats/get_involved/notification/schema.json
+++ b/content_schemas/dist/formats/get_involved/notification/schema.json
@@ -625,6 +625,11 @@
           "type": "string",
           "format": "uri"
         },
+        "medium_resolution_url": {
+          "description": "URL to a medium resolution version of the image, for use by devices that have high pixel density such as iphone.",
+          "type": "string",
+          "format": "uri"
+        },
         "url": {
           "description": "URL to the image. The image should be in a suitable resolution for display on the page.",
           "type": "string",

--- a/content_schemas/dist/formats/get_involved/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/get_involved/publisher_v2/schema.json
@@ -266,6 +266,11 @@
           "type": "string",
           "format": "uri"
         },
+        "medium_resolution_url": {
+          "description": "URL to a medium resolution version of the image, for use by devices that have high pixel density such as iphone.",
+          "type": "string",
+          "format": "uri"
+        },
         "url": {
           "description": "URL to the image. The image should be in a suitable resolution for display on the page.",
           "type": "string",

--- a/content_schemas/dist/formats/historic_appointments/frontend/schema.json
+++ b/content_schemas/dist/formats/historic_appointments/frontend/schema.json
@@ -507,6 +507,11 @@
           "type": "string",
           "format": "uri"
         },
+        "medium_resolution_url": {
+          "description": "URL to a medium resolution version of the image, for use by devices that have high pixel density such as iphone.",
+          "type": "string",
+          "format": "uri"
+        },
         "url": {
           "description": "URL to the image. The image should be in a suitable resolution for display on the page.",
           "type": "string",

--- a/content_schemas/dist/formats/historic_appointments/notification/schema.json
+++ b/content_schemas/dist/formats/historic_appointments/notification/schema.json
@@ -615,6 +615,11 @@
           "type": "string",
           "format": "uri"
         },
+        "medium_resolution_url": {
+          "description": "URL to a medium resolution version of the image, for use by devices that have high pixel density such as iphone.",
+          "type": "string",
+          "format": "uri"
+        },
         "url": {
           "description": "URL to the image. The image should be in a suitable resolution for display on the page.",
           "type": "string",

--- a/content_schemas/dist/formats/historic_appointments/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/historic_appointments/publisher_v2/schema.json
@@ -256,6 +256,11 @@
           "type": "string",
           "format": "uri"
         },
+        "medium_resolution_url": {
+          "description": "URL to a medium resolution version of the image, for use by devices that have high pixel density such as iphone.",
+          "type": "string",
+          "format": "uri"
+        },
         "url": {
           "description": "URL to the image. The image should be in a suitable resolution for display on the page.",
           "type": "string",

--- a/content_schemas/dist/formats/news_article/frontend/schema.json
+++ b/content_schemas/dist/formats/news_article/frontend/schema.json
@@ -625,6 +625,11 @@
           "type": "string",
           "format": "uri"
         },
+        "medium_resolution_url": {
+          "description": "URL to a medium resolution version of the image, for use by devices that have high pixel density such as iphone.",
+          "type": "string",
+          "format": "uri"
+        },
         "url": {
           "description": "URL to the image. The image should be in a suitable resolution for display on the page.",
           "type": "string",

--- a/content_schemas/dist/formats/news_article/notification/schema.json
+++ b/content_schemas/dist/formats/news_article/notification/schema.json
@@ -757,6 +757,11 @@
           "type": "string",
           "format": "uri"
         },
+        "medium_resolution_url": {
+          "description": "URL to a medium resolution version of the image, for use by devices that have high pixel density such as iphone.",
+          "type": "string",
+          "format": "uri"
+        },
         "url": {
           "description": "URL to the image. The image should be in a suitable resolution for display on the page.",
           "type": "string",

--- a/content_schemas/dist/formats/news_article/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/news_article/publisher_v2/schema.json
@@ -408,6 +408,11 @@
           "type": "string",
           "format": "uri"
         },
+        "medium_resolution_url": {
+          "description": "URL to a medium resolution version of the image, for use by devices that have high pixel density such as iphone.",
+          "type": "string",
+          "format": "uri"
+        },
         "url": {
           "description": "URL to the image. The image should be in a suitable resolution for display on the page.",
           "type": "string",

--- a/content_schemas/dist/formats/organisation/frontend/schema.json
+++ b/content_schemas/dist/formats/organisation/frontend/schema.json
@@ -809,6 +809,11 @@
           "type": "string",
           "format": "uri"
         },
+        "medium_resolution_url": {
+          "description": "URL to a medium resolution version of the image, for use by devices that have high pixel density such as iphone.",
+          "type": "string",
+          "format": "uri"
+        },
         "url": {
           "description": "URL to the image. The image should be in a suitable resolution for display on the page.",
           "type": "string",

--- a/content_schemas/dist/formats/organisation/notification/schema.json
+++ b/content_schemas/dist/formats/organisation/notification/schema.json
@@ -969,6 +969,11 @@
           "type": "string",
           "format": "uri"
         },
+        "medium_resolution_url": {
+          "description": "URL to a medium resolution version of the image, for use by devices that have high pixel density such as iphone.",
+          "type": "string",
+          "format": "uri"
+        },
         "url": {
           "description": "URL to the image. The image should be in a suitable resolution for display on the page.",
           "type": "string",

--- a/content_schemas/dist/formats/organisation/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/organisation/publisher_v2/schema.json
@@ -506,6 +506,11 @@
           "type": "string",
           "format": "uri"
         },
+        "medium_resolution_url": {
+          "description": "URL to a medium resolution version of the image, for use by devices that have high pixel density such as iphone.",
+          "type": "string",
+          "format": "uri"
+        },
         "url": {
           "description": "URL to the image. The image should be in a suitable resolution for display on the page.",
           "type": "string",

--- a/content_schemas/dist/formats/organisations_homepage/frontend/schema.json
+++ b/content_schemas/dist/formats/organisations_homepage/frontend/schema.json
@@ -491,6 +491,11 @@
           "type": "string",
           "format": "uri"
         },
+        "medium_resolution_url": {
+          "description": "URL to a medium resolution version of the image, for use by devices that have high pixel density such as iphone.",
+          "type": "string",
+          "format": "uri"
+        },
         "url": {
           "description": "URL to the image. The image should be in a suitable resolution for display on the page.",
           "type": "string",

--- a/content_schemas/dist/formats/organisations_homepage/notification/schema.json
+++ b/content_schemas/dist/formats/organisations_homepage/notification/schema.json
@@ -595,6 +595,11 @@
           "type": "string",
           "format": "uri"
         },
+        "medium_resolution_url": {
+          "description": "URL to a medium resolution version of the image, for use by devices that have high pixel density such as iphone.",
+          "type": "string",
+          "format": "uri"
+        },
         "url": {
           "description": "URL to the image. The image should be in a suitable resolution for display on the page.",
           "type": "string",

--- a/content_schemas/dist/formats/organisations_homepage/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/organisations_homepage/publisher_v2/schema.json
@@ -244,6 +244,11 @@
           "type": "string",
           "format": "uri"
         },
+        "medium_resolution_url": {
+          "description": "URL to a medium resolution version of the image, for use by devices that have high pixel density such as iphone.",
+          "type": "string",
+          "format": "uri"
+        },
         "url": {
           "description": "URL to the image. The image should be in a suitable resolution for display on the page.",
           "type": "string",

--- a/content_schemas/dist/formats/person/frontend/schema.json
+++ b/content_schemas/dist/formats/person/frontend/schema.json
@@ -497,6 +497,11 @@
           "type": "string",
           "format": "uri"
         },
+        "medium_resolution_url": {
+          "description": "URL to a medium resolution version of the image, for use by devices that have high pixel density such as iphone.",
+          "type": "string",
+          "format": "uri"
+        },
         "url": {
           "description": "URL to the image. The image should be in a suitable resolution for display on the page.",
           "type": "string",

--- a/content_schemas/dist/formats/person/notification/schema.json
+++ b/content_schemas/dist/formats/person/notification/schema.json
@@ -601,6 +601,11 @@
           "type": "string",
           "format": "uri"
         },
+        "medium_resolution_url": {
+          "description": "URL to a medium resolution version of the image, for use by devices that have high pixel density such as iphone.",
+          "type": "string",
+          "format": "uri"
+        },
         "url": {
           "description": "URL to the image. The image should be in a suitable resolution for display on the page.",
           "type": "string",

--- a/content_schemas/dist/formats/person/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/person/publisher_v2/schema.json
@@ -250,6 +250,11 @@
           "type": "string",
           "format": "uri"
         },
+        "medium_resolution_url": {
+          "description": "URL to a medium resolution version of the image, for use by devices that have high pixel density such as iphone.",
+          "type": "string",
+          "format": "uri"
+        },
         "url": {
           "description": "URL to the image. The image should be in a suitable resolution for display on the page.",
           "type": "string",

--- a/content_schemas/dist/formats/speech/frontend/schema.json
+++ b/content_schemas/dist/formats/speech/frontend/schema.json
@@ -581,6 +581,11 @@
           "type": "string",
           "format": "uri"
         },
+        "medium_resolution_url": {
+          "description": "URL to a medium resolution version of the image, for use by devices that have high pixel density such as iphone.",
+          "type": "string",
+          "format": "uri"
+        },
         "url": {
           "description": "URL to the image. The image should be in a suitable resolution for display on the page.",
           "type": "string",

--- a/content_schemas/dist/formats/speech/notification/schema.json
+++ b/content_schemas/dist/formats/speech/notification/schema.json
@@ -712,6 +712,11 @@
           "type": "string",
           "format": "uri"
         },
+        "medium_resolution_url": {
+          "description": "URL to a medium resolution version of the image, for use by devices that have high pixel density such as iphone.",
+          "type": "string",
+          "format": "uri"
+        },
         "url": {
           "description": "URL to the image. The image should be in a suitable resolution for display on the page.",
           "type": "string",

--- a/content_schemas/dist/formats/speech/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/speech/publisher_v2/schema.json
@@ -331,6 +331,11 @@
           "type": "string",
           "format": "uri"
         },
+        "medium_resolution_url": {
+          "description": "URL to a medium resolution version of the image, for use by devices that have high pixel density such as iphone.",
+          "type": "string",
+          "format": "uri"
+        },
         "url": {
           "description": "URL to the image. The image should be in a suitable resolution for display on the page.",
           "type": "string",

--- a/content_schemas/dist/formats/take_part/frontend/schema.json
+++ b/content_schemas/dist/formats/take_part/frontend/schema.json
@@ -487,6 +487,11 @@
           "type": "string",
           "format": "uri"
         },
+        "medium_resolution_url": {
+          "description": "URL to a medium resolution version of the image, for use by devices that have high pixel density such as iphone.",
+          "type": "string",
+          "format": "uri"
+        },
         "url": {
           "description": "URL to the image. The image should be in a suitable resolution for display on the page.",
           "type": "string",

--- a/content_schemas/dist/formats/take_part/notification/schema.json
+++ b/content_schemas/dist/formats/take_part/notification/schema.json
@@ -591,6 +591,11 @@
           "type": "string",
           "format": "uri"
         },
+        "medium_resolution_url": {
+          "description": "URL to a medium resolution version of the image, for use by devices that have high pixel density such as iphone.",
+          "type": "string",
+          "format": "uri"
+        },
         "url": {
           "description": "URL to the image. The image should be in a suitable resolution for display on the page.",
           "type": "string",

--- a/content_schemas/dist/formats/take_part/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/take_part/publisher_v2/schema.json
@@ -240,6 +240,11 @@
           "type": "string",
           "format": "uri"
         },
+        "medium_resolution_url": {
+          "description": "URL to a medium resolution version of the image, for use by devices that have high pixel density such as iphone.",
+          "type": "string",
+          "format": "uri"
+        },
         "url": {
           "description": "URL to the image. The image should be in a suitable resolution for display on the page.",
           "type": "string",

--- a/content_schemas/dist/formats/topical_event/frontend/schema.json
+++ b/content_schemas/dist/formats/topical_event/frontend/schema.json
@@ -306,15 +306,7 @@
           "format": "date-time"
         },
         "image": {
-          "properties": {
-            "alt_text": {
-              "type": "string"
-            },
-            "url": {
-              "type": "string",
-              "format": "uri"
-            }
-          }
+          "$ref": "#/definitions/image"
         },
         "ordered_featured_documents": {
           "description": "A set of featured documents to display for the Topical Event.",

--- a/content_schemas/dist/formats/topical_event/frontend/schema.json
+++ b/content_schemas/dist/formats/topical_event/frontend/schema.json
@@ -573,6 +573,11 @@
           "type": "string",
           "format": "uri"
         },
+        "medium_resolution_url": {
+          "description": "URL to a medium resolution version of the image, for use by devices that have high pixel density such as iphone.",
+          "type": "string",
+          "format": "uri"
+        },
         "url": {
           "description": "URL to the image. The image should be in a suitable resolution for display on the page.",
           "type": "string",

--- a/content_schemas/dist/formats/topical_event/notification/schema.json
+++ b/content_schemas/dist/formats/topical_event/notification/schema.json
@@ -677,6 +677,11 @@
           "type": "string",
           "format": "uri"
         },
+        "medium_resolution_url": {
+          "description": "URL to a medium resolution version of the image, for use by devices that have high pixel density such as iphone.",
+          "type": "string",
+          "format": "uri"
+        },
         "url": {
           "description": "URL to the image. The image should be in a suitable resolution for display on the page.",
           "type": "string",

--- a/content_schemas/dist/formats/topical_event/notification/schema.json
+++ b/content_schemas/dist/formats/topical_event/notification/schema.json
@@ -397,15 +397,7 @@
           "format": "date-time"
         },
         "image": {
-          "properties": {
-            "alt_text": {
-              "type": "string"
-            },
-            "url": {
-              "type": "string",
-              "format": "uri"
-            }
-          }
+          "$ref": "#/definitions/image"
         },
         "ordered_featured_documents": {
           "description": "A set of featured documents to display for the Topical Event.",

--- a/content_schemas/dist/formats/topical_event/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/topical_event/publisher_v2/schema.json
@@ -185,15 +185,7 @@
           "format": "date-time"
         },
         "image": {
-          "properties": {
-            "alt_text": {
-              "type": "string"
-            },
-            "url": {
-              "type": "string",
-              "format": "uri"
-            }
-          }
+          "$ref": "#/definitions/image"
         },
         "ordered_featured_documents": {
           "description": "A set of featured documents to display for the Topical Event.",

--- a/content_schemas/dist/formats/topical_event/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/topical_event/publisher_v2/schema.json
@@ -326,6 +326,11 @@
           "type": "string",
           "format": "uri"
         },
+        "medium_resolution_url": {
+          "description": "URL to a medium resolution version of the image, for use by devices that have high pixel density such as iphone.",
+          "type": "string",
+          "format": "uri"
+        },
         "url": {
           "description": "URL to the image. The image should be in a suitable resolution for display on the page.",
           "type": "string",

--- a/content_schemas/dist/formats/world_location_news/frontend/schema.json
+++ b/content_schemas/dist/formats/world_location_news/frontend/schema.json
@@ -499,6 +499,11 @@
           "type": "string",
           "format": "uri"
         },
+        "medium_resolution_url": {
+          "description": "URL to a medium resolution version of the image, for use by devices that have high pixel density such as iphone.",
+          "type": "string",
+          "format": "uri"
+        },
         "url": {
           "description": "URL to the image. The image should be in a suitable resolution for display on the page.",
           "type": "string",

--- a/content_schemas/dist/formats/world_location_news/notification/schema.json
+++ b/content_schemas/dist/formats/world_location_news/notification/schema.json
@@ -611,6 +611,11 @@
           "type": "string",
           "format": "uri"
         },
+        "medium_resolution_url": {
+          "description": "URL to a medium resolution version of the image, for use by devices that have high pixel density such as iphone.",
+          "type": "string",
+          "format": "uri"
+        },
         "url": {
           "description": "URL to the image. The image should be in a suitable resolution for display on the page.",
           "type": "string",

--- a/content_schemas/dist/formats/world_location_news/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/world_location_news/publisher_v2/schema.json
@@ -244,6 +244,11 @@
           "type": "string",
           "format": "uri"
         },
+        "medium_resolution_url": {
+          "description": "URL to a medium resolution version of the image, for use by devices that have high pixel density such as iphone.",
+          "type": "string",
+          "format": "uri"
+        },
         "url": {
           "description": "URL to the image. The image should be in a suitable resolution for display on the page.",
           "type": "string",

--- a/content_schemas/dist/formats/worldwide_organisation/frontend/schema.json
+++ b/content_schemas/dist/formats/worldwide_organisation/frontend/schema.json
@@ -628,6 +628,11 @@
           "type": "string",
           "format": "uri"
         },
+        "medium_resolution_url": {
+          "description": "URL to a medium resolution version of the image, for use by devices that have high pixel density such as iphone.",
+          "type": "string",
+          "format": "uri"
+        },
         "url": {
           "description": "URL to the image. The image should be in a suitable resolution for display on the page.",
           "type": "string",

--- a/content_schemas/dist/formats/worldwide_organisation/notification/schema.json
+++ b/content_schemas/dist/formats/worldwide_organisation/notification/schema.json
@@ -768,6 +768,11 @@
           "type": "string",
           "format": "uri"
         },
+        "medium_resolution_url": {
+          "description": "URL to a medium resolution version of the image, for use by devices that have high pixel density such as iphone.",
+          "type": "string",
+          "format": "uri"
+        },
         "url": {
           "description": "URL to the image. The image should be in a suitable resolution for display on the page.",
           "type": "string",

--- a/content_schemas/dist/formats/worldwide_organisation/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/worldwide_organisation/publisher_v2/schema.json
@@ -345,6 +345,11 @@
           "type": "string",
           "format": "uri"
         },
+        "medium_resolution_url": {
+          "description": "URL to a medium resolution version of the image, for use by devices that have high pixel density such as iphone.",
+          "type": "string",
+          "format": "uri"
+        },
         "url": {
           "description": "URL to the image. The image should be in a suitable resolution for display on the page.",
           "type": "string",

--- a/content_schemas/formats/shared/definitions/_whitehall.jsonnet
+++ b/content_schemas/formats/shared/definitions/_whitehall.jsonnet
@@ -35,6 +35,11 @@
         type: "string",
         format: "uri",
       },
+      medium_resolution_url: {
+        description: "URL to a medium resolution version of the image, for use by devices that have high pixel density such as iphone.",
+        type: "string",
+        format: "uri",
+      },
       high_resolution_url: {
         description: "URL to a high resolution version of the image, for use by third parties such as Twitter, Facebook or Slack. Used by the machine readable metadata component. Don't use this on user-facing web pages, as it might be very large.",
         type: "string",

--- a/content_schemas/formats/topical_event.jsonnet
+++ b/content_schemas/formats/topical_event.jsonnet
@@ -13,15 +13,7 @@
           type: "string",
         },
         image: {
-          properties: {
-            url: {
-              type: "string",
-              format: "uri",
-            },
-            alt_text: {
-              type: "string",
-            },
-          },
+          "$ref": "#/definitions/image",
         },
         start_date: {
           type: "string",

--- a/content_schemas/formats/topical_event.jsonnet
+++ b/content_schemas/formats/topical_event.jsonnet
@@ -14,13 +14,13 @@
         },
         image: {
           properties: {
-           url: {
-             type: "string",
-             format: "uri",
-           },
-           alt_text: {
-             type: "string",
-           },
+            url: {
+              type: "string",
+              format: "uri",
+            },
+            alt_text: {
+              type: "string",
+            },
           },
         },
         start_date: {


### PR DESCRIPTION
Public pages look better when they display images with various options for different devices. For example if an img element provides a srcset attribute, high pdi phones can opt to use the higher resolution image instead of a smaller image. Atm Topical Event pages use this. It is desireable to have more pages use this feature.

Whitehall needs to publish each image resolution and that requires this schema change.

[Trello](https://trello.com/c/l7AHikFh/233-story-implement-non-legacy-urls-for-topical-event-logo)