### PR TITLE
Add migration to mark worldwide offices as substituted

### DIFF
--- a/db/migrate/20240220153403_remove_worldwide_offices.rb
+++ b/db/migrate/20240220153403_remove_worldwide_offices.rb
@@ -1,0 +1,5 @@
+class RemoveWorldwideOffices < ActiveRecord::Migration[7.1]
+  def up
+    Edition.where(document_type: "worldwide_office", state: "published").find_each(&:substitute)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2023_11_19_172139) do
+ActiveRecord::Schema[7.1].define(version: 2024_02_20_153403) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 


### PR DESCRIPTION
This marks the worldwide offices as substituted. This is a state that means they have been replaced by another content item, without any gone state or redirect being pushed downstream into Content Store.

Depends on: https://github.com/alphagov/whitehall/pull/8859

[Trello card](https://trello.com/c/9ivR4TGQ)