### PR TITLE
Optionally send PublishIntent additions/deletions to content store asynchronously

### DIFF
--- a/app/commands/delete_publish_intent.rb
+++ b/app/commands/delete_publish_intent.rb
@@ -2,7 +2,14 @@ module Commands
   class DeletePublishIntent < BaseCommand
     def call
       if downstream
-        PublishingAPI.service(:live_content_store).delete_publish_intent(base_path)
+        enqueue = ENV.fetch("ENQUEUE_PUBLISH_INTENTS", false)
+        if enqueue == "true"
+          DeletePublishIntentWorker.perform_async(
+            "base_path" => base_path,
+          )
+        else
+          PublishingAPI.service(:live_content_store).delete_publish_intent(base_path)
+        end
       end
 
       Success.new({})

--- a/app/commands/put_publish_intent.rb
+++ b/app/commands/put_publish_intent.rb
@@ -5,7 +5,15 @@ module Commands
 
       if downstream
         payload = publish_intent
-        Adapters::ContentStore.put_publish_intent(base_path, payload)
+        enqueue = ENV.fetch("ENQUEUE_PUBLISH_INTENTS", false)
+        if enqueue == "true"
+          PutPublishIntentWorker.perform_async(
+            "base_path" => base_path,
+            "payload" => payload.to_json,
+          )
+        else
+          Adapters::ContentStore.put_publish_intent(base_path, payload)
+        end
       end
 
       Success.new(payload)

--- a/app/workers/delete_publish_intent_worker.rb
+++ b/app/workers/delete_publish_intent_worker.rb
@@ -1,0 +1,25 @@
+require "sidekiq-unique-jobs"
+
+class DeletePublishIntentWorker
+  include DownstreamQueue
+  include Sidekiq::Worker
+  include PerformAsyncInQueue
+
+  sidekiq_options queue: HIGH_QUEUE,
+                  lock: :until_executing,
+                  lock_args_method: :uniq_args,
+                  on_conflict: :log
+
+  def self.uniq_args(args)
+    [
+      args.first["base_path"],
+      name,
+    ]
+  end
+
+  def perform(args = {})
+    PublishingAPI.service(:live_content_store).delete_publish_intent(args["base_path"])
+  rescue AbortWorkerError => e
+    notify_airbrake(e, args)
+  end
+end

--- a/app/workers/put_publish_intent_worker.rb
+++ b/app/workers/put_publish_intent_worker.rb
@@ -1,0 +1,25 @@
+require "sidekiq-unique-jobs"
+
+class PutPublishIntentWorker
+  include DownstreamQueue
+  include Sidekiq::Worker
+  include PerformAsyncInQueue
+
+  sidekiq_options queue: HIGH_QUEUE,
+                  lock: :until_executing,
+                  lock_args_method: :uniq_args,
+                  on_conflict: :log
+
+  def self.uniq_args(args)
+    [
+      args.first["base_path"],
+      name,
+    ]
+  end
+
+  def perform(args = {})
+    Adapters::ContentStore.put_publish_intent(args["base_path"], JSON.parse(args["payload"]))
+  rescue AbortWorkerError => e
+    notify_airbrake(e, args)
+  end
+end

--- a/spec/commands/put_publish_intent_spec.rb
+++ b/spec/commands/put_publish_intent_spec.rb
@@ -17,10 +17,46 @@ RSpec.describe Commands::PutPublishIntent do
 
   context "when the downstream flag is set to false" do
     it "does not send any downstream requests" do
-      expect(DownstreamDraftWorker).not_to receive(:perform_async)
-      expect(DownstreamLiveWorker).not_to receive(:perform_async)
+      expect(Adapters::ContentStore).not_to receive(:put_publish_intent)
 
       described_class.call(payload, downstream: false)
+    end
+  end
+
+  context "when the downstream flag is set to true" do
+    context "and the ENQUEUE_PUBLISH_INTENTS flag is true" do
+      before do
+        ENV["ENQUEUE_PUBLISH_INTENTS"] = "true"
+      end
+
+      it "enqueues a PutPublishIntent job" do
+        expect(PutPublishIntentWorker).to receive(:perform_async)
+        described_class.call(payload, downstream: true)
+      end
+    end
+
+    context "and the ENQUEUE_PUBLISH_INTENTS flag is not true" do
+      before do
+        ENV["ENQUEUE_PUBLISH_INTENTS"] = "no"
+      end
+
+      it "does send downstream requests" do
+        expect(Adapters::ContentStore).to receive(:put_publish_intent)
+
+        described_class.call(payload, downstream: true)
+      end
+    end
+
+    context "and the ENQUEUE_PUBLISH_INTENTS flag is not present" do
+      before do
+        ENV.delete("ENQUEUE_PUBLISH_INTENTS")
+      end
+
+      it "does send downstream requests" do
+        expect(Adapters::ContentStore).to receive(:put_publish_intent)
+
+        described_class.call(payload, downstream: true)
+      end
     end
   end
 end


### PR DESCRIPTION
Our [plan for safely swapping content-store over to a PostgreSQL database](https://docs.google.com/document/d/14B3YE978TDbujYnGHL0gm_gnf_EwD5MSHx7iRF24-90/edit#heading=h.wctys5xv7gdn) relies on us being able to suspend all writes/deletions for the length of time needed to run a full Mongo-to-Postgres export. This is currently around 90 minutes, but may be longer for the live content-store as it gets heavy sustained traffic.

When running this on the draft content-store, we found that some publish-intent writes were still going through even when the publishing-api workers were disabled. The numbers were low (less than 10 in 2hrs) but they still need to be handled.

We decided that the best option was to temporarily change publishing-api to send these updates to content-store asynchronously, for the duration of the switchover. (see the [Trello card](https://trello.com/c/a7ngC11v/952-figure-out-how-to-handle-observed-puts-of-publish-intents-while-publishing-api-workers-were-disabled) for full details). When the workers get switched back on at the end of the switchover, these updates will be pulled off the queue and sent to the content-store automatically.

We think this is safe, as publishing-api [already checks for uniqueness](https://github.com/alphagov/publishing-api/blob/d8ded888f56a2ae7909a8baf45968ed15e90423a/app/models/path_reservation.rb#L25-L30) of a path reservation before propagating to the content-store, so the risk of an out-of-order execution resulting in a problem should be very low.

Update 8th Dec 16:39:
I've successfully tested this with a scheduled publish on integration - 
![image](https://github.com/alphagov/publishing-api/assets/134501/00ae4d0d-8814-41b5-bcc7-045523eab79a)
...which showed up correctly in content-store:
```
> PublishIntent.order('created_at desc').first(1).pluck('base_path', 'created_at')
=> [["/government/news/test-new-news-story-5", Fri, 08 Dec 2023 16:32:50.131144000 UTC +00:00]]
```

So we'll merge this as close as possible to the start of the maintenance period on Monday 


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
