### PR TITLE
Don't pin Ruby patch version for the base image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG ruby_version=3.3.1
+ARG ruby_version=3.3
 ARG base_image=ghcr.io/alphagov/govuk-ruby-base:$ruby_version
 ARG builder_image=ghcr.io/alphagov/govuk-ruby-builder:$ruby_version
 


### PR DESCRIPTION
We want the most recent patch version to be the default.

This is a bulk change consisting of 5 PRs in different repos and will be globally approved. There is no need to review individually.