### PR TITLE
Add pact tests for new Schema endpoints

### DIFF
--- a/spec/service_consumers/pact_helper.rb
+++ b/spec/service_consumers/pact_helper.rb
@@ -56,6 +56,32 @@ Pact.provider_states_for "GDS API Adapters" do
     end
   end
 
+  provider_state "there are publisher schemas" do
+    set_up do
+      schemas = {
+        "/govuk/publishing-api/content_schemas/dist/formats/email_address/publisher_v2/schema.json": {
+          type: "object",
+          required: %w[a],
+          properties: {
+            email_address: { "some" => "schema" },
+          },
+        },
+        "/govuk/publishing-api/content_schemas/dist/formats/tax_license/publisher_v2/schema.json": {
+          type: "object",
+          required: %w[a],
+          properties: {
+            tax_license: { "another" => "schema" },
+          },
+        },
+      }
+
+      allow(GovukSchemas::Schema)
+        .to receive(:all)
+        .with(schema_type: "publisher")
+        .and_return(schemas)
+    end
+  end
+
   provider_state "no content exists" do
     set_up do
       stub_request(:put, Regexp.new("\\A#{Regexp.escape(Plek.find('content-store'))}/content"))

--- a/spec/service_consumers/pact_helper.rb
+++ b/spec/service_consumers/pact_helper.rb
@@ -101,6 +101,15 @@ Pact.provider_states_for "GDS API Adapters" do
     end
   end
 
+  provider_state "there is not a schema for an email_address" do
+    set_up do
+      allow(GovukSchemas::Schema)
+        .to receive(:find)
+        .with(publisher_schema: "email_address")
+        .and_raise(Errno::ENOENT)
+    end
+  end
+
   provider_state "no content exists" do
     set_up do
       stub_request(:put, Regexp.new("\\A#{Regexp.escape(Plek.find('content-store'))}/content"))

--- a/spec/service_consumers/pact_helper.rb
+++ b/spec/service_consumers/pact_helper.rb
@@ -82,6 +82,25 @@ Pact.provider_states_for "GDS API Adapters" do
     end
   end
 
+  provider_state "there is a schema for an email_address" do
+    set_up do
+      email_address_schema = {
+        "/govuk/publishing-api/content_schemas/dist/formats/email_address/publisher_v2/schema.json": {
+          type: "object",
+          required: %w[a],
+          properties: {
+            email_address: { "some" => "schema" },
+          },
+        },
+      }
+
+      allow(GovukSchemas::Schema)
+        .to receive(:find)
+        .with(publisher_schema: "email_address")
+        .and_return(email_address_schema)
+    end
+  end
+
   provider_state "no content exists" do
     set_up do
       stub_request(:put, Regexp.new("\\A#{Regexp.escape(Plek.find('content-store'))}/content"))


### PR DESCRIPTION
## Changes in this PR

* [We've recently added new Schema endpoints](https://github.com/alphagov/publishing-api/pull/2767) for listing and getting individual schemas
* We now want to add [helpers into the GDS API Adapters](https://github.com/alphagov/gds-api-adapters/pull/1275) to support this and so have to come back to add Pact tests here