### PR TITLE
Add ability to requeue only published content

### DIFF
--- a/lib/requeue_content_by_scope.rb
+++ b/lib/requeue_content_by_scope.rb
@@ -1,0 +1,43 @@
+class RequeueContentByScope
+  DEFAULT_ACTION = "bulk.reindex".freeze
+  DEFAULT_BATCH_SIZE = 1_000
+
+  IMPORT_QUEUE_JOBS_LIMIT = 5_000
+  IMPORT_QUEUE_JOBS_LIMIT_WAIT_DURATION = 5.seconds
+
+  def initialize(scope, action: DEFAULT_ACTION, batch_size: DEFAULT_BATCH_SIZE)
+    raise ArgumentError, "Action must be provided" if action.blank?
+    # Major updates would spam subscribers with email alerts
+    raise ArgumentError, "Requeuing major updates is disruptive and not allowed" if /major/.match?(action)
+
+    @scope = scope.select(:id)
+    @action = action
+
+    @batch_size = batch_size
+  end
+
+  def call
+    scope.find_each(batch_size:) do |edition|
+      while queue.size > IMPORT_QUEUE_JOBS_LIMIT
+        warn "Pending jobs have exceeded limit of #{IMPORT_QUEUE_JOBS_LIMIT}, waiting for some " \
+          "jobs to clear before continuing."
+
+        sleep IMPORT_QUEUE_JOBS_LIMIT_WAIT_DURATION
+      end
+
+      RequeueContent.perform_async(edition.id, version, action)
+    end
+  end
+
+private
+
+  attr_reader :scope, :action, :batch_size
+
+  def version
+    @version ||= Event.maximum(:id)
+  end
+
+  def queue
+    @queue ||= Sidekiq::Queue.new("import")
+  end
+end

--- a/spec/lib/requeue_content_by_scope_spec.rb
+++ b/spec/lib/requeue_content_by_scope_spec.rb
@@ -1,0 +1,64 @@
+RSpec.describe RequeueContentByScope do
+  subject(:requeue_content_by_scope) { described_class.new(Edition.all, action:) }
+
+  let(:action) { "reticulate.splines" }
+
+  let(:queue) { instance_double(Sidekiq::Queue, size: 0) }
+
+  context "when a blank action is provided" do
+    let(:action) { "" }
+
+    it "raises an error on initialize" do
+      expect { requeue_content_by_scope }.to raise_error(ArgumentError)
+    end
+  end
+
+  context "when a major action is provided" do
+    let(:action) { "major.disaster" }
+
+    it "raises an error on initialize" do
+      expect { requeue_content_by_scope }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe "#call" do
+    let!(:editions) { create_list(:edition, 3) }
+    let!(:version) { create(:event, id: 1989) }
+
+    before do
+      allow(Sidekiq::Queue).to receive(:new).and_return(queue)
+      allow(RequeueContent).to receive(:perform_async)
+    end
+
+    it "requeues content for the provided scope" do
+      requeue_content_by_scope.call
+
+      editions.each do |edition|
+        expect(RequeueContent).to have_received(:perform_async)
+          .with(edition.id, 1989, "reticulate.splines").once
+      end
+      expect(RequeueContent).to have_received(:perform_async).exactly(3).times
+    end
+
+    context "when the queue has reached its limit" do
+      let(:queue_size) { 5_001 }
+
+      before do
+        allow(queue).to receive(:size).and_return(5001, 4999)
+        allow(requeue_content_by_scope).to receive(:sleep)
+      end
+
+      it "waits for the queue size to decrease" do
+        requeue_content_by_scope.call
+
+        expect(requeue_content_by_scope).to have_received(:sleep).at_least(:once)
+      end
+
+      it "logs a warning message" do
+        expect { requeue_content_by_scope.call }.to output(
+          /Pending jobs have exceeded limit/,
+        ).to_stderr
+      end
+    end
+  end
+end


### PR DESCRIPTION
For our initial bulk import of data into `search-api-v2`, we are only
interested in published content that is visible to users, and having to
consume all content is slowing down the initial import significantly and
putting unnecessary load on Publishing API.

Also cleans up and refactors the Rake tasks, and adds tests for this
functionality.

- Add new `queue:requeue_all_the_published_things` task to specifically
  requeue only published editions
- Refactor as much logic as possible from `queue:*` Rake tasks into a
  library class so that shared stuff doesn't have to be repeated and its
  effects can actually be tested
- Use `Edition.live` scope instead of `.where(content_store: :live)`
- Stop joining on Document with `.with_document` scope as no attributes
  from that model are used
- Resolve some inaccurate comments and descriptions for Rake tasks
  (published vs live)