### PR TITLE
Stop pushing to old pact broker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,13 +112,6 @@ jobs:
       - run: bundle exec rake pact:publish
         env:
           PACT_CONSUMER_VERSION: branch-${{ github.ref_name }}
-          PACT_BROKER_BASE_URL: https://pact-broker.cloudapps.digital
-          PACT_BROKER_USERNAME: ${{ secrets.GOVUK_PACT_BROKER_USERNAME }}
-          PACT_BROKER_PASSWORD: ${{ secrets.GOVUK_PACT_BROKER_PASSWORD }}
-          PACT_PATTERN: tmp/pacts/*.json
-      - run: bundle exec rake pact:publish
-        env:
-          PACT_CONSUMER_VERSION: branch-${{ github.ref_name }}
           PACT_BROKER_BASE_URL: https://govuk-pact-broker-6991351eca05.herokuapp.com
           PACT_BROKER_USERNAME: ${{ secrets.GOVUK_PACT_BROKER_USERNAME }}
           PACT_BROKER_PASSWORD: ${{ secrets.GOVUK_PACT_BROKER_PASSWORD }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,7 @@ jobs:
     needs: test-ruby
     uses: alphagov/content-store/.github/workflows/verify-pact.yml@main
     with:
-      ref: deployed-to-production
+      ref: main
       pact_artifact: pacts
 
   publish-pacts:


### PR DESCRIPTION
[Trello card](https://trello.com/c/7f3F6Xij/3338-migrate-from-the-old-paas-based-pact-broker-to-the-new-instance-on-heroku)

We are currently migrating our Pact Broker instance from PaaS to Heroku. Content Store has now been fully migrated to the new Pact Broker instance, so we can now stop publishing pacts to the old one.

Also a drive-by update: The `deployed-to-production` branch is no longer automatically updated on deploy, so it's currently pointing to an old pre-replatforming commit. This PR updates our CI to use the `verify-pact` workflow from the `main` branch of Content Store instead.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️