### PR TITLE
Include default news image in linked entity

### DIFF
--- a/lib/expansion_rules.rb
+++ b/lib/expansion_rules.rb
@@ -111,7 +111,7 @@ module_function
   TRAVEL_ADVICE_FIELDS = (DEFAULT_FIELDS + details_fields(:country, :change_description)).freeze
   WORLD_LOCATION_FIELDS = %i[content_id title schema_name locale analytics_identifier].freeze
   WORLDWIDE_OFFICE_FIELDS = (DEFAULT_FIELDS + details_fields(:access_and_opening_times)).freeze
-  WORLDWIDE_ORGANISATION_FIELDS = (DEFAULT_FIELDS_AND_DESCRIPTION + details_fields(:logo, :world_location_names)).freeze
+  WORLDWIDE_ORGANISATION_FIELDS = (DEFAULT_FIELDS_AND_DESCRIPTION + details_fields(:logo, :world_location_names, :default_news_image)).freeze
 
   CUSTOM_EXPANSION_FIELDS_FOR_PEOPLE = (
     %i[

--- a/spec/lib/expansion_rules_spec.rb
+++ b/spec/lib/expansion_rules_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe ExpansionRules do
     let(:travel_advice_fields) { default_fields + [%i[details country], %i[details change_description]] }
     let(:world_location_fields) { %i[content_id title schema_name locale analytics_identifier] }
     let(:worldwide_office_fields) { default_fields + [%i[details access_and_opening_times]] }
-    let(:worldwide_organisation_fields) { default_fields_and_description + [%i[details logo]] + [%i[details world_location_names]] }
+    let(:worldwide_organisation_fields) { default_fields_and_description + [%i[details logo]] + [%i[details world_location_names]] + [%i[details default_news_image]] }
 
     specify { expect(rules.expansion_fields(:redirect)).to eq([]) }
     specify { expect(rules.expansion_fields(:gone)).to eq([]) }


### PR DESCRIPTION
A WorldwideOrganisation includes a default news image, this is currently
added to the main document by Whithall when it publishes, which is
different to how Organisation handles the same behaviour.

We want to make the two entities implementation the same, our first step
on this path is to include the default_news_image in a
worldwide_organisation when included as a link in another content item.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
