### PR TITLE
Configure CI to publish pacts to broker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,11 +95,41 @@ jobs:
       ref: deployed-to-production
       pact_artifact: pacts
 
+  publish-pacts:
+    needs:
+      - test-ruby
+    if: ${{ github.ref == 'refs/heads/main' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+      - uses: actions/download-artifact@v3
+        with:
+          name: pacts
+          path: tmp/pacts
+      - run: bundle exec rake pact:publish
+        env:
+          PACT_CONSUMER_VERSION: branch-${{ github.ref_name }}
+          PACT_BROKER_BASE_URL: https://pact-broker.cloudapps.digital
+          PACT_BROKER_USERNAME: ${{ secrets.GOVUK_PACT_BROKER_USERNAME }}
+          PACT_BROKER_PASSWORD: ${{ secrets.GOVUK_PACT_BROKER_PASSWORD }}
+          PACT_PATTERN: tmp/pacts/*.json
+      - run: bundle exec rake pact:publish
+        env:
+          PACT_CONSUMER_VERSION: branch-${{ github.ref_name }}
+          PACT_BROKER_BASE_URL: https://govuk-pact-broker-6991351eca05.herokuapp.com
+          PACT_BROKER_USERNAME: ${{ secrets.GOVUK_PACT_BROKER_USERNAME }}
+          PACT_BROKER_PASSWORD: ${{ secrets.GOVUK_PACT_BROKER_PASSWORD }}
+          PACT_PATTERN: tmp/pacts/*.json
+
   delete-pact-artifact:
     name: Delete Pact artifact
     needs:
       - test-ruby
       - run-content-store-pact-tests
+      - publish-pacts
     # Run whenever test-ruby is a success regardless of run-content-store-pact-tests outcome
     if: ${{ needs.test-ruby.result == 'success' && always() }}
     runs-on: ubuntu-latest

--- a/Rakefile
+++ b/Rakefile
@@ -5,6 +5,17 @@ require File.expand_path("config/application", __dir__)
 
 begin
   require "pact/tasks"
+  require "pact_broker/client/tasks"
+
+  PactBroker::Client::PublicationTask.new do |task|
+    task.consumer_version = ENV.fetch("PACT_CONSUMER_VERSION")
+    task.pact_broker_base_url = ENV.fetch("PACT_BROKER_BASE_URL")
+    task.pact_broker_basic_auth = {
+      username: ENV.fetch("PACT_BROKER_USERNAME"),
+      password: ENV.fetch("PACT_BROKER_PASSWORD"),
+    }
+    task.pattern = ENV["PACT_PATTERN"] if ENV["PACT_PATTERN"]
+  end
 rescue LoadError
   # Pact isn't available in all environments
 end


### PR DESCRIPTION
[Trello card](https://trello.com/c/7f3F6Xij/3338-migrate-from-the-old-paas-based-pact-broker-to-the-new-instance-on-heroku)

The Publishing API <-> Content Store pact isn't currently being published to the broker as part of Publishing API's CI, meaning that Content Store's CI is currently running pact verification against a ~7 month old version of this pact.

We are currently migrating our Pact Broker instance from PaaS to Heroku, so this PR (temporarily) configures CI to publish to both instances. In a later PR we will remove the reference to the old instance.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.