### PR TITLE
Remove non-edition links for worldwide offices

### DIFF
--- a/content_schemas/dist/formats/worldwide_office/publisher_v2/links.json
+++ b/content_schemas/dist/formats/worldwide_office/publisher_v2/links.json
@@ -10,10 +10,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "contact": {
-          "description": "Contact details for this Worldwide Office",
-          "$ref": "#/definitions/guid_list"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"
@@ -70,10 +66,6 @@
         },
         "topics": {
           "description": "Powers the /topic section of the site. These are known as specialist sectors in some legacy apps.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "worldwide_organisation": {
-          "description": "The Worldwide Organisation that this Worldwide Office belongs to",
           "$ref": "#/definitions/guid_list"
         }
       }

--- a/content_schemas/formats/worldwide_office.jsonnet
+++ b/content_schemas/formats/worldwide_office.jsonnet
@@ -54,8 +54,4 @@
     },
     worldwide_organisation: "The Worldwide Organisation that this Worldwide Office belongs to",
   },
-  links: (import "shared/base_links.jsonnet") + {
-    contact: "Contact details for this Worldwide Office",
-    worldwide_organisation: "The Worldwide Organisation that this Worldwide Office belongs to",
-  },
 }


### PR DESCRIPTION
In https://github.com/alphagov/whitehall/pull/8910, we removed the presentation of non-edition links for worldwide offices.

Therefore we can remove them from the schema.

Depends on https://github.com/alphagov/whitehall/pull/8910.

[Trello card](https://trello.com/c/5Nr1NieG)