### PR TITLE
Rename farming grant options finder

### DIFF
--- a/.github/workflows/test-content-schemas-2.yml
+++ b/.github/workflows/test-content-schemas-2.yml
@@ -65,9 +65,9 @@ jobs:
 
   test-specialist-publisher:
     name: Test Specialist Publisher
-    uses: alphagov/specialist-publisher/.github/workflows/rspec.yml@main
+    uses: alphagov/specialist-publisher/.github/workflows/rspec.yml@rename-farming-grant-options-finder
     with:
-      ref: 'main'
+      ref: 'rename-farming-grant-options-finder'
       publishingApiRef: ${{ github.ref }}
 
   test-travel-advice-publisher:

--- a/content_schemas/allowed_document_types.yml
+++ b/content_schemas/allowed_document_types.yml
@@ -46,7 +46,7 @@
 - export_health_certificate
 - external_content
 - facet
-- farming_grant_option
+- farming_grant
 - fatality_notice
 - field_of_operation
 - fields_of_operation

--- a/content_schemas/dist/formats/generic/frontend/schema.json
+++ b/content_schemas/dist/formats/generic/frontend/schema.json
@@ -82,7 +82,7 @@
         "export_health_certificate",
         "external_content",
         "facet",
-        "farming_grant_option",
+        "farming_grant",
         "fatality_notice",
         "field_of_operation",
         "fields_of_operation",

--- a/content_schemas/dist/formats/generic/notification/schema.json
+++ b/content_schemas/dist/formats/generic/notification/schema.json
@@ -106,7 +106,7 @@
         "export_health_certificate",
         "external_content",
         "facet",
-        "farming_grant_option",
+        "farming_grant",
         "fatality_notice",
         "field_of_operation",
         "fields_of_operation",

--- a/content_schemas/dist/formats/generic/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/generic/publisher_v2/schema.json
@@ -92,7 +92,7 @@
         "export_health_certificate",
         "external_content",
         "facet",
-        "farming_grant_option",
+        "farming_grant",
         "fatality_notice",
         "field_of_operation",
         "fields_of_operation",

--- a/content_schemas/dist/formats/generic_with_external_related_links/frontend/schema.json
+++ b/content_schemas/dist/formats/generic_with_external_related_links/frontend/schema.json
@@ -82,7 +82,7 @@
         "export_health_certificate",
         "external_content",
         "facet",
-        "farming_grant_option",
+        "farming_grant",
         "fatality_notice",
         "field_of_operation",
         "fields_of_operation",

--- a/content_schemas/dist/formats/generic_with_external_related_links/notification/schema.json
+++ b/content_schemas/dist/formats/generic_with_external_related_links/notification/schema.json
@@ -106,7 +106,7 @@
         "export_health_certificate",
         "external_content",
         "facet",
-        "farming_grant_option",
+        "farming_grant",
         "fatality_notice",
         "field_of_operation",
         "fields_of_operation",

--- a/content_schemas/dist/formats/generic_with_external_related_links/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/generic_with_external_related_links/publisher_v2/schema.json
@@ -92,7 +92,7 @@
         "export_health_certificate",
         "external_content",
         "facet",
-        "farming_grant_option",
+        "farming_grant",
         "fatality_notice",
         "field_of_operation",
         "fields_of_operation",

--- a/content_schemas/dist/formats/specialist_document/frontend/schema.json
+++ b/content_schemas/dist/formats/specialist_document/frontend/schema.json
@@ -48,7 +48,7 @@
         "employment_tribunal_decision",
         "esi_fund",
         "export_health_certificate",
-        "farming_grant_option",
+        "farming_grant",
         "flood_and_coastal_erosion_risk_management_research_report",
         "international_development_fund",
         "licence_transaction",
@@ -687,7 +687,7 @@
           "$ref": "#/definitions/flood_and_coastal_erosion_risk_management_research_report"
         },
         {
-          "$ref": "#/definitions/farming_grant_option_metadata"
+          "$ref": "#/definitions/farming_grant_metadata"
         },
         {
           "$ref": "#/definitions/maib_report_metadata"
@@ -1700,7 +1700,7 @@
         }
       }
     },
-    "farming_grant_option_metadata": {
+    "farming_grant_metadata": {
       "type": "object",
       "additionalProperties": false,
       "properties": {

--- a/content_schemas/dist/formats/specialist_document/notification/schema.json
+++ b/content_schemas/dist/formats/specialist_document/notification/schema.json
@@ -72,7 +72,7 @@
         "employment_tribunal_decision",
         "esi_fund",
         "export_health_certificate",
-        "farming_grant_option",
+        "farming_grant",
         "flood_and_coastal_erosion_risk_management_research_report",
         "international_development_fund",
         "licence_transaction",
@@ -775,7 +775,7 @@
           "$ref": "#/definitions/flood_and_coastal_erosion_risk_management_research_report"
         },
         {
-          "$ref": "#/definitions/farming_grant_option_metadata"
+          "$ref": "#/definitions/farming_grant_metadata"
         },
         {
           "$ref": "#/definitions/maib_report_metadata"
@@ -1788,7 +1788,7 @@
         }
       }
     },
-    "farming_grant_option_metadata": {
+    "farming_grant_metadata": {
       "type": "object",
       "additionalProperties": false,
       "properties": {

--- a/content_schemas/dist/formats/specialist_document/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/specialist_document/publisher_v2/schema.json
@@ -58,7 +58,7 @@
         "employment_tribunal_decision",
         "esi_fund",
         "export_health_certificate",
-        "farming_grant_option",
+        "farming_grant",
         "flood_and_coastal_erosion_risk_management_research_report",
         "international_development_fund",
         "licence_transaction",
@@ -611,7 +611,7 @@
           "$ref": "#/definitions/flood_and_coastal_erosion_risk_management_research_report"
         },
         {
-          "$ref": "#/definitions/farming_grant_option_metadata"
+          "$ref": "#/definitions/farming_grant_metadata"
         },
         {
           "$ref": "#/definitions/maib_report_metadata"
@@ -1624,7 +1624,7 @@
         }
       }
     },
-    "farming_grant_option_metadata": {
+    "farming_grant_metadata": {
       "type": "object",
       "additionalProperties": false,
       "properties": {

--- a/content_schemas/examples/specialist_document/frontend/farming-grant.json
+++ b/content_schemas/examples/specialist_document/frontend/farming-grant.json
@@ -51,7 +51,7 @@
   },
   "public_updated_at": "2015-07-10T13:09:46+00:00",
   "schema_name": "specialist_document",
-  "document_type": "farming_grant_option",
+  "document_type": "farming_grant",
   "links": {
     "organisations": [
       {
@@ -112,7 +112,7 @@
         "locale": "en",
         "public_updated_at": "2017-03-15T14:44:21Z",
         "schema_name": "finder",
-        "title": "Farming grant options finder",
+        "title": "Find funding for land or farms",
         "withdrawn": false,
         "details": {
           "facets": [

--- a/content_schemas/formats/shared/definitions/_specialist_document.jsonnet
+++ b/content_schemas/formats/shared/definitions/_specialist_document.jsonnet
@@ -54,7 +54,7 @@
         "$ref": "#/definitions/flood_and_coastal_erosion_risk_management_research_report",
       },
       {
-        "$ref": "#/definitions/farming_grant_option_metadata",
+        "$ref": "#/definitions/farming_grant_metadata",
       },
       {
         "$ref": "#/definitions/maib_report_metadata",
@@ -1788,7 +1788,7 @@
       },
     },
   },
-  farming_grant_option_metadata: {
+  farming_grant_metadata: {
     type: "object",
     additionalProperties: false,
     properties: {

--- a/content_schemas/formats/specialist_document.jsonnet
+++ b/content_schemas/formats/specialist_document.jsonnet
@@ -14,7 +14,7 @@
     "employment_tribunal_decision",
     "esi_fund",
     "export_health_certificate",
-    "farming_grant_option",
+    "farming_grant",
     "flood_and_coastal_erosion_risk_management_research_report",
     "international_development_fund",
     "licence_transaction",

--- a/lib/tasks/remove_draft_specialist_finder_docs.rake
+++ b/lib/tasks/remove_draft_specialist_finder_docs.rake
@@ -1,6 +1,6 @@
 desc "Remove draft specialist finder docs by type"
 task :remove_draft_specialist_finder_docs, [:document_type] => :environment do |_, args|
-  # document_type example: "farming_grant_option"
+  # document_type example: "farming_grant"
   raise "Missing parameter: document_type" unless args.document_type
 
   results = Queries::GetContentCollection.new(fields: %w[content_id], document_types: args.document_type).call


### PR DESCRIPTION
The users wanted the title changed, which introduces a bit of inconsistency with the way other document models and associated files are named in specialist publisher, so we are updating the name of the finder across publishing-api, search and publisher.

We  had to change how we run the tests so that we can merge these changes in, followed by the specialist publisher ones. PR to revert changes [here](https://github.com/alphagov/publishing-api/pull/2734).

[trello card](https://trello.com/c/e0KYS9mQ/2584-farming-grant-options-breadcrumb-not-showing-not-able-to-save-documents)