### PR TITLE
WIP simplify allowed_link_types

### DIFF
--- a/lib/expansion_rules/multi_level_links.rb
+++ b/lib/expansion_rules/multi_level_links.rb
@@ -9,11 +9,11 @@ class ExpansionRules::MultiLevelLinks
     @next_cache[link_types_path.to_s] ||= begin
       raise "Can't operate on an empty link_types_path" if link_types_path.empty?
 
-      # look up all the paths for the next level and the level beyond it
-      extra_item1 = paths(length: link_types_path.length + 1)
-      extra_item2 = paths(length: link_types_path.length + 2)
-      # match the next link for ones of these fit our provided paths
-      (extra_item1 + extra_item2).uniq
+      # Get all the paths one part longer than the provided path
+      # For each path, get the next link type following that path,
+      # or null if the paths aren't compatible.
+      # Drop the nulls, and return unique link types.
+      paths(length: link_types_path.length + 1)
         .map { |path| next_link_type_in_path(link_types_path, path) }
         .compact
         .uniq


### PR DESCRIPTION
I don't understand why we need paths of 1 and 2 items longer...

Doing this commit to see if any tests fail, basically.
