### PR TITLE
Add a warning and a TODO for the filter_editions method

### DIFF
--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -9,6 +9,12 @@ class Link < ApplicationRecord
   validate :association_presence
 
   def self.filter_editions(scope, filters)
+    if filters.size > 1
+      # TODO: richard.towers - temporary warning to check whether this method is ever
+      #       called with multiple filters. The code looks wrong, so if it's not being
+      #       called we should make this an error and only support a single filter.
+      logger.warn("filter_editions called with multiple filters. These will be ANDed together in a way that probably isn't what we want. Filters were: #{filters.inspect}")
+    end
     join_sql = <<-SQL.strip_heredoc
       INNER JOIN link_sets ON link_sets.content_id = documents.content_id
       INNER JOIN links ON links.link_set_id = link_sets.id

--- a/docs/api.md
+++ b/docs/api.md
@@ -381,8 +381,7 @@ and a state has been specified, the draft is returned.
     e.g. `link_organisations=056a9ff6-2ed1-4942-9f06-92df03da741d`
     will restrict the documents returned to those that have a link
     with type `organisations` to the document with specified content
-    id. Query parameters matching this form can be specified multiple
-    times.
+    id.
 - `locale` *(optional, default "en")*
   - Accepts: An available locale from the [Rails I18n gem][i18n-gem]
   - Used to restrict documents to a given locale.


### PR DESCRIPTION
The filter_editions method looks broken if multiple filters are passed.

The docs say:

>    link_* (optional)
>    Accepts a content_id.
>    Used to restrict documents to those linking to another document, e.g. link_organisations=056a9ff6-2ed1-4942-9f06-92df03da741d will restrict the documents returned to those that have a link with type organisations to the document with specified content id. Query parameters matching this form can be specified multiple times.

... but if you actually passed multiple filters, they'd be ANDed together, so unless they were all identical they'd never match anything.

Initially just adding this warning, but if the logs don't show any warnings I'll just make the method take a single filter, instead of a list. Hopefully with https://github.com/alphagov/publishing-api/pull/2747 this method will be simple enough that we can just inline it (it's only called in one place).

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
