### PR TITLE
Add rake task to remove draft specialist finder docs

### DIFF
--- a/lib/tasks/remove_draft_specialist_finder_docs.rake
+++ b/lib/tasks/remove_draft_specialist_finder_docs.rake
@@ -1,0 +1,12 @@
+desc "Remove draft specialist finder docs by type"
+task :remove_draft_specialist_finder_docs, [:document_type] => :environment do |_, args|
+  # document_type example: "farming_grant_option"
+  raise "Missing parameter: document_type" unless args.document_type
+
+  results = Queries::GetContentCollection.new(fields: %w[content_id], document_types: args.document_type).call
+  results.map do |payload|
+    Commands::V2::DiscardDraft.call(payload.deep_symbolize_keys)
+  rescue StandardError => e
+    Sidekiq.logger.info(e)
+  end
+end


### PR DESCRIPTION
The users were testing in production/started adding content as draft, then requested changes to be made to the schema.

Adding a rake task to remove existing content in order to release changes.
