### PR TITLE
Revert "Add pages array to worldwide organisations"

### DIFF
--- a/content_schemas/dist/formats/guide/frontend/schema.json
+++ b/content_schemas/dist/formats/guide/frontend/schema.json
@@ -566,9 +566,6 @@
             "type": "string",
             "format": "uri"
           },
-          "summary": {
-            "type": "string"
-          },
           "title": {
             "type": "string"
           }

--- a/content_schemas/dist/formats/guide/notification/schema.json
+++ b/content_schemas/dist/formats/guide/notification/schema.json
@@ -689,9 +689,6 @@
             "type": "string",
             "format": "uri"
           },
-          "summary": {
-            "type": "string"
-          },
           "title": {
             "type": "string"
           }

--- a/content_schemas/dist/formats/guide/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/guide/publisher_v2/schema.json
@@ -338,9 +338,6 @@
             "type": "string",
             "format": "uri"
           },
-          "summary": {
-            "type": "string"
-          },
           "title": {
             "type": "string"
           }

--- a/content_schemas/dist/formats/travel_advice/frontend/schema.json
+++ b/content_schemas/dist/formats/travel_advice/frontend/schema.json
@@ -692,9 +692,6 @@
             "type": "string",
             "format": "uri"
           },
-          "summary": {
-            "type": "string"
-          },
           "title": {
             "type": "string"
           }

--- a/content_schemas/dist/formats/travel_advice/notification/schema.json
+++ b/content_schemas/dist/formats/travel_advice/notification/schema.json
@@ -818,9 +818,6 @@
             "type": "string",
             "format": "uri"
           },
-          "summary": {
-            "type": "string"
-          },
           "title": {
             "type": "string"
           }

--- a/content_schemas/dist/formats/travel_advice/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/travel_advice/publisher_v2/schema.json
@@ -461,9 +461,6 @@
             "type": "string",
             "format": "uri"
           },
-          "summary": {
-            "type": "string"
-          },
           "title": {
             "type": "string"
           }

--- a/content_schemas/dist/formats/worldwide_organisation/frontend/schema.json
+++ b/content_schemas/dist/formats/worldwide_organisation/frontend/schema.json
@@ -297,14 +297,6 @@
       "description": "The main content provided as HTML rendered from govspeak",
       "type": "string"
     },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "type": "string"
-        }
-      ]
-    },
     "change_history": {
       "type": "array",
       "items": {
@@ -528,17 +520,11 @@
               "content_id": {
                 "$ref": "#/definitions/guid"
               },
-              "path": {
-                "type": "string"
-              },
               "title": {
                 "type": "string"
               }
             }
           }
-        },
-        "page_parts": {
-          "$ref": "#/definitions/parts"
         },
         "people_role_associations": {
           "type": "array",
@@ -899,33 +885,6 @@
         "zh-hk",
         "zh-tw"
       ]
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "additionalProperties": false,
-        "properties": {
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "summary": {
-            "type": "string"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",

--- a/content_schemas/dist/formats/worldwide_organisation/notification/schema.json
+++ b/content_schemas/dist/formats/worldwide_organisation/notification/schema.json
@@ -432,14 +432,6 @@
       "description": "The main content provided as HTML rendered from govspeak",
       "type": "string"
     },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/multiple_content_types"
-        }
-      ]
-    },
     "change_history": {
       "type": "array",
       "items": {
@@ -663,17 +655,11 @@
               "content_id": {
                 "$ref": "#/definitions/guid"
               },
-              "path": {
-                "type": "string"
-              },
               "title": {
                 "type": "string"
               }
             }
           }
-        },
-        "page_parts": {
-          "$ref": "#/definitions/parts"
         },
         "people_role_associations": {
           "type": "array",
@@ -1047,52 +1033,6 @@
         "zh-hk",
         "zh-tw"
       ]
-    },
-    "multiple_content_types": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "required": [
-          "content_type",
-          "content"
-        ],
-        "additionalProperties": false,
-        "properties": {
-          "content": {
-            "type": "string"
-          },
-          "content_type": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "additionalProperties": false,
-        "properties": {
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "summary": {
-            "type": "string"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
     },
     "payload_version": {
       "description": "Counter to indicate when the payload was generated",

--- a/content_schemas/dist/formats/worldwide_organisation/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/worldwide_organisation/publisher_v2/schema.json
@@ -204,14 +204,6 @@
       "description": "The main content provided as HTML rendered from govspeak",
       "type": "string"
     },
-    "body_html_and_govspeak": {
-      "description": "The main content provided as HTML with the govspeak markdown it's rendered from",
-      "anyOf": [
-        {
-          "$ref": "#/definitions/multiple_content_types"
-        }
-      ]
-    },
     "description_optional": {
       "anyOf": [
         {
@@ -411,17 +403,11 @@
               "content_id": {
                 "$ref": "#/definitions/guid"
               },
-              "path": {
-                "type": "string"
-              },
               "title": {
                 "type": "string"
               }
             }
           }
-        },
-        "page_parts": {
-          "$ref": "#/definitions/parts"
         },
         "people_role_associations": {
           "type": "array",
@@ -656,52 +642,6 @@
         "zh-hk",
         "zh-tw"
       ]
-    },
-    "multiple_content_types": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "required": [
-          "content_type",
-          "content"
-        ],
-        "additionalProperties": false,
-        "properties": {
-          "content": {
-            "type": "string"
-          },
-          "content_type": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "parts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "required": [
-          "title",
-          "slug",
-          "body"
-        ],
-        "additionalProperties": false,
-        "properties": {
-          "body": {
-            "$ref": "#/definitions/body_html_and_govspeak"
-          },
-          "slug": {
-            "type": "string",
-            "format": "uri"
-          },
-          "summary": {
-            "type": "string"
-          },
-          "title": {
-            "type": "string"
-          }
-        }
-      }
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",

--- a/content_schemas/examples/worldwide_organisation/frontend/worldwide_organisation.json
+++ b/content_schemas/examples/worldwide_organisation/frontend/worldwide_organisation.json
@@ -146,25 +146,14 @@
     "ordered_corporate_information_pages": [
       {
         "title": "Complaints procedure",
-        "content_id": "e6329651-2b52-43a3-9830-8ca18919eaeb",
-        "path": "about/complaints-procedure"
+        "content_id": "e6329651-2b52-43a3-9830-8ca18919eaeb"
+      },
+      {
+        "title": "Our Personal information charter explains how we treat your personal information.",
+        "content_id": "5f5560f5-7631-11e4-a3cb-005056011aef"
       }
     ],
     "secondary_corporate_information_pages": "Our <a class=\"govuk-link\" href=\"/world/organisations/british-deputy-high-commission-hyderabad/about/personal-information-charter\">Personal information charter</a> explains how we treat your personal information.",
-    "page_parts": [
-      {
-        "body": "<h2 id=\"public-holidays\">Public holidays</h2> <p>Our offices will be closed for the following public holidays in 2013:</p> <table> <thead> <tr> <th scope=\"col\">Date</th> <th scope=\"col\">Offices</th> </tr> </thead> <tbody> <tr> <td>Tuesday 1 January</td> <td>New Year’s Day</td> </tr> <tr> <td>Monday 14 January</td> <td>Makar Sankranti</td> </tr> <tr> <td>Wednesday 27 March</td> <td>Holi</td> </tr> <tr> <td>Friday 29 March</td> <td>Good Friday</td> </tr> <tr> <td>Monday 1 April</td> <td>Easter Monday</td> </tr> <tr> <td>Thursday 11 April</td> <td>Ugadi (Telugu New Year)</td> </tr> <tr> <td>Friday 24 May</td> <td>Queen’s Birthday Privilege Holiday</td> </tr> <tr> <td>Thursday 15 August</td> <td>Independence Day</td> </tr> <tr> <td>Monday 9 September</td> <td>Ganesh Chaturthi</td> </tr> <tr> <td>Wednesday 2 October</td> <td>Gandhi Jayanti</td> </tr> <tr> <td>Wednesday 16 October</td> <td>Id-ul-Zuha/Bakrid</td> </tr> <tr> <td>Monday 4 November</td> <td>Diwali Balipratipada (Hindu New Year</td> </tr> <tr> <td>Wednesday 25 December</td> <td>Christmas</td> </tr> <tr> <td>Thursday 26 December</td> <td>Boxing Day</td> </tr> <tr> <td>Friday 27 December</td> <td>Christmas Privilege Holiday</td> </tr> </tbody> </table> <p>Holidays that fall on Saturdays & Sundays have been excluded from this list.</p> ",
-        "slug": "about/personal-information-charter",
-        "summary": "Public holidays information about the British Deputy High Commission Hyderabad.",
-        "title": "Personal information charter"
-      },
-      {
-        "body": "<h2 id=\"complaints-feedback-and-suggestions-on-consular-services\">Complaints, feedback and suggestions on consular services</h2> <p>If you have any complaints, feedback or suggestions about the consular service provided, please send details of your complaint using our <a rel=\"external\" href=\"https://www.contact-embassy.service.gov.uk/?country=United%20Kingdom&post=Feedback%20team\">online feedback form</a>, or in writing to:</p> <div class=\"address\"><div class=\"adr org fn\"><p> <br>Customer Interaction Team <br> Consular Directorate <br> Room WH4.36 <br> Foreign, Commonwealth & Development Office <br> King Charles Street <br> London <br> SW1A 2AH <br> <br> </p></div></div> <h2 id=\"customer-research\">Customer research</h2> <p>We also work with partner research agencies to conduct customer satisfaction research on our services. If you have sought consular assistance overseas and have provided your contact details to us, we may ask you to take part in our customer satisfaction research. Find out more about <a href=\"https://www.gov.uk/government/organisations/foreign-commonwealth-office/about/complaints-procedure#our-feedback-programme-and-research\">our feedback programme and research</a>.</p> <h3 id=\"we-are-not-able-to-respond-to-any-queries-or-complaints-about-uk-visas-or-british-passports\">We are not able to respond to any queries or complaints about UK visas or British passports.</h3> <h2 id=\"passports\">Passports</h2> <p>If your complaint is about British passports, contact <a href=\"https://www.gov.uk/government/organisations/hm-passport-office/about/complaints-procedure\">HM Passport Office</a>.</p> <h2 id=\"visas\">Visas</h2> <p>If your complaint is about UK visas, contact <a href=\"https://www.gov.uk/government/organisations/uk-visas-and-immigration/about/complaints-procedure\">UK Visas and Immigration</a>.</p> <p>Or if you have a query or feedback on UK visa services provided in India, please visit the <a href=\"https://www.gov.uk/government/organisations/uk-visas-and-immigration\">UK visas website</a>.</p> <h2 id=\"report-immigration-or-border-crimes\">Report immigration or border crimes</h2> <p>If you wish to report someone who is working illegally, has no right to be in the UK or is involved in immigration crime or smuggling activity, visit <a rel=\"external\" href=\"https://www.amsallegations.homeoffice.gov.uk/default.aspx/RenderForm/?F.Name=Lf62UB7cz4C\">this page</a>.</p> <p>Allegations made by email, post, or other means will not be processed.</p> \"\n",
-        "slug": "about/complaints-procedure",
-        "summary": "The Foreign, Commonwealth & Development Office is committed to providing a high-quality service to everyone we deal with. We welcome your views on the services that the Embassy provides, as they will help us to identify what we do well and what we could do better.",
-        "title": "Complaints procedure"
-      }
-    ],
     "world_location_names": [
       {
         "content_id": "5e9f047a-7706-11e4-a3cb-005056011aef",

--- a/content_schemas/formats/shared/definitions/multi_part_pages.jsonnet
+++ b/content_schemas/formats/shared/definitions/multi_part_pages.jsonnet
@@ -17,9 +17,6 @@
           type: "string",
           format: "uri",
         },
-        summary: {
-          type: "string",
-        },
         body: {
           "$ref": "#/definitions/body_html_and_govspeak",
         },

--- a/content_schemas/formats/worldwide_organisation.jsonnet
+++ b/content_schemas/formats/worldwide_organisation.jsonnet
@@ -20,9 +20,6 @@
           "type": "array",
           "items": (import "shared/definitions/_worldwide_office.jsonnet"),
         },
-        page_parts: {
-          "$ref": "#/definitions/parts",
-        },
         office_contact_associations: {
           type: "array",
           items: {
@@ -56,9 +53,6 @@
                 "$ref": "#/definitions/guid",
               },
               title: {
-                type: "string",
-              },
-              path: {
                 type: "string",
               },
             },


### PR DESCRIPTION
https://trello.com/c/npYpoK31

In previous commits, we added support for Worldwide Organisations and their offices to be presented within a single content item.

This approach was decided against, since there were issues with translated organisations.

Reverts alphagov/publishing-api#2637