### PR TITLE
Remove topic from publishing-api specs

### DIFF
--- a/spec/commands/v2/patch_link_set_spec.rb
+++ b/spec/commands/v2/patch_link_set_spec.rb
@@ -1,15 +1,15 @@
 RSpec.describe Commands::V2::PatchLinkSet do
   let(:expected_content_store_payload) { { base_path: "/vat-rates" } }
   let(:content_id) { SecureRandom.uuid }
-  let(:topics) { 3.times.map { SecureRandom.uuid } }
-  let(:topics_shuffled) { topics.shuffle }
+  let(:taxons) { 3.times.map { SecureRandom.uuid } }
+  let(:taxons_shuffled) { taxons.shuffle }
   let(:parent) { [SecureRandom.uuid] }
 
   let(:payload) do
     {
       content_id:,
       links: {
-        topics: topics * 2, # test deduplication
+        taxons: taxons * 2, # test deduplication
         parent:,
       },
     }
@@ -20,7 +20,7 @@ RSpec.describe Commands::V2::PatchLinkSet do
     {
       content_id:,
       links: {
-        topics: topics_shuffled * 2, # test deduplication
+        taxons: taxons_shuffled * 2, # test deduplication
         parent:,
       },
     }
@@ -51,8 +51,8 @@ RSpec.describe Commands::V2::PatchLinkSet do
       expect(link_set.content_id).to eq(content_id)
 
       links = link_set.links
-      expect(links.map(&:link_type)).to eq(%w[parent topics topics topics])
-      expect(links.map(&:target_content_id)).to eq(parent + topics)
+      expect(links.map(&:link_type)).to eq(%w[parent taxons taxons taxons])
+      expect(links.map(&:target_content_id)).to eq(parent + taxons)
     end
 
     it "doesn't reject an empty links hash, but doesn't delete links either" do
@@ -89,7 +89,7 @@ RSpec.describe Commands::V2::PatchLinkSet do
         content_id:,
         version: 1,
         links: {
-          topics:,
+          taxons:,
           parent:,
         },
       )
@@ -103,8 +103,8 @@ RSpec.describe Commands::V2::PatchLinkSet do
       expect(link_set.content_id).to eq(content_id)
 
       links = link_set.links
-      expect(links.map(&:link_type)).to eq(%w[parent topics topics topics])
-      expect(links.map(&:target_content_id)).to eq(parent + topics_shuffled)
+      expect(links.map(&:link_type)).to eq(%w[parent taxons taxons taxons])
+      expect(links.map(&:target_content_id)).to eq(parent + taxons_shuffled)
     end
   end
 
@@ -119,13 +119,13 @@ RSpec.describe Commands::V2::PatchLinkSet do
         links: [
           create(
             :link,
-            link_type: "topics",
-            target_content_id: topics.first,
+            link_type: "taxons",
+            target_content_id: taxons.first,
           ),
           create(
             :link,
-            link_type: "topics",
-            target_content_id: topics.second,
+            link_type: "taxons",
+            target_content_id: taxons.second,
           ),
           create(
             :link,
@@ -154,8 +154,8 @@ RSpec.describe Commands::V2::PatchLinkSet do
       link_set = LinkSet.last
       links = link_set.links
 
-      topics_links = links.where(link_type: "topics")
-      expect(topics_links.map(&:target_content_id)).to eq(topics)
+      taxons_links = links.where(link_type: "taxons")
+      expect(taxons_links.map(&:target_content_id)).to eq(taxons)
     end
 
     it "does not affect links for groups that do not appear in the payload" do
@@ -184,7 +184,7 @@ RSpec.describe Commands::V2::PatchLinkSet do
         content_id:,
         version: 2,
         links: {
-          topics:,
+          taxons:,
           parent:,
           related:,
         },
@@ -408,14 +408,14 @@ RSpec.describe Commands::V2::PatchLinkSet do
     let(:content_id) { edition.document.content_id }
 
     let(:payload) do
-      { content_id:, links: { topics: [link_b] } }
+      { content_id:, links: { taxons: [link_b] } }
     end
 
     before do
       create(
         :link_set,
         content_id:,
-        links_hash: { topics: [link_a] },
+        links_hash: { taxons: [link_a] },
       )
     end
 

--- a/spec/commands/v2/publish_spec.rb
+++ b/spec/commands/v2/publish_spec.rb
@@ -529,7 +529,7 @@ RSpec.describe Commands::V2::Publish do
         create(
           :live_edition,
           document:,
-          links_hash: { topics: [link_a] },
+          links_hash: { taxons: [link_a] },
         )
       end
 
@@ -537,7 +537,7 @@ RSpec.describe Commands::V2::Publish do
         create(
           :draft_edition,
           document:,
-          links_hash: { topics: [link_b] },
+          links_hash: { taxons: [link_b] },
           user_facing_version: 2,
         )
       end

--- a/spec/commands/v2/unpublish_spec.rb
+++ b/spec/commands/v2/unpublish_spec.rb
@@ -402,7 +402,7 @@ RSpec.describe Commands::V2::Unpublish do
           :draft_edition,
           document:,
           user_facing_version: 2,
-          links_hash: { topics: [link_b] },
+          links_hash: { taxons: [link_b] },
         )
       end
 
@@ -410,7 +410,7 @@ RSpec.describe Commands::V2::Unpublish do
         create(
           :live_edition,
           document:,
-          links_hash: { topics: [link_a] },
+          links_hash: { taxons: [link_a] },
         )
       end
 

--- a/spec/controllers/v2/content_items_controller_spec.rb
+++ b/spec/controllers/v2/content_items_controller_spec.rb
@@ -18,8 +18,8 @@ RSpec.describe V2::ContentItemsController do
       :draft_edition,
       document: document_en,
       base_path: "/content.en",
-      document_type: "topic",
-      schema_name: "topic",
+      document_type: "taxon",
+      schema_name: "taxon",
       user_facing_version: 2,
     )
   end
@@ -31,8 +31,8 @@ RSpec.describe V2::ContentItemsController do
         :draft_edition,
         document: document_ar,
         base_path: "/content.ar",
-        document_type: "topic",
-        schema_name: "topic",
+        document_type: "taxon",
+        schema_name: "taxon",
         user_facing_version: 2,
       )
       @en_live_content = create(
@@ -40,15 +40,15 @@ RSpec.describe V2::ContentItemsController do
         document: document_en,
         base_path: "/content.en",
         document_type: "guide",
-        schema_name: "topic",
+        schema_name: "taxon",
         user_facing_version: 1,
       )
       @ar_live_content = create(
         :live_edition,
         document: document_ar,
         base_path: "/content.ar",
-        document_type: "topic",
-        schema_name: "topic",
+        document_type: "taxon",
+        schema_name: "taxon",
         user_facing_version: 1,
       )
     end
@@ -58,8 +58,8 @@ RSpec.describe V2::ContentItemsController do
         create(
           :superseded_edition,
           base_path: "/foo",
-          document_type: "topic",
-          schema_name: "topic",
+          document_type: "taxon",
+          schema_name: "taxon",
           title: "zip",
           user_facing_version: 1,
         )
@@ -69,8 +69,8 @@ RSpec.describe V2::ContentItemsController do
           :live_edition,
           base_path: "/foo",
           document: previous_live_version.document,
-          document_type: "topic",
-          schema_name: "topic",
+          document_type: "taxon",
+          schema_name: "taxon",
           title: "bar",
           description: "stuff",
           user_facing_version: 2,
@@ -179,7 +179,7 @@ RSpec.describe V2::ContentItemsController do
 
     context "with pagination params" do
       before do
-        get :index, params: { content_format: "topic", fields: %w[content_id], start: "0", page_size: "20" }
+        get :index, params: { content_format: "taxon", fields: %w[content_id], start: "0", page_size: "20" }
       end
 
       it "is successful" do
@@ -193,7 +193,7 @@ RSpec.describe V2::ContentItemsController do
 
     context "without pagination params" do
       before do
-        get :index, params: { content_format: "topic", fields: %w[content_id] }
+        get :index, params: { content_format: "taxon", fields: %w[content_id] }
       end
       it "is successful" do
         expect(response.status).to eq(200)
@@ -349,7 +349,7 @@ RSpec.describe V2::ContentItemsController do
         link_set = create(:link_set, content_id:)
         create(:link, link_set:, target_content_id: org_content_id)
 
-        get :index, params: { content_format: "topic", fields: %w[content_id], link_organisations: org_content_id.to_s }
+        get :index, params: { content_format: "taxon", fields: %w[content_id], link_organisations: org_content_id.to_s }
       end
 
       it "is successful" do
@@ -384,7 +384,7 @@ RSpec.describe V2::ContentItemsController do
           :draft_edition,
           document: document_ar,
           base_path: "/content.ar",
-          schema_name: "topic",
+          schema_name: "taxon",
           user_facing_version: 2,
         )
 

--- a/spec/controllers/v2/link_sets_controller_spec.rb
+++ b/spec/controllers/v2/link_sets_controller_spec.rb
@@ -42,14 +42,14 @@ RSpec.describe V2::LinkSetsController do
   describe "get_linked" do
     context "called without providing fields parameter" do
       it "is unsuccessful" do
-        get :get_linked, params: { content_id:, link_type: "topic" }
+        get :get_linked, params: { content_id:, link_type: "taxon" }
         expect(response.status).to eq(422)
       end
     end
 
     context "called with empty fields parameter" do
       it "is unsuccessful" do
-        get :get_linked, params: { content_id:, link_type: "topic", fields: [] }
+        get :get_linked, params: { content_id:, link_type: "taxon", fields: [] }
 
         expect(response.status).to eq(422)
       end
@@ -67,7 +67,7 @@ RSpec.describe V2::LinkSetsController do
 
     context "for an existing edition" do
       before do
-        get :get_linked, params: { content_id:, link_type: "topic", fields: %w[content_id] }
+        get :get_linked, params: { content_id:, link_type: "taxon", fields: %w[content_id] }
       end
 
       it "is successful" do
@@ -77,7 +77,7 @@ RSpec.describe V2::LinkSetsController do
 
     context "for a non-existing edition" do
       before do
-        get :get_linked, params: { content_id: SecureRandom.uuid, link_type: "topic", fields: %w[content_id] }
+        get :get_linked, params: { content_id: SecureRandom.uuid, link_type: "taxon", fields: %w[content_id] }
       end
 
       it "is unsuccessful" do

--- a/spec/queries/get_content_collection_spec.rb
+++ b/spec/queries/get_content_collection_spec.rb
@@ -4,14 +4,14 @@ RSpec.describe Queries::GetContentCollection do
       create(
         :draft_edition,
         base_path: "/a",
-        document_type: "topic",
-        schema_name: "topic",
+        document_type: "taxon",
+        schema_name: "taxon",
       )
       create(
         :draft_edition,
         base_path: "/b",
-        document_type: "topic",
-        schema_name: "topic",
+        document_type: "taxon",
+        schema_name: "taxon",
       )
       create(
         :draft_edition,
@@ -54,7 +54,7 @@ RSpec.describe Queries::GetContentCollection do
 
     it "returns the editions matching the type" do
       expect(Queries::GetContentCollection.new(
-        document_types: "topic",
+        document_types: "taxon",
         fields: %w[base_path locale publication_state],
       ).call).to match_array([
         hash_including("base_path" => "/a", "publication_state" => "draft", "locale" => "en"),
@@ -64,7 +64,7 @@ RSpec.describe Queries::GetContentCollection do
 
     it "returns the editions matching all types when given an array" do
       expect(Queries::GetContentCollection.new(
-        document_types: %w[topic mainstream_browse_page],
+        document_types: %w[taxon mainstream_browse_page],
         fields: %w[base_path locale publication_state],
       ).call).to match_array([
         hash_including("base_path" => "/a", "publication_state" => "draft", "locale" => "en"),
@@ -78,12 +78,12 @@ RSpec.describe Queries::GetContentCollection do
     create(
       :draft_edition,
       base_path: "/a",
-      document_type: "topic",
-      schema_name: "topic",
+      document_type: "taxon",
+      schema_name: "taxon",
     )
 
     expect(Queries::GetContentCollection.new(
-      document_types: "topic",
+      document_types: "taxon",
       fields: %w[base_path publication_state],
     ).call).to match_array([
       hash_including("base_path" => "/a", "publication_state" => "draft"),
@@ -94,18 +94,18 @@ RSpec.describe Queries::GetContentCollection do
     create(
       :draft_edition,
       base_path: "/draft",
-      document_type: "topic",
-      schema_name: "topic",
+      document_type: "taxon",
+      schema_name: "taxon",
     )
     create(
       :live_edition,
       base_path: "/live",
-      document_type: "topic",
-      schema_name: "topic",
+      document_type: "taxon",
+      schema_name: "taxon",
     )
 
     expect(Queries::GetContentCollection.new(
-      document_types: "topic",
+      document_types: "taxon",
       fields: %w[base_path publication_state],
     ).call).to match_array([
       hash_including("base_path" => "/draft", "publication_state" => "draft"),
@@ -117,13 +117,13 @@ RSpec.describe Queries::GetContentCollection do
     it "can include information about the unpublishing" do
       edition = create(
         :unpublished_edition,
-        document_type: "topic",
+        document_type: "taxon",
       )
       unpublishing = Unpublishing.find_by(edition:)
 
       expect(
         Queries::GetContentCollection.new(
-          document_types: "topic",
+          document_types: "taxon",
           fields: %w[base_path publication_state unpublishing],
         ).call,
       ).to match_array(
@@ -144,7 +144,7 @@ RSpec.describe Queries::GetContentCollection do
   context "when there's no items for the format" do
     it "returns an empty array" do
       expect(Queries::GetContentCollection.new(
-        document_types: "topic",
+        document_types: "taxon",
         fields: %w[base_path],
       ).call.to_a).to eq([])
     end
@@ -154,7 +154,7 @@ RSpec.describe Queries::GetContentCollection do
     it "raises an error" do
       expect {
         Queries::GetContentCollection.new(
-          document_types: "topic",
+          document_types: "taxon",
           fields: %w[not_existing],
         ).call
       }.to raise_error(CommandError)
@@ -166,29 +166,29 @@ RSpec.describe Queries::GetContentCollection do
       create(
         :draft_edition,
         base_path: "/a",
-        document_type: "topic",
-        schema_name: "topic",
+        document_type: "taxon",
+        schema_name: "taxon",
         publishing_app: "publisher",
       )
       create(
         :draft_edition,
         base_path: "/b",
-        document_type: "topic",
-        schema_name: "topic",
+        document_type: "taxon",
+        schema_name: "taxon",
         publishing_app: "publisher",
       )
       create(
         :draft_edition,
         base_path: "/c",
-        document_type: "topic",
-        schema_name: "topic",
+        document_type: "taxon",
+        schema_name: "taxon",
         publishing_app: "whitehall",
       )
     end
 
     it "returns items corresponding to the publishing_app parameter if present" do
       expect(Queries::GetContentCollection.new(
-        document_types: "topic",
+        document_types: "taxon",
         fields: %w[publishing_app publication_state],
         filters: { publishing_app: "publisher" },
       ).call).to match_array([
@@ -199,7 +199,7 @@ RSpec.describe Queries::GetContentCollection do
 
     it "returns items for all apps if publishing_app is not present" do
       expect(Queries::GetContentCollection.new(
-        document_types: "topic",
+        document_types: "taxon",
         fields: %w[publishing_app publication_state],
       ).call).to match_array([
         hash_including("publishing_app" => "publisher", "publication_state" => "draft"),
@@ -215,35 +215,35 @@ RSpec.describe Queries::GetContentCollection do
         :draft_edition,
         document: create(:document, locale: "en"),
         base_path: "/content.en",
-        document_type: "topic",
-        schema_name: "topic",
+        document_type: "taxon",
+        schema_name: "taxon",
       )
       create(
         :draft_edition,
         document: create(:document, locale: "ar"),
         base_path: "/content.ar",
-        document_type: "topic",
-        schema_name: "topic",
+        document_type: "taxon",
+        schema_name: "taxon",
       )
       create(
         :live_edition,
         document: create(:document, locale: "en"),
         base_path: "/content.en",
-        document_type: "topic",
-        schema_name: "topic",
+        document_type: "taxon",
+        schema_name: "taxon",
       )
       create(
         :live_edition,
         document: create(:document, locale: "ar"),
         base_path: "/content.ar",
-        document_type: "topic",
-        schema_name: "topic",
+        document_type: "taxon",
+        schema_name: "taxon",
       )
     end
 
     it "returns the editions filtered by 'en' locale by default" do
       expect(Queries::GetContentCollection.new(
-        document_types: "topic",
+        document_types: "taxon",
         fields: %w[base_path publication_state],
       ).call).to match_array([
         hash_including("base_path" => "/content.en", "publication_state" => "draft"),
@@ -253,7 +253,7 @@ RSpec.describe Queries::GetContentCollection do
 
     it "returns the editions filtered by locale parameter" do
       expect(Queries::GetContentCollection.new(
-        document_types: "topic",
+        document_types: "taxon",
         fields: %w[base_path publication_state],
         filters: { locale: "ar" },
       ).call).to match_array([
@@ -264,7 +264,7 @@ RSpec.describe Queries::GetContentCollection do
 
     it "returns all editions if the locale parameter is 'all'" do
       expect(Queries::GetContentCollection.new(
-        document_types: "topic",
+        document_types: "taxon",
         fields: %w[base_path publication_state],
         filters: { locale: "all" },
       ).call).to match_array([
@@ -386,22 +386,22 @@ RSpec.describe Queries::GetContentCollection do
         :draft_edition,
         base_path: "/z",
         details: { foo: :bar },
-        document_type: "topic",
-        schema_name: "topic",
+        document_type: "taxon",
+        schema_name: "taxon",
         publishing_app: "publisher",
       )
       create(
         :draft_edition,
         base_path: "/b",
         details: { baz: :bat },
-        document_type: "topic",
-        schema_name: "topic",
+        document_type: "taxon",
+        schema_name: "taxon",
         publishing_app: "publisher",
       )
     end
     it "returns the details hash" do
       expect(Queries::GetContentCollection.new(
-        document_types: "topic",
+        document_types: "taxon",
         fields: %w[details publication_state],
         filters: { publishing_app: "publisher" },
       ).call).to match_array([
@@ -416,19 +416,19 @@ RSpec.describe Queries::GetContentCollection do
       create(
         :live_edition,
         base_path: "/bar/foo",
-        document_type: "topic",
-        schema_name: "topic",
+        document_type: "taxon",
+        schema_name: "taxon",
         title: "Baz",
         details: {
           body: "A page about windows.",
-          internal_name: "newtopic",
+          internal_name: "newtaxon",
         },
       )
       create(
         :live_edition,
         base_path: "/baz",
-        document_type: "topic",
-        schema_name: "topic",
+        document_type: "taxon",
+        schema_name: "taxon",
         title: "zip",
         description: "foo",
         details: {
@@ -442,7 +442,7 @@ RSpec.describe Queries::GetContentCollection do
 
     subject do
       Queries::GetContentCollection.new(
-        document_types: "topic",
+        document_types: "taxon",
         fields: %w[base_path],
         search_query:,
         search_in:,
@@ -474,7 +474,7 @@ RSpec.describe Queries::GetContentCollection do
 
       context "with multiple nested fields" do
         let(:search_in) { ["details.body", "details.internal_name"] }
-        let(:search_query) { "newtopic" }
+        let(:search_query) { "newtaxon" }
         it "finds the edition" do
           expect(subject.call.map(&:to_hash)).to eq([{ "base_path" => "/bar/foo" }])
         end
@@ -542,8 +542,8 @@ RSpec.describe Queries::GetContentCollection do
           create(
             :draft_edition,
             base_path:,
-            document_type: "topic",
-            schema_name: "topic",
+            document_type: "taxon",
+            schema_name: "taxon",
             public_updated_at:,
           )
         end
@@ -553,8 +553,8 @@ RSpec.describe Queries::GetContentCollection do
           create(
             :live_edition,
             base_path:,
-            document_type: "topic",
-            schema_name: "topic",
+            document_type: "taxon",
+            schema_name: "taxon",
             public_updated_at:,
           )
         end
@@ -562,7 +562,7 @@ RSpec.describe Queries::GetContentCollection do
 
       it "limits the results returned" do
         editions = Queries::GetContentCollection.new(
-          document_types: "topic",
+          document_types: "taxon",
           fields: %w[publishing_app],
           pagination: Pagination.new(offset: 0, per_page: 3),
         ).call
@@ -572,7 +572,7 @@ RSpec.describe Queries::GetContentCollection do
 
       it "fetches results from a specified index" do
         editions = Queries::GetContentCollection.new(
-          document_types: "topic",
+          document_types: "taxon",
           fields: %w[base_path],
           pagination: Pagination.new(offset: 1, per_page: 2),
         ).call
@@ -582,7 +582,7 @@ RSpec.describe Queries::GetContentCollection do
 
       it "when per_page is higher than results we only receive remaining editions" do
         editions = Queries::GetContentCollection.new(
-          document_types: "topic",
+          document_types: "taxon",
           fields: %w[base_path],
           pagination: Pagination.new(offset: 3, per_page: 8),
         ).call.to_a
@@ -593,7 +593,7 @@ RSpec.describe Queries::GetContentCollection do
 
       it "returns all items when no pagination params are specified" do
         editions = Queries::GetContentCollection.new(
-          document_types: "topic",
+          document_types: "taxon",
           fields: %w[publishing_app],
         ).call
 
@@ -633,11 +633,11 @@ RSpec.describe Queries::GetContentCollection do
 
   describe "#total" do
     it "returns the number of editions" do
-      create(:edition, base_path: "/a", schema_name: "topic", document_type: "topic")
-      create(:edition, base_path: "/b", schema_name: "topic", document_type: "topic")
+      create(:edition, base_path: "/a", schema_name: "taxon", document_type: "taxon")
+      create(:edition, base_path: "/b", schema_name: "taxon", document_type: "taxon")
 
       expect(Queries::GetContentCollection.new(
-        document_types: "topic",
+        document_types: "taxon",
         fields: %w[base_path locale publication_state],
       ).total).to eq(2)
     end
@@ -649,28 +649,28 @@ RSpec.describe Queries::GetContentCollection do
         create(
           :live_edition,
           document:,
-          document_type: "topic",
-          schema_name: "topic",
+          document_type: "taxon",
+          schema_name: "taxon",
           user_facing_version: 1,
         )
 
         create(
           :draft_edition,
           document:,
-          document_type: "topic",
-          schema_name: "topic",
+          document_type: "taxon",
+          schema_name: "taxon",
           user_facing_version: 2,
         )
       end
 
       it "returns the latest item only" do
         expect(Queries::GetContentCollection.new(
-          document_types: "topic",
+          document_types: "taxon",
           fields: %w[base_path locale publication_state],
         ).total).to eq(1)
 
         expect(Queries::GetContentCollection.new(
-          document_types: "topic",
+          document_types: "taxon",
           fields: %w[base_path locale publication_state],
         ).call.first["publication_state"]).to eq("draft")
       end

--- a/spec/queries/get_link_changes_spec.rb
+++ b/spec/queries/get_link_changes_spec.rb
@@ -1,9 +1,9 @@
 RSpec.describe Queries::GetLinkChanges do
   describe "#as_hash" do
     it "returns the link changes with the correct data" do
-      create(:link_change, link_type: "topics")
+      create(:link_change, link_type: "taxons")
 
-      result = Queries::GetLinkChanges.new(link_types: "topics").as_hash
+      result = Queries::GetLinkChanges.new(link_types: "taxons").as_hash
 
       change = result[:link_changes].first.deep_symbolize_keys
 
@@ -15,9 +15,9 @@ RSpec.describe Queries::GetLinkChanges do
     it "expands the source and target" do
       document = create(:document, content_id: "1dd96f5d-c260-438b-ba58-57ba910e9291")
       create(:edition, document:, title: "Content Foo")
-      create(:link_change, link_type: "topics", source_content_id: document.content_id)
+      create(:link_change, link_type: "taxons", source_content_id: document.content_id)
 
-      result = Queries::GetLinkChanges.new(link_types: "topics").as_hash
+      result = Queries::GetLinkChanges.new(link_types: "taxons").as_hash
 
       change = result[:link_changes].first.deep_symbolize_keys
       expect(change[:source].keys).to match_array(%i[title base_path content_id])

--- a/spec/requests/content_item_requests/endpoint_behaviour_spec.rb
+++ b/spec/requests/content_item_requests/endpoint_behaviour_spec.rb
@@ -1,11 +1,11 @@
 RSpec.describe "Endpoint behaviour", type: :request do
   context "GET /v2/content" do
-    let(:request_path) { "/v2/content?document_type=topic&fields[]=title&fields[]=description" }
+    let(:request_path) { "/v2/content?document_type=taxon&fields[]=title&fields[]=description" }
     let(:request_body) { "" }
     let(:request_method) { :get }
 
     it "responds with 200" do
-      get "/v2/content?document_type=topic&fields[]=title&fields[]=description"
+      get "/v2/content?document_type=taxon&fields[]=title&fields[]=description"
       expect(response.status).to eq(200)
     end
   end

--- a/spec/service_consumers/pact_helper.rb
+++ b/spec/service_consumers/pact_helper.rb
@@ -225,8 +225,8 @@ Pact.provider_states_for "GDS API Adapters" do
       create(
         :draft_edition,
         document: en_doc,
-        document_type: "topic",
-        schema_name: "topic",
+        document_type: "taxon",
+        schema_name: "taxon",
         public_updated_at: "2015-01-03",
         user_facing_version: 1,
       )
@@ -234,8 +234,8 @@ Pact.provider_states_for "GDS API Adapters" do
       create(
         :draft_edition,
         document: fr_doc,
-        document_type: "topic",
-        schema_name: "topic",
+        document_type: "taxon",
+        schema_name: "taxon",
         public_updated_at: "2015-01-02",
         user_facing_version: 1,
       )
@@ -243,8 +243,8 @@ Pact.provider_states_for "GDS API Adapters" do
       create(
         :draft_edition,
         document: ar_doc,
-        document_type: "topic",
-        schema_name: "topic",
+        document_type: "taxon",
+        schema_name: "taxon",
         public_updated_at: "2015-01-01",
         user_facing_version: 1,
       )
@@ -258,8 +258,8 @@ Pact.provider_states_for "GDS API Adapters" do
       create(
         :superseded_edition,
         document:,
-        document_type: "topic",
-        schema_name: "topic",
+        document_type: "taxon",
+        schema_name: "taxon",
         public_updated_at: "2015-01-03",
         user_facing_version: 1,
       )
@@ -267,8 +267,8 @@ Pact.provider_states_for "GDS API Adapters" do
       create(
         :live_edition,
         document:,
-        document_type: "topic",
-        schema_name: "topic",
+        document_type: "taxon",
+        schema_name: "taxon",
         public_updated_at: "2015-01-03",
         user_facing_version: 2,
       )
@@ -311,7 +311,7 @@ Pact.provider_states_for "GDS API Adapters" do
     end
   end
 
-  provider_state "there are four content items with document_type 'topic'" do
+  provider_state "there are four content items with document_type 'taxon'" do
     set_up do
       (1..4).each do |index|
         create(
@@ -319,14 +319,14 @@ Pact.provider_states_for "GDS API Adapters" do
           title: "title_#{index}",
           document: create(:document),
           base_path: "/path_#{index}",
-          document_type: "topic",
+          document_type: "taxon",
           public_updated_at: Time.zone.local(2018, 12 - index, 1, 12, 0, 0),
         )
       end
     end
   end
 
-  provider_state "there is content with document_type 'topic'" do
+  provider_state "there is content with document_type 'taxon'" do
     set_up do
       document_a = create(
         :document,
@@ -338,8 +338,8 @@ Pact.provider_states_for "GDS API Adapters" do
         title: "Content Item A",
         document: document_a,
         base_path: "/a-base-path",
-        document_type: "topic",
-        schema_name: "topic",
+        document_type: "taxon",
+        schema_name: "taxon",
         public_updated_at: "2015-01-02",
         details: {
           internal_name: "an internal name",
@@ -357,8 +357,8 @@ Pact.provider_states_for "GDS API Adapters" do
         document: document_b,
         base_path: "/another-base-path",
         public_updated_at: "2015-01-01",
-        document_type: "topic",
-        schema_name: "topic",
+        document_type: "taxon",
+        schema_name: "taxon",
       )
     end
   end
@@ -415,7 +415,7 @@ Pact.provider_states_for "GDS API Adapters" do
       end
     end
   end
-  provider_state "there is content with document_type 'topic' for multiple publishing apps" do
+  provider_state "there is content with document_type 'taxon' for multiple publishing apps" do
     set_up do
       document_a = create(:document)
       document_b = create(:document)
@@ -426,8 +426,8 @@ Pact.provider_states_for "GDS API Adapters" do
         document: document_a,
         title: "Content Item A",
         base_path: "/a-base-path",
-        document_type: "topic",
-        schema_name: "topic",
+        document_type: "taxon",
+        schema_name: "taxon",
       )
 
       create(
@@ -435,8 +435,8 @@ Pact.provider_states_for "GDS API Adapters" do
         document: document_b,
         title: "Content Item B",
         base_path: "/another-base-path",
-        document_type: "topic",
-        schema_name: "topic",
+        document_type: "taxon",
+        schema_name: "taxon",
       )
 
       create(
@@ -444,14 +444,14 @@ Pact.provider_states_for "GDS API Adapters" do
         document: document_c,
         title: "Content Item C",
         base_path: "/yet-another-base-path",
-        document_type: "topic",
-        schema_name: "topic",
+        document_type: "taxon",
+        schema_name: "taxon",
         publishing_app: "whitehall",
       )
     end
   end
 
-  provider_state "there are two documents with a 'topic' link to another document" do
+  provider_state "there are two documents with a 'taxon' link to another document" do
     set_up do
       content_id1 = "6cb2cf8c-670f-4de3-97d5-6ad9114581c7"
       content_id2 = "08dfd5c3-d935-4e81-88fd-cfe65b78893d"
@@ -492,8 +492,8 @@ Pact.provider_states_for "GDS API Adapters" do
       link_set1 = create(:link_set, content_id: content_id3)
       link_set2 = create(:link_set, content_id: content_id2)
 
-      create(:link, link_set: link_set1, link_type: "topic", target_content_id: content_id1)
-      create(:link, link_set: link_set2, link_type: "topic", target_content_id: content_id1)
+      create(:link, link_set: link_set1, link_type: "taxon", target_content_id: content_id1)
+      create(:link, link_set: link_set2, link_type: "taxon", target_content_id: content_id1)
     end
   end
 
@@ -504,8 +504,8 @@ Pact.provider_states_for "GDS API Adapters" do
       create(
         :draft_edition,
         document:,
-        document_type: "topic",
-        schema_name: "topic",
+        document_type: "taxon",
+        schema_name: "taxon",
         details: { foo: :bar },
       )
     end


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

## What

Remove specialist topics from publishing-api tests.

## Why

Retiring specialist topics.
[Trello ticket](https://trello.com/c/y1ysrube/2493-remove-topic-from-publishing-api-specs)