### PR TITLE
Provide token to `delete-artifact` workflow item

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     name: SNYK security analysis
     uses: alphagov/govuk-infrastructure/.github/workflows/snyk-security.yml@main
     secrets: inherit
-  
+
   codeql-sast:
     name: CodeQL SAST scan
     uses: alphagov/govuk-infrastructure/.github/workflows/codeql-analysis.yml@main
@@ -25,7 +25,7 @@ jobs:
   dependency-review:
     name: Dependency Review scan
     uses: alphagov/govuk-infrastructure/.github/workflows/dependency-review.yml@main
-  
+
   security-analysis:
     name: Security Analysis
     uses: alphagov/govuk-infrastructure/.github/workflows/brakeman.yml@main
@@ -147,4 +147,4 @@ jobs:
       - uses: geekyeggo/delete-artifact@v4
         with:
           name: pacts
-
+          token: ${{ secrets.GOVUK_CI_GITHUB_API_TOKEN }}


### PR DESCRIPTION
In https://github.com/alphagov/publishing-api/pull/2595, we updated `delete-artifact` from version 3 to 4.

However this version [now uses the GitHub REST API](https://github.com/GeekyEggo/delete-artifact/pull/17) and therefore requires a token. Therefore updating the workflow to provide this token.