### PR TITLE
hmrc-manuals-api testsuite is rspec, not minitest.

### DIFF
--- a/.github/workflows/test-content-schemas-1.yml
+++ b/.github/workflows/test-content-schemas-1.yml
@@ -107,7 +107,7 @@ jobs:
 
   test-hmrc-manuals-api:
     name: Test HMRC Manuals API
-    uses: alphagov/hmrc-manuals-api/.github/workflows/minitest.yml@main
+    uses: alphagov/hmrc-manuals-api/.github/workflows/rspec.yml@main
     with:
       ref: 'main'
       publishingApiRef: ${{ github.ref }}


### PR DESCRIPTION
- https://github.com/alphagov/hmrc-manuals-api/pull/872
- https://github.com/alphagov/hmrc-manuals-api/pull/874

Last one hopefully!