### PR TITLE
Allow edition links for worldwide organisations

### DIFF
--- a/content_schemas/dist/formats/call_for_evidence/frontend/schema.json
+++ b/content_schemas/dist/formats/call_for_evidence/frontend/schema.json
@@ -151,7 +151,7 @@
         },
         "roles": {
           "description": "Government roles that are associated with this document, typically the role part of a role association",
-          "$ref": "#/definitions/frontend_links_with_base_path"
+          "$ref": "#/definitions/frontend_links"
         },
         "secondary_to_step_navs": {
           "description": "Link type automatically added by Publishing API",

--- a/content_schemas/dist/formats/call_for_evidence/notification/schema.json
+++ b/content_schemas/dist/formats/call_for_evidence/notification/schema.json
@@ -169,7 +169,7 @@
         },
         "roles": {
           "description": "Government roles that are associated with this document, typically the role part of a role association",
-          "$ref": "#/definitions/frontend_links_with_base_path"
+          "$ref": "#/definitions/frontend_links"
         },
         "secondary_to_step_navs": {
           "description": "Link type automatically added by Publishing API",

--- a/content_schemas/dist/formats/consultation/frontend/schema.json
+++ b/content_schemas/dist/formats/consultation/frontend/schema.json
@@ -151,7 +151,7 @@
         },
         "roles": {
           "description": "Government roles that are associated with this document, typically the role part of a role association",
-          "$ref": "#/definitions/frontend_links_with_base_path"
+          "$ref": "#/definitions/frontend_links"
         },
         "secondary_to_step_navs": {
           "description": "Link type automatically added by Publishing API",

--- a/content_schemas/dist/formats/consultation/notification/schema.json
+++ b/content_schemas/dist/formats/consultation/notification/schema.json
@@ -169,7 +169,7 @@
         },
         "roles": {
           "description": "Government roles that are associated with this document, typically the role part of a role association",
-          "$ref": "#/definitions/frontend_links_with_base_path"
+          "$ref": "#/definitions/frontend_links"
         },
         "secondary_to_step_navs": {
           "description": "Link type automatically added by Publishing API",

--- a/content_schemas/dist/formats/fatality_notice/frontend/schema.json
+++ b/content_schemas/dist/formats/fatality_notice/frontend/schema.json
@@ -147,7 +147,7 @@
         },
         "roles": {
           "description": "Government roles that are associated with this document, typically the role part of a role association",
-          "$ref": "#/definitions/frontend_links_with_base_path"
+          "$ref": "#/definitions/frontend_links"
         },
         "secondary_to_step_navs": {
           "description": "Link type automatically added by Publishing API",

--- a/content_schemas/dist/formats/fatality_notice/notification/schema.json
+++ b/content_schemas/dist/formats/fatality_notice/notification/schema.json
@@ -165,7 +165,7 @@
         },
         "roles": {
           "description": "Government roles that are associated with this document, typically the role part of a role association",
-          "$ref": "#/definitions/frontend_links_with_base_path"
+          "$ref": "#/definitions/frontend_links"
         },
         "secondary_to_step_navs": {
           "description": "Link type automatically added by Publishing API",

--- a/content_schemas/dist/formats/news_article/frontend/schema.json
+++ b/content_schemas/dist/formats/news_article/frontend/schema.json
@@ -154,7 +154,7 @@
         },
         "roles": {
           "description": "Government roles that are associated with this document, typically the role part of a role association",
-          "$ref": "#/definitions/frontend_links_with_base_path"
+          "$ref": "#/definitions/frontend_links"
         },
         "secondary_to_step_navs": {
           "description": "Link type automatically added by Publishing API",

--- a/content_schemas/dist/formats/news_article/notification/schema.json
+++ b/content_schemas/dist/formats/news_article/notification/schema.json
@@ -172,7 +172,7 @@
         },
         "roles": {
           "description": "Government roles that are associated with this document, typically the role part of a role association",
-          "$ref": "#/definitions/frontend_links_with_base_path"
+          "$ref": "#/definitions/frontend_links"
         },
         "secondary_to_step_navs": {
           "description": "Link type automatically added by Publishing API",

--- a/content_schemas/dist/formats/publication/frontend/schema.json
+++ b/content_schemas/dist/formats/publication/frontend/schema.json
@@ -170,7 +170,7 @@
         },
         "roles": {
           "description": "Government roles that are associated with this document, typically the role part of a role association",
-          "$ref": "#/definitions/frontend_links_with_base_path"
+          "$ref": "#/definitions/frontend_links"
         },
         "secondary_to_step_navs": {
           "description": "Link type automatically added by Publishing API",

--- a/content_schemas/dist/formats/publication/notification/schema.json
+++ b/content_schemas/dist/formats/publication/notification/schema.json
@@ -188,7 +188,7 @@
         },
         "roles": {
           "description": "Government roles that are associated with this document, typically the role part of a role association",
-          "$ref": "#/definitions/frontend_links_with_base_path"
+          "$ref": "#/definitions/frontend_links"
         },
         "secondary_to_step_navs": {
           "description": "Link type automatically added by Publishing API",

--- a/content_schemas/dist/formats/speech/frontend/schema.json
+++ b/content_schemas/dist/formats/speech/frontend/schema.json
@@ -154,7 +154,7 @@
         },
         "roles": {
           "description": "Government roles that are associated with this document, typically the role part of a role association",
-          "$ref": "#/definitions/frontend_links_with_base_path"
+          "$ref": "#/definitions/frontend_links"
         },
         "secondary_to_step_navs": {
           "description": "Link type automatically added by Publishing API",

--- a/content_schemas/dist/formats/speech/notification/schema.json
+++ b/content_schemas/dist/formats/speech/notification/schema.json
@@ -172,7 +172,7 @@
         },
         "roles": {
           "description": "Government roles that are associated with this document, typically the role part of a role association",
-          "$ref": "#/definitions/frontend_links_with_base_path"
+          "$ref": "#/definitions/frontend_links"
         },
         "secondary_to_step_navs": {
           "description": "Link type automatically added by Publishing API",

--- a/content_schemas/dist/formats/worldwide_organisation/frontend/schema.json
+++ b/content_schemas/dist/formats/worldwide_organisation/frontend/schema.json
@@ -63,6 +63,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "contacts": {
+          "description": "The contacts linked to offices of this Worldwide Organisation",
+          "$ref": "#/definitions/frontend_links"
+        },
         "corporate_information_pages": {
           "description": "Corporate information pages for this Worldwide Organisation",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -154,12 +158,12 @@
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "role_appointments": {
-          "description": "Link type automatically added by Publishing API",
+          "description": "Role appointments associated with people from this Worldwide Organisation",
           "$ref": "#/definitions/frontend_links"
         },
         "roles": {
           "description": "All roles associated with this Worldwide Organisation",
-          "$ref": "#/definitions/frontend_links_with_base_path"
+          "$ref": "#/definitions/frontend_links"
         },
         "secondary_role_person": {
           "description": "The person currently appointed to a secondary role in this Worldwide Organisation",
@@ -366,6 +370,25 @@
             }
           }
         },
+        "office_contact_associations": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "office_content_id",
+              "contact_content_id"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "contact_content_id": {
+                "$ref": "#/definitions/guid"
+              },
+              "office_content_id": {
+                "$ref": "#/definitions/guid"
+              }
+            }
+          }
+        },
         "ordered_corporate_information_pages": {
           "description": "A set of links to corporate information pages to display for the worldwide organisation.",
           "type": "array",
@@ -382,6 +405,41 @@
               },
               "title": {
                 "type": "string"
+              }
+            }
+          }
+        },
+        "people_role_associations": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "person_content_id",
+              "role_appointments"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "person_content_id": {
+                "$ref": "#/definitions/guid"
+              },
+              "role_appointments": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "required": [
+                    "role_appointment_content_id",
+                    "role_content_id"
+                  ],
+                  "additionalProperties": false,
+                  "properties": {
+                    "role_appointment_content_id": {
+                      "$ref": "#/definitions/guid"
+                    },
+                    "role_content_id": {
+                      "$ref": "#/definitions/guid"
+                    }
+                  }
+                }
               }
             }
           }

--- a/content_schemas/dist/formats/worldwide_organisation/notification/schema.json
+++ b/content_schemas/dist/formats/worldwide_organisation/notification/schema.json
@@ -81,6 +81,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "contacts": {
+          "description": "The contacts linked to offices of this Worldwide Organisation",
+          "$ref": "#/definitions/frontend_links"
+        },
         "corporate_information_pages": {
           "description": "Corporate information pages for this Worldwide Organisation",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -172,12 +176,12 @@
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "role_appointments": {
-          "description": "Link type automatically added by Publishing API",
+          "description": "Role appointments associated with people from this Worldwide Organisation",
           "$ref": "#/definitions/frontend_links"
         },
         "roles": {
           "description": "All roles associated with this Worldwide Organisation",
-          "$ref": "#/definitions/frontend_links_with_base_path"
+          "$ref": "#/definitions/frontend_links"
         },
         "secondary_role_person": {
           "description": "The person currently appointed to a secondary role in this Worldwide Organisation",
@@ -227,6 +231,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "contacts": {
+          "description": "The contacts linked to offices of this Worldwide Organisation",
+          "$ref": "#/definitions/guid_list"
+        },
         "corporate_information_pages": {
           "description": "Corporate information pages for this Worldwide Organisation",
           "$ref": "#/definitions/guid_list"
@@ -291,6 +299,10 @@
         },
         "primary_role_person": {
           "description": "The person currently appointed to a primary role in this Worldwide Organisation",
+          "$ref": "#/definitions/guid_list"
+        },
+        "role_appointments": {
+          "description": "Role appointments associated with people from this Worldwide Organisation",
           "$ref": "#/definitions/guid_list"
         },
         "roles": {
@@ -493,6 +505,25 @@
             }
           }
         },
+        "office_contact_associations": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "office_content_id",
+              "contact_content_id"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "contact_content_id": {
+                "$ref": "#/definitions/guid"
+              },
+              "office_content_id": {
+                "$ref": "#/definitions/guid"
+              }
+            }
+          }
+        },
         "ordered_corporate_information_pages": {
           "description": "A set of links to corporate information pages to display for the worldwide organisation.",
           "type": "array",
@@ -509,6 +540,41 @@
               },
               "title": {
                 "type": "string"
+              }
+            }
+          }
+        },
+        "people_role_associations": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "person_content_id",
+              "role_appointments"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "person_content_id": {
+                "$ref": "#/definitions/guid"
+              },
+              "role_appointments": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "required": [
+                    "role_appointment_content_id",
+                    "role_content_id"
+                  ],
+                  "additionalProperties": false,
+                  "properties": {
+                    "role_appointment_content_id": {
+                      "$ref": "#/definitions/guid"
+                    },
+                    "role_content_id": {
+                      "$ref": "#/definitions/guid"
+                    }
+                  }
+                }
               }
             }
           }

--- a/content_schemas/dist/formats/worldwide_organisation/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/worldwide_organisation/publisher_v2/schema.json
@@ -59,6 +59,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "contacts": {
+          "description": "The contacts linked to offices of this Worldwide Organisation",
+          "$ref": "#/definitions/guid_list"
+        },
         "corporate_information_pages": {
           "description": "Corporate information pages for this Worldwide Organisation",
           "$ref": "#/definitions/guid_list"
@@ -81,6 +85,10 @@
         },
         "primary_role_person": {
           "description": "The person currently appointed to a primary role in this Worldwide Organisation",
+          "$ref": "#/definitions/guid_list"
+        },
+        "role_appointments": {
+          "description": "Role appointments associated with people from this Worldwide Organisation",
           "$ref": "#/definitions/guid_list"
         },
         "roles": {
@@ -245,6 +253,25 @@
             }
           }
         },
+        "office_contact_associations": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "office_content_id",
+              "contact_content_id"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "contact_content_id": {
+                "$ref": "#/definitions/guid"
+              },
+              "office_content_id": {
+                "$ref": "#/definitions/guid"
+              }
+            }
+          }
+        },
         "ordered_corporate_information_pages": {
           "description": "A set of links to corporate information pages to display for the worldwide organisation.",
           "type": "array",
@@ -261,6 +288,41 @@
               },
               "title": {
                 "type": "string"
+              }
+            }
+          }
+        },
+        "people_role_associations": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "person_content_id",
+              "role_appointments"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "person_content_id": {
+                "$ref": "#/definitions/guid"
+              },
+              "role_appointments": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "required": [
+                    "role_appointment_content_id",
+                    "role_content_id"
+                  ],
+                  "additionalProperties": false,
+                  "properties": {
+                    "role_appointment_content_id": {
+                      "$ref": "#/definitions/guid"
+                    },
+                    "role_content_id": {
+                      "$ref": "#/definitions/guid"
+                    }
+                  }
+                }
               }
             }
           }

--- a/content_schemas/dist/formats/worldwide_organisation/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/worldwide_organisation/publisher_v2/schema.json
@@ -59,8 +59,44 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "corporate_information_pages": {
+          "description": "Corporate information pages for this Worldwide Organisation",
+          "$ref": "#/definitions/guid_list"
+        },
+        "home_page_offices": {
+          "description": "The offices, other than the main office, to be shown on the home page of this Worldwide Organisation",
+          "$ref": "#/definitions/guid_list"
+        },
+        "main_office": {
+          "description": "The main office for this Worldwide Organisation",
+          "$ref": "#/definitions/guid_list"
+        },
+        "office_staff": {
+          "description": "People currently appointed to office staff roles in this Worldwide Organisation",
+          "$ref": "#/definitions/guid_list"
+        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "primary_role_person": {
+          "description": "The person currently appointed to a primary role in this Worldwide Organisation",
+          "$ref": "#/definitions/guid_list"
+        },
+        "roles": {
+          "description": "All roles associated with this Worldwide Organisation",
+          "$ref": "#/definitions/guid_list"
+        },
+        "secondary_role_person": {
+          "description": "The person currently appointed to a secondary role in this Worldwide Organisation",
+          "$ref": "#/definitions/guid_list"
+        },
+        "sponsoring_organisations": {
+          "description": "Sponsoring organisations for this Worldwide Organisation",
+          "$ref": "#/definitions/guid_list"
+        },
+        "world_locations": {
+          "description": "World Locations associated with this Worldwide Organisation",
           "$ref": "#/definitions/guid_list"
         }
       }

--- a/content_schemas/examples/worldwide_organisation/frontend/worldwide_organisation.json
+++ b/content_schemas/examples/worldwide_organisation/frontend/worldwide_organisation.json
@@ -17,6 +17,49 @@
       "crest": "single-identity",
       "formatted_title": "British Deputy High Commission<br/>Hyderabad"
     },
+    "office_contact_associations": [
+      {
+        "office_content_id": "58c83be0-6264-4cb0-a652-126d57e8c0b7",
+        "contact_content_id": "410c4c3b-5c1c-4617-b603-4356bedcc85e"
+      },
+      {
+        "office_content_id": "0fae3258-42cf-4c87-baf4-4c514b851b35",
+        "contact_content_id": "53df7197-901c-48fc-b9b4-ed649903f1f0"
+      },
+      {
+        "office_content_id": "a9e4a8a4-4b7d-44bd-9d04-b0e910141c22",
+        "contact_content_id": "d7196415-647c-4b81-8e9f-8436c53e45f0"
+      }
+    ],
+    "people_role_associations": [
+      {
+        "person_content_id": "8532daf3-c0f1-11e4-8223-005056011aef",
+        "role_appointments": [
+          {
+            "role_appointment_content_id": "7458595d-f14a-4b49-bdd2-093e279f947e",
+            "role_content_id": "8464e2a4-c0f1-11e4-8223-005056011aef"
+          }
+        ]
+      },
+      {
+        "person_content_id": "c3ff6a9c-47db-40a3-bad8-6c58c29db38f",
+        "role_appointments": [
+          {
+            "role_appointment_content_id": "df1b3645-9f2b-4fbb-9aef-1fbdbe993b39",
+            "role_content_id": "875fd6b2-8574-4053-999c-ada182f1ff14"
+          }
+        ]
+      },
+      {
+        "person_content_id": "ce444f49-5d65-47b3-b1fb-8fbbd9523ce4",
+        "role_appointments": [
+          {
+            "role_appointment_content_id": "f8f78d38-0738-470c-a8b8-849c38bdb4e0",
+            "role_content_id": "8467b19c-c0f1-11e4-8223-005056011aef"
+          }
+        ]
+      }
+    ],
     "social_media_links": [
       {
         "href": "http://www.facebook.com/bhcindia?ref=mf",
@@ -77,6 +120,116 @@
     ]
   },
   "links": {
+    "contacts": [
+      {
+        "content_id": "410c4c3b-5c1c-4617-b603-4356bedcc85e",
+        "title": "British Embassy Madrid",
+        "locale": "en",
+        "document_type": "contact",
+        "public_updated_at": "2023-05-25T12:46:54Z",
+        "schema_name": "contact",
+        "withdrawn": false,
+        "details": {
+          "description": "Use our contact form for consular enquiries: \r\nwww.gov.uk/contact-consulate-madrid\r\n",
+          "title": "British Embassy Madrid",
+          "contact_form_links": null,
+          "post_addresses": [
+            {
+              "locality": "Madrid",
+              "postal_code": "28046",
+              "street_address": "Torre Emperador Castellana\r\nPaseo de la Castellana 259D ",
+              "world_location": "Spain",
+              "iso2_country_code": "es"
+            }
+          ],
+          "email_addresses": null,
+          "phone_numbers": [
+            {
+              "title": "Telephone",
+              "number": "+34 91 714 6300 / +44 20 7008 5000"
+            },
+            {
+              "title": "Fax",
+              "number": "+34 917 146 301"
+            }
+          ]
+        },
+        "links": {}
+      },
+      {
+        "content_id": "53df7197-901c-48fc-b9b4-ed649903f1f0",
+        "title": "Department for Business and Trade Dusseldorf",
+        "locale": "en",
+        "document_type": "contact",
+        "public_updated_at": "2023-03-07T15:44:04Z",
+        "schema_name": "contact",
+        "withdrawn": false,
+        "details": {
+          "description": null,
+          "title": "Department for Business and Trade Dusseldorf",
+          "contact_form_links": null,
+          "post_addresses": [
+            {
+              "title": "British Consulate-General",
+              "locality": "Dusseldorf",
+              "postal_code": "40227",
+              "street_address": "Willi-Becker-Allee 10 ",
+              "world_location": "Germany",
+              "iso2_country_code": "de"
+            }
+          ],
+          "email_addresses": [
+            {
+              "email": "DITGermany.Enquiries@fcdo.gov.uk",
+              "title": "British Consulate-General"
+            }
+          ],
+          "phone_numbers": [
+            {
+              "title": "Enquiries",
+              "number": "+49 (0)211 94480"
+            }
+          ]
+        },
+        "links": {}
+      },
+      {
+        "content_id": "d7196415-647c-4b81-8e9f-8436c53e45f0",
+        "title": "Department for Business and Trade Munich",
+        "locale": "en",
+        "document_type": "contact",
+        "public_updated_at": "2023-03-07T15:44:23Z",
+        "schema_name": "contact",
+        "withdrawn": false,
+        "details": {
+          "description": null,
+          "title": "Department for Business and Trade Munich",
+          "contact_form_links": null,
+          "post_addresses": [
+            {
+              "title": "British Consulate-General",
+              "locality": "81675 Munich",
+              "street_address": "Moehlstr. 5 ",
+              "world_location": "Germany",
+              "iso2_country_code": "de"
+            }
+          ],
+          "email_addresses": [
+            {
+              "email": "DITGermany.Enquiries@fcdo.gov.uk",
+              "title": "British Consulate-General"
+            }
+          ],
+          "phone_numbers": [
+            {
+              "title": "Enquiries",
+              "number": "+49 (0)89 211090"
+            }
+          ]
+        },
+        "links": {}
+      }
+    ],
     "corporate_information_pages": [
       {
         "content_id": "5f5560f5-7631-11e4-a3cb-005056011aef",
@@ -132,76 +285,7 @@
         "public_updated_at": "2022-11-17T21:46:54Z",
         "schema_name": "person",
         "withdrawn": false,
-        "links": {
-          "role_appointments": [
-            {
-              "content_id": "f8f78d38-0738-470c-a8b8-849c38bdb4e0",
-              "title": "Rachel Galloway - British Consul General in Atlanta",
-              "locale": "en",
-              "document_type": "role_appointment",
-              "public_updated_at": "2022-07-27T19:56:38Z",
-              "schema_name": "role_appointment",
-              "withdrawn": false,
-              "details": {
-                "started_on": "2022-07-14T00:00:00+01:00",
-                "ended_on": null,
-                "current": true,
-                "person_appointment_order": 7856
-              },
-              "links": {
-                "role": [
-                  {
-                    "content_id": "8467b19c-c0f1-11e4-8223-005056011aef",
-                    "title": "British Consul General in Atlanta",
-                    "locale": "en",
-                    "document_type": "worldwide_office_staff_role",
-                    "public_updated_at": "2013-03-19T13:25:22Z",
-                    "schema_name": "role",
-                    "withdrawn": false,
-                    "details": {
-                      "body": "<p>The Consul General is the senior UK official in a Consulate General, which is a subordinate office to the Embassy or High Commission, usually located in another major city. The Consul General represents the UK government and is typically responsible for consular, visa and trade activities in their city or region.</p>\n",
-                      "role_payment_type": null
-                    },
-                    "links": {}
-                  }
-                ]
-              }
-            },
-            {
-              "content_id": "77e88159-3b5f-44f2-9127-6a0b916af09d",
-              "title": "Rachel Galloway - British Ambassador to North Macedonia",
-              "locale": "en",
-              "document_type": "role_appointment",
-              "public_updated_at": "2022-06-21T07:25:12Z",
-              "schema_name": "role_appointment",
-              "withdrawn": false,
-              "details": {
-                "started_on": "2018-07-26T00:00:00+01:00",
-                "ended_on": "2022-06-20T00:00:00+01:00",
-                "current": false,
-                "person_appointment_order": 4951
-              },
-              "links": {
-                "role": [
-                  {
-                    "content_id": "8461c0a6-c0f1-11e4-8223-005056011aef",
-                    "title": "British Ambassador to North Macedonia",
-                    "locale": "en",
-                    "document_type": "ambassador_role",
-                    "public_updated_at": "2022-09-14T15:01:02Z",
-                    "schema_name": "role",
-                    "withdrawn": false,
-                    "details": {
-                      "body": "<p>The Ambassador represents His Majesty The King and the UK government in the country to which they are appointed. They are responsible for the direction and work of the Embassy and its Consulates, including political work, trade and investment, press and cultural relations, and visa and consular services.</p>\n",
-                      "role_payment_type": null
-                    },
-                    "links": {}
-                  }
-                ]
-              }
-            }
-          ]
-        },
+        "links": {},
         "api_url": "https://www.integration.publishing.service.gov.uk/api/content/government/people/rachel-galloway",
         "web_url": "https://www.integration.publishing.service.gov.uk/government/people/rachel-galloway"
       }
@@ -224,210 +308,105 @@
           },
           "privy_counsellor": false
         },
-        "links": {
-          "role_appointments": [
-            {
-              "content_id": "80e8cdc7-e9a2-424a-83f8-b59e7e5a3d7a",
-              "title": "Karen Pierce DCMG - Ambassador and Permanent Representative, UK Mission to the UN and Other International Organisations, Geneva",
-              "locale": "en",
-              "document_type": "role_appointment",
-              "public_updated_at": "2018-06-14T12:52:00Z",
-              "schema_name": "role_appointment",
-              "withdrawn": false,
-              "details": {
-                "started_on": "2012-05-07T00:00:00+01:00",
-                "ended_on": "2015-03-28T00:00:00+00:00",
-                "current": false,
-                "person_appointment_order": 869
-              },
-              "links": {
-                "role": [
-                  {
-                    "content_id": "8467becc-c0f1-11e4-8223-005056011aef",
-                    "title": "Ambassador and Permanent Representative, UK Mission to the WTO, UN and Other International Organisations (Geneva)",
-                    "locale": "en",
-                    "document_type": "ambassador_role",
-                    "public_updated_at": "2020-01-27T13:47:31Z",
-                    "schema_name": "role",
-                    "withdrawn": false,
-                    "details": {
-                      "body": "<p>The Ambassador’s role is to represent the UK within an international organisation, engaging with every other country or organisation that belongs to or observes the body. The Ambassador is also responsible for the direction and work of the Mission. Ambassadors to multilateral missions are often referred to as ‘Permanent Representatives’.</p>\n",
-                      "role_payment_type": null
-                    },
-                    "links": {}
-                  }
-                ]
-              }
-            },
-            {
-              "content_id": "2dd5ec5e-3120-4374-8209-a318639ac437",
-              "title": "Karen Pierce DCMG - British Ambassador to Afghanistan",
-              "locale": "en",
-              "document_type": "role_appointment",
-              "public_updated_at": "2019-05-23T09:34:18Z",
-              "schema_name": "role_appointment",
-              "withdrawn": false,
-              "details": {
-                "started_on": "2015-05-22T00:00:00+01:00",
-                "ended_on": "2016-01-24T00:00:00+00:00",
-                "current": false,
-                "person_appointment_order": 2757
-              },
-              "links": {
-                "role": [
-                  {
-                    "content_id": "8464cedb-c0f1-11e4-8223-005056011aef",
-                    "title": "British Ambassador to Afghanistan",
-                    "locale": "en",
-                    "document_type": "ambassador_role",
-                    "public_updated_at": "2015-05-31T07:36:40Z",
-                    "schema_name": "role",
-                    "withdrawn": false,
-                    "details": {
-                      "body": "<p>The Ambassador represents Her Majesty The Queen and the UK government in the country to which they are appointed. They are responsible for the direction and work of the Embassy and its Consulates, including political work, trade and investment, press and cultural relations, and visa and consular services.</p>\n",
-                      "role_payment_type": null
-                    },
-                    "links": {}
-                  }
-                ]
-              }
-            },
-            {
-              "content_id": "196985a6-42c0-4998-8e93-5f29462bc49e",
-              "title": "Karen Pierce DCMG - Chief Operating Officer",
-              "locale": "en",
-              "document_type": "role_appointment",
-              "public_updated_at": "2018-06-14T12:52:00Z",
-              "schema_name": "role_appointment",
-              "withdrawn": false,
-              "details": {
-                "started_on": "2016-02-03T00:00:00+00:00",
-                "ended_on": "2017-05-01T00:00:00+01:00",
-                "current": false,
-                "person_appointment_order": 3213
-              },
-              "links": {
-                "role": [
-                  {
-                    "content_id": "84614ca8-c0f1-11e4-8223-005056011aef",
-                    "title": "Chief Operating Officer",
-                    "locale": "en",
-                    "document_type": "board_member_role",
-                    "public_updated_at": "2017-05-19T11:36:19Z",
-                    "schema_name": "role",
-                    "withdrawn": false,
-                    "details": {
-                      "body": "<p>Board members give corporate leadership to the <abbr title=\"Foreign &amp; Commonwealth Office\">FCO</abbr> by ensuring that the department meets the foreign policy priorities, Public Service Agreements targets and service delivery targets set by ministers. The Chief Operating Officer is responsible for the running of the <abbr title=\"Foreign &amp; Commonwealth Office\">FCO</abbr> as an organisation and has the following areas of responsibility:</p>\n\n<ul>\n  <li>human resources</li>\n  <li>finance</li>\n  <li>estates</li>\n  <li>security</li>\n  <li>IT</li>\n  <li>corporate services</li>\n  <li>protocol</li>\n</ul>\n\n",
-                      "role_payment_type": null
-                    },
-                    "links": {}
-                  }
-                ]
-              }
-            },
-            {
-              "content_id": "ff77c76b-de20-461e-b926-2651e0ea971d",
-              "title": "Karen Pierce DCMG - Director General, Political",
-              "locale": "en",
-              "document_type": "role_appointment",
-              "public_updated_at": "2018-12-18T10:38:46Z",
-              "schema_name": "role_appointment",
-              "withdrawn": false,
-              "details": {
-                "started_on": "2017-04-24T00:00:00+01:00",
-                "ended_on": "2018-03-25T00:00:00+00:00",
-                "current": false,
-                "person_appointment_order": 4052
-              },
-              "links": {
-                "role": [
-                  {
-                    "content_id": "f393dd96-436b-410b-bb92-273e4a065c64",
-                    "title": "Director General, Political",
-                    "locale": "en",
-                    "document_type": "board_member_role",
-                    "public_updated_at": "2018-12-18T10:38:46Z",
-                    "schema_name": "role",
-                    "withdrawn": false,
-                    "details": {
-                      "body": "<p>Board members give corporate leadership to the Foreign &amp; Commonwealth Office by ensuring that the department meets the foreign policy priorities, Public Service Agreements targets and service delivery targets set by ministers. The Director General, Political focuses on the UK’s key foreign policy objectives and has the following areas of responsibility and regions:</p>\n\n<ul>\n  <li>the Government’s foreign policy priorities, international crises and conflict, maintenance of international peace and security</li>\n  <li>European Union Common Foreign and Security Policy (CFSP) and Common Security and Defence Policy \n (CSDP)</li>\n  <li>the UK relationship with the United States</li>\n  <li>Middle East and North Africa</li>\n  <li>South Asia and Afghanistan</li>\n  <li>Western Balkans</li>\n  <li>Eastern Mediterranean</li>\n  <li>United Nations, including the UN Security Council, and other multilateral fora</li>\n</ul>\n\n",
-                      "role_payment_type": null
-                    },
-                    "links": {}
-                  }
-                ]
-              }
-            },
-            {
-              "content_id": "78d30f38-79db-4a09-ad3f-b5fbdea4b7a3",
-              "title": "Karen Pierce DCMG -  Ambassador and Permanent Representative, UK Mission to the UN New York",
-              "locale": "en",
-              "document_type": "role_appointment",
-              "public_updated_at": "2020-03-23T07:49:38Z",
-              "schema_name": "role_appointment",
-              "withdrawn": false,
-              "details": {
-                "started_on": "2018-03-26T00:00:00+01:00",
-                "ended_on": "2020-03-16T00:00:00+00:00",
-                "current": false,
-                "person_appointment_order": 4697
-              },
-              "links": {
-                "role": [
-                  {
-                    "content_id": "8467d91c-c0f1-11e4-8223-005056011aef",
-                    "title": " Ambassador and Permanent Representative, UK Mission to the UN New York",
-                    "locale": "en",
-                    "document_type": "ambassador_role",
-                    "public_updated_at": "2013-03-14T21:57:11Z",
-                    "schema_name": "role",
-                    "withdrawn": false,
-                    "details": {
-                      "body": "<p>The Ambassador’s role is to represent the UK within an international organisation, engaging with every other country or organisation that belongs to or observes the body. The Ambassador is also responsible for the direction and work of the Mission. Ambassadors to multilateral missions are often referred to as ‘Permanent Representatives’.</p>\n",
-                      "role_payment_type": null
-                    },
-                    "links": {}
-                  }
-                ]
-              }
-            },
-            {
-              "content_id": "7458595d-f14a-4b49-bdd2-093e279f947e",
-              "title": "Karen Pierce DCMG - British Ambassador designate to the USA",
-              "locale": "en",
-              "document_type": "role_appointment",
-              "public_updated_at": "2020-03-23T07:52:16Z",
-              "schema_name": "role_appointment",
-              "withdrawn": false,
-              "details": {
-                "started_on": "2020-03-17T00:00:00+00:00",
-                "ended_on": null,
-                "current": true,
-                "person_appointment_order": 6144
-              },
-              "links": {
-                "role": [
-                  {
-                    "content_id": "8464e2a4-c0f1-11e4-8223-005056011aef",
-                    "title": "British Ambassador to the USA",
-                    "locale": "en",
-                    "document_type": "ambassador_role",
-                    "public_updated_at": "2022-09-13T18:43:23Z",
-                    "schema_name": "role",
-                    "withdrawn": false,
-                    "details": {
-                      "body": "<p>The Ambassador represents His Majesty The King and the UK government in the country to which they are appointed. They are responsible for the direction and work of the Embassy and its Consulates, including political work, trade and investment, press and cultural relations, and visa and consular services.</p>\n",
-                      "role_payment_type": null
-                    },
-                    "links": {}
-                  }
-                ]
-              }
-            }
-          ]
-        },
+        "links": {},
         "api_url": "https://www.integration.publishing.service.gov.uk/api/content/government/people/karen-pierce",
         "web_url": "https://www.integration.publishing.service.gov.uk/government/people/karen-pierce"
+      }
+    ],
+    "role_appointments": [
+      {
+        "content_id": "7458595d-f14a-4b49-bdd2-093e279f947e",
+        "title": "Karen Pierce DCMG - British Ambassador designate to the USA",
+        "locale": "en",
+        "document_type": "role_appointment",
+        "public_updated_at": "2020-03-23T07:52:16Z",
+        "schema_name": "role_appointment",
+        "withdrawn": false,
+        "details": {
+          "started_on": "2020-03-17T00:00:00+00:00",
+          "ended_on": null,
+          "current": true,
+          "person_appointment_order": 6144
+        },
+        "links": {}
+      },
+      {
+        "content_id": "df1b3645-9f2b-4fbb-9aef-1fbdbe993b39",
+        "title": "Justin Sosne - Consul (Business and Government Affairs) at UK Government Office in Raleigh",
+        "locale": "en",
+        "document_type": "role_appointment",
+        "public_updated_at": "2023-04-04T21:12:07Z",
+        "schema_name": "role_appointment",
+        "withdrawn": false,
+        "details": {
+          "started_on": "2021-05-01T00:00:00+01:00",
+          "ended_on": null,
+          "current": true,
+          "person_appointment_order": 1
+        },
+        "links": {
+          "role": []
+        }
+      },
+      {
+        "content_id": "f8f78d38-0738-470c-a8b8-849c38bdb4e0",
+        "title": "Rachel Galloway - British Consul General in Atlanta",
+        "locale": "en",
+        "document_type": "role_appointment",
+        "public_updated_at": "2022-07-27T19:56:38Z",
+        "schema_name": "role_appointment",
+        "withdrawn": false,
+        "details": {
+          "started_on": "2022-07-14T00:00:00+01:00",
+          "ended_on": null,
+          "current": true,
+          "person_appointment_order": 7856
+        },
+        "links": {}
+      }
+    ],
+    "roles": [
+      {
+        "content_id": "8467b19c-c0f1-11e4-8223-005056011aef",
+        "title": "British Consul General in Atlanta",
+        "locale": "en",
+        "document_type": "worldwide_office_staff_role",
+        "public_updated_at": "2013-03-19T13:25:22Z",
+        "schema_name": "role",
+        "withdrawn": false,
+        "details": {
+          "body": "<p>The Consul General is the senior UK official in a Consulate General, which is a subordinate office to the Embassy or High Commission, usually located in another major city. The Consul General represents the UK government and is typically responsible for consular, visa and trade activities in their city or region.</p>\n",
+          "role_payment_type": null
+        },
+        "links": {}
+      },
+      {
+        "content_id": "8464e2a4-c0f1-11e4-8223-005056011aef",
+        "title": "British Ambassador to the USA",
+        "locale": "en",
+        "document_type": "ambassador_role",
+        "public_updated_at": "2022-09-13T18:43:23Z",
+        "schema_name": "role",
+        "withdrawn": false,
+        "details": {
+          "body": "<p>The Ambassador represents His Majesty The King and the UK government in the country to which they are appointed. They are responsible for the direction and work of the Embassy and its Consulates, including political work, trade and investment, press and cultural relations, and visa and consular services.</p>\n",
+          "role_payment_type": null
+        },
+        "links": {}
+      },
+      {
+        "content_id": "875fd6b2-8574-4053-999c-ada182f1ff14",
+        "title": "Consul (Business and Government Affairs) at UK Government Office in Raleigh",
+        "locale": "en",
+        "document_type": "worldwide_office_staff_role",
+        "public_updated_at": "2019-04-23T15:34:29Z",
+        "schema_name": "role",
+        "withdrawn": false,
+        "details": {
+          "body": "<p>The Consul (Business and Government Affairs) at the UK Government Office in Raleigh works to promote UK business, economic and political ties with North Carolina.</p>\n",
+          "role_payment_type": null
+        },
+        "links": {}
       }
     ],
     "secondary_role_person": [
@@ -441,43 +420,7 @@
         "public_updated_at": "2023-04-04T21:14:42Z",
         "schema_name": "person",
         "withdrawn": false,
-        "links": {
-          "role_appointments": [
-            {
-              "content_id": "df1b3645-9f2b-4fbb-9aef-1fbdbe993b39",
-              "title": "Justin Sosne - Consul (Business and Government Affairs) at UK Government Office in Raleigh",
-              "locale": "en",
-              "document_type": "role_appointment",
-              "public_updated_at": "2023-04-04T21:12:07Z",
-              "schema_name": "role_appointment",
-              "withdrawn": false,
-              "details": {
-                "started_on": "2021-05-01T00:00:00+01:00",
-                "ended_on": null,
-                "current": true,
-                "person_appointment_order": 1
-              },
-              "links": {
-                "role": [
-                  {
-                    "content_id": "875fd6b2-8574-4053-999c-ada182f1ff14",
-                    "title": "Consul (Business and Government Affairs) at UK Government Office in Raleigh",
-                    "locale": "en",
-                    "document_type": "worldwide_office_staff_role",
-                    "public_updated_at": "2019-04-23T15:34:29Z",
-                    "schema_name": "role",
-                    "withdrawn": false,
-                    "details": {
-                      "body": "<p>The Consul (Business and Government Affairs) at the UK Government Office in Raleigh works to promote UK business, economic and political ties with North Carolina.</p>\n",
-                      "role_payment_type": null
-                    },
-                    "links": {}
-                  }
-                ]
-              }
-            }
-          ]
-        },
+        "links": {},
         "api_url": "https://www.integration.publishing.service.gov.uk/api/content/government/people/justin-sosne",
         "web_url": "https://www.integration.publishing.service.gov.uk/government/people/justin-sosne"
       }
@@ -493,45 +436,7 @@
         "public_updated_at": "2023-05-17T15:30:59Z",
         "schema_name": "worldwide_office",
         "withdrawn": false,
-        "links": {
-          "contact": [
-            {
-              "content_id": "410c4c3b-5c1c-4617-b603-4356bedcc85e",
-              "title": "British Embassy Madrid",
-              "locale": "en",
-              "document_type": "contact",
-              "public_updated_at": "2023-05-25T12:46:54Z",
-              "schema_name": "contact",
-              "withdrawn": false,
-              "details": {
-                "description": "Use our contact form for consular enquiries: \r\nwww.gov.uk/contact-consulate-madrid\r\n",
-                "title": "British Embassy Madrid",
-                "contact_form_links": null,
-                "post_addresses": [
-                  {
-                    "locality": "Madrid",
-                    "postal_code": "28046",
-                    "street_address": "Torre Emperador Castellana\r\nPaseo de la Castellana 259D ",
-                    "world_location": "Spain",
-                    "iso2_country_code": "es"
-                  }
-                ],
-                "email_addresses": null,
-                "phone_numbers": [
-                  {
-                    "title": "Telephone",
-                    "number": "+34 91 714 6300 / +44 20 7008 5000"
-                  },
-                  {
-                    "title": "Fax",
-                    "number": "+34 917 146 301"
-                  }
-                ]
-              },
-              "links": {}
-            }
-          ]
-        },
+        "links": {},
         "details": {
           "access_and_opening_times": "<div class=\"govspeak\"><h2 id=\"privacy-notice\">Privacy notice</h2>\n\n<p>If you visit the British Embassy Madrid see our <a href=\"https://www.gov.uk/government/publications/fcdo-privacy-notice-visitors-to-diplomatic-missions-and-residences-during-the-coronavirus-covid-19-pandemic\" class=\"govuk-link\">privacy notice for visitors</a> which explains how we will process your data for security and public health management reasons.</p>\n\n<h2 id=\"opening-hours\">Opening hours</h2>\n\n<p>British Embassy opening hours: Monday to Friday, 8:30am to 5pm</p>\n\n<p>The British Consulate General in Madrid is open by appointment only.</p>\n\n<p>24/7 support is available by telephone for all routine enquiries and emergencies. Please call + (34) 91 714 6300</p>\n\n<h2 id=\"public-holidays\">2023 public holidays</h2>\n\n<p>Our offices will be closed for the following public holidays in 2023:</p>\n\n<table>\n  <thead>\n    <tr>\n      <th scope=\"col\">Date</th>\n      <th scope=\"col\">Public holiday</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <td>Monday 2 January</td>\n      <td>New Year’s Day (substitute day)</td>\n    </tr>\n    <tr>\n      <td>Friday 6 January</td>\n      <td>Epifanía del Señor</td>\n    </tr>\n    <tr>\n      <td>Thursday 6 April</td>\n      <td>Maundy Thursday</td>\n    </tr>\n    <tr>\n      <td>Friday 7 April</td>\n      <td>Good Friday</td>\n    </tr>\n    <tr>\n      <td>Monday 10 April</td>\n      <td>Easter Monday</td>\n    </tr>\n    <tr>\n      <td>Monday 1 May</td>\n      <td>International Worker’s Day</td>\n    </tr>\n    <tr>\n      <td>Tuesday 2 May</td>\n      <td>Día de la Comunidad de Madrid</td>\n    </tr>\n    <tr>\n      <td>Monday 8 May</td>\n      <td>Coronation of His Majesty King Charles III</td>\n    </tr>\n    <tr>\n      <td>Tuesday 15 August</td>\n      <td>Asuncion de la Virgen</td>\n    </tr>\n    <tr>\n      <td>Thursday 12 October</td>\n      <td>Fiesta Nacional de España</td>\n    </tr>\n    <tr>\n      <td>Wednesday 1 November</td>\n      <td>Día de Todos los Santos</td>\n    </tr>\n    <tr>\n      <td>Wednesday 6 December</td>\n      <td>Constitution Day</td>\n    </tr>\n    <tr>\n      <td>Friday 8 December</td>\n      <td>Día Inmaculada Concepción</td>\n    </tr>\n    <tr>\n      <td>Monday 25 December</td>\n      <td>Christmas Day</td>\n    </tr>\n    <tr>\n      <td>Tuesday 26 December</td>\n      <td>Boxing Day</td>\n    </tr>\n  </tbody>\n</table>\n\n<h2 id=\"map\">Map</h2>\n<p>You can find a map of our office location on our <a rel=\"external\" href=\"http://maps.google.com/maps/ms?hl=en&ie=UTF8&msa=0&msid=115412150757145224958.00046f4c14d86aedbed2f&z=17\" class=\"govuk-link\">Google Map page.</a></p>\n\n<h2 id=\"disabled-access\">Disabled access</h2>\n<p>Our offices are fully equipped with facilities for disabled visitors including lifts and ramps for wheelchairs. If you need special assistance, please contact us before your visit.</p>\n\n<h2 id=\"security-regulations\">Security regulations</h2>\n<p>The British Embassy Madrid security regulations, in line with all British diplomatic missions world-wide, do not permit visitors to enter the embassy with mobile telephones, laptops, PDAs or any other similar electrical devices. We prefer that you arrive at the embassy without them.   If this is not possible we  will  retain them at the entrance during your visit.  Visitors are required to pass through a number of security checks where such items will be detected.</p>\n\n<p>Weapons (including pepper sprays), or any object that our security staff consider could be used as a weapon (scissors, screwdrivers, small blades), are also forbidden. These will not be retained by our staff. Should you arrive with such an object you will not be granted access but will be asked to return without it.</p>\n\n<p>These regulations are intended to help us ensure the security for our staff and visitors. Your co-operation is appreciated.</p>\n\n<h2 id=\"parking\">Parking</h2>\n<p>Unfortunately there is no public parking in Torre Espacio itself. The nearest public car park is La Paz car park, which is next to the Hospital La Paz and directly opposite Torre Espacio.</p>\n\n<p>La Paz car park can be accessed via Calle del Arzobispo Morcillo, next to the Hospital de la Paz on the north side of Torre Espacio. The car park offers:</p>\n\n<ul>\n  <li>24 hour service</li>\n  <li>emergency battery for starting vehicles</li>\n  <li>wheelchair hire service</li>\n  <li>discount vouchers for business premises and available advertising spots</li>\n</ul>\n\n<p>More details on La Paz car park can be found on the <a rel=\"external\" href=\"http://www.metrovacesa.com/web/productos/aparcamientos/alquilar/promocion/aparcamiento-la-paz/13.422/\" class=\"govuk-link\">MetroVacesa website</a></p>\n\n<p>If La Paz car park is full, there is a large public car park at Plaza Castilla (about 15 minutes walk from our offices). To get to the consulate-general from Plaza Castilla, take the metro to Begoña - see instructions below on how to arrive by metro.</p>\n\n<h2 id=\"bus\">Bus</h2>\n<p>For those who prefer to travel by bus to Torre Espacio you can find detailed information on <a rel=\"external\" href=\"http://www.emtmadrid.es/index.html?lang=eng\" class=\"govuk-link\">Madrid’s municipal transport website</a> where you can plan your personalised route.</p>\n\n<h2 id=\"metro\">Metro</h2>\n<p>The nearest metro stop is metro Begoña (linea 10). When arriving at the station Begoña take the exit sign posted La Paz or you will have a much longer walk to the Torre Espacio. Route maps and service information can be found on the <a rel=\"external\" href=\"http://www.metromadrid.es/es/index.html\" class=\"govuk-link\">MetroMadrid website</a>.</p>\n</div>"
         },
@@ -550,47 +455,7 @@
         "public_updated_at": "2023-05-17T15:36:02Z",
         "schema_name": "worldwide_office",
         "withdrawn": false,
-        "links": {
-          "contact": [
-            {
-              "content_id": "53df7197-901c-48fc-b9b4-ed649903f1f0",
-              "title": "Department for Business and Trade Dusseldorf",
-              "locale": "en",
-              "document_type": "contact",
-              "public_updated_at": "2023-03-07T15:44:04Z",
-              "schema_name": "contact",
-              "withdrawn": false,
-              "details": {
-                "description": null,
-                "title": "Department for Business and Trade Dusseldorf",
-                "contact_form_links": null,
-                "post_addresses": [
-                  {
-                    "title": "British Consulate-General",
-                    "locality": "Dusseldorf",
-                    "postal_code": "40227",
-                    "street_address": "Willi-Becker-Allee 10 ",
-                    "world_location": "Germany",
-                    "iso2_country_code": "de"
-                  }
-                ],
-                "email_addresses": [
-                  {
-                    "email": "DITGermany.Enquiries@fcdo.gov.uk",
-                    "title": "British Consulate-General"
-                  }
-                ],
-                "phone_numbers": [
-                  {
-                    "title": "Enquiries",
-                    "number": "+49 (0)211 94480"
-                  }
-                ]
-              },
-              "links": {}
-            }
-          ]
-        },
+        "links": {},
         "details": {
           "access_and_opening_times": "<div class=\"govspeak\"><h2 id=\"privacy-notice\">Privacy notice</h2>\n\n<p>If you visit the British Embassy Madrid see our <a href=\"https://www.gov.uk/government/publications/fcdo-privacy-notice-visitors-to-diplomatic-missions-and-residences-during-the-coronavirus-covid-19-pandemic\" class=\"govuk-link\">privacy notice for visitors</a> which explains how we will process your data for security and public health management reasons.</p>\n\n<h2 id=\"opening-hours\">Opening hours</h2>\n\n<p>British Embassy opening hours: Monday to Friday, 8:30am to 5pm</p>\n\n<p>The British Consulate General in Madrid is open by appointment only.</p>\n\n<p>24/7 support is available by telephone for all routine enquiries and emergencies. Please call + (34) 91 714 6300</p>\n\n<h2 id=\"public-holidays\">2023 public holidays</h2>\n\n<p>Our offices will be closed for the following public holidays in 2023:</p>\n\n<table>\n  <thead>\n    <tr>\n      <th scope=\"col\">Date</th>\n      <th scope=\"col\">Public holiday</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <td>Monday 2 January</td>\n      <td>New Year’s Day (substitute day)</td>\n    </tr>\n    <tr>\n      <td>Friday 6 January</td>\n      <td>Epifanía del Señor</td>\n    </tr>\n    <tr>\n      <td>Thursday 6 April</td>\n      <td>Maundy Thursday</td>\n    </tr>\n    <tr>\n      <td>Friday 7 April</td>\n      <td>Good Friday</td>\n    </tr>\n    <tr>\n      <td>Monday 10 April</td>\n      <td>Easter Monday</td>\n    </tr>\n    <tr>\n      <td>Monday 1 May</td>\n      <td>International Worker’s Day</td>\n    </tr>\n    <tr>\n      <td>Tuesday 2 May</td>\n      <td>Día de la Comunidad de Madrid</td>\n    </tr>\n    <tr>\n      <td>Monday 8 May</td>\n      <td>Coronation of His Majesty King Charles III</td>\n    </tr>\n    <tr>\n      <td>Tuesday 15 August</td>\n      <td>Asuncion de la Virgen</td>\n    </tr>\n    <tr>\n      <td>Thursday 12 October</td>\n      <td>Fiesta Nacional de España</td>\n    </tr>\n    <tr>\n      <td>Wednesday 1 November</td>\n      <td>Día de Todos los Santos</td>\n    </tr>\n    <tr>\n      <td>Wednesday 6 December</td>\n      <td>Constitution Day</td>\n    </tr>\n    <tr>\n      <td>Friday 8 December</td>\n      <td>Día Inmaculada Concepción</td>\n    </tr>\n    <tr>\n      <td>Monday 25 December</td>\n      <td>Christmas Day</td>\n    </tr>\n    <tr>\n      <td>Tuesday 26 December</td>\n      <td>Boxing Day</td>\n    </tr>\n  </tbody>\n</table>\n\n<h2 id=\"map\">Map</h2>\n<p>You can find a map of our office location on our <a rel=\"external\" href=\"http://maps.google.com/maps/ms?hl=en&ie=UTF8&msa=0&msid=115412150757145224958.00046f4c14d86aedbed2f&z=17\" class=\"govuk-link\">Google Map page.</a></p>\n\n<h2 id=\"disabled-access\">Disabled access</h2>\n<p>Our offices are fully equipped with facilities for disabled visitors including lifts and ramps for wheelchairs. If you need special assistance, please contact us before your visit.</p>\n\n<h2 id=\"security-regulations\">Security regulations</h2>\n<p>The British Embassy Madrid security regulations, in line with all British diplomatic missions world-wide, do not permit visitors to enter the embassy with mobile telephones, laptops, PDAs or any other similar electrical devices. We prefer that you arrive at the embassy without them.   If this is not possible we  will  retain them at the entrance during your visit.  Visitors are required to pass through a number of security checks where such items will be detected.</p>\n\n<p>Weapons (including pepper sprays), or any object that our security staff consider could be used as a weapon (scissors, screwdrivers, small blades), are also forbidden. These will not be retained by our staff. Should you arrive with such an object you will not be granted access but will be asked to return without it.</p>\n\n<p>These regulations are intended to help us ensure the security for our staff and visitors. Your co-operation is appreciated.</p>\n\n<h2 id=\"parking\">Parking</h2>\n<p>Unfortunately there is no public parking in Torre Espacio itself. The nearest public car park is La Paz car park, which is next to the Hospital La Paz and directly opposite Torre Espacio.</p>\n\n<p>La Paz car park can be accessed via Calle del Arzobispo Morcillo, next to the Hospital de la Paz on the north side of Torre Espacio. The car park offers:</p>\n\n<ul>\n  <li>24 hour service</li>\n  <li>emergency battery for starting vehicles</li>\n  <li>wheelchair hire service</li>\n  <li>discount vouchers for business premises and available advertising spots</li>\n</ul>\n\n<p>More details on La Paz car park can be found on the <a rel=\"external\" href=\"http://www.metrovacesa.com/web/productos/aparcamientos/alquilar/promocion/aparcamiento-la-paz/13.422/\" class=\"govuk-link\">MetroVacesa website</a></p>\n\n<p>If La Paz car park is full, there is a large public car park at Plaza Castilla (about 15 minutes walk from our offices). To get to the consulate-general from Plaza Castilla, take the metro to Begoña - see instructions below on how to arrive by metro.</p>\n\n<h2 id=\"bus\">Bus</h2>\n<p>For those who prefer to travel by bus to Torre Espacio you can find detailed information on <a rel=\"external\" href=\"http://www.emtmadrid.es/index.html?lang=eng\" class=\"govuk-link\">Madrid’s municipal transport website</a> where you can plan your personalised route.</p>\n\n<h2 id=\"metro\">Metro</h2>\n<p>The nearest metro stop is metro Begoña (linea 10). When arriving at the station Begoña take the exit sign posted La Paz or you will have a much longer walk to the Torre Espacio. Route maps and service information can be found on the <a rel=\"external\" href=\"http://www.metromadrid.es/es/index.html\" class=\"govuk-link\">MetroMadrid website</a>.</p>\n</div>"
         },
@@ -607,46 +472,7 @@
         "public_updated_at": "2023-05-17T15:36:04Z",
         "schema_name": "worldwide_office",
         "withdrawn": false,
-        "links": {
-          "contact": [
-            {
-              "content_id": "d7196415-647c-4b81-8e9f-8436c53e45f0",
-              "title": "Department for Business and Trade Munich",
-              "locale": "en",
-              "document_type": "contact",
-              "public_updated_at": "2023-03-07T15:44:23Z",
-              "schema_name": "contact",
-              "withdrawn": false,
-              "details": {
-                "description": null,
-                "title": "Department for Business and Trade Munich",
-                "contact_form_links": null,
-                "post_addresses": [
-                  {
-                    "title": "British Consulate-General",
-                    "locality": "81675 Munich",
-                    "street_address": "Moehlstr. 5 ",
-                    "world_location": "Germany",
-                    "iso2_country_code": "de"
-                  }
-                ],
-                "email_addresses": [
-                  {
-                    "email": "DITGermany.Enquiries@fcdo.gov.uk",
-                    "title": "British Consulate-General"
-                  }
-                ],
-                "phone_numbers": [
-                  {
-                    "title": "Enquiries",
-                    "number": "+49 (0)89 211090"
-                  }
-                ]
-              },
-              "links": {}
-            }
-          ]
-        },
+        "links": {},
         "details": {
           "access_and_opening_times": null
         },

--- a/content_schemas/formats/worldwide_organisation.jsonnet
+++ b/content_schemas/formats/worldwide_organisation.jsonnet
@@ -9,6 +9,25 @@
           "$ref": "#/definitions/body",
         },
         logo: (import "shared/definitions/_organisation_logo.jsonnet"),
+        office_contact_associations: {
+          type: "array",
+          items: {
+            type: "object",
+            additionalProperties: false,
+            required: [
+              "office_content_id",
+              "contact_content_id",
+            ],
+            properties: {
+              office_content_id: {
+                "$ref": "#/definitions/guid",
+              },
+              contact_content_id: {
+                "$ref": "#/definitions/guid",
+              },
+            },
+          },
+        },
         ordered_corporate_information_pages: {
           type: "array",
           items: {
@@ -28,6 +47,41 @@
             },
           },
           description: "A set of links to corporate information pages to display for the worldwide organisation.",
+        },
+        people_role_associations: {
+          type: "array",
+          items: {
+            type: "object",
+            additionalProperties: false,
+            required: [
+              "person_content_id",
+              "role_appointments",
+            ],
+            properties: {
+              person_content_id: {
+                "$ref": "#/definitions/guid",
+              },
+              role_appointments: {
+                type: "array",
+                items: {
+                  type: "object",
+                  additionalProperties: false,
+                  required: [
+                    "role_appointment_content_id",
+                    "role_content_id",
+                  ],
+                  properties: {
+                    role_appointment_content_id: {
+                      "$ref": "#/definitions/guid",
+                    },
+                    role_content_id: {
+                      "$ref": "#/definitions/guid",
+                    },
+                  },
+                },
+              },
+            },
+          },
         },
         secondary_corporate_information_pages: {
           type: "string",
@@ -69,6 +123,7 @@
     roles: "All roles associated with this Worldwide Organisation",
   },
   edition_links: (import "shared/base_edition_links.jsonnet") + {
+    contacts: "The contacts linked to offices of this Worldwide Organisation",
     corporate_information_pages: "Corporate information pages for this Worldwide Organisation",
     main_office: "The main office for this Worldwide Organisation",
     home_page_offices: "The offices, other than the main office, to be shown on the home page of this Worldwide Organisation",
@@ -77,6 +132,7 @@
     office_staff: "People currently appointed to office staff roles in this Worldwide Organisation",
     sponsoring_organisations: "Sponsoring organisations for this Worldwide Organisation",
     world_locations: "World Locations associated with this Worldwide Organisation",
+    role_appointments: "Role appointments associated with people from this Worldwide Organisation",
     roles: "All roles associated with this Worldwide Organisation",
   },
 }

--- a/content_schemas/formats/worldwide_organisation.jsonnet
+++ b/content_schemas/formats/worldwide_organisation.jsonnet
@@ -68,4 +68,15 @@
     world_locations: "World Locations associated with this Worldwide Organisation",
     roles: "All roles associated with this Worldwide Organisation",
   },
+  edition_links: (import "shared/base_edition_links.jsonnet") + {
+    corporate_information_pages: "Corporate information pages for this Worldwide Organisation",
+    main_office: "The main office for this Worldwide Organisation",
+    home_page_offices: "The offices, other than the main office, to be shown on the home page of this Worldwide Organisation",
+    primary_role_person: "The person currently appointed to a primary role in this Worldwide Organisation",
+    secondary_role_person: "The person currently appointed to a secondary role in this Worldwide Organisation",
+    office_staff: "People currently appointed to office staff roles in this Worldwide Organisation",
+    sponsoring_organisations: "Sponsoring organisations for this Worldwide Organisation",
+    world_locations: "World Locations associated with this Worldwide Organisation",
+    roles: "All roles associated with this Worldwide Organisation",
+  },
 }

--- a/lib/schema_generator/format.rb
+++ b/lib/schema_generator/format.rb
@@ -261,6 +261,7 @@ module SchemaGenerator
       ALLOWED_KEYS = %w[description required minItems maxItems].freeze
       LINKS_WITHOUT_BASE_PATHS = %w[
         contact
+        contacts
         facets
         home_page_offices
         main_office
@@ -283,6 +284,8 @@ module SchemaGenerator
         ordered_special_representatives
         ordered_traffic_commissioners
         primary_role_person
+        role_appointments
+        roles
         secondary_role_person
         world_locations
         worldwide_organisation


### PR DESCRIPTION
We are working in Whitehall to make Worldwide Organisation editionable.

Therefore we need to be able to link the links to editions, rather than documents, to prevent draft updates becoming live before publication.

The standard links will be removed once https://github.com/alphagov/whitehall/pull/8734 is merged.

Depends on https://github.com/alphagov/government-frontend/pull/3055.

[Trello card](https://trello.com/c/yNJwHw4K)