### PR TITLE
Add API methods to get schema information

### DIFF
--- a/app/controllers/v2/schemas_controller.rb
+++ b/app/controllers/v2/schemas_controller.rb
@@ -1,0 +1,11 @@
+module V2
+  class SchemasController < ApplicationController
+    def index
+      render json: SchemaService.all_schemas
+    end
+
+    def show
+      render json: SchemaService.find_schema_by_name(params[:id])
+    end
+  end
+end

--- a/app/services/schema_service.rb
+++ b/app/services/schema_service.rb
@@ -5,4 +5,11 @@ class SchemaService
                         .select { |k| k.ends_with?("schema.json") }
                         .transform_keys { |k| format_regex.match(k)[1] }
   end
+
+  def self.find_schema_by_name(name)
+    GovukSchemas::Schema.find(publisher_schema: name)
+  rescue Errno::ENOENT
+    message = "Could not find publisher schema with name: #{name}"
+    raise CommandError.new(code: 404, message:)
+  end
 end

--- a/app/services/schema_service.rb
+++ b/app/services/schema_service.rb
@@ -1,0 +1,8 @@
+class SchemaService
+  def self.all_schemas
+    format_regex = Regexp.new(".+\/formats\/([a-z_]+)\/.+")
+    GovukSchemas::Schema.all(schema_type: "publisher")
+                        .select { |k| k.ends_with?("schema.json") }
+                        .transform_keys { |k| format_regex.match(k)[1] }
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,6 +36,8 @@ Rails.application.routes.draw do
       get "/linkables", to: "content_items#linkables"
 
       get "/links/changes", to: "link_changes#index"
+
+      resources :schemas, only: %i[index show]
     end
   end
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -24,6 +24,8 @@ message queue for other apps (e.g. `email-alert-service`) to consume.
 - [`GET /v2/links/changes`](#get-v2linkschanges)
 - [`GET /v2/editions`](#get-v2editions)
 - [`POST /v2/links/by-content-id`](#post-v2linksby-content-id)
+- [`GET /v2/schemas`](#get-v2schemas)
+- [`GET /v2/schemas/:schema_name`](#get-v2schemasschema_name)
 - [`POST /lookup-by-base-path`](#post-lookup-by-base-path)
 - [`PUT /paths/:base_path`](#put-pathsbase_path)
 - [`DELETE /paths/:base_path`](#delete-pathsbase_path)
@@ -630,6 +632,15 @@ mapping of `content_id` to `links` hash.
 
 - `content_ids[]` *(required)*
   - An array of `content_id`s to query by. This can be no longer than 1000 ids, or the API will return a 413 error.
+
+## `GET /v2/schemas`
+
+Lists all the schemas used by Publishing API. Returns an a mapping of a schema
+name to its JSON schema.
+
+## `GET /v2/schemas/:schema_name`
+
+Gets a schema by its name. Returns the relevant JSON schema if found, 404 if not.
 
 ## `POST /lookup-by-base-path`
 

--- a/spec/requests/schema_requests_spec.rb
+++ b/spec/requests/schema_requests_spec.rb
@@ -1,0 +1,56 @@
+RSpec.describe "Schema requests", type: :request do
+  describe "GET /v2/schemas" do
+    let(:schemas) do
+      {
+        "foo": { "some": "schema" },
+        "bar": { "another": "schema" },
+      }.with_indifferent_access
+    end
+
+    before do
+      allow(SchemaService).to receive(:all_schemas) { schemas }
+    end
+
+    it "returns all schemas" do
+      get "/v2/schemas"
+
+      expect(parsed_response).to eq(schemas)
+    end
+  end
+
+  describe "GET /v2/schemas/:schema_name" do
+    let(:schema) do
+      {
+        type: "other",
+        required: %w[b],
+        properties: {
+          b: { "type" => "string" },
+        },
+      }.with_indifferent_access
+    end
+
+    describe "when a schema exists" do
+      before do
+        allow(SchemaService).to receive(:find_schema_by_name).with("other") { schema }
+      end
+
+      it "returns a schema" do
+        get "/v2/schemas/other"
+
+        expect(parsed_response).to eq(schema)
+      end
+    end
+
+    describe "when a schema does not exist" do
+      before do
+        allow(GovukSchemas::Schema).to receive(:find).and_raise(CommandError.new(code: 404, message: "some message"))
+      end
+
+      it "returns 404" do
+        get "/v2/schemas/other"
+
+        expect(response.status).to eql 404
+      end
+    end
+  end
+end

--- a/spec/services/schema_service_spec.rb
+++ b/spec/services/schema_service_spec.rb
@@ -1,0 +1,42 @@
+RSpec.describe SchemaService do
+  describe "#all_schemas" do
+    let(:schemas) do
+      {
+        "/govuk/publishing-api/content_schemas/dist/formats/foo/publisher_v2/schema.json": {
+          type: "object",
+          required: %w[a],
+          properties: {
+            a: { "type" => "integer" },
+          },
+        },
+        "/govuk/publishing-api/content_schemas/dist/formats/bar/publisher_v2/links.json": {
+          type: "object",
+          required: %w[a],
+          properties: {
+            a: { "type" => "integer" },
+          },
+        },
+        "/govuk/publishing-api/content_schemas/dist/formats/baz/publisher_v2/schema.json": {
+          type: "object",
+          required: %w[a],
+          properties: {
+            a: { "type" => "integer" },
+          },
+        },
+      }.with_indifferent_access
+    end
+
+    before do
+      allow(GovukSchemas::Schema).to receive(:all).with(schema_type: "publisher") { schemas }
+    end
+
+    it "returns all schemas" do
+      expected_schemas = {
+        "foo": schemas[:"/govuk/publishing-api/content_schemas/dist/formats/foo/publisher_v2/schema.json"],
+        "baz": schemas[:"/govuk/publishing-api/content_schemas/dist/formats/baz/publisher_v2/schema.json"],
+      }.with_indifferent_access
+
+      expect(SchemaService.all_schemas).to eq(expected_schemas)
+    end
+  end
+end

--- a/spec/services/schema_service_spec.rb
+++ b/spec/services/schema_service_spec.rb
@@ -39,4 +39,38 @@ RSpec.describe SchemaService do
       expect(SchemaService.all_schemas).to eq(expected_schemas)
     end
   end
+
+  describe "find_schema_by_name" do
+    let(:schema) do
+      {
+        type: "other",
+        required: %w[b],
+        properties: {
+          b: { "type" => "string" },
+        },
+      }.with_indifferent_access
+    end
+
+    describe "when a schema exists" do
+      before do
+        allow(GovukSchemas::Schema).to receive(:find).with(publisher_schema: "other") { schema }
+      end
+
+      it "returns a schema" do
+        expect(SchemaService.find_schema_by_name("other")).to eq(schema)
+      end
+    end
+
+    describe "when a schema does not exist" do
+      before do
+        allow(GovukSchemas::Schema).to receive(:find).with(publisher_schema: "any").and_raise(Errno::ENOENT)
+      end
+
+      it "throws an error" do
+        expect { SchemaService.find_schema_by_name("any") }.to raise_error(
+          an_instance_of(CommandError).and(having_attributes(code: 404, message: "Could not find publisher schema with name: any")),
+        )
+      end
+    end
+  end
 end


### PR DESCRIPTION
This adds some API methods to return information about the schemas that Publishing API knows about, as well as fetching a schema by name. This allows us to get up to date schema information without having to have a local copy of the schemas stored somewhere and using the [GOV.UK Schemas](https://github.com/alphagov/govuk_schemas/) gem.

This will allow the content modelling team to have a way to create many different types of reusable content using the Publishing API as a single source of truth for the schema, rather than having to keep fields, validation rules etc in two places.

Happy to chat through in more detail if anyone needs any more context / has any questions!