### PR TITLE
Update WorldwideOrganisation schema

### DIFF
--- a/content_schemas/dist/formats/worldwide_organisation/frontend/schema.json
+++ b/content_schemas/dist/formats/worldwide_organisation/frontend/schema.json
@@ -338,6 +338,9 @@
         "change_history": {
           "$ref": "#/definitions/change_history"
         },
+        "default_news_image": {
+          "$ref": "#/definitions/image"
+        },
         "logo": {
           "description": "The organisation's logo, including the logo image and formatted name.",
           "type": "object",

--- a/content_schemas/dist/formats/worldwide_organisation/notification/schema.json
+++ b/content_schemas/dist/formats/worldwide_organisation/notification/schema.json
@@ -473,6 +473,9 @@
         "change_history": {
           "$ref": "#/definitions/change_history"
         },
+        "default_news_image": {
+          "$ref": "#/definitions/image"
+        },
         "logo": {
           "description": "The organisation's logo, including the logo image and formatted name.",
           "type": "object",

--- a/content_schemas/dist/formats/worldwide_organisation/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/worldwide_organisation/publisher_v2/schema.json
@@ -221,6 +221,9 @@
         "body": {
           "$ref": "#/definitions/body"
         },
+        "default_news_image": {
+          "$ref": "#/definitions/image"
+        },
         "logo": {
           "description": "The organisation's logo, including the logo image and formatted name.",
           "type": "object",

--- a/content_schemas/examples/worldwide_organisation/frontend/worldwide_organisation.json
+++ b/content_schemas/examples/worldwide_organisation/frontend/worldwide_organisation.json
@@ -17,6 +17,10 @@
       "crest": "single-identity",
       "formatted_title": "British Deputy High Commission<br/>Hyderabad"
     },
+    "default_news_image": {
+      "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/default_news_organisation_image_data/file/548/s300_fcdo-main-building.jpg",
+      "high_resolution_url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/default_news_organisation_image_data/file/548/s960_fcdo-main-building.jpg"
+    },
     "office_contact_associations": [
       {
         "office_content_id": "58c83be0-6264-4cb0-a652-126d57e8c0b7",

--- a/content_schemas/formats/worldwide_organisation.jsonnet
+++ b/content_schemas/formats/worldwide_organisation.jsonnet
@@ -9,6 +9,9 @@
           "$ref": "#/definitions/body",
         },
         logo: (import "shared/definitions/_organisation_logo.jsonnet"),
+        default_news_image: {
+          "$ref": "#/definitions/image",
+        },
         office_contact_associations: {
           type: "array",
           items: {


### PR DESCRIPTION
Whilst WorldwideOrganisation has a default news image, it does not form
part of the schema like other content types and so will not be exposed
as a possible link.

Here we add the default news image to the `details` property of the schema.

The property is not required as it is not required on the content
itself and so that we can manage the deployment.

Part of: https://trello.com/c/k4iXUPJU

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
