### PR TITLE
Add edition links to worldwide corporate information pages

### DIFF
--- a/content_schemas/dist/formats/worldwide_corporate_information_page/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/worldwide_corporate_information_page/publisher_v2/schema.json
@@ -80,8 +80,17 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "parent": {
+          "description": "The parent content item.",
+          "$ref": "#/definitions/guid_list",
+          "maxItems": 1
+        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "worldwide_organisation": {
+          "description": "The Worldwide Organisation that this Worldwide Corporate Information Page belongs to",
           "$ref": "#/definitions/guid_list"
         }
       }

--- a/content_schemas/formats/worldwide_corporate_information_page.jsonnet
+++ b/content_schemas/formats/worldwide_corporate_information_page.jsonnet
@@ -14,4 +14,11 @@
   links: (import "shared/base_links.jsonnet") + {
     worldwide_organisation: "The Worldwide Organisation that this Worldwide Corporate Information Page belongs to",
   },
+  edition_links: (import "shared/base_edition_links.jsonnet") + {
+    worldwide_organisation: "The Worldwide Organisation that this Worldwide Corporate Information Page belongs to",
+    parent: {
+      description: "The parent content item.",
+      maxItems: 1,
+    },
+  },
 }


### PR DESCRIPTION
https://trello.com/c/2VqUBhuS

We are working to make worldwide organisations and their pages editionable.

Therefore we need to be able to link the links to editions, rather than
documents, to prevent draft updates becoming live before publication.

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
