### PR TITLE
Unpublishes /info page prefix route

### DIFF
--- a/lib/tasks/tmp_unpublish_info_page.rake
+++ b/lib/tasks/tmp_unpublish_info_page.rake
@@ -1,0 +1,12 @@
+desc "Unpublishes /info page as part of the info-frontend retirement"
+task tmp_unpublish_info_pages: :environment do
+  info_page = Edition.live.find_by_base_path("/info")
+
+  payload = {
+    content_id: info_page.content_id,
+    type: "gone",
+    discard_drafts: true,
+  }
+
+  Commands::V2::Unpublish.call(payload)
+end


### PR DESCRIPTION
After running the migration all /info pages will return a 410.

Originally created the rake task in info-frontend [1] (where the route is published), however the publishing-api bearer token no longer exists so moving the tmp migration to publishing-api.

Didn't particularly trust the content-id specified in info-frontend [2] so pulling the id from the edition in publishing-api. A manual check shows they're both the same.

## Example page after rake task run

<img width="1137" alt="Screenshot 2024-02-26 at 17 29 35" src="https://github.com/alphagov/publishing-api/assets/24479188/0831c711-5a01-4ed9-9366-a635aef4eb08">

Trello:
https://trello.com/c/zODyxEf3/2372-unpublish-info-prefix-route-and-mark-as-gone

[1]: https://github.com/alphagov/info-frontend/pull/1363
[2]: https://github.com/alphagov/info-frontend/blob/07e5bd441549d3ea7697584cf6d474f0f1de0674/lib/tasks/publishing_api.rake#L19

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
