### PR TITLE
Update hmrc_manual schema example

### DIFF
--- a/content_schemas/examples/hmrc_manual/frontend/vat-government-public-bodies.json
+++ b/content_schemas/examples/hmrc_manual/frontend/vat-government-public-bodies.json
@@ -107,6 +107,13 @@
         "title": "Police authorities: summary of activities: liabilities I to M",
         "published_at": "2014-03-05T15:11:32+00:00",
         "base_path": "/hmrc-internal-manuals/vat-government-and-public-bodies/vatgpb5350"
+      },
+      {
+        "change_note": "Title to come",
+        "section_id": "VATGPB5390",
+        "title": "",
+        "published_at": "2015-03-05T15:16:20+00:00",
+        "base_path": "/hmrc-internal-manuals/vat-government-and-public-bodies/vatgpb5390"
       }
     ],
     "organisations": [


### PR DESCRIPTION
HMRC manuals API currently sends HMRC manual updates to the frontend with empty title fields. Updating this schema example to reflect that.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
