### PR TITLE
Remove topics from base_links and whitehall_edition_links

### DIFF
--- a/content_schemas/dist/formats/answer/frontend/schema.json
+++ b/content_schemas/dist/formats/answer/frontend/schema.json
@@ -148,10 +148,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
         }
       }
     },

--- a/content_schemas/dist/formats/answer/notification/schema.json
+++ b/content_schemas/dist/formats/answer/notification/schema.json
@@ -166,10 +166,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
         }
       }
     },
@@ -239,10 +235,6 @@
         },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/guid_list"
         }
       }

--- a/content_schemas/dist/formats/answer/publisher_v2/links.json
+++ b/content_schemas/dist/formats/answer/publisher_v2/links.json
@@ -63,10 +63,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/guid_list"
         }
       }
     },

--- a/content_schemas/dist/formats/calendar/frontend/schema.json
+++ b/content_schemas/dist/formats/calendar/frontend/schema.json
@@ -148,10 +148,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
         }
       }
     },

--- a/content_schemas/dist/formats/calendar/notification/schema.json
+++ b/content_schemas/dist/formats/calendar/notification/schema.json
@@ -166,10 +166,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
         }
       }
     },
@@ -239,10 +235,6 @@
         },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/guid_list"
         }
       }

--- a/content_schemas/dist/formats/calendar/publisher_v2/links.json
+++ b/content_schemas/dist/formats/calendar/publisher_v2/links.json
@@ -63,10 +63,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/guid_list"
         }
       }
     },

--- a/content_schemas/dist/formats/call_for_evidence/frontend/schema.json
+++ b/content_schemas/dist/formats/call_for_evidence/frontend/schema.json
@@ -167,9 +167,6 @@
         },
         "topical_events": {
           "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "topics": {
-          "$ref": "#/definitions/frontend_links_with_base_path"
         }
       }
     },

--- a/content_schemas/dist/formats/call_for_evidence/notification/schema.json
+++ b/content_schemas/dist/formats/call_for_evidence/notification/schema.json
@@ -185,9 +185,6 @@
         },
         "topical_events": {
           "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "topics": {
-          "$ref": "#/definitions/frontend_links_with_base_path"
         }
       }
     },
@@ -273,9 +270,6 @@
           "$ref": "#/definitions/guid_list"
         },
         "topical_events": {
-          "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
           "$ref": "#/definitions/guid_list"
         }
       }

--- a/content_schemas/dist/formats/call_for_evidence/publisher_v2/links.json
+++ b/content_schemas/dist/formats/call_for_evidence/publisher_v2/links.json
@@ -82,10 +82,6 @@
         },
         "topical_events": {
           "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/guid_list"
         }
       }
     },

--- a/content_schemas/dist/formats/call_for_evidence/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/call_for_evidence/publisher_v2/schema.json
@@ -99,9 +99,6 @@
         },
         "topical_events": {
           "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
-          "$ref": "#/definitions/guid_list"
         }
       }
     },

--- a/content_schemas/dist/formats/case_study/frontend/schema.json
+++ b/content_schemas/dist/formats/case_study/frontend/schema.json
@@ -157,10 +157,6 @@
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "world_locations": {
           "$ref": "#/definitions/frontend_links"
         },

--- a/content_schemas/dist/formats/case_study/notification/schema.json
+++ b/content_schemas/dist/formats/case_study/notification/schema.json
@@ -175,10 +175,6 @@
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "world_locations": {
           "$ref": "#/definitions/frontend_links"
         },
@@ -261,10 +257,6 @@
         },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/guid_list"
         },
         "world_locations": {

--- a/content_schemas/dist/formats/case_study/publisher_v2/links.json
+++ b/content_schemas/dist/formats/case_study/publisher_v2/links.json
@@ -72,10 +72,6 @@
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
         },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/guid_list"
-        },
         "world_locations": {
           "$ref": "#/definitions/guid_list"
         },

--- a/content_schemas/dist/formats/completed_transaction/frontend/schema.json
+++ b/content_schemas/dist/formats/completed_transaction/frontend/schema.json
@@ -148,10 +148,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
         }
       }
     },

--- a/content_schemas/dist/formats/completed_transaction/notification/schema.json
+++ b/content_schemas/dist/formats/completed_transaction/notification/schema.json
@@ -166,10 +166,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
         }
       }
     },
@@ -239,10 +235,6 @@
         },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/guid_list"
         }
       }

--- a/content_schemas/dist/formats/completed_transaction/publisher_v2/links.json
+++ b/content_schemas/dist/formats/completed_transaction/publisher_v2/links.json
@@ -63,10 +63,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/guid_list"
         }
       }
     },

--- a/content_schemas/dist/formats/consultation/frontend/schema.json
+++ b/content_schemas/dist/formats/consultation/frontend/schema.json
@@ -167,9 +167,6 @@
         },
         "topical_events": {
           "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "topics": {
-          "$ref": "#/definitions/frontend_links_with_base_path"
         }
       }
     },

--- a/content_schemas/dist/formats/consultation/notification/schema.json
+++ b/content_schemas/dist/formats/consultation/notification/schema.json
@@ -185,9 +185,6 @@
         },
         "topical_events": {
           "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "topics": {
-          "$ref": "#/definitions/frontend_links_with_base_path"
         }
       }
     },
@@ -273,9 +270,6 @@
           "$ref": "#/definitions/guid_list"
         },
         "topical_events": {
-          "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
           "$ref": "#/definitions/guid_list"
         }
       }

--- a/content_schemas/dist/formats/consultation/publisher_v2/links.json
+++ b/content_schemas/dist/formats/consultation/publisher_v2/links.json
@@ -82,10 +82,6 @@
         },
         "topical_events": {
           "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/guid_list"
         }
       }
     },

--- a/content_schemas/dist/formats/consultation/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/consultation/publisher_v2/schema.json
@@ -99,9 +99,6 @@
         },
         "topical_events": {
           "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
-          "$ref": "#/definitions/guid_list"
         }
       }
     },

--- a/content_schemas/dist/formats/contact/frontend/schema.json
+++ b/content_schemas/dist/formats/contact/frontend/schema.json
@@ -152,10 +152,6 @@
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "world_locations": {
           "$ref": "#/definitions/frontend_links"
         }

--- a/content_schemas/dist/formats/contact/notification/schema.json
+++ b/content_schemas/dist/formats/contact/notification/schema.json
@@ -170,10 +170,6 @@
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "world_locations": {
           "$ref": "#/definitions/frontend_links"
         }
@@ -248,10 +244,6 @@
         },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/guid_list"
         },
         "world_locations": {

--- a/content_schemas/dist/formats/contact/publisher_v2/links.json
+++ b/content_schemas/dist/formats/contact/publisher_v2/links.json
@@ -67,10 +67,6 @@
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
         },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/guid_list"
-        },
         "world_locations": {
           "$ref": "#/definitions/guid_list"
         }

--- a/content_schemas/dist/formats/coronavirus_landing_page/frontend/schema.json
+++ b/content_schemas/dist/formats/coronavirus_landing_page/frontend/schema.json
@@ -148,10 +148,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
         }
       }
     },

--- a/content_schemas/dist/formats/coronavirus_landing_page/notification/schema.json
+++ b/content_schemas/dist/formats/coronavirus_landing_page/notification/schema.json
@@ -166,10 +166,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
         }
       }
     },
@@ -239,10 +235,6 @@
         },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/guid_list"
         }
       }

--- a/content_schemas/dist/formats/coronavirus_landing_page/publisher_v2/links.json
+++ b/content_schemas/dist/formats/coronavirus_landing_page/publisher_v2/links.json
@@ -63,10 +63,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/guid_list"
         }
       }
     },

--- a/content_schemas/dist/formats/corporate_information_page/frontend/schema.json
+++ b/content_schemas/dist/formats/corporate_information_page/frontend/schema.json
@@ -177,10 +177,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
         }
       }
     },

--- a/content_schemas/dist/formats/corporate_information_page/notification/schema.json
+++ b/content_schemas/dist/formats/corporate_information_page/notification/schema.json
@@ -195,10 +195,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
         }
       }
     },
@@ -276,10 +272,6 @@
         },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/guid_list"
         }
       }

--- a/content_schemas/dist/formats/corporate_information_page/publisher_v2/links.json
+++ b/content_schemas/dist/formats/corporate_information_page/publisher_v2/links.json
@@ -71,10 +71,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/guid_list"
         }
       }
     },

--- a/content_schemas/dist/formats/detailed_guide/frontend/schema.json
+++ b/content_schemas/dist/formats/detailed_guide/frontend/schema.json
@@ -162,9 +162,6 @@
         },
         "topical_events": {
           "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "topics": {
-          "$ref": "#/definitions/frontend_links_with_base_path"
         }
       }
     },

--- a/content_schemas/dist/formats/detailed_guide/notification/schema.json
+++ b/content_schemas/dist/formats/detailed_guide/notification/schema.json
@@ -180,9 +180,6 @@
         },
         "topical_events": {
           "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "topics": {
-          "$ref": "#/definitions/frontend_links_with_base_path"
         }
       }
     },
@@ -266,9 +263,6 @@
           "$ref": "#/definitions/guid_list"
         },
         "topical_events": {
-          "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
           "$ref": "#/definitions/guid_list"
         }
       }

--- a/content_schemas/dist/formats/detailed_guide/publisher_v2/links.json
+++ b/content_schemas/dist/formats/detailed_guide/publisher_v2/links.json
@@ -77,10 +77,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/guid_list"
         }
       }
     },

--- a/content_schemas/dist/formats/detailed_guide/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/detailed_guide/publisher_v2/schema.json
@@ -94,9 +94,6 @@
         },
         "topical_events": {
           "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
-          "$ref": "#/definitions/guid_list"
         }
       }
     },

--- a/content_schemas/dist/formats/document_collection/frontend/schema.json
+++ b/content_schemas/dist/formats/document_collection/frontend/schema.json
@@ -170,9 +170,6 @@
         },
         "topical_events": {
           "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "topics": {
-          "$ref": "#/definitions/frontend_links_with_base_path"
         }
       }
     },

--- a/content_schemas/dist/formats/document_collection/notification/schema.json
+++ b/content_schemas/dist/formats/document_collection/notification/schema.json
@@ -188,9 +188,6 @@
         },
         "topical_events": {
           "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "topics": {
-          "$ref": "#/definitions/frontend_links_with_base_path"
         }
       }
     },
@@ -282,9 +279,6 @@
           "$ref": "#/definitions/guid_list"
         },
         "topical_events": {
-          "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
           "$ref": "#/definitions/guid_list"
         }
       }

--- a/content_schemas/dist/formats/document_collection/publisher_v2/links.json
+++ b/content_schemas/dist/formats/document_collection/publisher_v2/links.json
@@ -89,10 +89,6 @@
         "topical_events": {
           "description": "The topical events that are part of this document collection.",
           "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/guid_list"
         }
       }
     },

--- a/content_schemas/dist/formats/document_collection/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/document_collection/publisher_v2/schema.json
@@ -96,9 +96,6 @@
         },
         "topical_events": {
           "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
-          "$ref": "#/definitions/guid_list"
         }
       }
     },

--- a/content_schemas/dist/formats/email_alert_signup/frontend/schema.json
+++ b/content_schemas/dist/formats/email_alert_signup/frontend/schema.json
@@ -148,10 +148,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
         }
       }
     },

--- a/content_schemas/dist/formats/email_alert_signup/notification/schema.json
+++ b/content_schemas/dist/formats/email_alert_signup/notification/schema.json
@@ -166,10 +166,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
         }
       }
     },
@@ -239,10 +235,6 @@
         },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/guid_list"
         }
       }

--- a/content_schemas/dist/formats/email_alert_signup/publisher_v2/links.json
+++ b/content_schemas/dist/formats/email_alert_signup/publisher_v2/links.json
@@ -63,10 +63,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/guid_list"
         }
       }
     },

--- a/content_schemas/dist/formats/embassies_index/frontend/schema.json
+++ b/content_schemas/dist/formats/embassies_index/frontend/schema.json
@@ -148,10 +148,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
         }
       }
     },

--- a/content_schemas/dist/formats/embassies_index/notification/schema.json
+++ b/content_schemas/dist/formats/embassies_index/notification/schema.json
@@ -166,10 +166,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
         }
       }
     },
@@ -239,10 +235,6 @@
         },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/guid_list"
         }
       }

--- a/content_schemas/dist/formats/embassies_index/publisher_v2/links.json
+++ b/content_schemas/dist/formats/embassies_index/publisher_v2/links.json
@@ -63,10 +63,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/guid_list"
         }
       }
     },

--- a/content_schemas/dist/formats/facet/frontend/schema.json
+++ b/content_schemas/dist/formats/facet/frontend/schema.json
@@ -148,10 +148,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
         }
       }
     },

--- a/content_schemas/dist/formats/facet/notification/schema.json
+++ b/content_schemas/dist/formats/facet/notification/schema.json
@@ -166,10 +166,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
         }
       }
     },
@@ -239,10 +235,6 @@
         },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/guid_list"
         }
       }

--- a/content_schemas/dist/formats/facet/publisher_v2/links.json
+++ b/content_schemas/dist/formats/facet/publisher_v2/links.json
@@ -63,10 +63,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/guid_list"
         }
       }
     },

--- a/content_schemas/dist/formats/fatality_notice/frontend/schema.json
+++ b/content_schemas/dist/formats/fatality_notice/frontend/schema.json
@@ -160,10 +160,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
         }
       }
     },

--- a/content_schemas/dist/formats/fatality_notice/notification/schema.json
+++ b/content_schemas/dist/formats/fatality_notice/notification/schema.json
@@ -178,10 +178,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
         }
       }
     },
@@ -264,10 +260,6 @@
         },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/guid_list"
         }
       }

--- a/content_schemas/dist/formats/fatality_notice/publisher_v2/links.json
+++ b/content_schemas/dist/formats/fatality_notice/publisher_v2/links.json
@@ -75,10 +75,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/guid_list"
         }
       }
     },

--- a/content_schemas/dist/formats/field_of_operation/frontend/schema.json
+++ b/content_schemas/dist/formats/field_of_operation/frontend/schema.json
@@ -152,10 +152,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
         }
       }
     },

--- a/content_schemas/dist/formats/field_of_operation/notification/schema.json
+++ b/content_schemas/dist/formats/field_of_operation/notification/schema.json
@@ -170,10 +170,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
         }
       }
     },
@@ -247,10 +243,6 @@
         },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/guid_list"
         }
       }

--- a/content_schemas/dist/formats/field_of_operation/publisher_v2/links.json
+++ b/content_schemas/dist/formats/field_of_operation/publisher_v2/links.json
@@ -67,10 +67,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/guid_list"
         }
       }
     },

--- a/content_schemas/dist/formats/fields_of_operation/frontend/schema.json
+++ b/content_schemas/dist/formats/fields_of_operation/frontend/schema.json
@@ -152,10 +152,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
         }
       }
     },

--- a/content_schemas/dist/formats/fields_of_operation/notification/schema.json
+++ b/content_schemas/dist/formats/fields_of_operation/notification/schema.json
@@ -170,10 +170,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
         }
       }
     },
@@ -247,10 +243,6 @@
         },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/guid_list"
         }
       }

--- a/content_schemas/dist/formats/fields_of_operation/publisher_v2/links.json
+++ b/content_schemas/dist/formats/fields_of_operation/publisher_v2/links.json
@@ -67,10 +67,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/guid_list"
         }
       }
     },

--- a/content_schemas/dist/formats/finder/frontend/schema.json
+++ b/content_schemas/dist/formats/finder/frontend/schema.json
@@ -154,10 +154,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
         }
       }
     },

--- a/content_schemas/dist/formats/finder/notification/schema.json
+++ b/content_schemas/dist/formats/finder/notification/schema.json
@@ -172,10 +172,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
         }
       }
     },
@@ -254,10 +250,6 @@
         },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/guid_list"
         }
       }

--- a/content_schemas/dist/formats/finder/publisher_v2/links.json
+++ b/content_schemas/dist/formats/finder/publisher_v2/links.json
@@ -72,10 +72,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/guid_list"
         }
       }
     },

--- a/content_schemas/dist/formats/finder_email_signup/frontend/schema.json
+++ b/content_schemas/dist/formats/finder_email_signup/frontend/schema.json
@@ -150,10 +150,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
         }
       }
     },

--- a/content_schemas/dist/formats/finder_email_signup/notification/schema.json
+++ b/content_schemas/dist/formats/finder_email_signup/notification/schema.json
@@ -168,10 +168,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
         }
       }
     },
@@ -243,10 +239,6 @@
         },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/guid_list"
         }
       }

--- a/content_schemas/dist/formats/finder_email_signup/publisher_v2/links.json
+++ b/content_schemas/dist/formats/finder_email_signup/publisher_v2/links.json
@@ -65,10 +65,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/guid_list"
         }
       }
     },

--- a/content_schemas/dist/formats/generic/frontend/schema.json
+++ b/content_schemas/dist/formats/generic/frontend/schema.json
@@ -326,10 +326,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
         }
       }
     },

--- a/content_schemas/dist/formats/generic/notification/schema.json
+++ b/content_schemas/dist/formats/generic/notification/schema.json
@@ -344,10 +344,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
         }
       }
     },
@@ -417,10 +413,6 @@
         },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/guid_list"
         }
       }

--- a/content_schemas/dist/formats/generic/publisher_v2/links.json
+++ b/content_schemas/dist/formats/generic/publisher_v2/links.json
@@ -63,10 +63,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/guid_list"
         }
       }
     },

--- a/content_schemas/dist/formats/generic_with_external_related_links/frontend/schema.json
+++ b/content_schemas/dist/formats/generic_with_external_related_links/frontend/schema.json
@@ -326,10 +326,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
         }
       }
     },

--- a/content_schemas/dist/formats/generic_with_external_related_links/notification/schema.json
+++ b/content_schemas/dist/formats/generic_with_external_related_links/notification/schema.json
@@ -344,10 +344,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
         }
       }
     },
@@ -417,10 +413,6 @@
         },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/guid_list"
         }
       }

--- a/content_schemas/dist/formats/generic_with_external_related_links/publisher_v2/links.json
+++ b/content_schemas/dist/formats/generic_with_external_related_links/publisher_v2/links.json
@@ -63,10 +63,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/guid_list"
         }
       }
     },

--- a/content_schemas/dist/formats/get_involved/frontend/schema.json
+++ b/content_schemas/dist/formats/get_involved/frontend/schema.json
@@ -152,10 +152,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
         }
       }
     },

--- a/content_schemas/dist/formats/get_involved/notification/schema.json
+++ b/content_schemas/dist/formats/get_involved/notification/schema.json
@@ -170,10 +170,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
         }
       }
     },
@@ -247,10 +243,6 @@
         },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/guid_list"
         }
       }

--- a/content_schemas/dist/formats/get_involved/publisher_v2/links.json
+++ b/content_schemas/dist/formats/get_involved/publisher_v2/links.json
@@ -67,10 +67,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/guid_list"
         }
       }
     },

--- a/content_schemas/dist/formats/government/frontend/schema.json
+++ b/content_schemas/dist/formats/government/frontend/schema.json
@@ -148,10 +148,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
         }
       }
     },

--- a/content_schemas/dist/formats/government/notification/schema.json
+++ b/content_schemas/dist/formats/government/notification/schema.json
@@ -166,10 +166,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
         }
       }
     },
@@ -239,10 +235,6 @@
         },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/guid_list"
         }
       }

--- a/content_schemas/dist/formats/government/publisher_v2/links.json
+++ b/content_schemas/dist/formats/government/publisher_v2/links.json
@@ -63,10 +63,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/guid_list"
         }
       }
     },

--- a/content_schemas/dist/formats/guide/frontend/schema.json
+++ b/content_schemas/dist/formats/guide/frontend/schema.json
@@ -148,10 +148,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
         }
       }
     },

--- a/content_schemas/dist/formats/guide/notification/schema.json
+++ b/content_schemas/dist/formats/guide/notification/schema.json
@@ -166,10 +166,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
         }
       }
     },
@@ -239,10 +235,6 @@
         },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/guid_list"
         }
       }

--- a/content_schemas/dist/formats/guide/publisher_v2/links.json
+++ b/content_schemas/dist/formats/guide/publisher_v2/links.json
@@ -63,10 +63,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/guid_list"
         }
       }
     },

--- a/content_schemas/dist/formats/help_page/frontend/schema.json
+++ b/content_schemas/dist/formats/help_page/frontend/schema.json
@@ -148,10 +148,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
         }
       }
     },

--- a/content_schemas/dist/formats/help_page/notification/schema.json
+++ b/content_schemas/dist/formats/help_page/notification/schema.json
@@ -166,10 +166,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
         }
       }
     },
@@ -239,10 +235,6 @@
         },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/guid_list"
         }
       }

--- a/content_schemas/dist/formats/help_page/publisher_v2/links.json
+++ b/content_schemas/dist/formats/help_page/publisher_v2/links.json
@@ -63,10 +63,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/guid_list"
         }
       }
     },

--- a/content_schemas/dist/formats/historic_appointment/frontend/schema.json
+++ b/content_schemas/dist/formats/historic_appointment/frontend/schema.json
@@ -152,10 +152,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
         }
       }
     },

--- a/content_schemas/dist/formats/historic_appointment/notification/schema.json
+++ b/content_schemas/dist/formats/historic_appointment/notification/schema.json
@@ -170,10 +170,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
         }
       }
     },
@@ -247,10 +243,6 @@
         },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/guid_list"
         }
       }

--- a/content_schemas/dist/formats/historic_appointment/publisher_v2/links.json
+++ b/content_schemas/dist/formats/historic_appointment/publisher_v2/links.json
@@ -67,10 +67,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/guid_list"
         }
       }
     },

--- a/content_schemas/dist/formats/historic_appointments/frontend/schema.json
+++ b/content_schemas/dist/formats/historic_appointments/frontend/schema.json
@@ -152,10 +152,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
         }
       }
     },

--- a/content_schemas/dist/formats/historic_appointments/notification/schema.json
+++ b/content_schemas/dist/formats/historic_appointments/notification/schema.json
@@ -170,10 +170,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
         }
       }
     },
@@ -247,10 +243,6 @@
         },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/guid_list"
         }
       }

--- a/content_schemas/dist/formats/historic_appointments/publisher_v2/links.json
+++ b/content_schemas/dist/formats/historic_appointments/publisher_v2/links.json
@@ -67,10 +67,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/guid_list"
         }
       }
     },

--- a/content_schemas/dist/formats/history/frontend/schema.json
+++ b/content_schemas/dist/formats/history/frontend/schema.json
@@ -148,10 +148,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
         }
       }
     },

--- a/content_schemas/dist/formats/history/notification/schema.json
+++ b/content_schemas/dist/formats/history/notification/schema.json
@@ -166,10 +166,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
         }
       }
     },
@@ -239,10 +235,6 @@
         },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/guid_list"
         }
       }

--- a/content_schemas/dist/formats/history/publisher_v2/links.json
+++ b/content_schemas/dist/formats/history/publisher_v2/links.json
@@ -63,10 +63,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/guid_list"
         }
       }
     },

--- a/content_schemas/dist/formats/hmrc_manual/frontend/schema.json
+++ b/content_schemas/dist/formats/hmrc_manual/frontend/schema.json
@@ -148,10 +148,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
         }
       }
     },

--- a/content_schemas/dist/formats/hmrc_manual/notification/schema.json
+++ b/content_schemas/dist/formats/hmrc_manual/notification/schema.json
@@ -166,10 +166,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
         }
       }
     },
@@ -239,10 +235,6 @@
         },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/guid_list"
         }
       }

--- a/content_schemas/dist/formats/hmrc_manual/publisher_v2/links.json
+++ b/content_schemas/dist/formats/hmrc_manual/publisher_v2/links.json
@@ -63,10 +63,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/guid_list"
         }
       }
     },

--- a/content_schemas/dist/formats/hmrc_manual_section/frontend/schema.json
+++ b/content_schemas/dist/formats/hmrc_manual_section/frontend/schema.json
@@ -148,10 +148,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
         }
       }
     },

--- a/content_schemas/dist/formats/hmrc_manual_section/notification/schema.json
+++ b/content_schemas/dist/formats/hmrc_manual_section/notification/schema.json
@@ -166,10 +166,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
         }
       }
     },
@@ -239,10 +235,6 @@
         },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/guid_list"
         }
       }

--- a/content_schemas/dist/formats/hmrc_manual_section/publisher_v2/links.json
+++ b/content_schemas/dist/formats/hmrc_manual_section/publisher_v2/links.json
@@ -63,10 +63,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/guid_list"
         }
       }
     },

--- a/content_schemas/dist/formats/how_government_works/frontend/schema.json
+++ b/content_schemas/dist/formats/how_government_works/frontend/schema.json
@@ -152,10 +152,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
         }
       }
     },

--- a/content_schemas/dist/formats/how_government_works/notification/schema.json
+++ b/content_schemas/dist/formats/how_government_works/notification/schema.json
@@ -170,10 +170,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
         }
       }
     },
@@ -247,10 +243,6 @@
         },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/guid_list"
         }
       }

--- a/content_schemas/dist/formats/how_government_works/publisher_v2/links.json
+++ b/content_schemas/dist/formats/how_government_works/publisher_v2/links.json
@@ -67,10 +67,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/guid_list"
         }
       }
     },

--- a/content_schemas/dist/formats/html_publication/frontend/schema.json
+++ b/content_schemas/dist/formats/html_publication/frontend/schema.json
@@ -150,10 +150,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
         }
       }
     },

--- a/content_schemas/dist/formats/html_publication/notification/schema.json
+++ b/content_schemas/dist/formats/html_publication/notification/schema.json
@@ -168,10 +168,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
         }
       }
     },
@@ -243,10 +239,6 @@
         },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/guid_list"
         }
       }

--- a/content_schemas/dist/formats/html_publication/publisher_v2/links.json
+++ b/content_schemas/dist/formats/html_publication/publisher_v2/links.json
@@ -68,10 +68,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/guid_list"
         }
       }
     },

--- a/content_schemas/dist/formats/licence/frontend/schema.json
+++ b/content_schemas/dist/formats/licence/frontend/schema.json
@@ -148,10 +148,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
         }
       }
     },

--- a/content_schemas/dist/formats/licence/notification/schema.json
+++ b/content_schemas/dist/formats/licence/notification/schema.json
@@ -166,10 +166,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
         }
       }
     },
@@ -239,10 +235,6 @@
         },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/guid_list"
         }
       }

--- a/content_schemas/dist/formats/licence/publisher_v2/links.json
+++ b/content_schemas/dist/formats/licence/publisher_v2/links.json
@@ -63,10 +63,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/guid_list"
         }
       }
     },

--- a/content_schemas/dist/formats/local_transaction/frontend/schema.json
+++ b/content_schemas/dist/formats/local_transaction/frontend/schema.json
@@ -148,10 +148,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
         }
       }
     },

--- a/content_schemas/dist/formats/local_transaction/notification/schema.json
+++ b/content_schemas/dist/formats/local_transaction/notification/schema.json
@@ -166,10 +166,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
         }
       }
     },
@@ -239,10 +235,6 @@
         },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/guid_list"
         }
       }

--- a/content_schemas/dist/formats/local_transaction/publisher_v2/links.json
+++ b/content_schemas/dist/formats/local_transaction/publisher_v2/links.json
@@ -63,10 +63,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/guid_list"
         }
       }
     },

--- a/content_schemas/dist/formats/mainstream_browse_page/frontend/schema.json
+++ b/content_schemas/dist/formats/mainstream_browse_page/frontend/schema.json
@@ -164,10 +164,6 @@
         "top_level_browse_pages": {
           "description": "All top-level browse pages",
           "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
         }
       }
     },

--- a/content_schemas/dist/formats/mainstream_browse_page/notification/schema.json
+++ b/content_schemas/dist/formats/mainstream_browse_page/notification/schema.json
@@ -182,10 +182,6 @@
         "top_level_browse_pages": {
           "description": "All top-level browse pages",
           "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
         }
       }
     },
@@ -271,10 +267,6 @@
         },
         "top_level_browse_pages": {
           "description": "All top-level browse pages",
-          "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/guid_list"
         }
       }

--- a/content_schemas/dist/formats/mainstream_browse_page/publisher_v2/links.json
+++ b/content_schemas/dist/formats/mainstream_browse_page/publisher_v2/links.json
@@ -79,10 +79,6 @@
         "top_level_browse_pages": {
           "description": "All top-level browse pages",
           "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/guid_list"
         }
       }
     },

--- a/content_schemas/dist/formats/manual/frontend/schema.json
+++ b/content_schemas/dist/formats/manual/frontend/schema.json
@@ -149,10 +149,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
         }
       }
     },

--- a/content_schemas/dist/formats/manual/notification/schema.json
+++ b/content_schemas/dist/formats/manual/notification/schema.json
@@ -167,10 +167,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
         }
       }
     },
@@ -245,10 +241,6 @@
         },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/guid_list"
         }
       }

--- a/content_schemas/dist/formats/manual/publisher_v2/links.json
+++ b/content_schemas/dist/formats/manual/publisher_v2/links.json
@@ -68,10 +68,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/guid_list"
         }
       }
     },

--- a/content_schemas/dist/formats/manual_section/frontend/schema.json
+++ b/content_schemas/dist/formats/manual_section/frontend/schema.json
@@ -149,10 +149,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
         }
       }
     },

--- a/content_schemas/dist/formats/manual_section/notification/schema.json
+++ b/content_schemas/dist/formats/manual_section/notification/schema.json
@@ -167,10 +167,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
         }
       }
     },
@@ -245,10 +241,6 @@
         },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/guid_list"
         }
       }

--- a/content_schemas/dist/formats/manual_section/publisher_v2/links.json
+++ b/content_schemas/dist/formats/manual_section/publisher_v2/links.json
@@ -68,10 +68,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/guid_list"
         }
       }
     },

--- a/content_schemas/dist/formats/ministers_index/frontend/schema.json
+++ b/content_schemas/dist/formats/ministers_index/frontend/schema.json
@@ -180,10 +180,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
         }
       }
     },

--- a/content_schemas/dist/formats/ministers_index/notification/schema.json
+++ b/content_schemas/dist/formats/ministers_index/notification/schema.json
@@ -198,10 +198,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
         }
       }
     },
@@ -303,10 +299,6 @@
         },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/guid_list"
         }
       }

--- a/content_schemas/dist/formats/ministers_index/publisher_v2/links.json
+++ b/content_schemas/dist/formats/ministers_index/publisher_v2/links.json
@@ -95,10 +95,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/guid_list"
         }
       }
     },

--- a/content_schemas/dist/formats/need/frontend/schema.json
+++ b/content_schemas/dist/formats/need/frontend/schema.json
@@ -148,10 +148,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
         }
       }
     },

--- a/content_schemas/dist/formats/need/notification/schema.json
+++ b/content_schemas/dist/formats/need/notification/schema.json
@@ -166,10 +166,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
         }
       }
     },
@@ -239,10 +235,6 @@
         },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/guid_list"
         }
       }

--- a/content_schemas/dist/formats/need/publisher_v2/links.json
+++ b/content_schemas/dist/formats/need/publisher_v2/links.json
@@ -63,10 +63,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/guid_list"
         }
       }
     },

--- a/content_schemas/dist/formats/news_article/frontend/schema.json
+++ b/content_schemas/dist/formats/news_article/frontend/schema.json
@@ -172,10 +172,6 @@
           "description": "The topical events this content item relates to.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "world_locations": {
           "description": "The world locations this content item is about.",
           "$ref": "#/definitions/frontend_links"

--- a/content_schemas/dist/formats/news_article/notification/schema.json
+++ b/content_schemas/dist/formats/news_article/notification/schema.json
@@ -190,10 +190,6 @@
           "description": "The topical events this content item relates to.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "world_locations": {
           "description": "The world locations this content item is about.",
           "$ref": "#/definitions/frontend_links"
@@ -290,10 +286,6 @@
         },
         "topical_events": {
           "description": "The topical events this content item relates to.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/guid_list"
         },
         "world_locations": {

--- a/content_schemas/dist/formats/news_article/publisher_v2/links.json
+++ b/content_schemas/dist/formats/news_article/publisher_v2/links.json
@@ -84,10 +84,6 @@
           "description": "The topical events this content item relates to.",
           "$ref": "#/definitions/guid_list"
         },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/guid_list"
-        },
         "world_locations": {
           "description": "The world locations this content item is about.",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/dist/formats/organisation/frontend/schema.json
+++ b/content_schemas/dist/formats/organisation/frontend/schema.json
@@ -204,10 +204,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
         }
       }
     },

--- a/content_schemas/dist/formats/organisation/notification/schema.json
+++ b/content_schemas/dist/formats/organisation/notification/schema.json
@@ -222,10 +222,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
         }
       }
     },
@@ -351,10 +347,6 @@
         },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/guid_list"
         }
       }

--- a/content_schemas/dist/formats/organisation/publisher_v2/links.json
+++ b/content_schemas/dist/formats/organisation/publisher_v2/links.json
@@ -119,10 +119,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/guid_list"
         }
       }
     },

--- a/content_schemas/dist/formats/organisations_homepage/frontend/schema.json
+++ b/content_schemas/dist/formats/organisations_homepage/frontend/schema.json
@@ -148,10 +148,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
         }
       }
     },

--- a/content_schemas/dist/formats/organisations_homepage/notification/schema.json
+++ b/content_schemas/dist/formats/organisations_homepage/notification/schema.json
@@ -166,10 +166,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
         }
       }
     },
@@ -239,10 +235,6 @@
         },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/guid_list"
         }
       }

--- a/content_schemas/dist/formats/organisations_homepage/publisher_v2/links.json
+++ b/content_schemas/dist/formats/organisations_homepage/publisher_v2/links.json
@@ -63,10 +63,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/guid_list"
         }
       }
     },

--- a/content_schemas/dist/formats/person/frontend/schema.json
+++ b/content_schemas/dist/formats/person/frontend/schema.json
@@ -148,10 +148,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
         }
       }
     },

--- a/content_schemas/dist/formats/person/notification/schema.json
+++ b/content_schemas/dist/formats/person/notification/schema.json
@@ -166,10 +166,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
         }
       }
     },
@@ -239,10 +235,6 @@
         },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/guid_list"
         }
       }

--- a/content_schemas/dist/formats/person/publisher_v2/links.json
+++ b/content_schemas/dist/formats/person/publisher_v2/links.json
@@ -63,10 +63,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/guid_list"
         }
       }
     },

--- a/content_schemas/dist/formats/place/frontend/schema.json
+++ b/content_schemas/dist/formats/place/frontend/schema.json
@@ -148,10 +148,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
         }
       }
     },

--- a/content_schemas/dist/formats/place/notification/schema.json
+++ b/content_schemas/dist/formats/place/notification/schema.json
@@ -166,10 +166,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
         }
       }
     },
@@ -239,10 +235,6 @@
         },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/guid_list"
         }
       }

--- a/content_schemas/dist/formats/place/publisher_v2/links.json
+++ b/content_schemas/dist/formats/place/publisher_v2/links.json
@@ -63,10 +63,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/guid_list"
         }
       }
     },

--- a/content_schemas/dist/formats/publication/frontend/schema.json
+++ b/content_schemas/dist/formats/publication/frontend/schema.json
@@ -187,9 +187,6 @@
         "topical_events": {
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "topics": {
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "world_locations": {
           "$ref": "#/definitions/frontend_links"
         }

--- a/content_schemas/dist/formats/publication/notification/schema.json
+++ b/content_schemas/dist/formats/publication/notification/schema.json
@@ -205,9 +205,6 @@
         "topical_events": {
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "topics": {
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "world_locations": {
           "$ref": "#/definitions/frontend_links"
         }
@@ -298,9 +295,6 @@
           "$ref": "#/definitions/guid_list"
         },
         "topical_events": {
-          "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
           "$ref": "#/definitions/guid_list"
         },
         "world_locations": {

--- a/content_schemas/dist/formats/publication/publisher_v2/links.json
+++ b/content_schemas/dist/formats/publication/publisher_v2/links.json
@@ -86,10 +86,6 @@
         "topical_events": {
           "$ref": "#/definitions/guid_list"
         },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/guid_list"
-        },
         "world_locations": {
           "$ref": "#/definitions/guid_list"
         }

--- a/content_schemas/dist/formats/publication/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/publication/publisher_v2/schema.json
@@ -119,9 +119,6 @@
         "topical_events": {
           "$ref": "#/definitions/guid_list"
         },
-        "topics": {
-          "$ref": "#/definitions/guid_list"
-        },
         "world_locations": {
           "$ref": "#/definitions/guid_list"
         }

--- a/content_schemas/dist/formats/role/frontend/schema.json
+++ b/content_schemas/dist/formats/role/frontend/schema.json
@@ -169,10 +169,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
         }
       }
     },

--- a/content_schemas/dist/formats/role/notification/schema.json
+++ b/content_schemas/dist/formats/role/notification/schema.json
@@ -187,10 +187,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
         }
       }
     },
@@ -269,10 +265,6 @@
         },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/guid_list"
         }
       }

--- a/content_schemas/dist/formats/role/publisher_v2/links.json
+++ b/content_schemas/dist/formats/role/publisher_v2/links.json
@@ -72,10 +72,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/guid_list"
         }
       }
     },

--- a/content_schemas/dist/formats/role_appointment/frontend/schema.json
+++ b/content_schemas/dist/formats/role_appointment/frontend/schema.json
@@ -156,10 +156,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
         }
       }
     },

--- a/content_schemas/dist/formats/role_appointment/notification/schema.json
+++ b/content_schemas/dist/formats/role_appointment/notification/schema.json
@@ -174,10 +174,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
         }
       }
     },
@@ -255,10 +251,6 @@
         },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/guid_list"
         }
       }

--- a/content_schemas/dist/formats/role_appointment/publisher_v2/links.json
+++ b/content_schemas/dist/formats/role_appointment/publisher_v2/links.json
@@ -71,10 +71,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/guid_list"
         }
       }
     },

--- a/content_schemas/dist/formats/service_manual_guide/frontend/schema.json
+++ b/content_schemas/dist/formats/service_manual_guide/frontend/schema.json
@@ -156,10 +156,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
         }
       }
     },

--- a/content_schemas/dist/formats/service_manual_guide/notification/schema.json
+++ b/content_schemas/dist/formats/service_manual_guide/notification/schema.json
@@ -174,10 +174,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
         }
       }
     },
@@ -255,10 +251,6 @@
         },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/guid_list"
         }
       }

--- a/content_schemas/dist/formats/service_manual_guide/publisher_v2/links.json
+++ b/content_schemas/dist/formats/service_manual_guide/publisher_v2/links.json
@@ -71,10 +71,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/guid_list"
         }
       }
     },

--- a/content_schemas/dist/formats/service_manual_homepage/frontend/schema.json
+++ b/content_schemas/dist/formats/service_manual_homepage/frontend/schema.json
@@ -148,10 +148,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
         }
       }
     },

--- a/content_schemas/dist/formats/service_manual_homepage/notification/schema.json
+++ b/content_schemas/dist/formats/service_manual_homepage/notification/schema.json
@@ -166,10 +166,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
         }
       }
     },
@@ -239,10 +235,6 @@
         },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/guid_list"
         }
       }

--- a/content_schemas/dist/formats/service_manual_homepage/publisher_v2/links.json
+++ b/content_schemas/dist/formats/service_manual_homepage/publisher_v2/links.json
@@ -63,10 +63,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/guid_list"
         }
       }
     },

--- a/content_schemas/dist/formats/service_manual_service_standard/frontend/schema.json
+++ b/content_schemas/dist/formats/service_manual_service_standard/frontend/schema.json
@@ -152,10 +152,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
         }
       }
     },

--- a/content_schemas/dist/formats/service_manual_service_standard/notification/schema.json
+++ b/content_schemas/dist/formats/service_manual_service_standard/notification/schema.json
@@ -170,10 +170,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
         }
       }
     },
@@ -247,10 +243,6 @@
         },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/guid_list"
         }
       }

--- a/content_schemas/dist/formats/service_manual_service_standard/publisher_v2/links.json
+++ b/content_schemas/dist/formats/service_manual_service_standard/publisher_v2/links.json
@@ -67,10 +67,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/guid_list"
         }
       }
     },

--- a/content_schemas/dist/formats/service_manual_service_toolkit/frontend/schema.json
+++ b/content_schemas/dist/formats/service_manual_service_toolkit/frontend/schema.json
@@ -148,10 +148,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
         }
       }
     },

--- a/content_schemas/dist/formats/service_manual_service_toolkit/notification/schema.json
+++ b/content_schemas/dist/formats/service_manual_service_toolkit/notification/schema.json
@@ -166,10 +166,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
         }
       }
     },
@@ -239,10 +235,6 @@
         },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/guid_list"
         }
       }

--- a/content_schemas/dist/formats/service_manual_service_toolkit/publisher_v2/links.json
+++ b/content_schemas/dist/formats/service_manual_service_toolkit/publisher_v2/links.json
@@ -63,10 +63,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/guid_list"
         }
       }
     },

--- a/content_schemas/dist/formats/service_manual_topic/frontend/schema.json
+++ b/content_schemas/dist/formats/service_manual_topic/frontend/schema.json
@@ -160,10 +160,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
         }
       }
     },

--- a/content_schemas/dist/formats/service_manual_topic/notification/schema.json
+++ b/content_schemas/dist/formats/service_manual_topic/notification/schema.json
@@ -178,10 +178,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
         }
       }
     },
@@ -263,10 +259,6 @@
         },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/guid_list"
         }
       }

--- a/content_schemas/dist/formats/service_manual_topic/publisher_v2/links.json
+++ b/content_schemas/dist/formats/service_manual_topic/publisher_v2/links.json
@@ -75,10 +75,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/guid_list"
         }
       }
     },

--- a/content_schemas/dist/formats/service_sign_in/frontend/schema.json
+++ b/content_schemas/dist/formats/service_sign_in/frontend/schema.json
@@ -148,10 +148,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
         }
       }
     },

--- a/content_schemas/dist/formats/service_sign_in/notification/schema.json
+++ b/content_schemas/dist/formats/service_sign_in/notification/schema.json
@@ -166,10 +166,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
         }
       }
     },
@@ -239,10 +235,6 @@
         },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/guid_list"
         }
       }

--- a/content_schemas/dist/formats/service_sign_in/publisher_v2/links.json
+++ b/content_schemas/dist/formats/service_sign_in/publisher_v2/links.json
@@ -63,10 +63,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/guid_list"
         }
       }
     },

--- a/content_schemas/dist/formats/simple_smart_answer/frontend/schema.json
+++ b/content_schemas/dist/formats/simple_smart_answer/frontend/schema.json
@@ -148,10 +148,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
         }
       }
     },

--- a/content_schemas/dist/formats/simple_smart_answer/notification/schema.json
+++ b/content_schemas/dist/formats/simple_smart_answer/notification/schema.json
@@ -166,10 +166,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
         }
       }
     },
@@ -239,10 +235,6 @@
         },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/guid_list"
         }
       }

--- a/content_schemas/dist/formats/simple_smart_answer/publisher_v2/links.json
+++ b/content_schemas/dist/formats/simple_smart_answer/publisher_v2/links.json
@@ -63,10 +63,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/guid_list"
         }
       }
     },

--- a/content_schemas/dist/formats/smart_answer/frontend/schema.json
+++ b/content_schemas/dist/formats/smart_answer/frontend/schema.json
@@ -148,10 +148,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
         }
       }
     },

--- a/content_schemas/dist/formats/smart_answer/notification/schema.json
+++ b/content_schemas/dist/formats/smart_answer/notification/schema.json
@@ -166,10 +166,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
         }
       }
     },
@@ -239,10 +235,6 @@
         },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/guid_list"
         }
       }

--- a/content_schemas/dist/formats/smart_answer/publisher_v2/links.json
+++ b/content_schemas/dist/formats/smart_answer/publisher_v2/links.json
@@ -63,10 +63,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/guid_list"
         }
       }
     },

--- a/content_schemas/dist/formats/special_route/frontend/schema.json
+++ b/content_schemas/dist/formats/special_route/frontend/schema.json
@@ -151,10 +151,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
         }
       }
     },

--- a/content_schemas/dist/formats/special_route/notification/schema.json
+++ b/content_schemas/dist/formats/special_route/notification/schema.json
@@ -169,10 +169,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
         }
       }
     },
@@ -242,10 +238,6 @@
         },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/guid_list"
         }
       }

--- a/content_schemas/dist/formats/special_route/publisher_v2/links.json
+++ b/content_schemas/dist/formats/special_route/publisher_v2/links.json
@@ -63,10 +63,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/guid_list"
         }
       }
     },

--- a/content_schemas/dist/formats/specialist_document/frontend/schema.json
+++ b/content_schemas/dist/formats/specialist_document/frontend/schema.json
@@ -180,10 +180,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
         }
       }
     },

--- a/content_schemas/dist/formats/specialist_document/notification/schema.json
+++ b/content_schemas/dist/formats/specialist_document/notification/schema.json
@@ -198,10 +198,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
         }
       }
     },
@@ -272,10 +268,6 @@
         },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/guid_list"
         }
       }

--- a/content_schemas/dist/formats/specialist_document/publisher_v2/links.json
+++ b/content_schemas/dist/formats/specialist_document/publisher_v2/links.json
@@ -63,10 +63,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/guid_list"
         }
       }
     },

--- a/content_schemas/dist/formats/speech/frontend/schema.json
+++ b/content_schemas/dist/formats/speech/frontend/schema.json
@@ -176,10 +176,6 @@
         "topical_events": {
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "world_locations": {
           "$ref": "#/definitions/frontend_links"
         }

--- a/content_schemas/dist/formats/speech/notification/schema.json
+++ b/content_schemas/dist/formats/speech/notification/schema.json
@@ -194,10 +194,6 @@
         "topical_events": {
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "world_locations": {
           "$ref": "#/definitions/frontend_links"
         }
@@ -293,10 +289,6 @@
           "$ref": "#/definitions/guid_list"
         },
         "topical_events": {
-          "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/guid_list"
         },
         "world_locations": {

--- a/content_schemas/dist/formats/speech/publisher_v2/links.json
+++ b/content_schemas/dist/formats/speech/publisher_v2/links.json
@@ -88,10 +88,6 @@
         "topical_events": {
           "$ref": "#/definitions/guid_list"
         },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/guid_list"
-        },
         "world_locations": {
           "$ref": "#/definitions/guid_list"
         }

--- a/content_schemas/dist/formats/statistical_data_set/frontend/schema.json
+++ b/content_schemas/dist/formats/statistical_data_set/frontend/schema.json
@@ -152,10 +152,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
         }
       }
     },

--- a/content_schemas/dist/formats/statistical_data_set/notification/schema.json
+++ b/content_schemas/dist/formats/statistical_data_set/notification/schema.json
@@ -170,10 +170,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
         }
       }
     },
@@ -247,10 +243,6 @@
         },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/guid_list"
         }
       }

--- a/content_schemas/dist/formats/statistical_data_set/publisher_v2/links.json
+++ b/content_schemas/dist/formats/statistical_data_set/publisher_v2/links.json
@@ -67,10 +67,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/guid_list"
         }
       }
     },

--- a/content_schemas/dist/formats/statistics_announcement/frontend/schema.json
+++ b/content_schemas/dist/formats/statistics_announcement/frontend/schema.json
@@ -151,10 +151,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
         }
       }
     },

--- a/content_schemas/dist/formats/statistics_announcement/notification/schema.json
+++ b/content_schemas/dist/formats/statistics_announcement/notification/schema.json
@@ -169,10 +169,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
         }
       }
     },
@@ -241,10 +237,6 @@
         },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/guid_list"
         }
       }

--- a/content_schemas/dist/formats/statistics_announcement/publisher_v2/links.json
+++ b/content_schemas/dist/formats/statistics_announcement/publisher_v2/links.json
@@ -61,10 +61,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/guid_list"
         }
       }
     },

--- a/content_schemas/dist/formats/take_part/frontend/schema.json
+++ b/content_schemas/dist/formats/take_part/frontend/schema.json
@@ -148,10 +148,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
         }
       }
     },

--- a/content_schemas/dist/formats/take_part/notification/schema.json
+++ b/content_schemas/dist/formats/take_part/notification/schema.json
@@ -166,10 +166,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
         }
       }
     },
@@ -239,10 +235,6 @@
         },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/guid_list"
         }
       }

--- a/content_schemas/dist/formats/take_part/publisher_v2/links.json
+++ b/content_schemas/dist/formats/take_part/publisher_v2/links.json
@@ -63,10 +63,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/guid_list"
         }
       }
     },

--- a/content_schemas/dist/formats/taxon/frontend/schema.json
+++ b/content_schemas/dist/formats/taxon/frontend/schema.json
@@ -160,10 +160,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
         }
       }
     },

--- a/content_schemas/dist/formats/taxon/notification/schema.json
+++ b/content_schemas/dist/formats/taxon/notification/schema.json
@@ -178,10 +178,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
         }
       }
     },
@@ -263,10 +259,6 @@
         },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/guid_list"
         }
       }

--- a/content_schemas/dist/formats/taxon/publisher_v2/links.json
+++ b/content_schemas/dist/formats/taxon/publisher_v2/links.json
@@ -71,10 +71,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/guid_list"
         }
       }
     },

--- a/content_schemas/dist/formats/topic/frontend/schema.json
+++ b/content_schemas/dist/formats/topic/frontend/schema.json
@@ -152,10 +152,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
         }
       }
     },

--- a/content_schemas/dist/formats/topic/notification/schema.json
+++ b/content_schemas/dist/formats/topic/notification/schema.json
@@ -170,10 +170,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
         }
       }
     },
@@ -247,10 +243,6 @@
         },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/guid_list"
         }
       }

--- a/content_schemas/dist/formats/topic/publisher_v2/links.json
+++ b/content_schemas/dist/formats/topic/publisher_v2/links.json
@@ -67,10 +67,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/guid_list"
         }
       }
     },

--- a/content_schemas/dist/formats/topical_event/frontend/schema.json
+++ b/content_schemas/dist/formats/topical_event/frontend/schema.json
@@ -148,10 +148,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
         }
       }
     },

--- a/content_schemas/dist/formats/topical_event/notification/schema.json
+++ b/content_schemas/dist/formats/topical_event/notification/schema.json
@@ -166,10 +166,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
         }
       }
     },
@@ -239,10 +235,6 @@
         },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/guid_list"
         }
       }

--- a/content_schemas/dist/formats/topical_event/publisher_v2/links.json
+++ b/content_schemas/dist/formats/topical_event/publisher_v2/links.json
@@ -63,10 +63,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/guid_list"
         }
       }
     },

--- a/content_schemas/dist/formats/topical_event_about_page/frontend/schema.json
+++ b/content_schemas/dist/formats/topical_event_about_page/frontend/schema.json
@@ -148,10 +148,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
         }
       }
     },

--- a/content_schemas/dist/formats/topical_event_about_page/notification/schema.json
+++ b/content_schemas/dist/formats/topical_event_about_page/notification/schema.json
@@ -166,10 +166,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
         }
       }
     },
@@ -239,10 +235,6 @@
         },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/guid_list"
         }
       }

--- a/content_schemas/dist/formats/topical_event_about_page/publisher_v2/links.json
+++ b/content_schemas/dist/formats/topical_event_about_page/publisher_v2/links.json
@@ -63,10 +63,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/guid_list"
         }
       }
     },

--- a/content_schemas/dist/formats/transaction/frontend/schema.json
+++ b/content_schemas/dist/formats/transaction/frontend/schema.json
@@ -148,10 +148,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
         }
       }
     },

--- a/content_schemas/dist/formats/transaction/notification/schema.json
+++ b/content_schemas/dist/formats/transaction/notification/schema.json
@@ -166,10 +166,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
         }
       }
     },
@@ -239,10 +235,6 @@
         },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/guid_list"
         }
       }

--- a/content_schemas/dist/formats/transaction/publisher_v2/links.json
+++ b/content_schemas/dist/formats/transaction/publisher_v2/links.json
@@ -63,10 +63,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/guid_list"
         }
       }
     },

--- a/content_schemas/dist/formats/travel_advice/frontend/schema.json
+++ b/content_schemas/dist/formats/travel_advice/frontend/schema.json
@@ -151,10 +151,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
         }
       }
     },

--- a/content_schemas/dist/formats/travel_advice/notification/schema.json
+++ b/content_schemas/dist/formats/travel_advice/notification/schema.json
@@ -169,10 +169,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
         }
       }
     },
@@ -245,10 +241,6 @@
         },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/guid_list"
         }
       }

--- a/content_schemas/dist/formats/travel_advice/publisher_v2/links.json
+++ b/content_schemas/dist/formats/travel_advice/publisher_v2/links.json
@@ -66,10 +66,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/guid_list"
         }
       }
     },

--- a/content_schemas/dist/formats/travel_advice_index/frontend/schema.json
+++ b/content_schemas/dist/formats/travel_advice_index/frontend/schema.json
@@ -151,10 +151,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
         }
       }
     },

--- a/content_schemas/dist/formats/travel_advice_index/notification/schema.json
+++ b/content_schemas/dist/formats/travel_advice_index/notification/schema.json
@@ -169,10 +169,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
         }
       }
     },
@@ -245,10 +241,6 @@
         },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/guid_list"
         }
       }

--- a/content_schemas/dist/formats/travel_advice_index/publisher_v2/links.json
+++ b/content_schemas/dist/formats/travel_advice_index/publisher_v2/links.json
@@ -66,10 +66,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/guid_list"
         }
       }
     },

--- a/content_schemas/dist/formats/working_group/frontend/schema.json
+++ b/content_schemas/dist/formats/working_group/frontend/schema.json
@@ -148,10 +148,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
         }
       }
     },

--- a/content_schemas/dist/formats/working_group/notification/schema.json
+++ b/content_schemas/dist/formats/working_group/notification/schema.json
@@ -166,10 +166,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
         }
       }
     },
@@ -239,10 +235,6 @@
         },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/guid_list"
         }
       }

--- a/content_schemas/dist/formats/working_group/publisher_v2/links.json
+++ b/content_schemas/dist/formats/working_group/publisher_v2/links.json
@@ -63,10 +63,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/guid_list"
         }
       }
     },

--- a/content_schemas/dist/formats/world_index/frontend/schema.json
+++ b/content_schemas/dist/formats/world_index/frontend/schema.json
@@ -148,10 +148,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
         }
       }
     },

--- a/content_schemas/dist/formats/world_index/notification/schema.json
+++ b/content_schemas/dist/formats/world_index/notification/schema.json
@@ -166,10 +166,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
         }
       }
     },
@@ -239,10 +235,6 @@
         },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/guid_list"
         }
       }

--- a/content_schemas/dist/formats/world_index/publisher_v2/links.json
+++ b/content_schemas/dist/formats/world_index/publisher_v2/links.json
@@ -63,10 +63,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/guid_list"
         }
       }
     },

--- a/content_schemas/dist/formats/world_location/frontend/schema.json
+++ b/content_schemas/dist/formats/world_location/frontend/schema.json
@@ -152,10 +152,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
         }
       }
     },

--- a/content_schemas/dist/formats/world_location/notification/schema.json
+++ b/content_schemas/dist/formats/world_location/notification/schema.json
@@ -170,10 +170,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
         }
       }
     },
@@ -247,10 +243,6 @@
         },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/guid_list"
         }
       }

--- a/content_schemas/dist/formats/world_location/publisher_v2/links.json
+++ b/content_schemas/dist/formats/world_location/publisher_v2/links.json
@@ -63,10 +63,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/guid_list"
         }
       }
     },

--- a/content_schemas/dist/formats/world_location_news/frontend/schema.json
+++ b/content_schemas/dist/formats/world_location_news/frontend/schema.json
@@ -153,10 +153,6 @@
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "worldwide_organisations": {
           "description": "Linked Worldwide Organisations (only used for International Delegations)",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/content_schemas/dist/formats/world_location_news/notification/schema.json
+++ b/content_schemas/dist/formats/world_location_news/notification/schema.json
@@ -171,10 +171,6 @@
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "worldwide_organisations": {
           "description": "Linked Worldwide Organisations (only used for International Delegations)",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -251,10 +247,6 @@
         },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/guid_list"
         },
         "worldwide_organisations": {

--- a/content_schemas/dist/formats/world_location_news/publisher_v2/links.json
+++ b/content_schemas/dist/formats/world_location_news/publisher_v2/links.json
@@ -68,10 +68,6 @@
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
         },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/guid_list"
-        },
         "worldwide_organisations": {
           "description": "Linked Worldwide Organisations (only used for International Delegations)",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/dist/formats/worldwide_corporate_information_page/frontend/schema.json
+++ b/content_schemas/dist/formats/worldwide_corporate_information_page/frontend/schema.json
@@ -170,10 +170,6 @@
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "worldwide_organisation": {
           "description": "The Worldwide Organisation that this Worldwide Corporate Information Page belongs to",
           "$ref": "#/definitions/frontend_links"

--- a/content_schemas/dist/formats/worldwide_corporate_information_page/notification/schema.json
+++ b/content_schemas/dist/formats/worldwide_corporate_information_page/notification/schema.json
@@ -188,10 +188,6 @@
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "worldwide_organisation": {
           "description": "The Worldwide Organisation that this Worldwide Corporate Information Page belongs to",
           "$ref": "#/definitions/frontend_links"
@@ -264,10 +260,6 @@
         },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/guid_list"
         },
         "worldwide_organisation": {

--- a/content_schemas/dist/formats/worldwide_corporate_information_page/publisher_v2/links.json
+++ b/content_schemas/dist/formats/worldwide_corporate_information_page/publisher_v2/links.json
@@ -64,10 +64,6 @@
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
         },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/guid_list"
-        },
         "worldwide_organisation": {
           "description": "The Worldwide Organisation that this Worldwide Corporate Information Page belongs to",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/dist/formats/worldwide_office/frontend/schema.json
+++ b/content_schemas/dist/formats/worldwide_office/frontend/schema.json
@@ -153,10 +153,6 @@
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "worldwide_organisation": {
           "description": "The Worldwide Organisation that this Worldwide Office belongs to",
           "$ref": "#/definitions/frontend_links"

--- a/content_schemas/dist/formats/worldwide_office/notification/schema.json
+++ b/content_schemas/dist/formats/worldwide_office/notification/schema.json
@@ -171,10 +171,6 @@
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "worldwide_organisation": {
           "description": "The Worldwide Organisation that this Worldwide Office belongs to",
           "$ref": "#/definitions/frontend_links"
@@ -251,10 +247,6 @@
         },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/guid_list"
         },
         "worldwide_organisation": {

--- a/content_schemas/dist/formats/worldwide_office/publisher_v2/links.json
+++ b/content_schemas/dist/formats/worldwide_office/publisher_v2/links.json
@@ -63,10 +63,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/guid_list"
         }
       }
     },

--- a/content_schemas/dist/formats/worldwide_organisation/frontend/schema.json
+++ b/content_schemas/dist/formats/worldwide_organisation/frontend/schema.json
@@ -185,10 +185,6 @@
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "world_locations": {
           "description": "World Locations associated with this Worldwide Organisation",
           "$ref": "#/definitions/frontend_links"

--- a/content_schemas/dist/formats/worldwide_organisation/notification/schema.json
+++ b/content_schemas/dist/formats/worldwide_organisation/notification/schema.json
@@ -203,10 +203,6 @@
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "world_locations": {
           "description": "World Locations associated with this Worldwide Organisation",
           "$ref": "#/definitions/frontend_links"
@@ -319,10 +315,6 @@
         },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
-          "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
           "$ref": "#/definitions/guid_list"
         },
         "world_locations": {

--- a/content_schemas/dist/formats/worldwide_organisation/publisher_v2/links.json
+++ b/content_schemas/dist/formats/worldwide_organisation/publisher_v2/links.json
@@ -63,10 +63,6 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
-        },
-        "topics": {
-          "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/guid_list"
         }
       }
     },

--- a/content_schemas/examples/call_for_evidence/frontend/closed_call_for_evidence.json
+++ b/content_schemas/examples/call_for_evidence/frontend/closed_call_for_evidence.json
@@ -69,17 +69,6 @@
         "document_type": "organisation",
         "analytics_identifier": "D1198"
       }
-    ],
-    "topics": [
-      {
-        "content_id": "62e08e6f-9161-42c6-b9dd-0cf8fcab2c69",
-        "title": "Climate change and energy",
-        "api_path": "/api/content/environment/climate-change-energy",
-        "base_path": "/environment/climate-change-energy",
-        "api_url": "https://www.gov.uk/api/content/environment/climate-change-energy",
-        "web_url": "https://www.gov.uk/environment/climate-change-energy",
-        "locale": "en"
-      }
     ]
   }
 }

--- a/content_schemas/examples/consultation/frontend/open_consultation.json
+++ b/content_schemas/examples/consultation/frontend/open_consultation.json
@@ -85,18 +85,6 @@
         "web_url": "https://www.gov.uk/government/world/topic/higher-education",
         "locale": "en"
       }
-    ],
-    "topics": [
-      {
-        "content_id": "d8ceea35-f206-459c-ad31-4793218111ec",
-        "title": "Higher education administration",
-        "base_path": "/topic/higher-education/administration",
-        "api_path": "/api/content/topic/higher-education/administration",
-        "api_url": "https://www.gov.uk/api/content/topic/higher-education/administration",
-        "web_url": "https://www.gov.uk/topic/higher-education/administration",
-        "locale": "en",
-        "document_type": "topic"
-      }
     ]
   }
 }

--- a/content_schemas/examples/consultation/frontend/unopened_consultation.json
+++ b/content_schemas/examples/consultation/frontend/unopened_consultation.json
@@ -90,18 +90,6 @@
         "locale": "en",
         "document_type": "document_collection"
       }
-    ],
-    "topics": [
-      {
-        "content_id": "ce0487a3-72a9-4348-acd8-0d5b41a5a724",
-        "title": "Nuclear regulation",
-        "api_path": "/api/content/topic/environmental-management/nuclear-regulation",
-        "base_path": "/topic/environmental-management/nuclear-regulation",
-        "api_url": "https://www.gov.uk/api/content/topic/environmental-management/nuclear-regulation",
-        "web_url": "https://www.gov.uk/topic/environmental-management/nuclear-regulation",
-        "locale": "en",
-        "document_type": "topic"
-      }
     ]
   }
 }

--- a/content_schemas/examples/detailed_guide/frontend/best-practice-detailed-guide.json
+++ b/content_schemas/examples/detailed_guide/frontend/best-practice-detailed-guide.json
@@ -138,24 +138,6 @@
         "web_url": "https://www.gov.uk/government/organisations/uk-visas-and-immigration"
       }
     ],
-    "topics": [
-      {
-        "api_path": "/api/content/topic/immigration-operational-guidance/sponsorship",
-        "base_path": "/topic/immigration-operational-guidance/sponsorship",
-        "content_id": "72f7b519-bd58-422a-8eee-b3f0c63aaeeb",
-        "description": "List of information about Sponsorship.",
-        "document_type": "topic",
-        "locale": "en",
-        "public_updated_at": "2015-08-11T14:45:09Z",
-        "schema_name": "topic",
-        "title": "Sponsorship",
-        "withdrawn": false,
-        "links": {
-        },
-        "api_url": "https://www.gov.uk/api/content/topic/immigration-operational-guidance/sponsorship",
-        "web_url": "https://www.gov.uk/topic/immigration-operational-guidance/sponsorship"
-      }
-    ],
     "available_translations": [
       {
         "title": "Apply for a Tier 4 sponsor licence",

--- a/content_schemas/examples/detailed_guide/frontend/detailed_guide.json
+++ b/content_schemas/examples/detailed_guide/frontend/detailed_guide.json
@@ -117,28 +117,6 @@
           ]
         }
       }
-    ],
-    "topics": [
-      {
-        "content_id": "6e1d83bc-d37a-447c-bdac-31be4b441417",
-        "title": "PAYE",
-        "base_path": "/topic/business-tax/paye",
-        "api_path": "/api/content/topic/business-tax/paye",
-        "api_url": "https://www.gov.uk/api/content/topic/business-tax/paye",
-        "web_url": "https://www.gov.uk/topic/business-tax/paye",
-        "locale": "en",
-        "document_type": "topic"
-      },
-      {
-        "content_id": "a481832e-5f10-4d3b-8131-a064b36730ae",
-        "title": "Business tax",
-        "base_path": "/topic/business-tax",
-        "api_path": "/api/content/topic/business-tax",
-        "api_url": "https://www.gov.uk/api/content/topic/business-tax",
-        "web_url": "https://www.gov.uk/topic/business-tax",
-        "locale": "en",
-        "document_type": "topic"
-      }
     ]
   }
 }

--- a/content_schemas/examples/detailed_guide/frontend/political_detailed_guide.json
+++ b/content_schemas/examples/detailed_guide/frontend/political_detailed_guide.json
@@ -102,28 +102,6 @@
         "locale": "en",
         "document_type": "detailed_guide"
       }
-    ],
-    "topics": [
-      {
-        "content_id": "0d59f5e7-a230-4bac-b02c-624a59a34dab",
-        "title": "Low carbon energy",
-        "api_path": "/api/content/topic/climate-change-energy/low-carbon-energy",
-        "base_path": "/topic/climate-change-energy/low-carbon-energy",
-        "api_url": "https://www.gov.uk/api/content/topic/climate-change-energy/low-carbon-energy",
-        "web_url": "https://www.gov.uk/topic/climate-change-energy/low-carbon-energy",
-        "locale": "en",
-        "document_type": "topic"
-      },
-      {
-        "content_id": "57c6699d-ceda-4168-9d23-3fed774ca776",
-        "title": "Climate change and energy",
-        "api_path": "/api/content/topic/climate-change-energy",
-        "base_path": "/topic/climate-change-energy",
-        "api_url": "https://www.gov.uk/api/content/topic/climate-change-energy",
-        "web_url": "https://www.gov.uk/topic/climate-change-energy",
-        "locale": "en",
-        "document_type": "topic"
-      }
     ]
   }
 }

--- a/content_schemas/examples/detailed_guide/frontend/translated_detailed_guide.json
+++ b/content_schemas/examples/detailed_guide/frontend/translated_detailed_guide.json
@@ -182,36 +182,6 @@
         "title": "Prepare a charity trustees' annual report",
         "web_url": "https://www.gov.uk/guidance/prepare-a-charity-trustees-annual-report"
       }
-    ],
-    "topics": [
-      {
-        "analytics_identifier": null,
-        "api_path": "/api/content/topic/running-charity/money-accounts",
-        "api_url": "https://www.gov.uk/api/content/topic/running-charity/money-accounts",
-        "base_path": "/topic/running-charity/money-accounts",
-        "content_id": "6db5a402-5916-4820-89a6-a19c6c9e085e",
-        "description": "List of information about Charity money, tax and accounts.",
-        "document_type": "topic",
-        "locale": "en",
-        "public_updated_at": "2015-08-11T15:10:00.000+00:00",
-        "schema_name": "topic",
-        "title": "Charity money, tax and accounts",
-        "web_url": "https://www.gov.uk/topic/running-charity/money-accounts"
-      },
-      {
-        "analytics_identifier": null,
-        "api_path": "/api/content/topic/running-charity/managing-charity",
-        "api_url": "https://www.gov.uk/api/content/topic/running-charity/managing-charity",
-        "base_path": "/topic/running-charity/managing-charity",
-        "content_id": "cf2ab891-5bd9-4788-8254-f9444423719c",
-        "description": "List of information about Managing your charity.",
-        "document_type": "topic",
-        "locale": "en",
-        "public_updated_at": "2016-03-21T13:12:32.000+00:00",
-        "schema_name": "topic",
-        "title": "Managing your charity",
-        "web_url": "https://www.gov.uk/topic/running-charity/managing-charity"
-      }
     ]
   },
   "locale": "en",

--- a/content_schemas/examples/document_collection/frontend/best-practice-document-collection.json
+++ b/content_schemas/examples/document_collection/frontend/best-practice-document-collection.json
@@ -252,24 +252,6 @@
         "web_url": "https://www.gov.uk/government/policies/road-safety"
       }
     ],
-    "topics": [
-      {
-        "api_path": "/api/content/topic/driving-motorcyle-instructors/improving-training-skills",
-        "base_path": "/topic/driving-motorcyle-instructors/improving-training-skills",
-        "content_id": "13c0788e-ed54-4b91-ac96-bac7f795c390",
-        "description": "List of information about Improving your training skills.",
-        "document_type": "topic",
-        "locale": "en",
-        "public_updated_at": "2017-02-24T16:33:23Z",
-        "schema_name": "topic",
-        "title": "Improving your training skills",
-        "withdrawn": false,
-        "links": {
-        },
-        "api_url": "https://www.gov.uk/api/content/topic/driving-motorcyle-instructors/improving-training-skills",
-        "web_url": "https://www.gov.uk/topic/driving-motorcyle-instructors/improving-training-skills"
-      }
-    ],
     "available_translations": [
       {
         "title": "National standards for driving and riding",

--- a/content_schemas/examples/document_collection/frontend/document_collection.json
+++ b/content_schemas/examples/document_collection/frontend/document_collection.json
@@ -253,27 +253,6 @@
         "locale": "en"
       }
     ],
-    "topics": [
-      {
-        "content_id": "6e1d83bc-d37a-447c-bdac-31be4b441417",
-        "title": "PAYE",
-        "base_path": "/topic/business-tax/paye",
-        "api_path": "/api/content/topic/business-tax/paye",
-        "api_url": "https://www.gov.uk/api/content/topic/business-tax/paye",
-        "web_url": "https://www.gov.uk/topic/business-tax/paye",
-        "locale": "en",
-        "document_type": "topic"
-      },
-      {
-        "content_id": "a481832e-5f10-4d3b-8131-a064b36730ae",
-        "title": "Business tax",
-        "base_path": "/topic/business-tax",
-        "api_path": "/api/content/topic/business-tax",
-        "api_url": "https://www.gov.uk/api/content/topic/business-tax",
-        "web_url": "https://www.gov.uk/topic/business-tax",
-        "locale": "en"
-      }
-    ],
     "policies": [
       {
         "content_id": "ec736c24-aed1-4635-8f3c-389222ca312d",

--- a/content_schemas/examples/guide/frontend/guide-with-facet-groups.json
+++ b/content_schemas/examples/guide/frontend/guide-with-facet-groups.json
@@ -636,25 +636,6 @@
         "web_url": "http://www.dev.gov.uk/education/school-curriculum"
       }
     ],
-    "topics": [
-      {
-        "analytics_identifier": null,
-        "api_path": "/api/content/topic/schools-colleges-childrens-services/curriculum-qualifications",
-        "base_path": "/topic/schools-colleges-childrens-services/curriculum-qualifications",
-        "content_id": "28e39d16-c279-46c6-a7cd-b0a807686928",
-        "description": "List of information about Curriculum and qualifications.",
-        "document_type": "topic",
-        "locale": "en",
-        "public_updated_at": "2016-12-15T16:08:00Z",
-        "schema_name": "topic",
-        "title": "Curriculum and qualifications",
-        "withdrawn": false,
-        "links": {
-        },
-        "api_url": "http://www.dev.gov.uk/api/content/topic/schools-colleges-childrens-services/curriculum-qualifications",
-        "web_url": "http://www.dev.gov.uk/topic/schools-colleges-childrens-services/curriculum-qualifications"
-      }
-    ],
     "available_translations": [
       {
         "title": "The national curriculum",

--- a/content_schemas/examples/guide/frontend/guide-with-no-parent.json
+++ b/content_schemas/examples/guide/frontend/guide-with-no-parent.json
@@ -673,25 +673,6 @@
         "web_url": "http://www.dev.gov.uk/education/school-curriculum"
       }
     ],
-    "topics": [
-      {
-        "analytics_identifier": null,
-        "api_path": "/api/content/topic/schools-colleges-childrens-services/curriculum-qualifications",
-        "base_path": "/topic/schools-colleges-childrens-services/curriculum-qualifications",
-        "content_id": "28e39d16-c279-46c6-a7cd-b0a807686928",
-        "description": "List of information about Curriculum and qualifications.",
-        "document_type": "topic",
-        "locale": "en",
-        "public_updated_at": "2016-12-15T16:08:00Z",
-        "schema_name": "topic",
-        "title": "Curriculum and qualifications",
-        "withdrawn": false,
-        "links": {
-        },
-        "api_url": "http://www.dev.gov.uk/api/content/topic/schools-colleges-childrens-services/curriculum-qualifications",
-        "web_url": "http://www.dev.gov.uk/topic/schools-colleges-childrens-services/curriculum-qualifications"
-      }
-    ],
     "available_translations": [
       {
         "title": "The national curriculum",

--- a/content_schemas/examples/guide/frontend/guide-with-related-link-overrides.json
+++ b/content_schemas/examples/guide/frontend/guide-with-related-link-overrides.json
@@ -711,25 +711,6 @@
         "web_url": "http://www.dev.gov.uk/education/school-curriculum"
       }
     ],
-    "topics": [
-      {
-        "analytics_identifier": null,
-        "api_path": "/api/content/topic/schools-colleges-childrens-services/curriculum-qualifications",
-        "base_path": "/topic/schools-colleges-childrens-services/curriculum-qualifications",
-        "content_id": "28e39d16-c279-46c6-a7cd-b0a807686928",
-        "description": "List of information about Curriculum and qualifications.",
-        "document_type": "topic",
-        "locale": "en",
-        "public_updated_at": "2016-12-15T16:08:00Z",
-        "schema_name": "topic",
-        "title": "Curriculum and qualifications",
-        "withdrawn": false,
-        "links": {
-        },
-        "api_url": "http://www.dev.gov.uk/api/content/topic/schools-colleges-childrens-services/curriculum-qualifications",
-        "web_url": "http://www.dev.gov.uk/topic/schools-colleges-childrens-services/curriculum-qualifications"
-      }
-    ],
     "available_translations": [
       {
         "title": "The national curriculum",

--- a/content_schemas/examples/guide/frontend/guide-with-step-navs.json
+++ b/content_schemas/examples/guide/frontend/guide-with-step-navs.json
@@ -860,25 +860,6 @@
         "web_url": "http://www.dev.gov.uk/education/school-curriculum"
       }
     ],
-    "topics": [
-      {
-        "analytics_identifier": null,
-        "api_path": "/api/content/topic/schools-colleges-childrens-services/curriculum-qualifications",
-        "base_path": "/topic/schools-colleges-childrens-services/curriculum-qualifications",
-        "content_id": "28e39d16-c279-46c6-a7cd-b0a807686928",
-        "description": "List of information about Curriculum and qualifications.",
-        "document_type": "topic",
-        "locale": "en",
-        "public_updated_at": "2016-12-15T16:08:00Z",
-        "schema_name": "topic",
-        "title": "Curriculum and qualifications",
-        "withdrawn": false,
-        "links": {
-        },
-        "api_url": "http://www.dev.gov.uk/api/content/topic/schools-colleges-childrens-services/curriculum-qualifications",
-        "web_url": "http://www.dev.gov.uk/topic/schools-colleges-childrens-services/curriculum-qualifications"
-      }
-    ],
     "available_translations": [
       {
         "title": "The national curriculum",

--- a/content_schemas/examples/guide/frontend/guide.json
+++ b/content_schemas/examples/guide/frontend/guide.json
@@ -711,25 +711,6 @@
         "web_url": "http://www.dev.gov.uk/education/school-curriculum"
       }
     ],
-    "topics": [
-      {
-        "analytics_identifier": null,
-        "api_path": "/api/content/topic/schools-colleges-childrens-services/curriculum-qualifications",
-        "base_path": "/topic/schools-colleges-childrens-services/curriculum-qualifications",
-        "content_id": "28e39d16-c279-46c6-a7cd-b0a807686928",
-        "description": "List of information about Curriculum and qualifications.",
-        "document_type": "topic",
-        "locale": "en",
-        "public_updated_at": "2016-12-15T16:08:00Z",
-        "schema_name": "topic",
-        "title": "Curriculum and qualifications",
-        "withdrawn": false,
-        "links": {
-        },
-        "api_url": "http://www.dev.gov.uk/api/content/topic/schools-colleges-childrens-services/curriculum-qualifications",
-        "web_url": "http://www.dev.gov.uk/topic/schools-colleges-childrens-services/curriculum-qualifications"
-      }
-    ],
     "available_translations": [
       {
         "title": "The national curriculum",

--- a/content_schemas/examples/guide/frontend/single-page-guide-with-step-navs-and-hide-navigation.json
+++ b/content_schemas/examples/guide/frontend/single-page-guide-with-step-navs-and-hide-navigation.json
@@ -1385,24 +1385,6 @@
         "web_url": "https://www.gov.uk/transport/car-driving-tests"
       }
     ],
-    "topics": [
-      {
-        "api_path": "/api/content/topic/driving-tests-and-learning-to-drive/car",
-        "base_path": "/topic/driving-tests-and-learning-to-drive/car",
-        "content_id": "d28083b0-7176-4279-bbb8-9ac62e8f0757",
-        "description": "Services and information for car driving tests and learning to drive a car.",
-        "document_type": "topic",
-        "locale": "en",
-        "public_updated_at": "2018-04-06T14:11:32Z",
-        "schema_name": "topic",
-        "title": "Cars",
-        "withdrawn": false,
-        "links": {
-        },
-        "api_url": "https://www.gov.uk/api/content/topic/driving-tests-and-learning-to-drive/car",
-        "web_url": "https://www.gov.uk/topic/driving-tests-and-learning-to-drive/car"
-      }
-    ],
     "available_translations": [
       {
         "title": "Driving test: cars",

--- a/content_schemas/examples/guide/frontend/single-page-guide.json
+++ b/content_schemas/examples/guide/frontend/single-page-guide.json
@@ -417,25 +417,6 @@
         "web_url": "http://www.dev.gov.uk/browse/visas-immigration/arriving-in-the-uk"
       }
     ],
-    "topics": [
-      {
-        "analytics_identifier": null,
-        "api_path": "/api/content/topic/animal-welfare/pets",
-        "base_path": "/topic/animal-welfare/pets",
-        "content_id": "3e275a11-0fae-425b-a7a1-fe434594693f",
-        "description": "List of information about pets.",
-        "document_type": "topic",
-        "locale": "en",
-        "public_updated_at": "2015-08-11T15:03:41Z",
-        "schema_name": "topic",
-        "title": "Pets",
-        "withdrawn": false,
-        "links": {
-        },
-        "api_url": "http://www.dev.gov.uk/api/content/topic/animal-welfare/pets",
-        "web_url": "http://www.dev.gov.uk/topic/animal-welfare/pets"
-      }
-    ],
     "available_translations": [
       {
         "title": "Bringing your pet dog, cat or ferret to the UK",

--- a/content_schemas/examples/manual/frontend/content-design.json
+++ b/content_schemas/examples/manual/frontend/content-design.json
@@ -134,23 +134,6 @@
       "api_url": "https://www.gov.uk/api/content/society-and-culture/charities-honours",
       "web_url": "https://www.gov.uk/society-and-culture/charities-honours"
     }],
-    "topics": [
-      {
-        "content_id": "4dfaf37e-33ea-4f56-9d06-24cebd0f6995",
-        "title": "Content and publishing",
-        "locale": "en",
-        "api_path": "/api/content/topic/government-digital-guidance/content-publishing",
-        "base_path": "/topic/government-digital-guidance/content-publishing",
-        "document_type": "topic",
-        "public_updated_at": "2017-05-19T13:59:21Z",
-        "schema_name": "topic",
-        "withdrawn": false,
-        "links": {
-        },
-        "api_url": "https://www.gov.uk/api/content/topic/government-digital-guidance/content-publishing",
-        "web_url": "https://www.gov.uk/topic/government-digital-guidance/content-publishing"
-      }
-    ],
     "organisations": [
       {
         "content_id": "af07d5a5-df63-4ddc-9383-6a666845ebe9",

--- a/content_schemas/examples/publication/frontend/best-practice-form-2.json
+++ b/content_schemas/examples/publication/frontend/best-practice-form-2.json
@@ -138,24 +138,6 @@
         "web_url": "https://www.gov.uk/government/policies/road-safety"
       }
     ],
-    "topics": [
-      {
-        "api_path": "/api/content/topic/driving-motorcyle-instructors/motorycle-instructors",
-        "base_path": "/topic/driving-motorcyle-instructors/motorycle-instructors",
-        "content_id": "bf2a913f-89d2-45bd-8078-0d4c9b664437",
-        "description": "List of information about Motorcycle instructors.",
-        "document_type": "topic",
-        "locale": "en",
-        "public_updated_at": "2017-10-07T22:09:12Z",
-        "schema_name": "topic",
-        "title": "Motorcycle instructors",
-        "withdrawn": false,
-        "links": {
-        },
-        "api_url": "https://www.gov.uk/api/content/topic/driving-motorcyle-instructors/motorycle-instructors",
-        "web_url": "https://www.gov.uk/topic/driving-motorcyle-instructors/motorycle-instructors"
-      }
-    ],
     "available_translations": [
       {
         "title": "Apply to be a certified motorcycle instructor",

--- a/content_schemas/examples/publication/frontend/best-practice-guidance.json
+++ b/content_schemas/examples/publication/frontend/best-practice-guidance.json
@@ -174,24 +174,6 @@
         "web_url": "https://www.gov.uk/government/policies/road-safety"
       }
     ],
-    "topics": [
-      {
-        "api_path": "/api/content/topic/driving-motorcyle-instructors/improving-training-skills",
-        "base_path": "/topic/driving-motorcyle-instructors/improving-training-skills",
-        "content_id": "13c0788e-ed54-4b91-ac96-bac7f795c390",
-        "description": "List of information about Improving your training skills.",
-        "document_type": "topic",
-        "locale": "en",
-        "public_updated_at": "2017-02-24T16:33:23Z",
-        "schema_name": "topic",
-        "title": "Improving your training skills",
-        "withdrawn": false,
-        "links": {
-        },
-        "api_url": "https://www.gov.uk/api/content/topic/driving-motorcyle-instructors/improving-training-skills",
-        "web_url": "https://www.gov.uk/topic/driving-motorcyle-instructors/improving-training-skills"
-      }
-    ],
     "available_translations": [
       {
         "title": "Learning to drive a car syllabus",

--- a/content_schemas/examples/publication/frontend/best-practice-statutory-guidance.json
+++ b/content_schemas/examples/publication/frontend/best-practice-statutory-guidance.json
@@ -317,24 +317,6 @@
         "web_url": "https://www.gov.uk/education/local-authority-schools-funding"
       }
     ],
-    "topics": [
-      {
-        "api_path": "/api/content/topic/schools-colleges-childrens-services/school-college-funding-finance",
-        "base_path": "/topic/schools-colleges-childrens-services/school-college-funding-finance",
-        "content_id": "91a00dfb-bef5-4c90-ae08-5feeb4f8ba40",
-        "description": "List of information about School and college funding and finance.",
-        "document_type": "topic",
-        "locale": "en",
-        "public_updated_at": "2016-12-15T16:11:15Z",
-        "schema_name": "topic",
-        "title": "School and college funding and finance",
-        "withdrawn": false,
-        "links": {
-        },
-        "api_url": "https://www.gov.uk/api/content/topic/schools-colleges-childrens-services/school-college-funding-finance",
-        "web_url": "https://www.gov.uk/topic/schools-colleges-childrens-services/school-college-funding-finance"
-      }
-    ],
     "available_translations": [
       {
         "title": "Schemes for financing schools",

--- a/content_schemas/examples/simple_smart_answer/frontend/simple-smart-answer-with-step-navs.json
+++ b/content_schemas/examples/simple_smart_answer/frontend/simple-smart-answer-with-step-navs.json
@@ -507,25 +507,6 @@
         "web_url": "http://www.dev.gov.uk/browse/driving/teaching-people-to-drive"
       }
     ],
-    "topics": [
-      {
-        "analytics_identifier": null,
-        "api_path": "/api/content/topic/driving-motorcyle-instructors/approved-driving-instructors",
-        "base_path": "/topic/driving-motorcyle-instructors/approved-driving-instructors",
-        "content_id": "bb85c76f-b660-4426-a1c3-37313a2cea81",
-        "description": "Services and information for approved driving instructors (ADIs), including qualifying and managing your registration.",
-        "document_type": "topic",
-        "locale": "en",
-        "public_updated_at": "2016-09-30T15:13:23Z",
-        "schema_name": "topic",
-        "title": "Approved driving instructors (ADIs)",
-        "withdrawn": false,
-        "links": {
-        },
-        "api_url": "http://www.dev.gov.uk/api/content/topic/driving-motorcyle-instructors/approved-driving-instructors",
-        "web_url": "http://www.dev.gov.uk/topic/driving-motorcyle-instructors/approved-driving-instructors"
-      }
-    ],
     "available_translations": [
       {
         "title": "Become a driving instructor",

--- a/content_schemas/examples/simple_smart_answer/frontend/simple-smart-answer.json
+++ b/content_schemas/examples/simple_smart_answer/frontend/simple-smart-answer.json
@@ -265,25 +265,6 @@
         "web_url": "http://www.dev.gov.uk/browse/driving/teaching-people-to-drive"
       }
     ],
-    "topics": [
-      {
-        "analytics_identifier": null,
-        "api_path": "/api/content/topic/driving-motorcyle-instructors/approved-driving-instructors",
-        "base_path": "/topic/driving-motorcyle-instructors/approved-driving-instructors",
-        "content_id": "bb85c76f-b660-4426-a1c3-37313a2cea81",
-        "description": "Services and information for approved driving instructors (ADIs), including qualifying and managing your registration.",
-        "document_type": "topic",
-        "locale": "en",
-        "public_updated_at": "2016-09-30T15:13:23Z",
-        "schema_name": "topic",
-        "title": "Approved driving instructors (ADIs)",
-        "withdrawn": false,
-        "links": {
-        },
-        "api_url": "http://www.dev.gov.uk/api/content/topic/driving-motorcyle-instructors/approved-driving-instructors",
-        "web_url": "http://www.dev.gov.uk/topic/driving-motorcyle-instructors/approved-driving-instructors"
-      }
-    ],
     "available_translations": [
       {
         "title": "Become a driving instructor",

--- a/content_schemas/examples/transaction/frontend/transaction-with-step-navs.json
+++ b/content_schemas/examples/transaction/frontend/transaction-with-step-navs.json
@@ -272,25 +272,6 @@
         "api_path": "/api/content/council-tax-bands"
       }
     ],
-    "topics": [
-      {
-        "web_url": "http://www.dev.gov.uk/topic/local-government/council-tax",
-        "api_url": "http://www.dev.gov.uk/api/content/topic/local-government/council-tax",
-        "links": {
-        },
-        "withdrawn": false,
-        "title": "Council Tax",
-        "schema_name": "topic",
-        "analytics_identifier": null,
-        "api_path": "/api/content/topic/local-government/council-tax",
-        "base_path": "/topic/local-government/council-tax",
-        "content_id": "7eca7540-a65f-453e-b92f-df21b406d829",
-        "description": "List of information about Council Tax.",
-        "document_type": "topic",
-        "locale": "en",
-        "public_updated_at": "2017-01-26T10:26:48Z"
-      }
-    ],
     "parent": [
       {
         "web_url": "http://www.dev.gov.uk/browse/housing-local-services/council-tax",

--- a/content_schemas/examples/transaction/frontend/transaction-with-variants.json
+++ b/content_schemas/examples/transaction/frontend/transaction-with-variants.json
@@ -37,25 +37,6 @@
         "api_path": "/api/content/council-tax-bands-2"
       }
     ],
-    "topics": [
-      {
-        "web_url": "http://www.dev.gov.uk/topic/local-government/council-tax",
-        "api_url": "http://www.dev.gov.uk/api/content/topic/local-government/council-tax",
-        "links": {
-        },
-        "withdrawn": false,
-        "title": "Council Tax",
-        "schema_name": "topic",
-        "analytics_identifier": null,
-        "api_path": "/api/content/topic/local-government/council-tax",
-        "base_path": "/topic/local-government/council-tax",
-        "content_id": "7eca7540-a65f-453e-b92f-df21b406d829",
-        "description": "List of information about Council Tax.",
-        "document_type": "topic",
-        "locale": "en",
-        "public_updated_at": "2017-01-26T10:26:48Z"
-      }
-    ],
     "parent": [
       {
         "web_url": "http://www.dev.gov.uk/browse/housing-local-services/council-tax",

--- a/content_schemas/examples/transaction/frontend/transaction.json
+++ b/content_schemas/examples/transaction/frontend/transaction.json
@@ -30,25 +30,6 @@
         "api_path": "/api/content/council-tax-bands"
       }
     ],
-    "topics": [
-      {
-        "web_url": "http://www.dev.gov.uk/topic/local-government/council-tax",
-        "api_url": "http://www.dev.gov.uk/api/content/topic/local-government/council-tax",
-        "links": {
-        },
-        "withdrawn": false,
-        "title": "Council Tax",
-        "schema_name": "topic",
-        "analytics_identifier": null,
-        "api_path": "/api/content/topic/local-government/council-tax",
-        "base_path": "/topic/local-government/council-tax",
-        "content_id": "7eca7540-a65f-453e-b92f-df21b406d829",
-        "description": "List of information about Council Tax.",
-        "document_type": "topic",
-        "locale": "en",
-        "public_updated_at": "2017-01-26T10:26:48Z"
-      }
-    ],
     "parent": [
       {
         "web_url": "http://www.dev.gov.uk/browse/housing-local-services/council-tax",

--- a/content_schemas/formats/shared/base_links.jsonnet
+++ b/content_schemas/formats/shared/base_links.jsonnet
@@ -4,7 +4,6 @@
   ordered_related_items_overrides: "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
   mainstream_browse_pages: "Powers the /browse section of the site. These are known as sections in some legacy apps.",
   meets_user_needs: "The user needs this piece of content meets.",
-  topics: "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
   organisations: "All organisations linked to this content item. This should include lead organisations.",
   parent: {
     description: "The parent content item.",
@@ -18,5 +17,5 @@
   original_primary_publishing_organisation: "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
   lead_organisations: "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
   suggested_ordered_related_items: "Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms.",
-  finder: "Powers links from content back to finders the content is surfaced on"
+  finder: "Powers links from content back to finders the content is surfaced on",
 }

--- a/content_schemas/formats/shared/whitehall_edition_links.jsonnet
+++ b/content_schemas/formats/shared/whitehall_edition_links.jsonnet
@@ -12,5 +12,4 @@
   original_primary_publishing_organisation: "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
   related_policies: "",
   topical_events: "",
-  topics: "",
 }


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

Part of [🏔Epic | Remove specialist topic code from Publishing API [L]EPICS 🌀](https://trello.com/c/2LcbNRSQ/2417-%F0%9F%8F%94epic-remove-specialist-topic-code-from-publishing-api-l "‌")

## What

Remove topics from the two different types of links defined in publishing API. This work might be worth splitting into two PR’s, one for each link type.

## Why

We’ve retired all specialist topics, so in theory there should be no content items that contain a link to a specialist topic anymore.

[Trello card](https://trello.com/c/Kp2RyqOs/2486-remove-topics-from-baselinks-and-whitehalleditionlinks-l)

## How

Follow [https://github.com/alphagov/publishing-api/blob/main/docs/content_schemas/changing-an-existing-content-schema.md#removing-a-field-from-a-content-schema](https://github.com/alphagov/publishing-api/blob/main/docs/content_schemas/changing-an-existing-content-schema.md#removing-a-field-from-a-content-schema "‌")