### PR TITLE
Add Rake task to requeue all ever published editions

### DIFF
--- a/lib/tasks/queue.rake
+++ b/lib/tasks/queue.rake
@@ -51,6 +51,20 @@ namespace :queue do
     RequeueContentByScope.new(Edition.live, action: args.action).call
   end
 
+  # This is similar to requeue_all_the_things, but it enqueues the most relevant edition for all
+  # content that has at one point been published.
+  #
+  # This is suitable for downstream apps that need to know about all content past and present,
+  # not just that which is currently visible to users, for example to be able to delete content
+  # downstream that has been unpublished upstream.
+  desc "Add all published and unpublished editions to the message queue with a specified routing key"
+  task :requeue_all_the_ever_published_things, [:action] => :environment do |_, args|
+    RequeueContentByScope.new(
+      Edition.where(state: %w[published unpublished]),
+      action: args.action,
+    ).call
+  end
+
   # This is similar to requeue_all_the_things, but it only requeues published documents
   #
   # This is suitable for e.g. initial import of data into a new downstream app that doesn't care


### PR DESCRIPTION
We currently have two Rake tasks that requeue messages for content, one for all live editions, and another for all live and published editions. This adds a third one to requeue messages for all editions that are either published or unpublished, or in other words, all editions that are or have been published at one point or another.

For downstream applications that rely on incoming messages from Publishing API to keep their internal state consistent with upstream, it can be useful to also requeue messages for unpublished content - as they can be used to delete content where they may have missed the unpublishing message for whatever reason.