### PR TITLE
Remove mapped_specialist_topic_content_id

### DIFF
--- a/content_schemas/dist/formats/document_collection/frontend/schema.json
+++ b/content_schemas/dist/formats/document_collection/frontend/schema.json
@@ -376,9 +376,6 @@
         "government": {
           "$ref": "#/definitions/government"
         },
-        "mapped_specialist_topic_content_id": {
-          "type": "string"
-        },
         "political": {
           "$ref": "#/definitions/political"
         },

--- a/content_schemas/dist/formats/document_collection/notification/schema.json
+++ b/content_schemas/dist/formats/document_collection/notification/schema.json
@@ -485,9 +485,6 @@
         "government": {
           "$ref": "#/definitions/government"
         },
-        "mapped_specialist_topic_content_id": {
-          "type": "string"
-        },
         "political": {
           "$ref": "#/definitions/political"
         },

--- a/content_schemas/dist/formats/document_collection/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/document_collection/publisher_v2/schema.json
@@ -299,9 +299,6 @@
         "government": {
           "$ref": "#/definitions/government"
         },
-        "mapped_specialist_topic_content_id": {
-          "type": "string"
-        },
         "political": {
           "$ref": "#/definitions/political"
         },

--- a/content_schemas/formats/document_collection.jsonnet
+++ b/content_schemas/formats/document_collection.jsonnet
@@ -61,17 +61,14 @@
         brexit_no_deal_notice: {
           "$ref": "#/definitions/brexit_no_deal_notice",
         },
-        mapped_specialist_topic_content_id: {
-          type: "string",
-        }
       },
     },
   },
   edition_links: (import "shared/whitehall_edition_links.jsonnet") + {
     documents: "",
     taxonomy_topic_email_override: {
-        description: "The taxonomy topic that email subscriptions for this document collection should go to - only for document collections converted from specialist topics",
-        maxItems: 1
+      description: "The taxonomy topic that email subscriptions for this document collection should go to - only for document collections converted from specialist topics",
+      maxItems: 1,
     },
   },
   links: (import "shared/base_links.jsonnet") + {
@@ -85,8 +82,8 @@
     documents: "",
     topical_events: "The topical events that are part of this document collection.",
     taxonomy_topic_email_override: {
-        description: "The taxonomy topic that email subscriptions for this document collection should go to - only for document collections converted from specialist topics",
-        maxItems: 1
+      description: "The taxonomy topic that email subscriptions for this document collection should go to - only for document collections converted from specialist topics",
+      maxItems: 1,
     },
   },
 }


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.

# Warning

The following [PR](https://github.com/alphagov/whitehall/pull/8969) in the whitehall repository must be merged first.

# What

As part of work to retire specialist topics, we temporarily stored a mapping between the archived specialist topic and its document collection conversion. We should remove this once we’re done.

# Why

To keep the system clean and avoid unnecessary data.

[Trello card](https://trello.com/c/T6GgX4Vj/2503-remove-mappedspecialisttopiccontentid-from-document-collections-m-l)