### PR TITLE
Revert "Enable the pg_stat_statements postgres extension"

### DIFF
--- a/db/migrate/20240209150818_enable_pg_stat_statements.rb
+++ b/db/migrate/20240209150818_enable_pg_stat_statements.rb
@@ -1,5 +1,0 @@
-class EnablePgStatStatements < ActiveRecord::Migration[7.1]
-  def change
-    enable_extension "pg_stat_statements"
-  end
-end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,8 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_02_09_150818) do
+ActiveRecord::Schema[7.1].define(version: 2023_11_19_172139) do
   # These are extensions that must be enabled in order to support this database
-  enable_extension "pg_stat_statements"
   enable_extension "plpgsql"
 
   create_table "access_limits", id: :serial, force: :cascade do |t|


### PR DESCRIPTION
This reverts commit 16c4bec58ab9dea66dbef0b838ee0056a867381b from https://github.com/alphagov/publishing-api/pull/2632
