### PR TITLE
Revert changes to how specialist publisher tests run

### DIFF
--- a/.github/workflows/test-content-schemas-2.yml
+++ b/.github/workflows/test-content-schemas-2.yml
@@ -65,9 +65,9 @@ jobs:
 
   test-specialist-publisher:
     name: Test Specialist Publisher
-    uses: alphagov/specialist-publisher/.github/workflows/rspec.yml@rename-farming-grant-options-finder
+    uses: alphagov/specialist-publisher/.github/workflows/rspec.yml@main
     with:
-      ref: 'rename-farming-grant-options-finder'
+      ref: 'main'
       publishingApiRef: ${{ github.ref }}
 
   test-travel-advice-publisher:


### PR DESCRIPTION
Reverting changes to test content schemas. 

We changed these in order to allow merging some changes in publishing-api and specialist publisher. We are now changing it back to main.

For context, relevant PR that introduced the change: https://github.com/alphagov/publishing-api/pull/2731