### PR TITLE
Associate Document, LinkSet and Link

### DIFF
--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -4,6 +4,7 @@ class Document < ApplicationRecord
   belongs_to :owning_document, class_name: "Document", optional: true
   has_many :editions
   has_one :link_set, primary_key: "content_id", foreign_key: "content_id", inverse_of: :document
+  has_many :link_set_links, class_name: "Link", through: :link_set, source: :links
   has_one :draft, -> { where(content_store: "draft") }, class_name: "Edition"
   has_one :live, -> { where(content_store: "live") }, class_name: "Edition"
 

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -3,6 +3,7 @@ class Document < ApplicationRecord
 
   belongs_to :owning_document, class_name: "Document", optional: true
   has_many :editions
+  has_one :link_set, primary_key: "content_id", foreign_key: "content_id", inverse_of: :document
   has_one :draft, -> { where(content_store: "draft") }, class_name: "Edition"
   has_one :live, -> { where(content_store: "live") }, class_name: "Edition"
 

--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -17,18 +17,11 @@ class Link < ApplicationRecord
       #       called we should make this an error and only support a single filter.
       logger.warn("filter_editions called with multiple filters. These will be ANDed together in a way that probably isn't what we want. Filters were: #{filters.inspect}")
     end
-    join_sql = <<-SQL.strip_heredoc
-      INNER JOIN link_sets ON link_sets.content_id = documents.content_id
-      INNER JOIN links ON links.link_set_id = link_sets.id
-    SQL
 
-    scope = scope.joins(join_sql)
+    scope = scope.joins(document: :link_set_links)
 
     filters.each do |link_type, target_content_id|
-      scope = scope.where(
-        "links.link_type": link_type,
-        "links.target_content_id": target_content_id,
-      )
+      scope = scope.where(links: { link_type:, target_content_id: })
     end
 
     scope

--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -3,6 +3,8 @@ class Link < ApplicationRecord
 
   belongs_to :link_set, optional: true
   belongs_to :edition, optional: true
+  has_one :source_document, class_name: "Document", through: :link_set, source: :document
+  has_one :target_document, class_name: "Document", primary_key: :target_content_id, foreign_key: :content_id
 
   validates :target_content_id, presence: true, uuid: true
   validate :link_type_is_valid

--- a/app/models/link_set.rb
+++ b/app/models/link_set.rb
@@ -1,6 +1,7 @@
 class LinkSet < ApplicationRecord
   include FindOrCreateLocked
 
+  belongs_to :document, foreign_key: "content_id", primary_key: "content_id", inverse_of: :link_set, optional: true
   has_many :links, -> { order(link_type: :asc, position: :asc) }, dependent: :destroy
 
   # We could define the `==` method on `Link` to perform this check but that

--- a/spec/models/link_spec.rb
+++ b/spec/models/link_spec.rb
@@ -104,7 +104,7 @@ RSpec.describe Link do
     it "modifies a scope to filter linked editions" do
       expect(scope).to receive(:joins).with(anything).and_return(scope)
       expect(scope).to receive(:where)
-        .with("links.link_type": "organisations", "links.target_content_id": "12345")
+        .with(links: { link_type: "organisations", target_content_id: "12345" })
 
       described_class.filter_editions(scope, "organisations" => "12345")
     end


### PR DESCRIPTION
Add [rails associations](https://guides.rubyonrails.org/association_basics.html) to the Document, LinkSet and Link models to make interacting with them a little simpler.

I'm only making use of these in one place right now, because it was an obvious improvement. I imagine there are quite a few places in the Queries module where these associations would help us avoid bits of inline SQL in `joins()` statements, but a lot of that code is quite... scary.

My actual motivation for this is that we're going to want to write a complicated query for the GraphQL work which does something like "given this content id, get all the linked documents, and then find the published edition for each of them". This query will be a lot easier to write if we can use associations instead of inline SQL.

While I was thinking about 857b5c1 I think I spotted a problem with that method, so I'm going to raise another PR to add a warning to that one to see if it's used.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️