### PR TITLE
Enable the pg_stat_statements postgres extension

### DIFF
--- a/db/migrate/20240209150818_enable_pg_stat_statements.rb
+++ b/db/migrate/20240209150818_enable_pg_stat_statements.rb
@@ -1,0 +1,5 @@
+class EnablePgStatStatements < ActiveRecord::Migration[7.1]
+  def change
+    enable_extension "pg_stat_statements"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,9 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2023_11_19_172139) do
+ActiveRecord::Schema[7.1].define(version: 2024_02_09_150818) do
   # These are extensions that must be enabled in order to support this database
+  enable_extension "pg_stat_statements"
   enable_extension "plpgsql"
 
   create_table "access_limits", id: :serial, force: :cascade do |t|


### PR DESCRIPTION
  https://www.postgresql.org/docs/current/pgstatstatements.html

  > The pg_stat_statements module provides a means for tracking planning
  > and execution statistics of all SQL statements executed by a server.

This extension is extremely useful in establishing how queries are performing, which queries are particularly slow, and where to spend time on optimisations.

The performance impact of enabling the extension is widely reported to be small - in the order of 0.5% - https://dba.stackexchange.com/questions/303503/what-is-the-performance-impact-of-pg-stat-statements

The pg_stat_statements library is loaded by default for RDS databases using PostgreSQL 11 or later - https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_PerfInsights.UsingDashboard.AnalyzeDBLoad.AdditionalMetrics.PostgreSQL.html so enabling the extension should be all we need to do.

I'm particularly interested in the real world performance of some of the queries that happen during dependency resolution and link expansion. I'm hoping to make some improvements in this area soon, and it would be helpful to have statistics available to quantify the improvement.