### PR TITLE
LinkSet and Link can have many Documents

### DIFF
--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -3,7 +3,7 @@ class Document < ApplicationRecord
 
   belongs_to :owning_document, class_name: "Document", optional: true
   has_many :editions
-  has_one :link_set, primary_key: "content_id", foreign_key: "content_id", inverse_of: :document
+  has_one :link_set, primary_key: "content_id", foreign_key: "content_id", inverse_of: :documents
   has_many :link_set_links, class_name: "Link", through: :link_set, source: :links
   has_one :draft, -> { where(content_store: "draft") }, class_name: "Edition"
   has_one :live, -> { where(content_store: "live") }, class_name: "Edition"

--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -3,8 +3,11 @@ class Link < ApplicationRecord
 
   belongs_to :link_set, optional: true
   belongs_to :edition, optional: true
-  has_one :source_document, class_name: "Document", through: :link_set, source: :document
-  has_one :target_document, class_name: "Document", primary_key: :target_content_id, foreign_key: :content_id
+
+  # NOTE: links can have more than one source / target document, because there
+  # can be multiple documents with the same content_id and different locales
+  has_many :source_documents, class_name: "Document", through: :link_set, source: :documents
+  has_many :target_documents, class_name: "Document", primary_key: :target_content_id, foreign_key: :content_id
 
   validates :target_content_id, presence: true, uuid: true
   validate :link_type_is_valid

--- a/app/models/link_set.rb
+++ b/app/models/link_set.rb
@@ -1,7 +1,9 @@
 class LinkSet < ApplicationRecord
   include FindOrCreateLocked
 
-  belongs_to :document, foreign_key: "content_id", primary_key: "content_id", inverse_of: :link_set, optional: true
+  # NOTE: link sets can have more than one document, because there
+  # can be multiple documents with the same content_id and different locales
+  has_many :documents, foreign_key: "content_id", primary_key: "content_id", inverse_of: :link_set
   has_many :links, -> { order(link_type: :asc, position: :asc) }, dependent: :destroy
 
   # We could define the `==` method on `Link` to perform this check but that


### PR DESCRIPTION
content_id doesn't uniquely identify a document - there can be many documents with the same content_id and different locales.

That means that given a link_set, you can't find a single Document that it belongs to - it has many documents.

Similarly, links can in theory have multiple source and target documents, as either content_id could have multiple locales.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️