### PR TITLE
CSV Report for word usage

### DIFF
--- a/lib/tasks/csv_report.rake
+++ b/lib/tasks/csv_report.rake
@@ -1,6 +1,35 @@
 require "csv"
 
 namespace :csv_report do
+  desc "Finds all references to a word being used across full details fields - pass in comma separated list of words"
+  task word_usages: :environment do |_, args|
+    words = args.extras.to_a.uniq
+    batch_size = 1000
+    fields = %i[base_path title content_id locale publishing_app document_type]
+
+    csv = CSV.new($stdout)
+    csv << fields + %i[words]
+
+    live_editions = Edition.where(content_store: "live", state: "published")
+
+    total = live_editions.count
+
+    live_editions.includes(:document).find_each(batch_size:).with_index do |item, checked|
+      warn "checked #{checked}/#{total} (found #{csv.lineno - 1})" if (checked % batch_size).zero?
+
+      to_check = "#{item.title} #{item.description} #{item.details}"
+
+      matches = []
+      words.each { |word| matches << word if to_check.match?(/((?:\A|\W)#{word}(?:\W|\Z))/i) }
+
+      if matches.any?
+        csv << item.to_h.values_at(*fields) + [matches.join(",")]
+      end
+    end
+
+    warn "Completed search, found #{csv.lineno - 1} matches"
+  end
+
   desc "Prints a CSV of all editions that were published between the from and until timestamp"
   task :publishings_by_date_range, %i[from until] => :environment do |_, args|
     from_time = Time.zone.parse(args[:from])


### PR DESCRIPTION
Occasionally, we're asked to search for certain lists of words to see if they appear on GOV.UK.

This could be for a number of reasons, but most recently it's been to determine whether there's any offensive language on GOV.UK.

This adds a rake task to publishing-api which, given a list of words, will check the details of all published editions for those words.

It batches editions into groups of 1,000 using find_each. Performance here is very sensitive to index use - it needs to be able to order editions by ID, so we want it to use an index which includes id, but we also want to avoid scanning the huge number of superseded editions. The `content_store: "live"` condition allows postgres to use `index_editions_on_id_and_content_store` - if we only filter on `state: "published"` the database has to use a much less favourable index (since there's no single index on `state`).

I'm doing this in publishing-api rather than content store mostly because I can, but partly because I happen not to have a content-store database clone locally.

Heavilly based on https://github.com/alphagov/content-store/pull/1113, which is what we used last time we did this (before the content-store to postgres migration)