### PR TITLE
Add Argentina as country of origin to protected-food-drink-names finder

### DIFF
--- a/content_schemas/dist/formats/specialist_document/frontend/schema.json
+++ b/content_schemas/dist/formats/specialist_document/frontend/schema.json
@@ -2621,6 +2621,7 @@
               "united-kingdom",
               "albania",
               "andorra",
+              "argentina",
               "armenia",
               "australia",
               "austria",

--- a/content_schemas/dist/formats/specialist_document/notification/schema.json
+++ b/content_schemas/dist/formats/specialist_document/notification/schema.json
@@ -2749,6 +2749,7 @@
               "united-kingdom",
               "albania",
               "andorra",
+              "argentina",
               "armenia",
               "australia",
               "austria",

--- a/content_schemas/dist/formats/specialist_document/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/specialist_document/publisher_v2/schema.json
@@ -2430,6 +2430,7 @@
               "united-kingdom",
               "albania",
               "andorra",
+              "argentina",
               "armenia",
               "australia",
               "austria",

--- a/content_schemas/formats/shared/definitions/_specialist_document.jsonnet
+++ b/content_schemas/formats/shared/definitions/_specialist_document.jsonnet
@@ -2392,6 +2392,7 @@
             "united-kingdom",
             "albania",
             "andorra",
+            "argentina",
             "armenia",
             "australia",
             "austria",


### PR DESCRIPTION
## Description

There's been a zendesk request to add Argentina as a country of origin tot he protected food  and drink names finder.

## Trello ticket

https://trello.com/c/qOvnVF3r/2250-update-defra-specialist-finder

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
