### PR TITLE
Remove redundant comment about style violations

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,3 @@
-# Having a long routes file is not a style violation
 Rails.application.routes.draw do
   def content_id_constraint(request)
     UuidValidator.valid?(request.params[:content_id])


### PR DESCRIPTION
This was added in 57d7288ffc, but then the associated rubocop:disable directive was automatically removed in b4cf5370e3, leaving only the comment.

On its own, the comment has a kind of insecure tone - like someone who hasn't been accused of being unstylish, but is clearly worried that is how they're being perceived. There's nothing less stylish than being worried about style. Have a long routes file! Own it! Flaunt it! Never apologise for who you are.