### PR TITLE
2417 remove specialist topic code from publishing api l 4

### DIFF
--- a/content_schemas/dist/formats/email_alert_signup/frontend/schema.json
+++ b/content_schemas/dist/formats/email_alert_signup/frontend/schema.json
@@ -301,7 +301,6 @@
         "email_alert_type": {
           "type": "string",
           "enum": [
-            "topics",
             "policies",
             "countries"
           ]

--- a/content_schemas/dist/formats/email_alert_signup/notification/schema.json
+++ b/content_schemas/dist/formats/email_alert_signup/notification/schema.json
@@ -392,7 +392,6 @@
         "email_alert_type": {
           "type": "string",
           "enum": [
-            "topics",
             "policies",
             "countries"
           ]

--- a/content_schemas/dist/formats/email_alert_signup/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/email_alert_signup/publisher_v2/schema.json
@@ -180,7 +180,6 @@
         "email_alert_type": {
           "type": "string",
           "enum": [
-            "topics",
             "policies",
             "countries"
           ]

--- a/content_schemas/formats/email_alert_signup.jsonnet
+++ b/content_schemas/formats/email_alert_signup.jsonnet
@@ -37,7 +37,6 @@
         email_alert_type: {
           type: "string",
           enum: [
-            "topics",
             "policies",
             "countries",
           ],


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

Part of

[🏔Epic | Remove specialist topic code from Publishing API [L]EPICS 🌀](https://trello.com/c/2LcbNRSQ/2417-%F0%9F%8F%94epic-remove-specialist-topic-code-from-publishing-api-l "‌")

## What

Remove topics from email\_alert\_signup schema

## Why

Retiring specialist topics
[Trello card](https://trello.com/c/lJFANf8k/2488-remove-topics-from-emailalertsignup-schema-m-l)

## How

[https://github.com/alphagov/publishing-api/blob/main/docs/content_schemas/changing-an-existing-content-schema.md#removing-a-field-from-a-content-schema](https://github.com/alphagov/publishing-api/blob/main/docs/content_schemas/changing-an-existing-content-schema.md#removing-a-field-from-a-content-schema "‌")