### PR TITLE
Add missing index to link_changes table.

### DIFF
--- a/db/migrate/20231119172139_add_index_to_link_changes.rb
+++ b/db/migrate/20231119172139_add_index_to_link_changes.rb
@@ -1,0 +1,6 @@
+class AddIndexToLinkChanges < ActiveRecord::Migration[7.1]
+  disable_ddl_transaction!
+  def change
+    add_index :link_changes, %w[created_at], name: "index_link_changes_on_created_at", order: { created_at: :desc }, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_11_131421) do
+ActiveRecord::Schema[7.1].define(version: 2023_11_19_172139) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -127,6 +127,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_11_131421) do
     t.bigint "action_id", null: false
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
+    t.index ["created_at"], name: "index_link_changes_on_created_at", order: :desc
   end
 
   create_table "link_sets", id: :serial, force: :cascade do |t|


### PR DESCRIPTION
This fixes the timeouts on the [Tagging history] page in Content Tagger, which makes a request to `content-store/links/changes`. That request was doing a full table scan and sort and taking > 15 s to return, causing Content Tagger and the end-user request to time out.

`CONCURRENTLY` avoids holding a write lock over the table for the duration of the `CREATE INDEX`. (We have to tell ActiveRecord not to magically wrap the script in a transaction for us, because `CREATE INDEX CONCURRENTLY` uses transactions internally.)

The changes to schema.rb were generated by `rails db:migrate`.

[Tagging history]: https://content-tagger.staging.publishing.service.gov.uk/tagging_history

<details>
<summary>Before: query returns in ~16 s</summary>

```
2023-11-19 16:36:06 UTC:
10.12.31.129(54556):publishing_api@publishing_api_production:[1750]:LOG:
execute a8: SELECT "link_changes".* FROM "link_changes" WHERE
"link_changes"."link_type" = $1 ORDER BY "link_changes"."created_at"
DESC LIMIT $2
2023-11-19 16:36:06 UTC:
10.12.31.129(54556):publishing_api@publishing_api_production:[1750]:DETAIL:
parameters: $1 = 'taxons', $2 = '250'
2023-11-19 16:36:18 UTC:
10.12.31.129(43970):publishing_api@publishing_api_production:[3297]:LOG:
duration: 16123.111 ms
```

```sql
EXPLAIN
SELECT * FROM link_changes
WHERE link_type = 'taxons' ORDER BY created_at DESC LIMIT 250;
```

```
 Limit  (cost=1252197.63..1252226.80 rows=250 width=98)
   ->  Gather Merge  (cost=1252197.63..1368203.43 rows=994266 width=98)
         Workers Planned: 2
         ->  Sort  (cost=1251197.60..1252440.44 rows=497133 width=98)
               Sort Key: created_at DESC
               ->  Parallel Seq Scan on link_changes
                   (cost=0.00..1228911.67 rows=497133 width=98)
                     Filter: ((link_type)::text = 'taxons'::text)
```

</details>

<details>
<summary>After: query returns in ~1.6 ms</summary>

```sql
\timing

SELECT * FROM link_changes
WHERE link_type = 'taxons' ORDER BY created_at DESC LIMIT 250;
```

```
Time: 1.623 ms
```

```sql
EXPLAIN
SELECT * FROM link_changes
WHERE link_type = 'taxons' ORDER BY created_at DESC LIMIT 250;
```

```
 Limit  (cost=0.56..552.23 rows=250 width=98)
   ->  Index Scan using links_changes_created_at on link_changes
       (cost=0.56..2633001.31 rows=1193200 width=98)
         Filter: ((link_type)::text = 'taxons'::text)
```

</details>

Tested: the Tagging History page in content-tagger times out in integration/staging without this, whereas after creating the index it appears instantly. Deployed the migration to integration, to verify that it works end-toend and so you can compare [integration](https://content-tagger.integration.publishing.service.gov.uk/tagging_history) to [staging](https://content-tagger.staging.publishing.service.gov.uk/tagging_history).