### PR TITLE
Add Content Block Email Address content type

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -75,8 +75,8 @@ GEM
       minitest (>= 5.1)
       mutex_m
       tzinfo (~> 2.0)
-    addressable (2.8.6)
-      public_suffix (>= 2.0.2, < 6.0)
+    addressable (2.8.7)
+      public_suffix (>= 2.0.2, < 7.0)
     amq-protocol (2.3.2)
     ast (2.4.2)
     awesome_print (1.9.2)
@@ -150,6 +150,8 @@ GEM
     factory_bot_rails (6.4.3)
       factory_bot (~> 6.4)
       railties (>= 5.0.0)
+    faker (3.4.1)
+      i18n (>= 1.8.11, < 2)
     faraday (2.9.0)
       faraday-net_http (>= 2.0, < 3.2)
     faraday-net_http (3.1.0)
@@ -215,7 +217,8 @@ GEM
       rouge
       sprockets (>= 3)
       sprockets-rails
-    govuk_schemas (5.0.2)
+    govuk_schemas (5.0.4)
+      faker (~> 3.4.1)
       json-schema (>= 2.8, < 4.4)
     govuk_sidekiq (8.0.1)
       gds-api-adapters (>= 19.1.0)
@@ -569,7 +572,7 @@ GEM
       webrick
     psych (5.1.2)
       stringio
-    public_suffix (5.0.5)
+    public_suffix (6.0.0)
     puma (6.4.2)
       nio4r (~> 2.0)
     racc (1.8.0)

--- a/content_schemas/allowed_document_types.yml
+++ b/content_schemas/allowed_document_types.yml
@@ -22,6 +22,7 @@
 - closed_call_for_evidence
 - closed_consultation
 - cma_case
+- content_block_email_address
 - complaints_procedure
 - completed_transaction
 - consultation

--- a/content_schemas/dist/formats/content_block_email_address/notification/schema.json
+++ b/content_schemas/dist/formats/content_block_email_address/notification/schema.json
@@ -2,17 +2,29 @@
   "$schema": "http://json-schema.org/draft-04/schema#",
   "type": "object",
   "required": [
+    "analytics_identifier",
     "base_path",
     "content_id",
     "description",
     "details",
     "document_type",
+    "email_document_supertype",
+    "expanded_links",
+    "first_published_at",
+    "government_document_supertype",
+    "govuk_request_id",
     "links",
     "locale",
+    "payload_version",
+    "phase",
     "public_updated_at",
+    "publishing_app",
+    "redirects",
+    "rendering_app",
+    "routes",
     "schema_name",
     "title",
-    "updated_at"
+    "update_type"
   ],
   "additionalProperties": false,
   "properties": {
@@ -20,10 +32,22 @@
       "$ref": "#/definitions/analytics_identifier"
     },
     "base_path": {
-      "$ref": "#/definitions/absolute_path"
+      "type": "null"
     },
     "content_id": {
       "$ref": "#/definitions/guid"
+    },
+    "content_purpose_document_supertype": {
+      "description": "DEPRECATED. Use `content_purpose_subgroup`.",
+      "type": "string"
+    },
+    "content_purpose_subgroup": {
+      "description": "Document subgroup grouping documents by purpose. Narrows down the purpose defined in content_purpose_supergroup.",
+      "type": "string"
+    },
+    "content_purpose_supergroup": {
+      "description": "Document supergroup grouping documents by a purpose",
+      "type": "string"
     },
     "description": {
       "$ref": "#/definitions/description_optional"
@@ -34,199 +58,14 @@
     "document_type": {
       "type": "string",
       "enum": [
-        "aaib_report",
-        "about",
-        "about_our_services",
-        "accessible_documents_policy",
-        "access_and_opening",
-        "ai_assurance_portfolio_technique",
-        "algorithmic_transparency_record",
-        "ambassador_role",
-        "animal_disease_case",
-        "answer",
-        "asylum_support_decision",
-        "authored_article",
-        "board_member_role",
-        "business_finance_support_scheme",
-        "calendar",
-        "call_for_evidence",
-        "call_for_evidence_outcome",
-        "case_study",
-        "chief_professional_officer_role",
-        "chief_scientific_officer_role",
-        "chief_scientific_advisor_role",
-        "closed_call_for_evidence",
-        "closed_consultation",
-        "cma_case",
-        "content_block_email_address",
-        "complaints_procedure",
-        "completed_transaction",
-        "consultation",
-        "consultation_outcome",
-        "contact",
-        "coronavirus_landing_page",
-        "corporate_report",
-        "correspondence",
-        "countryside_stewardship_grant",
-        "decision",
-        "deputy_head_of_mission_role",
-        "detailed_guide",
-        "document_collection",
-        "drcf_digital_markets_research",
-        "drug_safety_update",
-        "email_alert_signup",
-        "embassies_index",
-        "employment_appeal_tribunal_decision",
-        "employment_tribunal_decision",
-        "equality_and_diversity",
-        "esi_fund",
-        "export_health_certificate",
-        "external_content",
-        "facet",
-        "farming_grant",
-        "fatality_notice",
-        "field_of_operation",
-        "fields_of_operation",
-        "finder",
-        "finder_email_signup",
-        "flood_and_coastal_erosion_risk_management_research_report",
-        "foi_release",
-        "form",
-        "get_involved",
-        "gone",
-        "government",
-        "government_response",
-        "governor_role",
-        "guidance",
-        "guide",
-        "help_page",
-        "high_commissioner_role",
-        "historic_appointment",
-        "historic_appointments",
-        "history",
-        "hmrc_manual",
-        "hmrc_manual_section",
-        "homepage",
-        "how_government_works",
-        "html_publication",
-        "impact_assessment",
-        "independent_report",
-        "international_development_fund",
-        "international_treaty",
-        "licence",
-        "license_finder",
-        "licence_transaction",
-        "link_collection",
-        "local_transaction",
-        "maib_report",
-        "mainstream_browse_page",
-        "marine_equipment_approved_recommendation",
-        "manual",
-        "manual_section",
-        "map",
-        "marine_notice",
-        "media_enquiries",
-        "medical_safety_alert",
-        "membership",
-        "military_role",
-        "ministerial_role",
-        "ministers_index",
-        "modern_slavery_statement",
-        "national",
-        "national_statistics",
-        "national_statistics_announcement",
-        "need",
-        "news_story",
-        "notice",
-        "official",
-        "official_statistics",
-        "official_statistics_announcement",
-        "open_call_for_evidence",
-        "open_consultation",
-        "oral_statement",
-        "organisation",
-        "our_energy_use",
-        "our_governance",
-        "person",
-        "personal_information_charter",
-        "petitions_and_campaigns",
-        "place",
-        "policy_paper",
-        "press_release",
-        "procurement",
-        "product_safety_alert_report_recall",
-        "promotional",
-        "protected_food_drink_name",
-        "publication_scheme",
-        "raib_report",
-        "recruitment",
-        "redirect",
-        "regulation",
-        "research",
-        "research_for_development_output",
-        "residential_property_tribunal_decision",
-        "role_appointment",
-        "search",
-        "service_manual_guide",
-        "service_manual_homepage",
-        "service_manual_service_standard",
-        "service_manual_service_toolkit",
-        "service_manual_topic",
-        "service_sign_in",
-        "service_standard_report",
-        "services_and_information",
-        "simple_smart_answer",
-        "smart_answer",
-        "social_media_use",
-        "special_representative_role",
-        "special_route",
-        "speech",
-        "staff_update",
-        "standard",
-        "statistical_data_set",
-        "statistics",
-        "statistics_announcement",
-        "statutory_guidance",
-        "statutory_instrument",
-        "step_by_step_nav",
-        "substitute",
-        "take_part",
-        "tax_tribunal_decision",
-        "taxon",
-        "terms_of_reference",
-        "topical_event",
-        "topical_event_about_page",
-        "traffic_commissioner_regulatory_decision",
-        "traffic_commissioner_role",
-        "transaction",
-        "transparency",
-        "travel_advice",
-        "travel_advice_index",
-        "utaac_decision",
-        "vanish",
-        "welsh_language_scheme",
-        "working_group",
-        "world_index",
-        "world_location",
-        "world_location_news",
-        "world_news_story",
-        "worldwide_office_staff_role",
-        "worldwide_office",
-        "worldwide_organisation",
-        "written_statement"
+        "content_block_email_address"
       ]
     },
-    "first_published_at": {
-      "anyOf": [
-        {
-          "$ref": "#/definitions/first_published_at"
-        },
-        {
-          "type": "null"
-        }
-      ]
+    "email_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
     },
-    "links": {
+    "expanded_links": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
@@ -330,14 +169,91 @@
         }
       }
     },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "government_document_supertype": {
+      "description": "Document supertype grouping intended to power the Whitehall finders and email subscriptions",
+      "type": "string"
+    },
+    "govuk_request_id": {
+      "$ref": "#/definitions/govuk_request_id"
+    },
+    "links": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "finder": {
+          "description": "Powers links from content back to finders the content is surfaced on",
+          "$ref": "#/definitions/guid_list"
+        },
+        "lead_organisations": {
+          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "mainstream_browse_pages": {
+          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "meets_user_needs": {
+          "description": "The user needs this piece of content meets.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "parent": {
+          "description": "The parent content item.",
+          "$ref": "#/definitions/guid_list",
+          "maxItems": 1
+        },
+        "policy_areas": {
+          "description": "A largely deprecated tag currently only used to power email alerts.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "primary_publishing_organisation": {
+          "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/guid_list",
+          "maxItems": 1
+        },
+        "suggested_ordered_related_items": {
+          "description": "Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
+          "$ref": "#/definitions/guid_list"
+        }
+      }
+    },
     "locale": {
       "$ref": "#/definitions/locale"
+    },
+    "navigation_document_supertype": {
+      "description": "Document type grouping powering the new taxonomy-based navigation pages",
+      "type": "string"
     },
     "need_ids": {
       "type": "array",
       "items": {
         "type": "string"
       }
+    },
+    "payload_version": {
+      "$ref": "#/definitions/payload_version"
     },
     "phase": {
       "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
@@ -349,14 +265,7 @@
       ]
     },
     "public_updated_at": {
-      "anyOf": [
-        {
-          "$ref": "#/definitions/public_updated_at"
-        },
-        {
-          "type": "null"
-        }
-      ]
+      "$ref": "#/definitions/public_updated_at"
     },
     "publishing_app": {
       "$ref": "#/definitions/publishing_app_name"
@@ -364,41 +273,42 @@
     "publishing_request_id": {
       "$ref": "#/definitions/publishing_request_id"
     },
-    "publishing_scheduled_at": {
-      "anyOf": [
-        {
-          "$ref": "#/definitions/publishing_scheduled_at"
-        },
-        {
-          "type": "null"
-        }
-      ]
+    "redirects": {
+      "type": "array",
+      "additionalItems": false,
+      "items": {}
     },
     "rendering_app": {
-      "$ref": "#/definitions/rendering_app"
+      "type": "null"
     },
-    "scheduled_publishing_delay_seconds": {
-      "anyOf": [
-        {
-          "$ref": "#/definitions/scheduled_publishing_delay_seconds"
-        },
-        {
-          "type": "null"
-        }
-      ]
+    "routes": {
+      "type": "array",
+      "additionalItems": false,
+      "items": {}
     },
     "schema_name": {
       "type": "string",
       "enum": [
-        "generic"
+        "content_block_email_address"
       ]
+    },
+    "search_user_need_document_supertype": {
+      "description": "Document supertype grouping core and government documents",
+      "type": "string"
     },
     "title": {
       "$ref": "#/definitions/title"
     },
-    "updated_at": {
-      "type": "string",
-      "format": "date-time"
+    "update_type": {
+      "$ref": "#/definitions/update_type"
+    },
+    "user_journey_document_supertype": {
+      "description": "Document type grouping powering analytics of user journeys",
+      "type": "string"
+    },
+    "user_need_document_supertype": {
+      "description": "DEPRECATED. Use `content_purpose_document_supertype`.",
+      "type": "string"
     },
     "withdrawn_notice": {
       "$ref": "#/definitions/withdrawn_notice"
@@ -457,10 +367,17 @@
     },
     "details": {
       "type": "object",
+      "required": [
+        "email_address"
+      ],
       "additionalProperties": false,
       "properties": {
         "change_history": {
           "$ref": "#/definitions/change_history"
+        },
+        "email_address": {
+          "type": "string",
+          "format": "email"
         }
       }
     },
@@ -602,9 +519,22 @@
         }
       }
     },
+    "govuk_request_id": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
     "guid": {
       "type": "string",
       "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
     },
     "locale": {
       "type": "string",
@@ -677,6 +607,10 @@
         "zh-tw"
       ]
     },
+    "payload_version": {
+      "description": "Counter to indicate when the payload was generated",
+      "type": "integer"
+    },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
       "type": "string",
@@ -730,44 +664,15 @@
         }
       ]
     },
-    "publishing_scheduled_at": {
-      "description": "When this content was last scheduled for publishing. Determined by the publishing intent sent by the publishing API.",
-      "type": "string",
-      "format": "date-time"
-    },
-    "rendering_app": {
-      "description": "The application that renders this item.",
-      "type": "string",
-      "enum": [
-        "account-api",
-        "calculators",
-        "calendars",
-        "collections",
-        "content-store",
-        "email-alert-frontend",
-        "email-campaign-frontend",
-        "feedback",
-        "finder-frontend",
-        "frontend",
-        "government-frontend",
-        "info-frontend",
-        "performanceplatform-big-screen-view",
-        "rummager",
-        "search-api",
-        "smartanswers",
-        "spotlight",
-        "static",
-        "tariff",
-        "whitehall-admin",
-        "whitehall-frontend"
-      ]
-    },
-    "scheduled_publishing_delay_seconds": {
-      "description": "The delay between the most recent scheduled and actual publishing times. Determined by the content store based on the publishing intent.",
-      "type": "integer"
-    },
     "title": {
       "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
     },
     "withdrawn_notice": {
       "type": "object",

--- a/content_schemas/dist/formats/content_block_email_address/publisher_v2/links.json
+++ b/content_schemas/dist/formats/content_block_email_address/publisher_v2/links.json
@@ -1,0 +1,86 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "bulk_publishing": {
+      "type": "boolean"
+    },
+    "links": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "finder": {
+          "description": "Powers links from content back to finders the content is surfaced on",
+          "$ref": "#/definitions/guid_list"
+        },
+        "lead_organisations": {
+          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "mainstream_browse_pages": {
+          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "meets_user_needs": {
+          "description": "The user needs this piece of content meets.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "parent": {
+          "description": "The parent content item.",
+          "$ref": "#/definitions/guid_list",
+          "maxItems": 1
+        },
+        "policy_areas": {
+          "description": "A largely deprecated tag currently only used to power email alerts.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "primary_publishing_organisation": {
+          "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/guid_list",
+          "maxItems": 1
+        },
+        "suggested_ordered_related_items": {
+          "description": "Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
+          "$ref": "#/definitions/guid_list"
+        }
+      }
+    },
+    "previous_version": {
+      "type": "string"
+    }
+  },
+  "definitions": {
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    }
+  }
+}

--- a/content_schemas/dist/formats/content_block_email_address/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/content_block_email_address/publisher_v2/schema.json
@@ -1,0 +1,316 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "required": [
+    "details",
+    "document_type",
+    "publishing_app",
+    "schema_name",
+    "title"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "auth_bypass_ids": {
+      "description": "A list of ids that will allow access to this item for non-authenticated users",
+      "$ref": "#/definitions/guid_list"
+    },
+    "base_path": {
+      "type": "null"
+    },
+    "bulk_publishing": {
+      "type": "boolean"
+    },
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "description": {
+      "$ref": "#/definitions/description_optional"
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "document_type": {
+      "type": "string",
+      "enum": [
+        "content_block_email_address"
+      ]
+    },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policy_areas": {
+          "description": "A largely deprecated tag currently only used to power email alerts.",
+          "$ref": "#/definitions/guid_list"
+        }
+      }
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "redirects": {
+      "type": "array",
+      "additionalItems": false,
+      "items": {}
+    },
+    "rendering_app": {
+      "type": "null"
+    },
+    "routes": {
+      "type": "array",
+      "additionalItems": false,
+      "items": {}
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "content_block_email_address"
+      ]
+    },
+    "title": {
+      "$ref": "#/definitions/title"
+    },
+    "update_type": {
+      "$ref": "#/definitions/update_type"
+    }
+  },
+  "definitions": {
+    "description": {
+      "type": "string"
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "auth_bypass_ids": {
+          "description": "Deprecated: auth_bypass_ids should be sent as a separate field",
+          "$ref": "#/definitions/guid_list"
+        },
+        "organisations": {
+          "description": "A list of organisation content ids permitted access to this item",
+          "$ref": "#/definitions/guid_list"
+        },
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "description_optional": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/description"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "details": {
+      "type": "object",
+      "required": [
+        "email_address"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "email_address": {
+          "type": "string",
+          "format": "email"
+        }
+      }
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "locale": {
+      "type": "string",
+      "enum": [
+        "ar",
+        "az",
+        "be",
+        "bg",
+        "bn",
+        "cs",
+        "cy",
+        "da",
+        "de",
+        "dr",
+        "el",
+        "en",
+        "es",
+        "es-419",
+        "et",
+        "fa",
+        "fi",
+        "fr",
+        "gd",
+        "gu",
+        "he",
+        "hi",
+        "hr",
+        "hu",
+        "hy",
+        "id",
+        "is",
+        "it",
+        "ja",
+        "ka",
+        "kk",
+        "ko",
+        "lt",
+        "lv",
+        "ms",
+        "mt",
+        "ne",
+        "nl",
+        "no",
+        "pa",
+        "pa-pk",
+        "pl",
+        "ps",
+        "pt",
+        "ro",
+        "ru",
+        "si",
+        "sk",
+        "sl",
+        "so",
+        "sq",
+        "sr",
+        "sv",
+        "sw",
+        "ta",
+        "th",
+        "tk",
+        "tr",
+        "uk",
+        "ur",
+        "uz",
+        "vi",
+        "yi",
+        "zh",
+        "zh-hk",
+        "zh-tw"
+      ]
+    },
+    "public_updated_at": {
+      "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "account-api",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-publisher",
+        "content-tagger",
+        "email-alert-frontend",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "government-frontend",
+        "hmrc-manuals-api",
+        "local-links-manager",
+        "manuals-publisher",
+        "maslow",
+        "performanceplatform-big-screen-view",
+        "publisher",
+        "rummager",
+        "search-admin",
+        "search-api",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "special-route-publisher",
+        "specialist-publisher",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "title": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    }
+  }
+}

--- a/content_schemas/dist/formats/generic/notification/schema.json
+++ b/content_schemas/dist/formats/generic/notification/schema.json
@@ -82,6 +82,7 @@
         "closed_call_for_evidence",
         "closed_consultation",
         "cma_case",
+        "content_block_email_address",
         "complaints_procedure",
         "completed_transaction",
         "consultation",

--- a/content_schemas/dist/formats/generic/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/generic/publisher_v2/schema.json
@@ -68,6 +68,7 @@
         "closed_call_for_evidence",
         "closed_consultation",
         "cma_case",
+        "content_block_email_address",
         "complaints_procedure",
         "completed_transaction",
         "consultation",

--- a/content_schemas/dist/formats/generic_with_external_related_links/frontend/schema.json
+++ b/content_schemas/dist/formats/generic_with_external_related_links/frontend/schema.json
@@ -58,6 +58,7 @@
         "closed_call_for_evidence",
         "closed_consultation",
         "cma_case",
+        "content_block_email_address",
         "complaints_procedure",
         "completed_transaction",
         "consultation",

--- a/content_schemas/dist/formats/generic_with_external_related_links/notification/schema.json
+++ b/content_schemas/dist/formats/generic_with_external_related_links/notification/schema.json
@@ -82,6 +82,7 @@
         "closed_call_for_evidence",
         "closed_consultation",
         "cma_case",
+        "content_block_email_address",
         "complaints_procedure",
         "completed_transaction",
         "consultation",

--- a/content_schemas/dist/formats/generic_with_external_related_links/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/generic_with_external_related_links/publisher_v2/schema.json
@@ -68,6 +68,7 @@
         "closed_call_for_evidence",
         "closed_consultation",
         "cma_case",
+        "content_block_email_address",
         "complaints_procedure",
         "completed_transaction",
         "consultation",

--- a/content_schemas/examples/content_block_email_address/publisher_v2/example.json
+++ b/content_schemas/examples/content_block_email_address/publisher_v2/example.json
@@ -1,0 +1,11 @@
+{
+  "locale": "en",
+  "schema_name": "content_block_email_address",
+  "document_type": "content_block_email_address",
+  "title": "Government Digital Service - General contact",
+  "description": "General contact email address for Government Digital Service",
+  "details": {
+    "email_address": "foo@example.com"
+  },
+  "publishing_app": "whitehall"
+}

--- a/content_schemas/formats/content_block_email_address.jsonnet
+++ b/content_schemas/formats/content_block_email_address.jsonnet
@@ -1,0 +1,19 @@
+(import "shared/default_format.jsonnet") + {
+  document_type: "content_block_email_address",
+  base_path: "forbidden",
+  routes: "forbidden",
+  rendering_app: "forbidden",
+  definitions: {
+    details: {
+      type: "object",
+      additionalProperties: false,
+      required: ["email_address"],
+      properties: {
+        email_address: {
+          type: "string",
+          format: "email",
+        },
+      },
+    },
+  },
+}


### PR DESCRIPTION
The Content Modelling Team are working on a spike to add the ability to publishing reusable pieces of content (“Content Blocks”) via Whitehall. The first content type we’re looking at is Email addresses, so we’re adding a simple content schema to cover this functionality.