### PR TITLE
Add new judges to the administrative-appeals-tribunal-decisions finder

### DIFF
--- a/content_schemas/examples/specialist_document/frontend/utaac-decision.json
+++ b/content_schemas/examples/specialist_document/frontend/utaac-decision.json
@@ -2132,6 +2132,10 @@
                   "value": "beech-j"
                 },
                 {
+                  "label": "Brewer, M",
+                  "value": "brewer-m"
+                },
+                {
                   "label": "Broderick, M",
                   "value": "broderick-m"
                 },
@@ -2150,6 +2154,10 @@
                 {
                   "label": "Burton, F",
                   "value": "burton-f"
+                },
+                {
+                  "label": "Butler, J",
+                  "value": "butler-j"
                 },
                 {
                   "label": "Caldwell, M",
@@ -2400,6 +2408,10 @@
                   "value": "skinner-j"
                 },
                 {
+                  "label": "Smith, J",
+                  "value": "smith-j"
+                },
+                {
                   "label": "Smith, R",
                   "value": "smith-r"
                 },
@@ -2410,6 +2422,10 @@
                 {
                   "label": "Stockman, O",
                   "value": "stockman-o"
+                },
+                {
+                  "label": "Stout, H",
+                  "value": "stout-h"
                 },
                 {
                   "label": "Thomas, J",


### PR DESCRIPTION
## Description

We've had a request to add some judges to the `administrative-appeals-tribunal-decisions` finder.

## Trello card

https://trello.com/c/GGuJwlAe/2251-update-specialist-finder

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
