### PR TITLE
Allow external redirects without a subdomain

### DIFF
--- a/app/validators/routes_and_redirects_validator.rb
+++ b/app/validators/routes_and_redirects_validator.rb
@@ -1,13 +1,13 @@
 class RoutesAndRedirectsValidator < ActiveModel::Validator
   EXTERNAL_HOST_ALLOW_LIST = %w[
-    .caa.co.uk
-    .gov.uk
-    .judiciary.uk
-    .moneyhelper.org.uk
-    .nationalhighways.co.uk
-    .nhs.uk
-    .police.uk
-    .ukri.org
+    caa.co.uk
+    gov.uk
+    judiciary.uk
+    moneyhelper.org.uk
+    nationalhighways.co.uk
+    nhs.uk
+    police.uk
+    ukri.org
   ].freeze
 
   def validate(record, base_path: nil)
@@ -176,7 +176,10 @@ private
     end
 
     def government_domain?(host)
-      host.end_with?(*EXTERNAL_HOST_ALLOW_LIST)
+      return true if EXTERNAL_HOST_ALLOW_LIST.include?(host)
+
+      host_allow_list_for_subdomains = EXTERNAL_HOST_ALLOW_LIST.map { |allowed_host| ".#{allowed_host}" }
+      host.end_with?(*host_allow_list_for_subdomains)
     end
 
     def invalid_destination?(destination)

--- a/spec/support/routes_and_redirects_validator.rb
+++ b/spec/support/routes_and_redirects_validator.rb
@@ -226,6 +226,7 @@ RSpec.shared_examples_for RoutesAndRedirectsValidator do
           http://new-vat-rates.campaignjservicepgov.uk/path/to/your/new/vat-rates
           https://fakesite.net/.new-vat-rates.campaign.gov.uk/path/to/your/new/vat-rates
           ftp://new-vat-rates.campaign.gov.uk/
+          https://evilgov.uk/
         ].each do |destination|
           edition.redirects = [{ path: "#{subject.base_path}/foo", type: "exact", destination: }]
 
@@ -244,6 +245,7 @@ RSpec.shared_examples_for RoutesAndRedirectsValidator do
           https://etl.beis.gov.uk/
           https://www.nhs.uk/
           https://www.ukri.org/
+          https://nationalhighways.co.uk/
           https://www.nationalhighways.co.uk/
           https://www.police.uk/
         ].each do |destination|


### PR DESCRIPTION
The external redirects list currently requires the domain to have a subdomain for the redirect to be valid, e.g. https://www.nationalhighways.co.uk is valid but https://nationalhighways.co.uk is not.

Removing the leading dot so we can permit redirects that don't contain a subdomain.

[Trello card](https://trello.com/c/LaeOzwYT)