### PR TITLE
Add No. 10 crest to whitehall schemas

### DIFF
--- a/content_schemas/dist/formats/organisation/frontend/schema.json
+++ b/content_schemas/dist/formats/organisation/frontend/schema.json
@@ -411,6 +411,7 @@
                 "hmrc",
                 "ho",
                 "mod",
+                "no10",
                 "portcullis",
                 "single-identity",
                 "so",

--- a/content_schemas/dist/formats/organisation/notification/schema.json
+++ b/content_schemas/dist/formats/organisation/notification/schema.json
@@ -554,6 +554,7 @@
                 "hmrc",
                 "ho",
                 "mod",
+                "no10",
                 "portcullis",
                 "single-identity",
                 "so",

--- a/content_schemas/dist/formats/organisation/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/organisation/publisher_v2/schema.json
@@ -242,6 +242,7 @@
                 "hmrc",
                 "ho",
                 "mod",
+                "no10",
                 "portcullis",
                 "single-identity",
                 "so",

--- a/content_schemas/dist/formats/organisations_homepage/frontend/schema.json
+++ b/content_schemas/dist/formats/organisations_homepage/frontend/schema.json
@@ -753,6 +753,7 @@
                   "hmrc",
                   "ho",
                   "mod",
+                  "no10",
                   "portcullis",
                   "single-identity",
                   "so",

--- a/content_schemas/dist/formats/organisations_homepage/notification/schema.json
+++ b/content_schemas/dist/formats/organisations_homepage/notification/schema.json
@@ -874,6 +874,7 @@
                   "hmrc",
                   "ho",
                   "mod",
+                  "no10",
                   "portcullis",
                   "single-identity",
                   "so",

--- a/content_schemas/dist/formats/organisations_homepage/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/organisations_homepage/publisher_v2/schema.json
@@ -520,6 +520,7 @@
                   "hmrc",
                   "ho",
                   "mod",
+                  "no10",
                   "portcullis",
                   "single-identity",
                   "so",

--- a/content_schemas/dist/formats/worldwide_organisation/frontend/schema.json
+++ b/content_schemas/dist/formats/worldwide_organisation/frontend/schema.json
@@ -350,6 +350,7 @@
                 "hmrc",
                 "ho",
                 "mod",
+                "no10",
                 "portcullis",
                 "single-identity",
                 "so",

--- a/content_schemas/dist/formats/worldwide_organisation/notification/schema.json
+++ b/content_schemas/dist/formats/worldwide_organisation/notification/schema.json
@@ -481,6 +481,7 @@
                 "hmrc",
                 "ho",
                 "mod",
+                "no10",
                 "portcullis",
                 "single-identity",
                 "so",

--- a/content_schemas/dist/formats/worldwide_organisation/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/worldwide_organisation/publisher_v2/schema.json
@@ -241,6 +241,7 @@
                 "hmrc",
                 "ho",
                 "mod",
+                "no10",
                 "portcullis",
                 "single-identity",
                 "so",

--- a/content_schemas/examples/organisation/frontend/number_10.json
+++ b/content_schemas/examples/organisation/frontend/number_10.json
@@ -1332,7 +1332,7 @@
         "details": {
           "logo": {
             "formatted_title": "Prime Minister&#39;s Office, 10 Downing Street",
-            "crest": "eo"
+            "crest": "no10"
           },
           "brand": "cabinet-office",
           "default_news_image": {
@@ -1373,7 +1373,7 @@
     "brand": "cabinet-office",
     "logo": {
       "formatted_title": "Prime Minister&#39;s Office, 10 Downing Street",
-      "crest": "eo"
+      "crest": "no10"
     },
     "foi_exempt": false,
     "ordered_corporate_information_pages": [

--- a/content_schemas/formats/shared/definitions/_organisation_logo.jsonnet
+++ b/content_schemas/formats/shared/definitions/_organisation_logo.jsonnet
@@ -17,6 +17,7 @@
         "hmrc",
         "ho",
         "mod",
+        "no10",
         "portcullis",
         "single-identity",
         "so",

--- a/content_schemas/formats/shared/definitions/_whitehall.jsonnet
+++ b/content_schemas/formats/shared/definitions/_whitehall.jsonnet
@@ -117,6 +117,7 @@
                 "hmrc",
                 "ho",
                 "mod",
+                "no10",
                 "portcullis",
                 "single-identity",
                 "so",


### PR DESCRIPTION
Adds support for No. 10 crest to Whitehall schemas

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
