### PR TITLE
Add withdrawal to unpublishing cases

### DIFF
--- a/app/downstream_payload.rb
+++ b/app/downstream_payload.rb
@@ -82,6 +82,7 @@ private
       when "gone" then gone_presenter
       when "vanish" then vanish_presenter
       when "substitute" then substitute_presenter
+      when "withdrawal" then content_presenter
       else
         logger.warn("Unexpected unpublishing type #{unpublishing.type}")
         content_presenter


### PR DESCRIPTION
content_presenter is already the fallback presenter, so all this does is suppress warnings for "Unexpected unpublishing type withdrawal". We're getting a few thousand logs of this kind per week[0].

I'm pretty sure that content_presenter is the correct choice here, as it will end up as an EditionPresenter, which has a specific withdrawal_notice method.

[0] - https://kibana.logit.io/s/13d1a0b1-f54f-407b-a4e5-f53ba653fac3/goto/23eae00a8aae5313779a07d129ac4f19?security_tenant=global
