### PR TITLE
Add photo id to vote promo to completed transactions

### DIFF
--- a/content_schemas/dist/formats/completed_transaction/frontend/schema.json
+++ b/content_schemas/dist/formats/completed_transaction/frontend/schema.json
@@ -313,6 +313,18 @@
               "properties": {
                 "category": {
                   "enum": [
+                    "bring_id_to_vote"
+                  ]
+                }
+              }
+            },
+            {
+              "required": [
+                "url"
+              ],
+              "properties": {
+                "category": {
+                  "enum": [
                     "organ_donor"
                   ]
                 }
@@ -349,7 +361,8 @@
                 "mot_reminder",
                 "organ_donor",
                 "register_to_vote",
-                "electric_vehicle"
+                "electric_vehicle",
+                "bring_id_to_vote"
               ]
             },
             "opt_in_url": {

--- a/content_schemas/dist/formats/completed_transaction/notification/schema.json
+++ b/content_schemas/dist/formats/completed_transaction/notification/schema.json
@@ -404,6 +404,18 @@
               "properties": {
                 "category": {
                   "enum": [
+                    "bring_id_to_vote"
+                  ]
+                }
+              }
+            },
+            {
+              "required": [
+                "url"
+              ],
+              "properties": {
+                "category": {
+                  "enum": [
                     "organ_donor"
                   ]
                 }
@@ -440,7 +452,8 @@
                 "mot_reminder",
                 "organ_donor",
                 "register_to_vote",
-                "electric_vehicle"
+                "electric_vehicle",
+                "bring_id_to_vote"
               ]
             },
             "opt_in_url": {

--- a/content_schemas/dist/formats/completed_transaction/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/completed_transaction/publisher_v2/schema.json
@@ -196,6 +196,18 @@
               "properties": {
                 "category": {
                   "enum": [
+                    "bring_id_to_vote"
+                  ]
+                }
+              }
+            },
+            {
+              "required": [
+                "url"
+              ],
+              "properties": {
+                "category": {
+                  "enum": [
                     "organ_donor"
                   ]
                 }
@@ -232,7 +244,8 @@
                 "mot_reminder",
                 "organ_donor",
                 "register_to_vote",
-                "electric_vehicle"
+                "electric_vehicle",
+                "bring_id_to_vote"
               ]
             },
             "opt_in_url": {

--- a/content_schemas/formats/completed_transaction.jsonnet
+++ b/content_schemas/formats/completed_transaction.jsonnet
@@ -18,6 +18,7 @@
                 "organ_donor",
                 "register_to_vote",
                 "electric_vehicle",
+                "bring_id_to_vote",
               ],
             },
             url: {
@@ -37,6 +38,12 @@
             {
               properties: {
                 category: { enum: ["mot_reminder"] }
+              },
+              required: ["url"]
+            },
+            {
+              properties: {
+                category: { enum: ["bring_id_to_vote"] }
               },
               required: ["url"]
             },


### PR DESCRIPTION
## What

Add new Bring Photo ID promo to Completed Transaction pages.

## Why

New Bring Photo ID Promo has been created for Completed Transaction pages and is selectable in publisher.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
