### PR TITLE
Remove CDEI from specialist finder examples

### DIFF
--- a/content_schemas/examples/specialist_document/frontend/ai-assurance-portfolio-technique.json
+++ b/content_schemas/examples/specialist_document/frontend/ai-assurance-portfolio-technique.json
@@ -93,29 +93,6 @@
   "links": {
     "organisations": [
       {
-        "analytics_identifier": "OT1280",
-        "api_path": "/api/content/government/organisations/centre-for-data-ethics-and-innovation",
-        "base_path": "/government/organisations/centre-for-data-ethics-and-innovation",
-        "content_id": "1405edcb-943d-42d2-8ec8-c51cd58335a5",
-        "description": "The CDEI is a government expert body enabling the trustworthy use of data and AI. CDEI is part of the Department for Science, Innovation and Technology.",
-        "document_type": "organisation",
-        "locale": "en",
-        "public_updated_at": "2015-03-10T16:23:14Z",
-        "schema_name": "organisation",
-        "title": "Centre for Data Ethics and Innovation",
-        "withdrawn": false,
-        "details": {
-          "brand": "cabinet-office",
-          "logo": {
-            "formatted_title": "Centre for<br/>Data Ethics<br/>and Innovation",
-            "crest": null
-          }
-        },
-        "links": {},
-        "api_url": "https://www.gov.uk/api/content/government/organisations/centre-for-data-ethics-and-innovation",
-        "web_url": "https://www.gov.uk/government/organisations/centre-for-data-ethics-and-innovation"
-      },
-      {
         "analytics_identifier": "D1381",
         "api_path": "/api/content/government/organisations/department-for-science-innovation-and-technology",
         "base_path": "/government/organisations/department-for-science-innovation-and-technology",
@@ -144,7 +121,6 @@
         "analytics_identifier": null,
         "api_path": "/api/content/ai-assurance-techniques",
         "base_path": "/ai-assurance-techniques",
-
         "content_id": "5e5890a0-329a-42d2-9637-9d8433fe97ae",
         "description": "Find out what AI assurance is and what AI assurance techniques you can use in your organisation.",
         "document_type": "finder",

--- a/content_schemas/examples/specialist_document/frontend/algorithmic-transparency-record.json
+++ b/content_schemas/examples/specialist_document/frontend/algorithmic-transparency-record.json
@@ -65,29 +65,6 @@
   "links": {
     "organisations": [
       {
-        "analytics_identifier": "OT1280",
-        "api_path": "/api/content/government/organisations/centre-for-data-ethics-and-innovation",
-        "base_path": "/government/organisations/centre-for-data-ethics-and-innovation",
-        "content_id": "1405edcb-943d-42d2-8ec8-c51cd58335a5",
-        "description": "The CDEI is a government expert body enabling the trustworthy use of data and AI. CDEI is part of the Department for Science, Innovation and Technology.",
-        "document_type": "organisation",
-        "locale": "en",
-        "public_updated_at": "2015-03-10T16:23:14Z",
-        "schema_name": "organisation",
-        "title": "Centre for Data Ethics and Innovation",
-        "withdrawn": false,
-        "details": {
-          "brand": "cabinet-office",
-          "logo": {
-            "formatted_title": "Centre for<br/>Data Ethics<br/>and Innovation",
-            "crest": null
-          }
-        },
-        "links": {},
-        "api_url": "https://www.gov.uk/api/content/government/organisations/centre-for-data-ethics-and-innovation",
-        "web_url": "https://www.gov.uk/government/organisations/centre-for-data-ethics-and-innovation"
-      },
-      {
         "analytics_identifier": "D1381",
         "api_path": "/api/content/government/organisations/department-for-science-innovation-and-technology",
         "base_path": "/government/organisations/department-for-science-innovation-and-technology",

--- a/content_schemas/examples/specialist_document/frontend/farming-grant-option.json
+++ b/content_schemas/examples/specialist_document/frontend/farming-grant-option.json
@@ -55,29 +55,6 @@
   "links": {
     "organisations": [
       {
-        "analytics_identifier": "OT1280",
-        "api_path": "/api/content/government/organisations/centre-for-data-ethics-and-innovation",
-        "base_path": "/government/organisations/centre-for-data-ethics-and-innovation",
-        "content_id": "1405edcb-943d-42d2-8ec8-c51cd58335a5",
-        "description": "The CDEI is a government expert body enabling the trustworthy use of data and AI. CDEI is part of the Department for Science, Innovation and Technology.",
-        "document_type": "organisation",
-        "locale": "en",
-        "public_updated_at": "2015-03-10T16:23:14Z",
-        "schema_name": "organisation",
-        "title": "Centre for Data Ethics and Innovation",
-        "withdrawn": false,
-        "details": {
-          "brand": "cabinet-office",
-          "logo": {
-            "formatted_title": "Centre for<br/>Data Ethics<br/>and Innovation",
-            "crest": null
-          }
-        },
-        "links": {},
-        "api_url": "https://www.gov.uk/api/content/government/organisations/centre-for-data-ethics-and-innovation",
-        "web_url": "https://www.gov.uk/government/organisations/centre-for-data-ethics-and-innovation"
-      },
-      {
         "analytics_identifier": "D1381",
         "api_path": "/api/content/government/organisations/department-for-science-innovation-and-technology",
         "base_path": "/government/organisations/department-for-science-innovation-and-technology",


### PR DESCRIPTION
CDEI is now part of DSIT and will be removed from the AI Assurance Portfolio finder as of
https://github.com/alphagov/specialist-publisher/pull/2614.

It probably shouldn't be in any of the specialist finder examples anymore, so let's update the example JSON to reflect that.

Trello: https://trello.com/c/tf946itm/2551-remove-centre-for-data-ethics-and-innovation-from-ai-assurance-techniques-finder

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
