### PR TITLE
Add substitute event for queue consumers

### DIFF
--- a/app/commands/v2/publish.rb
+++ b/app/commands/v2/publish.rb
@@ -177,6 +177,7 @@ module Commands
         # This enables changing the locale of some content where a
         # published edition for the previous locale still exists.
         published_edition_for_different_locale.substitute
+        SubstitutionHelper.substitute_message(published_edition_for_different_locale)
       end
 
       def set_timestamps

--- a/app/downstream_payload.rb
+++ b/app/downstream_payload.rb
@@ -60,6 +60,10 @@ private
     Presenters::VanishPresenter.from_edition(edition)
   end
 
+  def substitute_presenter
+    Presenters::SubstitutePresenter.from_edition(edition)
+  end
+
   def content_store_presenter
     if unpublishing
       return redirect_presenter if unpublishing.type == "redirect"
@@ -72,14 +76,20 @@ private
   end
 
   def message_queue_presenter
-    return redirect_presenter if edition.document_type == "redirect"
-    return content_presenter unless unpublished?
-
-    case unpublishing.type
-    when "redirect" then redirect_presenter
-    when "gone" then gone_presenter
-    when "vanish" then vanish_presenter
-    else content_presenter
+    if unpublished?
+      case unpublishing.type
+      when "redirect" then redirect_presenter
+      when "gone" then gone_presenter
+      when "vanish" then vanish_presenter
+      when "substitute" then substitute_presenter
+      else
+        logger.warn("Unexpected unpublishing type #{unpublishing.type}")
+        content_presenter
+      end
+    elsif edition.document_type == "redirect"
+      redirect_presenter
+    else
+      content_presenter
     end
   end
 end

--- a/app/presenters/substitute_presenter.rb
+++ b/app/presenters/substitute_presenter.rb
@@ -1,0 +1,30 @@
+class Presenters::SubstitutePresenter
+  def initialize(base_path:, content_id:, publishing_app:, locale:)
+    @base_path = base_path
+    @publishing_app = publishing_app
+    @content_id = content_id
+    @locale = locale
+  end
+
+  def self.from_edition(edition)
+    new(
+      base_path: edition.base_path,
+      content_id: edition.content_id,
+      locale: edition.locale,
+      publishing_app: edition.publishing_app,
+    )
+  end
+
+  def for_message_queue(payload_version)
+    {
+      document_type: "substitute",
+      schema_name: "substitute",
+      base_path: @base_path,
+      locale: @locale,
+      publishing_app: @publishing_app,
+      content_id: @content_id,
+      govuk_request_id: GdsApi::GovukHeaders.headers[:govuk_request_id],
+      payload_version:,
+    }
+  end
+end

--- a/app/substitution_helper.rb
+++ b/app/substitution_helper.rb
@@ -30,8 +30,14 @@ module SubstitutionHelper
         discard_draft(blocking_edition, downstream, nested, callbacks)
       else
         blocking_edition.substitute
+        substitute_message(blocking_edition)
       end
     end
+  end
+
+  def substitute_message(edition)
+    payload = DownstreamPayload.new(edition, Event.maximum_id)
+    DownstreamService.broadcast_to_message_queue(payload, "unpublish")
   end
 
 private

--- a/content_schemas/allowed_document_types.yml
+++ b/content_schemas/allowed_document_types.yml
@@ -151,6 +151,7 @@
 - statutory_guidance
 - statutory_instrument
 - step_by_step_nav
+- substitute # Not in the content store
 - take_part
 - tax_tribunal_decision
 - taxon

--- a/content_schemas/dist/formats/generic/frontend/schema.json
+++ b/content_schemas/dist/formats/generic/frontend/schema.json
@@ -187,6 +187,7 @@
         "statutory_guidance",
         "statutory_instrument",
         "step_by_step_nav",
+        "substitute",
         "take_part",
         "tax_tribunal_decision",
         "taxon",

--- a/content_schemas/dist/formats/generic/notification/schema.json
+++ b/content_schemas/dist/formats/generic/notification/schema.json
@@ -211,6 +211,7 @@
         "statutory_guidance",
         "statutory_instrument",
         "step_by_step_nav",
+        "substitute",
         "take_part",
         "tax_tribunal_decision",
         "taxon",

--- a/content_schemas/dist/formats/generic/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/generic/publisher_v2/schema.json
@@ -197,6 +197,7 @@
         "statutory_guidance",
         "statutory_instrument",
         "step_by_step_nav",
+        "substitute",
         "take_part",
         "tax_tribunal_decision",
         "taxon",

--- a/content_schemas/dist/formats/generic_with_external_related_links/frontend/schema.json
+++ b/content_schemas/dist/formats/generic_with_external_related_links/frontend/schema.json
@@ -187,6 +187,7 @@
         "statutory_guidance",
         "statutory_instrument",
         "step_by_step_nav",
+        "substitute",
         "take_part",
         "tax_tribunal_decision",
         "taxon",

--- a/content_schemas/dist/formats/generic_with_external_related_links/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/generic_with_external_related_links/publisher_v2/schema.json
@@ -197,6 +197,7 @@
         "statutory_guidance",
         "statutory_instrument",
         "step_by_step_nav",
+        "substitute",
         "take_part",
         "tax_tribunal_decision",
         "taxon",

--- a/content_schemas/dist/formats/substitute/notification/schema.json
+++ b/content_schemas/dist/formats/substitute/notification/schema.json
@@ -2,29 +2,13 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
   "required": [
-    "analytics_identifier",
     "base_path",
     "content_id",
-    "description",
-    "details",
     "document_type",
-    "email_document_supertype",
-    "expanded_links",
-    "first_published_at",
-    "government_document_supertype",
     "govuk_request_id",
-    "links",
     "locale",
     "payload_version",
-    "phase",
-    "public_updated_at",
-    "publishing_app",
-    "redirects",
-    "rendering_app",
-    "routes",
-    "schema_name",
-    "title",
-    "update_type"
+    "schema_name"
   ],
   "additionalProperties": false,
   "properties": {
@@ -50,193 +34,17 @@
       "type": "string"
     },
     "description": {
-      "$ref": "#/definitions/description_optional"
+      "type": "null"
     },
     "details": {
-      "$ref": "#/definitions/details"
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {}
     },
     "document_type": {
       "type": "string",
       "enum": [
-        "aaib_report",
-        "about",
-        "about_our_services",
-        "accessible_documents_policy",
-        "access_and_opening",
-        "ai_assurance_portfolio_technique",
-        "algorithmic_transparency_record",
-        "ambassador_role",
-        "animal_disease_case",
-        "answer",
-        "asylum_support_decision",
-        "authored_article",
-        "board_member_role",
-        "business_finance_support_scheme",
-        "calendar",
-        "call_for_evidence",
-        "call_for_evidence_outcome",
-        "case_study",
-        "chief_professional_officer_role",
-        "chief_scientific_officer_role",
-        "chief_scientific_advisor_role",
-        "closed_call_for_evidence",
-        "closed_consultation",
-        "cma_case",
-        "complaints_procedure",
-        "completed_transaction",
-        "consultation",
-        "consultation_outcome",
-        "contact",
-        "coronavirus_landing_page",
-        "corporate_report",
-        "correspondence",
-        "countryside_stewardship_grant",
-        "decision",
-        "deputy_head_of_mission_role",
-        "detailed_guide",
-        "document_collection",
-        "drcf_digital_markets_research",
-        "drug_safety_update",
-        "email_alert_signup",
-        "embassies_index",
-        "employment_appeal_tribunal_decision",
-        "employment_tribunal_decision",
-        "equality_and_diversity",
-        "esi_fund",
-        "export_health_certificate",
-        "external_content",
-        "facet",
-        "farming_grant_option",
-        "fatality_notice",
-        "field_of_operation",
-        "fields_of_operation",
-        "finder",
-        "finder_email_signup",
-        "flood_and_coastal_erosion_risk_management_research_report",
-        "foi_release",
-        "form",
-        "get_involved",
-        "gone",
-        "government",
-        "government_response",
-        "governor_role",
-        "guidance",
-        "guide",
-        "help_page",
-        "high_commissioner_role",
-        "historic_appointment",
-        "historic_appointments",
-        "history",
-        "hmrc_manual",
-        "hmrc_manual_section",
-        "homepage",
-        "how_government_works",
-        "html_publication",
-        "impact_assessment",
-        "independent_report",
-        "international_development_fund",
-        "international_treaty",
-        "licence",
-        "license_finder",
-        "licence_transaction",
-        "local_transaction",
-        "maib_report",
-        "mainstream_browse_page",
-        "marine_equipment_approved_recommendation",
-        "manual",
-        "manual_section",
-        "map",
-        "marine_notice",
-        "media_enquiries",
-        "medical_safety_alert",
-        "membership",
-        "military_role",
-        "ministerial_role",
-        "ministers_index",
-        "modern_slavery_statement",
-        "national",
-        "national_statistics",
-        "national_statistics_announcement",
-        "need",
-        "news_story",
-        "notice",
-        "official",
-        "official_statistics",
-        "official_statistics_announcement",
-        "open_call_for_evidence",
-        "open_consultation",
-        "oral_statement",
-        "organisation",
-        "our_energy_use",
-        "our_governance",
-        "person",
-        "personal_information_charter",
-        "petitions_and_campaigns",
-        "place",
-        "policy_paper",
-        "press_release",
-        "procurement",
-        "product_safety_alert_report_recall",
-        "promotional",
-        "protected_food_drink_name",
-        "publication_scheme",
-        "raib_report",
-        "recruitment",
-        "redirect",
-        "regulation",
-        "research",
-        "research_for_development_output",
-        "residential_property_tribunal_decision",
-        "role_appointment",
-        "search",
-        "service_manual_guide",
-        "service_manual_homepage",
-        "service_manual_service_standard",
-        "service_manual_service_toolkit",
-        "service_manual_topic",
-        "service_sign_in",
-        "service_standard_report",
-        "services_and_information",
-        "simple_smart_answer",
-        "smart_answer",
-        "social_media_use",
-        "special_representative_role",
-        "special_route",
-        "speech",
-        "staff_update",
-        "standard",
-        "statistical_data_set",
-        "statistics",
-        "statistics_announcement",
-        "statutory_guidance",
-        "statutory_instrument",
-        "step_by_step_nav",
-        "substitute",
-        "take_part",
-        "tax_tribunal_decision",
-        "taxon",
-        "terms_of_reference",
-        "topical_event",
-        "topical_event_about_page",
-        "traffic_commissioner_regulatory_decision",
-        "traffic_commissioner_role",
-        "transaction",
-        "transparency",
-        "travel_advice",
-        "travel_advice_index",
-        "uk_market_conformity_assessment_body",
-        "utaac_decision",
-        "vanish",
-        "welsh_language_scheme",
-        "working_group",
-        "world_index",
-        "world_location",
-        "world_location_news",
-        "world_news_story",
-        "worldwide_office_staff_role",
-        "worldwide_office",
-        "worldwide_organisation",
-        "written_statement"
+        "substitute"
       ]
     },
     "email_document_supertype": {
@@ -263,50 +71,13 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "finder": {
-          "description": "Powers links from content back to finders the content is surfaced on",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "lead_organisations": {
-          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "level_one_taxons": {
           "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "mainstream_browse_pages": {
-          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "meets_user_needs": {
-          "description": "The user needs this piece of content meets.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "ministers": {
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
-        },
-        "ordered_related_items": {
-          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "ordered_related_items_overrides": {
-          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "organisations": {
-          "description": "All organisations linked to this content item. This should include lead organisations.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "original_primary_publishing_organisation": {
-          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "parent": {
-          "description": "The parent content item.",
-          "$ref": "#/definitions/frontend_links_with_base_path",
-          "maxItems": 1
         },
         "part_of_step_navs": {
           "description": "Link type automatically added by Publishing API",
@@ -315,15 +86,6 @@
         "policies": {
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "policy_areas": {
-          "description": "A largely deprecated tag currently only used to power email alerts.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "primary_publishing_organisation": {
-          "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
-          "$ref": "#/definitions/frontend_links_with_base_path",
-          "maxItems": 1
         },
         "related_to_step_navs": {
           "description": "Link type automatically added by Publishing API",
@@ -335,14 +97,6 @@
         },
         "secondary_to_step_navs": {
           "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "suggested_ordered_related_items": {
-          "description": "Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "taxons": {
-          "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
         }
       }
@@ -360,62 +114,7 @@
     "links": {
       "type": "object",
       "additionalProperties": false,
-      "properties": {
-        "finder": {
-          "description": "Powers links from content back to finders the content is surfaced on",
-          "$ref": "#/definitions/guid_list"
-        },
-        "lead_organisations": {
-          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "mainstream_browse_pages": {
-          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "meets_user_needs": {
-          "description": "The user needs this piece of content meets.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "ordered_related_items": {
-          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "ordered_related_items_overrides": {
-          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "organisations": {
-          "description": "All organisations linked to this content item. This should include lead organisations.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "original_primary_publishing_organisation": {
-          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "parent": {
-          "description": "The parent content item.",
-          "$ref": "#/definitions/guid_list",
-          "maxItems": 1
-        },
-        "policy_areas": {
-          "description": "A largely deprecated tag currently only used to power email alerts.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "primary_publishing_organisation": {
-          "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
-          "$ref": "#/definitions/guid_list",
-          "maxItems": 1
-        },
-        "suggested_ordered_related_items": {
-          "description": "Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "taxons": {
-          "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/guid_list"
-        }
-      }
+      "properties": {}
     },
     "locale": {
       "$ref": "#/definitions/locale"
@@ -457,7 +156,7 @@
       "items": {}
     },
     "rendering_app": {
-      "$ref": "#/definitions/rendering_app"
+      "type": "null"
     },
     "routes": {
       "$ref": "#/definitions/routes"
@@ -465,7 +164,7 @@
     "schema_name": {
       "type": "string",
       "enum": [
-        "generic_with_external_related_links"
+        "substitute"
       ]
     },
     "search_user_need_document_supertype": {
@@ -473,7 +172,7 @@
       "type": "string"
     },
     "title": {
-      "$ref": "#/definitions/title"
+      "type": "null"
     },
     "update_type": {
       "$ref": "#/definitions/update_type"
@@ -491,9 +190,6 @@
     }
   },
   "definitions": {
-    "description": {
-      "type": "string"
-    },
     "absolute_path": {
       "description": "A path only. Query string and/or fragment are not allowed.",
       "type": "string",
@@ -509,72 +205,6 @@
           "type": "null"
         }
       ]
-    },
-    "change_history": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "required": [
-          "public_timestamp",
-          "note"
-        ],
-        "additionalProperties": false,
-        "properties": {
-          "note": {
-            "description": "A summary of the change",
-            "type": "string"
-          },
-          "public_timestamp": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      }
-    },
-    "description_optional": {
-      "anyOf": [
-        {
-          "$ref": "#/definitions/description"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "details": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "change_history": {
-          "$ref": "#/definitions/change_history"
-        },
-        "external_related_links": {
-          "$ref": "#/definitions/external_related_links"
-        }
-      }
-    },
-    "external_link": {
-      "type": "object",
-      "required": [
-        "title",
-        "url"
-      ],
-      "additionalProperties": false,
-      "properties": {
-        "title": {
-          "type": "string"
-        },
-        "url": {
-          "type": "string",
-          "format": "uri"
-        }
-      }
-    },
-    "external_related_links": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/external_link"
-      }
     },
     "first_published_at": {
       "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
@@ -724,13 +354,6 @@
       "type": "string",
       "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
     },
-    "guid_list": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/guid"
-      },
-      "uniqueItems": true
-    },
     "locale": {
       "type": "string",
       "enum": [
@@ -859,33 +482,6 @@
         }
       ]
     },
-    "rendering_app": {
-      "description": "The application that renders this item.",
-      "type": "string",
-      "enum": [
-        "account-api",
-        "calculators",
-        "calendars",
-        "collections",
-        "content-store",
-        "email-alert-frontend",
-        "email-campaign-frontend",
-        "feedback",
-        "finder-frontend",
-        "frontend",
-        "government-frontend",
-        "info-frontend",
-        "performanceplatform-big-screen-view",
-        "rummager",
-        "search-api",
-        "smartanswers",
-        "spotlight",
-        "static",
-        "tariff",
-        "whitehall-admin",
-        "whitehall-frontend"
-      ]
-    },
     "route": {
       "type": "object",
       "required": [
@@ -911,9 +507,6 @@
         "$ref": "#/definitions/route"
       },
       "minItems": 1
-    },
-    "title": {
-      "type": "string"
     },
     "update_type": {
       "enum": [

--- a/content_schemas/formats/substitute.jsonnet
+++ b/content_schemas/formats/substitute.jsonnet
@@ -1,0 +1,15 @@
+(import "shared/default_format.jsonnet") + {
+  document_type: "substitute",
+  rendering_app: "forbidden",
+  routes: "required",
+  redirects: "forbidden",
+  title: "forbidden",
+  description: "forbidden",
+  details: "forbidden",
+  edition_links: {},
+  links: {},
+  generate: {
+    publisher: false,
+    frontend: false,
+  },
+}

--- a/lib/schema_generator/notification_schema_generator.rb
+++ b/lib/schema_generator/notification_schema_generator.rb
@@ -29,7 +29,7 @@ module SchemaGenerator
     end
 
     def unpublishing_format?
-      %w[gone redirect vanish].include?(format.schema_name)
+      %w[gone redirect vanish substitute].include?(format.schema_name)
     end
 
     def properties

--- a/spec/commands/v2/publish_spec.rb
+++ b/spec/commands/v2/publish_spec.rb
@@ -308,6 +308,15 @@ RSpec.describe Commands::V2::Publish do
       end
 
       it "unpublishes the edition which is in the way" do
+        expect(PublishingAPI.service(:queue_publisher)).to receive(:send_message).with(
+          hash_including(content_id: other_edition.content_id, document_type: "substitute"),
+          hash_including(event_type: "unpublish"),
+        )
+        expect(PublishingAPI.service(:queue_publisher)).to receive(:send_message).with(
+          hash_including(content_id: draft_item.content_id),
+          hash_including(event_type: "major"),
+        )
+
         described_class.call(payload)
 
         updated_other_edition = Edition.find(other_edition.id)

--- a/spec/presenters/subtitute_presenter_spec.rb
+++ b/spec/presenters/subtitute_presenter_spec.rb
@@ -1,0 +1,14 @@
+RSpec.describe Presenters::SubstitutePresenter do
+  describe "#for_message_queue" do
+    let(:payload_version) { 1 }
+    let(:edition) { create(:unpublishing, type: "substitute").edition }
+
+    subject(:result) do
+      described_class.from_edition(edition).for_message_queue(payload_version)
+    end
+
+    it "matches the notification schema" do
+      expect(subject).to be_valid_against_notification_schema("substitute")
+    end
+  end
+end


### PR DESCRIPTION
This PR is largely a copy of #2652 that I made to get my head around Richards thinking. 

Trello: https://trello.com/c/xaN2Dhwk/1005-emit-an-event-when-documents-are-unpublished-through-subsitution

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
