### PR TITLE
Use edition links for Worldwide Offices

### DIFF
--- a/content_schemas/dist/formats/worldwide_office/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/worldwide_office/publisher_v2/schema.json
@@ -59,8 +59,21 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "contact": {
+          "description": "Contact details for this Worldwide Office",
+          "$ref": "#/definitions/guid_list"
+        },
+        "parent": {
+          "description": "The parent content item.",
+          "$ref": "#/definitions/guid_list",
+          "maxItems": 1
+        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "worldwide_organisation": {
+          "description": "The Worldwide Organisation that this Worldwide Office belongs to",
           "$ref": "#/definitions/guid_list"
         }
       }

--- a/content_schemas/formats/worldwide_office.jsonnet
+++ b/content_schemas/formats/worldwide_office.jsonnet
@@ -46,6 +46,14 @@
       },
     },
   },
+  edition_links: (import "shared/base_edition_links.jsonnet") + {
+    contact: "Contact details for this Worldwide Office",
+    parent: {
+      description: "The parent content item.",
+      maxItems: 1,
+    },
+    worldwide_organisation: "The Worldwide Organisation that this Worldwide Office belongs to",
+  },
   links: (import "shared/base_links.jsonnet") + {
     contact: "Contact details for this Worldwide Office",
     worldwide_organisation: "The Worldwide Organisation that this Worldwide Office belongs to",


### PR DESCRIPTION
We are working to make Worldwide Organisations and their offices editionable.

Therefore we need to be able to link the links to editions, rather than documents, to prevent draft updates becoming live before publication.

[Trello card](https://trello.com/c/5Nr1NieG)