### PR TITLE
Add `search_id` field to `world_location` schema

### DIFF
--- a/content_schemas/dist/formats/world_location/frontend/schema.json
+++ b/content_schemas/dist/formats/world_location/frontend/schema.json
@@ -311,6 +311,10 @@
         "external_related_links": {
           "$ref": "#/definitions/external_related_links"
         },
+        "search_id": {
+          "description": "A human-readable identifier used for filtering within Finder Frontend.",
+          "type": "string"
+        },
         "tags": {
           "$ref": "#/definitions/tags"
         }

--- a/content_schemas/dist/formats/world_location/notification/schema.json
+++ b/content_schemas/dist/formats/world_location/notification/schema.json
@@ -416,6 +416,10 @@
         "external_related_links": {
           "$ref": "#/definitions/external_related_links"
         },
+        "search_id": {
+          "description": "A human-readable identifier used for filtering within Finder Frontend.",
+          "type": "string"
+        },
         "tags": {
           "$ref": "#/definitions/tags"
         }

--- a/content_schemas/dist/formats/world_location/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/world_location/publisher_v2/schema.json
@@ -197,6 +197,10 @@
         "external_related_links": {
           "$ref": "#/definitions/external_related_links"
         },
+        "search_id": {
+          "description": "A human-readable identifier used for filtering within Finder Frontend.",
+          "type": "string"
+        },
         "tags": {
           "$ref": "#/definitions/tags"
         }

--- a/content_schemas/examples/worldwide_organisation/frontend/worldwide_organisation.json
+++ b/content_schemas/examples/worldwide_organisation/frontend/worldwide_organisation.json
@@ -550,6 +550,7 @@
       {
         "content_id": "5e9f047a-7706-11e4-a3cb-005056011aef",
         "title": "India",
+        "search_id": "india",
         "schema_name": "world_location",
         "locale": "en",
         "analytics_identifier": "WL61",
@@ -558,6 +559,7 @@
       {
         "content_id": "5e9f047a-7706-11e4-a3cb-005056011aee",
         "title": "Another location",
+        "search_id": "another-location",
         "schema_name": "world_location",
         "locale": "en",
         "analytics_identifier": "WLexample",

--- a/content_schemas/formats/world_location.jsonnet
+++ b/content_schemas/formats/world_location.jsonnet
@@ -16,6 +16,10 @@
         external_related_links: {
           "$ref": "#/definitions/external_related_links",
         },
+        search_id: {
+           type: "string",
+           description: "A human-readable identifier used for filtering within Finder Frontend.",
+        },
         tags: {
           "$ref": "#/definitions/tags",
         },


### PR DESCRIPTION
This is required as part of the migration from Search API v1 to v2. This field is currently pushed directly into Search API v1 by Whitehall, however v2 uses only the official schemas and therefore isn't able to access it.