### PR TITLE
Remove references to "govuk-content-schemas"

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -63,13 +63,7 @@ Rails.application.configure do
 
   if GovukSchemas::Schema.all.empty?
     raise <<-MESSAGE
-      No schemas found
-      The Publishing API service requires that the
-      govuk-content-schemas are available. These are accessed through
-      the GovukSchemas gem, which defaults to looking for the
-      govuk-content-schemas repository at ../govuk-content-schemas and
-      can be configured through the GOVUK_CONTENT_SCHEMAS_PATH
-      environment variable.
+      No schemas found by govuk_schemas gem.
     MESSAGE
   end
 

--- a/content_schemas/README.md
+++ b/content_schemas/README.md
@@ -31,7 +31,7 @@ bundle exec rake build_schemas
 * [How to change an existing content schema](../docs/content_schemas/changing-an-existing-content-schema.md)
 * [How to add a new content schema](../docs/content_schemas/adding-a-new-schema.md)
 * [Working with JSON Schema keywords](../docs/content_schemas/working-with-json-schema-keywords.md)
-* [Contract testing against govuk-content-schemas](../docs/content_schemas/contract-testing-against-schemas.md)
+* [Contract testing against the schemas](../docs/content_schemas/contract-testing-against-schemas.md)
 
 ## Licence
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,8 +1,7 @@
 # Publishing API's API
 
 This is the primary interface from publishing apps to the publishing pipeline.
-Applications PUT items as JSON conforming to a schema specified in
-[govuk-content-schemas][govuk-content-schemas-repo].
+Applications PUT items as JSON conforming to a schema specified in the `content_schemas` directory.
 
 Content locations are arbitrated internally by the Publishing API, the content
 is then forwarded to the live and draft content stores, and placed on the
@@ -68,8 +67,7 @@ Used to create or update a draft edition of a document. It will restrict
 creation if there is different document with a draft edition using the same
 `base_path`. Uses [optimistic-locking][optimistic-locking].
 
-The request must conform to the schema defined in govuk-content-schemas if it
-does not a 422 response will be returned.
+The request must conform to the schema. If it does not, a 422 response will be returned.
 
 If the request is successful, this endpoint will respond with the
 presented edition and [warnings](#warnings).
@@ -146,8 +144,7 @@ presented edition and [warnings](#warnings).
   - Required for a `document_type` that is not "redirect".
   - An array of route values.
 - `schema_name` *(required)*
-  - The name of the [GOV.UK content schema][govuk-content-schemas-repo]
-    that the request body will be validated against.
+  - The name of the schema that the request body will be validated against.
 - `title` *(conditionally required)*
   - Required for a `document_type` that is not "redirect" or "gone".
 - `update_type` *(optional)*
@@ -754,10 +751,9 @@ normal.
 - The `PublishingIntent` for the passed in base_path is removed from the
   content-store.
 
-[govuk-content-schemas-repo]: https://github.com/alphagov/govuk-content-schemas
 [optimistic-locking]: #optimistic-locking-previous_version
 [put-content-pact]: https://govuk-pact-broker-6991351eca05.herokuapp.com/pacts/provider/Publishing%20API/consumer/GDS%20API%20Adapters/latest#a_request_from_the_Whitehall_application_to_create_a_content_item_at_/test-item_given_/test-item_has_been_reserved_by_the_Publisher_application
-[routes-content-schema]: https://github.com/alphagov/govuk-content-schemas/blob/master/formats/shared/definitions/routes_redirects.jsonnet
+[routes-content-schema]: https://github.com/alphagov/publishing-api/blob/main/content_schemas/formats/shared/definitions/routes_redirects.jsonnet
 [put-intent-pact]: https://govuk-pact-broker-6991351eca05.herokuapp.com/pacts/provider/Publishing%20API/consumer/GDS%20API%20Adapters/latest#a_request_to_create_a_publish_intent_given_no_content_exists
 [delete-intent-pact]: https://govuk-pact-broker-6991351eca05.herokuapp.com/pacts/provider/Publishing%20API/consumer/GDS%20API%20Adapters/latest#a_request_to_delete_a_publish_intent_given_no_content_exists
 [iso-8601]: https://en.wikipedia.org/wiki/ISO_8601

--- a/docs/content_schemas/changing-an-existing-content-schema.md
+++ b/docs/content_schemas/changing-an-existing-content-schema.md
@@ -32,8 +32,7 @@ For example, imagine that you need to add a new optional field to the details ha
   1. revalidate all example files to check if they are still valid after this change. This will pass, because the new field is optional
 1. [Optional step] you could add an additional example to illustrate how your new field should be used. You can add a new file in [examples/case_study/frontend](/examples/case_study/frontend)
 1. create a new branch and commit and push your changes.
-   This will run a branch build of govuk-content-schemas.
-   This includes running the contract tests for each application which relies on the schemas.
+   This will run the contract tests for each application which relies on the schemas.
    You'll get immediate feedback about whether publishing applications generate content items compatible with the new schema.
 1. once the tests pass, someone will merge your pull request and the new schemas will be available to use
 1. Deploy your changes (see [`docs/deployment.md`](deployment.md) for details).

--- a/docs/content_schemas/contract-testing-against-schemas.md
+++ b/docs/content_schemas/contract-testing-against-schemas.md
@@ -1,18 +1,18 @@
 # Contract Testing against Schemas
 
-When changes are made to govuk-content-schemas, the test suite of each of the [dependent apps](https://github.com/alphagov/govuk-content-schemas/blob/aad248a867e878a496dcb488a4ba2170cebdb86b/Jenkinsfile#L7-L38) is run against that branch, to ensure that any changes are compatible.
+When changes are made to the schemas, the test suite of each of the [dependent apps](https://github.com/alphagov/publishing-api/blob/3fe9ae3b29b42bf6b9b5dcb8e71365a3a2d509d7/.github/workflows/test-content-schemas-1.yml#L17-L113) is run against that branch, to ensure that any changes are compatible.
 
 This method of contract testing is different to our usual [Pact tests](https://docs.publishing.service.gov.uk/manual/pact-broker.html).
 
 ## Background
 
-govuk-content-schemas contract testing was proposed in [RFC 4](https://gov-uk.atlassian.net/wiki/display/WH/RFC+4+%3A+Enabling+the+independent+iteration+of+formats+on+government-frontend) and described in the GOV.UK blog post "[Validating a distributed architecture with JSON Schema](https://gdstechnology.blog.gov.uk/2015/01/07/validating-a-distributed-architecture-with-json-schema/)".
+Contract testing (against what was at the time the "govuk-content-schemas" repo, which has since been merged into Publishing API) was proposed in [RFC 4](https://gov-uk.atlassian.net/wiki/display/WH/RFC+4+%3A+Enabling+the+independent+iteration+of+formats+on+government-frontend) and described in the GOV.UK blog post "[Validating a distributed architecture with JSON Schema](https://gdstechnology.blog.gov.uk/2015/01/07/validating-a-distributed-architecture-with-json-schema/)".
 
 We wanted to be able to evolve our publishing systems and have confidence that the changes we make will not break something. We could do this by running all the systems at the same time and testing end-to-end, but setting up such a configuration would be tricky, and keeping it working reliably in a reproducible way which avoids test interference would be very difficult.
 
 The idea of contract testing is to gain more confidence that the whole system works together properly, but without needing to run all the services at the same time. Instead we can test each service in isolation using a 'contract' which describes the expectations on each interacting service.
 
-## How govuk-content-schemas contract testing works
+## How schemas contract testing works
 
 Publishing involves three systems and two representations:
 
@@ -28,21 +28,21 @@ This comprises three things:
 
 1. json-schema files which define the *publishing representation* for a given format
 2. a curated set of frontend examples of that format, which are validated against the schemas
-3. [a mechanism to convert from the 'publisher' schemas to the 'frontend' schemas](https://github.com/alphagov/govuk-content-schemas/blob/main/lib/schema_generator/frontend_schema_generator.rb), simulating the behaviour of the content store
+3. [a mechanism to convert from the 'publisher' schemas to the 'frontend' schemas](../lib/schema_generator/frontend_schema_generator.rb), simulating the behaviour of the content store
 
 With those three parts we are able to verify the examples against the schemas.
 
 This means that if the frontend works ok with the curated examples, and if the publishing tool produces output which matches the schema, then we can be quite confident that the frontends will work with the data produced by the publishing tool.
 
-## Adding govuk-content-schemas contract tests to your app
+## Adding schema contract tests to your app
 
 You will need to provide tests in your app which are part of the full test suite, but can also be run separately from the other tests (unless your test suite is really fast and likely to stay fast). What you need to do differs depending upon the type of app.
 
 ### Frontend apps
 
-You should include tests which use the examples from the govuk-content-schemas to test whether your frontend works or not. [govuk_schemas](https://github.com/alphagov/govuk_schemas) provides code for doing this.
+You should include tests which use the examples from the schemas to test whether your frontend works or not. [govuk_schemas](https://github.com/alphagov/govuk_schemas) provides code for doing this.
 
-Ideally you should have a test which checks your app against every example for the formats it supports dynamically - so that examples added later are still tested in your app - there is an example in the [govuk_schemas](https://github.com/alphagov/govuk_schemas) README.
+Ideally you should have a test which checks your app against every example for the formats it supports dynamically - so that examples added later are still tested in your app.
 
 ### Publishing apps
 

--- a/docs/link-expansion.md
+++ b/docs/link-expansion.md
@@ -312,8 +312,7 @@ By default links contain the following fields:
   allowed by the schema
 - `locale` - The language this document is written in
 - `public_updated_at` - The date/time that this document  was last changed
-- `schema_name` - The [GOV.UK content schema][govuk-content-schema] that this
-  edition conforms to
+- `schema_name` - The schema (in `content_schemas`) that this edition conforms to
 - `title` - The title of the edition
 - `links` - Any [recursive links](#recursive-links) that are presented with a
   link representation of an edition
@@ -391,7 +390,6 @@ information.
 [content-store]: https://github.com/alphagov/content-store
 [downstream-draft-worker]: ../app/workers/downstream_draft_worker.rb
 [downstream-live-worker]: ../app/workers/downstream_live_worker.rb
-[govuk-content-schema]: https://github.com/alphagov/govuk-content-schemas
 [link-expansion]: ../lib/link_expansion.rb
 [link-expansion-rules]: ../lib/expansion_rules/link_expansion.rb
 [link-graph]: ../app/models/link_graph.rb

--- a/docs/publishing-application-examples.md
+++ b/docs/publishing-application-examples.md
@@ -98,7 +98,7 @@ the primary identifier for content in the Publishing API and content store.
 The convention is to use `SecureRandom.uuid` to generate a valid content_id.
 
 Details of how the payload should be constructed including required fields can
-be found in [govuk-content-schemas][govuk-content-schemas] where each format is
+be found in the content_schemas folder where each format is
 defined for both publishing and frontend applications. For example the payload
 for a [case study][case-study-schema] would need to provide `body` and
 `first_public_at` attributes along with other mandatory attributes such as
@@ -255,8 +255,7 @@ Is there anything wrong with the documentation? If so:
 
 [gds-sso-integration]: https://github.com/alphagov/gds-sso#integration-with-a-rails-3-app
 [publishing-api-gds-api-adapters]: https://github.com/alphagov/gds-api-adapters/blob/master/lib/gds_api/publishing_api_v2.rb
-[case-study-schema]: https://github.com/alphagov/govuk-content-schemas/blob/master/dist/formats/case_study/publisher_v2/schema.json
-[govuk-content-schemas]: https://github.com/alphagov/govuk-content-schemas
+[case-study-schema]: https://github.com/alphagov/publishing-api/blob/main/content_schemas/dist/formats/case_study/publisher_v2/schema.json
 [govuk-puppet]: https://github.com/alphagov/govuk-puppet
 [govuk-puppet-token-example]: https://github.com/alphagov/govuk-puppet/pull/6978
 [govuk-secrets]: https://github.com/alphagov/govuk-secrets

--- a/lib/expansion_rules.rb
+++ b/lib/expansion_rules.rb
@@ -70,8 +70,7 @@ module_function
     ministerial: :ministers,
   }.freeze
 
-  # These fields are required by the frontend_links definition in the
-  # govuk-content-schemas
+  # These fields are required by the frontend_links definition
   MANDATORY_FIELDS = %i[
     content_id
     title


### PR DESCRIPTION
This repo was archived in November 2022. The schemas have since been moved into Publishing API. These docs should be updated to reflect that.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
