### PR TITLE
Allow translations to be nested under their parent document

### DIFF
--- a/app/validators/routes_and_redirects_validator.rb
+++ b/app/validators/routes_and_redirects_validator.rb
@@ -103,11 +103,7 @@ private
     def below_base_path?(path, base_path)
       return true if path =~ %r{^#{base_path}\.[\w-]+\z}
 
-      path_segments = segments(path)
-      base_segments = segments(base_path)
-
-      pairs = base_segments.zip(path_segments)
-      pairs.all? { |a, b| a == b }
+      /^#{base_path}/.match?(path)
     end
 
     def segments(path)

--- a/app/validators/routes_and_redirects_validator.rb
+++ b/app/validators/routes_and_redirects_validator.rb
@@ -103,7 +103,10 @@ private
     def below_base_path?(path, base_path)
       return true if path =~ %r{^#{base_path}\.[\w-]+\z}
 
-      /^#{base_path}/.match?(path)
+      suffix = /\.([\w-]+\z)$/.match(base_path).to_a&.first || ""
+      base_path_without_suffix = base_path.gsub(suffix, "")
+
+      /^#{base_path_without_suffix}.*#{suffix}/.match?(path)
     end
 
     def segments(path)

--- a/spec/support/routes_and_redirects_validator.rb
+++ b/spec/support/routes_and_redirects_validator.rb
@@ -19,6 +19,30 @@ RSpec.shared_examples_for RoutesAndRedirectsValidator do
       expect(subject).to be_valid
     end
 
+    describe "with nested translated routes" do
+      let(:edition) { build(:edition, base_path: "/vat-rates.fr") }
+
+      it "is valid when a translated route is below the base path" do
+        edition.routes = [
+          { path: "/vat-rates.fr", type: "exact" },
+          { path: "/vat-rates/path/document.fr", type: "exact" },
+        ]
+
+        expect(subject).to be_valid
+      end
+
+      it "is invalid when a translated route is below the base path but has the wrong translation" do
+        edition.routes = [
+          { path: "/vat-rates.fr", type: "exact" },
+          { path: "/vat-rates/path/document.fr", type: "exact" },
+          { path: "/vat-rates/path/document.es", type: "exact" },
+        ]
+
+        expect(subject).to be_invalid
+        expect(subject.errors[:routes]).to eq(["path must be below the base path"])
+      end
+    end
+
     it "must have unique paths" do
       edition.routes = [
         { path: subject.base_path, type: "exact" },

--- a/spec/support/routes_and_redirects_validator.rb
+++ b/spec/support/routes_and_redirects_validator.rb
@@ -10,6 +10,15 @@ RSpec.shared_examples_for RoutesAndRedirectsValidator do
       expect(subject.errors[:routes]).to eq(["path must be below the base path"])
     end
 
+    it "is valid when a route has a document type suffix" do
+      edition.routes = [
+        { path: subject.base_path, type: "exact" },
+        { path: "#{subject.base_path}.atom", type: "exact" },
+      ]
+
+      expect(subject).to be_valid
+    end
+
     it "must have unique paths" do
       edition.routes = [
         { path: subject.base_path, type: "exact" },


### PR DESCRIPTION
We have a validation that currently prevents translated documents being nested within their parent document.
    
E.g. the following was previously invalid:
- Base path: /world/organisation/my-org.fr
- Route: /world/organisation/my-org/offices/local-office.fr

We must allow these to enable us to represent multi-part content with translations in a single content item.

[Trello card](https://trello.com/c/9ivR4TGQ)