### PR TITLE
Add extra logging to `DownstreamLiveWorker`

### DIFF
--- a/app/workers/downstream_live_worker.rb
+++ b/app/workers/downstream_live_worker.rb
@@ -41,6 +41,10 @@ class DownstreamLiveWorker
 
     if %w[published unpublished].include?(edition.state)
       event_type = message_queue_event_type || edition.update_type
+      Rails.logger.info(
+        "DownstreamLiveWorker#perform:" \
+        "Broadcasting #{content_id}@#{payload_version} to message queue as type #{event_type}",
+      )
       DownstreamService.broadcast_to_message_queue(payload, event_type)
     end
 


### PR DESCRIPTION
As part of the Search team's work, we're trying to understand why downstream consumers receive an unexpectedly high number of messages from Publishing API.

This adds some basic logging that should make it easier for us to investigate `DownstreamLiveWorker`'s exact behaviour whenever it broadcasts to the message queue.