### PR TITLE
Add office fields to worldwide organisation details

### DIFF
--- a/content_schemas/dist/formats/worldwide_office/frontend/schema.json
+++ b/content_schemas/dist/formats/worldwide_office/frontend/schema.json
@@ -306,6 +306,9 @@
         "change_history": {
           "$ref": "#/definitions/change_history"
         },
+        "contact_content_id": {
+          "$ref": "#/definitions/guid"
+        },
         "services": {
           "type": "array",
           "items": {
@@ -329,6 +332,13 @@
             }
           },
           "uniqueItems": true
+        },
+        "slug": {
+          "type": "string",
+          "format": "uri"
+        },
+        "title": {
+          "type": "string"
         },
         "type": {
           "description": "The type of Worldwide Office.",

--- a/content_schemas/dist/formats/worldwide_office/notification/schema.json
+++ b/content_schemas/dist/formats/worldwide_office/notification/schema.json
@@ -405,6 +405,9 @@
         "change_history": {
           "$ref": "#/definitions/change_history"
         },
+        "contact_content_id": {
+          "$ref": "#/definitions/guid"
+        },
         "services": {
           "type": "array",
           "items": {
@@ -428,6 +431,13 @@
             }
           },
           "uniqueItems": true
+        },
+        "slug": {
+          "type": "string",
+          "format": "uri"
+        },
+        "title": {
+          "type": "string"
         },
         "type": {
           "description": "The type of Worldwide Office.",

--- a/content_schemas/dist/formats/worldwide_office/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/worldwide_office/publisher_v2/schema.json
@@ -177,6 +177,9 @@
             "null"
           ]
         },
+        "contact_content_id": {
+          "$ref": "#/definitions/guid"
+        },
         "services": {
           "type": "array",
           "items": {
@@ -200,6 +203,13 @@
             }
           },
           "uniqueItems": true
+        },
+        "slug": {
+          "type": "string",
+          "format": "uri"
+        },
+        "title": {
+          "type": "string"
         },
         "type": {
           "description": "The type of Worldwide Office.",

--- a/content_schemas/dist/formats/worldwide_organisation/frontend/schema.json
+++ b/content_schemas/dist/formats/worldwide_organisation/frontend/schema.json
@@ -341,6 +341,63 @@
         "default_news_image": {
           "$ref": "#/definitions/image"
         },
+        "home_page_office_parts": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "access_and_opening_times": {
+                "description": "The access and opening times for this Worldwide Office.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "contact_content_id": {
+                "$ref": "#/definitions/guid"
+              },
+              "services": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "title": {
+                      "description": "The name of the service provided by this Worldwide Office.",
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "type": {
+                      "description": "The type of service provided by this Worldwide Office.",
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  }
+                },
+                "uniqueItems": true
+              },
+              "slug": {
+                "type": "string",
+                "format": "uri"
+              },
+              "title": {
+                "type": "string"
+              },
+              "type": {
+                "description": "The type of Worldwide Office.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            }
+          }
+        },
         "logo": {
           "description": "The organisation's logo, including the logo image and formatted name.",
           "type": "object",
@@ -370,6 +427,63 @@
             },
             "image": {
               "$ref": "#/definitions/image"
+            }
+          }
+        },
+        "main_office_parts": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "access_and_opening_times": {
+                "description": "The access and opening times for this Worldwide Office.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "contact_content_id": {
+                "$ref": "#/definitions/guid"
+              },
+              "services": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "title": {
+                      "description": "The name of the service provided by this Worldwide Office.",
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "type": {
+                      "description": "The type of service provided by this Worldwide Office.",
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  }
+                },
+                "uniqueItems": true
+              },
+              "slug": {
+                "type": "string",
+                "format": "uri"
+              },
+              "title": {
+                "type": "string"
+              },
+              "type": {
+                "description": "The type of Worldwide Office.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
             }
           }
         },

--- a/content_schemas/dist/formats/worldwide_organisation/notification/schema.json
+++ b/content_schemas/dist/formats/worldwide_organisation/notification/schema.json
@@ -476,6 +476,63 @@
         "default_news_image": {
           "$ref": "#/definitions/image"
         },
+        "home_page_office_parts": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "access_and_opening_times": {
+                "description": "The access and opening times for this Worldwide Office.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "contact_content_id": {
+                "$ref": "#/definitions/guid"
+              },
+              "services": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "title": {
+                      "description": "The name of the service provided by this Worldwide Office.",
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "type": {
+                      "description": "The type of service provided by this Worldwide Office.",
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  }
+                },
+                "uniqueItems": true
+              },
+              "slug": {
+                "type": "string",
+                "format": "uri"
+              },
+              "title": {
+                "type": "string"
+              },
+              "type": {
+                "description": "The type of Worldwide Office.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            }
+          }
+        },
         "logo": {
           "description": "The organisation's logo, including the logo image and formatted name.",
           "type": "object",
@@ -505,6 +562,63 @@
             },
             "image": {
               "$ref": "#/definitions/image"
+            }
+          }
+        },
+        "main_office_parts": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "access_and_opening_times": {
+                "description": "The access and opening times for this Worldwide Office.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "contact_content_id": {
+                "$ref": "#/definitions/guid"
+              },
+              "services": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "title": {
+                      "description": "The name of the service provided by this Worldwide Office.",
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "type": {
+                      "description": "The type of service provided by this Worldwide Office.",
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  }
+                },
+                "uniqueItems": true
+              },
+              "slug": {
+                "type": "string",
+                "format": "uri"
+              },
+              "title": {
+                "type": "string"
+              },
+              "type": {
+                "description": "The type of Worldwide Office.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
             }
           }
         },

--- a/content_schemas/dist/formats/worldwide_organisation/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/worldwide_organisation/publisher_v2/schema.json
@@ -224,6 +224,63 @@
         "default_news_image": {
           "$ref": "#/definitions/image"
         },
+        "home_page_office_parts": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "access_and_opening_times": {
+                "description": "The access and opening times for this Worldwide Office.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "contact_content_id": {
+                "$ref": "#/definitions/guid"
+              },
+              "services": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "title": {
+                      "description": "The name of the service provided by this Worldwide Office.",
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "type": {
+                      "description": "The type of service provided by this Worldwide Office.",
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  }
+                },
+                "uniqueItems": true
+              },
+              "slug": {
+                "type": "string",
+                "format": "uri"
+              },
+              "title": {
+                "type": "string"
+              },
+              "type": {
+                "description": "The type of Worldwide Office.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            }
+          }
+        },
         "logo": {
           "description": "The organisation's logo, including the logo image and formatted name.",
           "type": "object",
@@ -253,6 +310,63 @@
             },
             "image": {
               "$ref": "#/definitions/image"
+            }
+          }
+        },
+        "main_office_parts": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "access_and_opening_times": {
+                "description": "The access and opening times for this Worldwide Office.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "contact_content_id": {
+                "$ref": "#/definitions/guid"
+              },
+              "services": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "title": {
+                      "description": "The name of the service provided by this Worldwide Office.",
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "type": {
+                      "description": "The type of service provided by this Worldwide Office.",
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    }
+                  }
+                },
+                "uniqueItems": true
+              },
+              "slug": {
+                "type": "string",
+                "format": "uri"
+              },
+              "title": {
+                "type": "string"
+              },
+              "type": {
+                "description": "The type of Worldwide Office.",
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
             }
           }
         },

--- a/content_schemas/examples/worldwide_organisation/frontend/worldwide_organisation.json
+++ b/content_schemas/examples/worldwide_organisation/frontend/worldwide_organisation.json
@@ -21,6 +21,48 @@
       "url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/default_news_organisation_image_data/file/548/s300_fcdo-main-building.jpg",
       "high_resolution_url": "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/default_news_organisation_image_data/file/548/s960_fcdo-main-building.jpg"
     },
+    "home_page_office_parts": [
+      {
+        "access_and_opening_times": "Our opening times",
+        "contact_content_id": "53df7197-901c-48fc-b9b4-ed649903f1f0",
+        "services": [
+          {
+            "title": "Business Funding",
+            "type": "Business Funds"
+          },
+          {
+            "title": "Business Advice",
+            "type": "Business Advisory"
+          }
+        ],
+        "slug": "office/uk-trade-investment-duesseldorf",
+        "title": "Department for Business and Trade Dusseldorf",
+        "type": "Department for Business and Trade Office"
+      },
+      {
+        "access_and_opening_times": "Our opening times",
+        "contact_content_id": "d7196415-647c-4b81-8e9f-8436c53e45f0",
+        "services": [],
+        "slug": "office/uk-trade-investment-munich",
+        "title": "Department for Business and Trade Munich",
+        "type": "Department for Business and Trade Office"
+      }
+    ],
+    "main_office_parts": [
+      {
+        "access_and_opening_times": "Our opening times",
+        "contact_content_id": "410c4c3b-5c1c-4617-b603-4356bedcc85e",
+        "services": [
+          {
+            "title": "Emergency Travel Documents service",
+            "type": "Assistance Services"
+          }
+        ],
+        "slug": "office/british-embassy",
+        "title": "British Embassy",
+        "type": "Embassy"
+      }
+    ],
     "office_contact_associations": [
       {
         "office_content_id": "58c83be0-6264-4cb0-a652-126d57e8c0b7",

--- a/content_schemas/formats/shared/definitions/_worldwide_office.jsonnet
+++ b/content_schemas/formats/shared/definitions/_worldwide_office.jsonnet
@@ -1,0 +1,54 @@
+{
+  type: "object",
+  additionalProperties: false,
+  properties: {
+    access_and_opening_times: {
+      type: [
+        "string",
+        "null",
+      ],
+      description: "The access and opening times for this Worldwide Office.",
+    },
+    contact_content_id: {
+      "$ref": "#/definitions/guid",
+    },
+    services: {
+      type: "array",
+      uniqueItems: true,
+      items: {
+        type: "object",
+        additionalProperties: false,
+        properties: {
+          title: {
+            type: [
+              "string",
+              "null",
+            ],
+            description: "The name of the service provided by this Worldwide Office.",
+          },
+          type: {
+            type: [
+              "string",
+              "null",
+            ],
+            description: "The type of service provided by this Worldwide Office.",
+          }
+        }
+      }
+    },
+    slug: {
+      type: "string",
+      format: "uri",
+    },
+    title: {
+      type: "string",
+    },
+    type: {
+      type: [
+        "string",
+        "null",
+      ],
+      description: "The type of Worldwide Office.",
+    },
+  }
+}

--- a/content_schemas/formats/worldwide_office.jsonnet
+++ b/content_schemas/formats/worldwide_office.jsonnet
@@ -1,50 +1,7 @@
 (import "shared/default_format.jsonnet") + {
   document_type: "worldwide_office",
   definitions: (import "shared/definitions/_whitehall.jsonnet") + {
-    details: {
-      type: "object",
-      additionalProperties: false,
-      properties: {
-        access_and_opening_times: {
-           type: [
-             "string",
-             "null",
-           ],
-           description: "The access and opening times for this Worldwide Office.",
-        },
-        type: {
-          type: [
-            "string",
-            "null",
-          ],
-          description: "The type of Worldwide Office.",
-        },
-        services: {
-          type: "array",
-          uniqueItems: true,
-          items: {
-            type: "object",
-            additionalProperties: false,
-            properties: {
-              title: {
-                type: [
-                  "string",
-                  "null",
-                ],
-                description: "The name of the service provided by this Worldwide Office.",
-              },
-              type: {
-                type: [
-                  "string",
-                  "null",
-                ],
-                description: "The type of service provided by this Worldwide Office.",
-              }
-            }
-          }
-        },
-      },
-    },
+    details: (import "shared/definitions/_worldwide_office.jsonnet"),
   },
   links: (import "shared/base_links.jsonnet") + {
     contact: "Contact details for this Worldwide Office",

--- a/content_schemas/formats/worldwide_organisation.jsonnet
+++ b/content_schemas/formats/worldwide_organisation.jsonnet
@@ -12,6 +12,14 @@
         default_news_image: {
           "$ref": "#/definitions/image",
         },
+        "home_page_office_parts": {
+          "type": "array",
+          "items": (import "shared/definitions/_worldwide_office.jsonnet"),
+        },
+        "main_office_parts": {
+          "type": "array",
+          "items": (import "shared/definitions/_worldwide_office.jsonnet"),
+        },
         office_contact_associations: {
           type: "array",
           items: {


### PR DESCRIPTION
This will allow us to store the Worldwide Office details in the Worldwide Organisation, meaning we can represent this content as a single multi-part page.

The worldwide office detail is moved into a shared definition, so it can shared between the two types of office attached to a Worldwide Organisation and the existing Worldwide Office format.

[Trello card](https://trello.com/c/9ivR4TGQ)