### PR TITLE
Revert "Add editionable worldwide organisation doctype"

### DIFF
--- a/content_schemas/allowed_document_types.yml
+++ b/content_schemas/allowed_document_types.yml
@@ -36,7 +36,6 @@
 - document_collection
 - drcf_digital_markets_research
 - drug_safety_update
-- editionable_worldwide_organisation
 - email_alert_signup
 - embassies_index
 - employment_appeal_tribunal_decision

--- a/content_schemas/dist/formats/generic/frontend/schema.json
+++ b/content_schemas/dist/formats/generic/frontend/schema.json
@@ -72,7 +72,6 @@
         "document_collection",
         "drcf_digital_markets_research",
         "drug_safety_update",
-        "editionable_worldwide_organisation",
         "email_alert_signup",
         "embassies_index",
         "employment_appeal_tribunal_decision",

--- a/content_schemas/dist/formats/generic/notification/schema.json
+++ b/content_schemas/dist/formats/generic/notification/schema.json
@@ -96,7 +96,6 @@
         "document_collection",
         "drcf_digital_markets_research",
         "drug_safety_update",
-        "editionable_worldwide_organisation",
         "email_alert_signup",
         "embassies_index",
         "employment_appeal_tribunal_decision",

--- a/content_schemas/dist/formats/generic/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/generic/publisher_v2/schema.json
@@ -82,7 +82,6 @@
         "document_collection",
         "drcf_digital_markets_research",
         "drug_safety_update",
-        "editionable_worldwide_organisation",
         "email_alert_signup",
         "embassies_index",
         "employment_appeal_tribunal_decision",

--- a/content_schemas/dist/formats/generic_with_external_related_links/frontend/schema.json
+++ b/content_schemas/dist/formats/generic_with_external_related_links/frontend/schema.json
@@ -72,7 +72,6 @@
         "document_collection",
         "drcf_digital_markets_research",
         "drug_safety_update",
-        "editionable_worldwide_organisation",
         "email_alert_signup",
         "embassies_index",
         "employment_appeal_tribunal_decision",

--- a/content_schemas/dist/formats/generic_with_external_related_links/notification/schema.json
+++ b/content_schemas/dist/formats/generic_with_external_related_links/notification/schema.json
@@ -96,7 +96,6 @@
         "document_collection",
         "drcf_digital_markets_research",
         "drug_safety_update",
-        "editionable_worldwide_organisation",
         "email_alert_signup",
         "embassies_index",
         "employment_appeal_tribunal_decision",

--- a/content_schemas/dist/formats/generic_with_external_related_links/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/generic_with_external_related_links/publisher_v2/schema.json
@@ -82,7 +82,6 @@
         "document_collection",
         "drcf_digital_markets_research",
         "drug_safety_update",
-        "editionable_worldwide_organisation",
         "email_alert_signup",
         "embassies_index",
         "employment_appeal_tribunal_decision",


### PR DESCRIPTION
Reverts alphagov/publishing-api#2578

We're going to use the `worldwide_organisation` document type for the new editionable worldwide organisaitons for simplicity. See https://github.com/alphagov/whitehall/pull/8684

