### PR TITLE
Be explicit about using UTC

### DIFF
--- a/app/models/symbolize_json.rb
+++ b/app/models/symbolize_json.rb
@@ -20,7 +20,7 @@ module SymbolizeJSON
         new_hash[k.to_sym] = symbolize(v)
       end
     when ActiveSupport::TimeWithZone
-      value.iso8601
+      value.utc.iso8601
     else
       value
     end

--- a/app/presenters/edition_presenter.rb
+++ b/app/presenters/edition_presenter.rb
@@ -141,7 +141,7 @@ module Presenters
       unpublishing = edition.unpublishing
 
       if unpublishing && unpublishing.withdrawal?
-        withdrawn_at = (unpublishing.unpublished_at || unpublishing.created_at).iso8601
+        withdrawn_at = (unpublishing.unpublished_at || unpublishing.created_at).utc.iso8601
         {
           withdrawn_notice: {
             explanation: unpublishing.explanation,

--- a/app/presenters/gone_presenter.rb
+++ b/app/presenters/gone_presenter.rb
@@ -46,7 +46,7 @@ private
       base_path:,
       locale:,
       publishing_app:,
-      public_updated_at: public_updated_at&.iso8601,
+      public_updated_at: public_updated_at&.utc&.iso8601,
       details: {
         explanation:,
         alternative_path:,

--- a/app/presenters/redirect_presenter.rb
+++ b/app/presenters/redirect_presenter.rb
@@ -76,6 +76,6 @@ private
       public_updated_at:,
       first_published_at:,
     }.compact
-     .transform_values(&:iso8601)
+     .transform_values { |v| v.utc.iso8601 }
   end
 end

--- a/app/queries/get_expanded_links.rb
+++ b/app/queries/get_expanded_links.rb
@@ -59,7 +59,7 @@ module Queries
 
     def response(expanded_links, generated_date, version = nil)
       response = {
-        generated: generated_date.iso8601,
+        generated: generated_date.utc.iso8601,
         expanded_links:,
       }
       response[:version] = version if version

--- a/app/queries/get_link_changes.rb
+++ b/app/queries/get_link_changes.rb
@@ -23,7 +23,7 @@ module Queries
       end
 
       {
-        link_changes: results,
+        link_changes: SymbolizeJSON.symbolize(results),
       }
     end
 

--- a/app/queries/keyset_pagination.rb
+++ b/app/queries/keyset_pagination.rb
@@ -98,7 +98,9 @@ module Queries
     def key_for_record(record)
       key_fields.map do |k|
         value = record[k]
-        next value.iso8601(6) if value.respond_to?(:iso8601)
+        if value.is_a?(Time) || value.is_a?(Date)
+          next value.utc.iso8601(6)
+        end
 
         value.to_s
       end

--- a/lib/tasks/csv_report.rake
+++ b/lib/tasks/csv_report.rake
@@ -41,20 +41,22 @@ namespace :csv_report do
 
     csv << %w[published_at base_path content_id locale title document_type update_type first_publishing]
 
-    query = Edition.joins(:document)
-                   .where(published_at: from_time...until_time)
-                   .where.not(update_type: :republish)
-                   .order(published_at: :asc)
-                   .pluck(:published_at,
-                          :base_path,
-                          "documents.content_id",
-                          "documents.locale",
-                          :title,
-                          :document_type,
-                          :update_type,
-                          Arel.sql("(user_facing_version = 1)"))
+    Time.use_zone("UTC") do
+      query = Edition.joins(:document)
+                     .where(published_at: from_time...until_time)
+                     .where.not(update_type: :republish)
+                     .order(published_at: :asc)
+                     .pluck(:published_at,
+                            :base_path,
+                            "documents.content_id",
+                            "documents.locale",
+                            :title,
+                            :document_type,
+                            :update_type,
+                            Arel.sql("(user_facing_version = 1)"))
 
-    query.each { |row| csv << row }
+      query.each { |row| csv << row }
+    end
   end
 
   desc "Prints a CSV of all editions that were unpublished between the from and until timestamp"
@@ -68,18 +70,20 @@ namespace :csv_report do
 
     csv << %w[unpublished_at base_path content_id locale title document_type unpublishing_type]
 
-    query = Unpublishing.joins({ edition: :document })
-                        .where(created_at: from_time...until_time)
-                        .where.not(type: "substitute")
-                        .order(created_at: :asc)
-                        .pluck(:created_at,
-                               "editions.base_path",
-                               "documents.content_id",
-                               "documents.locale",
-                               "editions.title",
-                               "editions.document_type",
-                               :type)
+    Time.use_zone("UTC") do
+      query = Unpublishing.joins({ edition: :document })
+                          .where(created_at: from_time...until_time)
+                          .where.not(type: "substitute")
+                          .order(created_at: :asc)
+                          .pluck(:created_at,
+                                 "editions.base_path",
+                                 "documents.content_id",
+                                 "documents.locale",
+                                 "editions.title",
+                                 "editions.document_type",
+                                 :type)
 
-    query.each { |row| csv << row }
+      query.each { |row| csv << row }
+    end
   end
 end

--- a/spec/clients/content_store_writer_spec.rb
+++ b/spec/clients/content_store_writer_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe ContentStoreWriter do
 
   let(:publish_intent) do
     {
-      publish_time: Time.zone.now.iso8601,
+      publish_time: Time.now.utc.iso8601,
       publishing_app: "whitehall",
       rendering_app: "whitehall-frontend",
       routes: [

--- a/spec/clients/content_store_writer_spec.rb
+++ b/spec/clients/content_store_writer_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe ContentStoreWriter do
 
   let(:publish_intent) do
     {
-      publish_time: Time.now.utc.iso8601,
+      publish_time: Time.zone.now.utc.iso8601,
       publishing_app: "whitehall",
       rendering_app: "whitehall-frontend",
       routes: [

--- a/spec/commands/v2/put_content_spec.rb
+++ b/spec/commands/v2/put_content_spec.rb
@@ -156,13 +156,13 @@ RSpec.describe Commands::V2::PutContent do
     context "when the draft does not exist" do
       context "with a provided last_edited_at" do
         it "stores the provided timestamp" do
-          last_edited_at = 1.year.ago
+          last_edited_at = 1.year.ago.utc
 
           described_class.call(payload.merge(last_edited_at: last_edited_at.iso8601))
 
           edition = Edition.last
 
-          expect(edition.last_edited_at.iso8601).to eq(last_edited_at.iso8601)
+          expect(edition.last_edited_at.utc.iso8601).to eq(last_edited_at.iso8601)
         end
       end
 
@@ -172,7 +172,7 @@ RSpec.describe Commands::V2::PutContent do
 
           edition = Edition.last
 
-          expect(edition.last_edited_at.iso8601).to eq(Time.zone.now.iso8601)
+          expect(edition.last_edited_at.utc.iso8601).to eq(Time.now.utc.iso8601)
         end
       end
 
@@ -214,7 +214,7 @@ RSpec.describe Commands::V2::PutContent do
         %w[minor major republish].each do |update_type|
           context "with update_type of #{update_type}" do
             it "stores the provided timestamp" do
-              last_edited_at = 1.year.ago
+              last_edited_at = 1.year.ago.utc
 
               described_class.call(
                 payload.merge(
@@ -223,7 +223,7 @@ RSpec.describe Commands::V2::PutContent do
                 ),
               )
 
-              expect(edition.reload.last_edited_at.iso8601).to eq(last_edited_at.iso8601)
+              expect(edition.reload.last_edited_at.utc.iso8601).to eq(last_edited_at.iso8601)
             end
           end
         end
@@ -233,7 +233,7 @@ RSpec.describe Commands::V2::PutContent do
         Timecop.freeze do
           described_class.call(payload)
 
-          expect(edition.reload.last_edited_at.iso8601).to eq(Time.zone.now.iso8601)
+          expect(edition.reload.last_edited_at.utc.iso8601).to eq(Time.now.utc.iso8601)
         end
       end
 

--- a/spec/commands/v2/put_content_spec.rb
+++ b/spec/commands/v2/put_content_spec.rb
@@ -172,7 +172,7 @@ RSpec.describe Commands::V2::PutContent do
 
           edition = Edition.last
 
-          expect(edition.last_edited_at.utc.iso8601).to eq(Time.now.utc.iso8601)
+          expect(edition.last_edited_at.utc.iso8601).to eq(Time.zone.now.utc.iso8601)
         end
       end
 
@@ -233,7 +233,7 @@ RSpec.describe Commands::V2::PutContent do
         Timecop.freeze do
           described_class.call(payload)
 
-          expect(edition.reload.last_edited_at.utc.iso8601).to eq(Time.now.utc.iso8601)
+          expect(edition.reload.last_edited_at.utc.iso8601).to eq(Time.zone.now.utc.iso8601)
         end
       end
 

--- a/spec/factories/content_item_requests.rb
+++ b/spec/factories/content_item_requests.rb
@@ -6,7 +6,7 @@ FactoryBot.define do
     description { "Test description" }
     document_type { "answer" }
     schema_name { "answer" }
-    public_updated_at { Time.zone.now.iso8601 }
+    public_updated_at { Time.now.utc.iso8601 }
     publishing_app { "publisher" }
     rendering_app { "frontend" }
     locale { "en" }

--- a/spec/factories/content_item_requests.rb
+++ b/spec/factories/content_item_requests.rb
@@ -6,7 +6,7 @@ FactoryBot.define do
     description { "Test description" }
     document_type { "answer" }
     schema_name { "answer" }
-    public_updated_at { Time.now.utc.iso8601 }
+    public_updated_at { Time.zone.now.utc.iso8601 }
     publishing_app { "publisher" }
     rendering_app { "frontend" }
     locale { "en" }

--- a/spec/integration/put_content/content_with_a_previously_published_edition_spec.rb
+++ b/spec/integration/put_content/content_with_a_previously_published_edition_spec.rb
@@ -79,8 +79,8 @@ RSpec.describe "PUT /v2/content when creating a draft for a previously published
       put "/v2/content/#{content_id}", params: payload.to_json
 
       edition = Edition.last
-      expect(edition.major_published_at.iso8601)
-        .to eq(major_published_at.iso8601)
+      expect(edition.major_published_at.utc.iso8601)
+        .to eq(major_published_at.utc.iso8601)
     end
   end
 

--- a/spec/integration/put_content/content_with_a_previously_published_edition_spec.rb
+++ b/spec/integration/put_content/content_with_a_previously_published_edition_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe "PUT /v2/content when creating a draft for a previously published
       put "/v2/content/#{content_id}", params: payload.to_json
 
       edition = Edition.last
-      expect(edition.first_published_at.iso8601).to eq(new_first_published_at)
+      expect(edition.first_published_at.utc.iso8601).to eq(new_first_published_at)
     end
   end
 

--- a/spec/lib/data_hygiene/document_status_checker_spec.rb
+++ b/spec/lib/data_hygiene/document_status_checker_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe DataHygiene::DocumentStatusChecker do
       context "and there is an old content item" do
         let(:content_item) do
           content_item_for_base_path(base_path).merge(
-            "updated_at" => (edition.published_at - 1).iso8601,
+            "updated_at" => (edition.published_at - 1).utc.iso8601,
           )
         end
         before { stub_content_store_has_item(base_path, content_item) }
@@ -32,7 +32,7 @@ RSpec.describe DataHygiene::DocumentStatusChecker do
       context "and there is a recent content item" do
         let(:content_item) do
           content_item_for_base_path(base_path).merge(
-            "updated_at" => (edition.published_at + 1).iso8601,
+            "updated_at" => (edition.published_at + 1).utc.iso8601,
           )
         end
         before { stub_content_store_has_item(base_path, content_item) }

--- a/spec/models/change_note_spec.rb
+++ b/spec/models/change_note_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe ChangeNote do
 
       context "payload contains public_updated_at" do
         it "sets the change note public_timestamp to public_updated_at time" do
-          time = Time.zone.yesterday
+          time = Time.now.utc.yesterday
           payload[:public_updated_at] = time
           described_class.create_from_edition(payload, edition)
 

--- a/spec/models/change_note_spec.rb
+++ b/spec/models/change_note_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe ChangeNote do
 
       context "payload contains public_updated_at" do
         it "sets the change note public_timestamp to public_updated_at time" do
-          time = Time.now.utc.yesterday
+          time = Time.zone.now.utc.yesterday
           payload[:public_updated_at] = time
           described_class.create_from_edition(payload, edition)
 

--- a/spec/models/change_note_spec.rb
+++ b/spec/models/change_note_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe ChangeNote do
           expect { subject }.to change { ChangeNote.count }.by(1)
           result = ChangeNote.last
           expect(result.note).to eq "Excellent"
-          expect(result.public_timestamp.iso8601).to eq Time.zone.now.iso8601
+          expect(result.public_timestamp.utc.iso8601).to eq Time.zone.now.utc.iso8601
         end
       end
 

--- a/spec/models/symbolize_json_spec.rb
+++ b/spec/models/symbolize_json_spec.rb
@@ -10,6 +10,15 @@ RSpec.describe SymbolizeJSON do
     expect(subject.public_updated_at).to eq(Date.new(2000, 1, 1))
   end
 
+  it "emits times in different timezones as UTC" do
+    subject.public_updated_at = Time.utc(2000, 1, 1).in_time_zone("Eastern Time (US & Canada)")
+
+    subject.save!
+    subject.reload
+
+    expect(subject.public_updated_at).to eq(Time.utc(2000, 1, 1))
+  end
+
   context "json columns" do
     it "symbolizes hashes" do
       subject.details = { "foo" => "bar" }
@@ -55,5 +64,6 @@ RSpec.describe SymbolizeJSON do
       subject.reload
       expect(subject.details).to eq(nil)
     end
+
   end
 end

--- a/spec/models/symbolize_json_spec.rb
+++ b/spec/models/symbolize_json_spec.rb
@@ -64,6 +64,5 @@ RSpec.describe SymbolizeJSON do
       subject.reload
       expect(subject.details).to eq(nil)
     end
-
   end
 end

--- a/spec/presenters/edition_presenter_spec.rb
+++ b/spec/presenters/edition_presenter_spec.rb
@@ -178,7 +178,7 @@ RSpec.describe Presenters::EditionPresenter do
             expected.merge(
               withdrawn_notice: {
                 explanation: unpublishing.explanation,
-                withdrawn_at: unpublishing.created_at.iso8601,
+                withdrawn_at: unpublishing.created_at.utc.iso8601,
               },
             ),
           ),

--- a/spec/presenters/edition_presenter_spec.rb
+++ b/spec/presenters/edition_presenter_spec.rb
@@ -203,7 +203,7 @@ RSpec.describe Presenters::EditionPresenter do
               expected.merge(
                 withdrawn_notice: {
                   explanation: unpublishing.explanation,
-                  withdrawn_at: unpublishing.unpublished_at.iso8601,
+                  withdrawn_at: unpublishing.unpublished_at.utc.iso8601,
                 },
               ),
             ),

--- a/spec/presenters/gone_presenter_spec.rb
+++ b/spec/presenters/gone_presenter_spec.rb
@@ -11,6 +11,15 @@ RSpec.describe Presenters::GonePresenter do
       expect(subject).to be_valid_against_notification_schema("gone")
     end
 
+    context "with unpublished_at set" do
+      let(:unpublishing) { create(:unpublishing, unpublished_at: Time.utc(2000, 1, 1)) }
+      let(:edition) { unpublishing.edition }
+
+      it "presents public_updated_at as the unpublishings unpublished_at time in UTC" do
+        expect(subject[:public_updated_at]).to eql(unpublishing.unpublished_at.utc.iso8601)
+      end
+    end
+
     context "with a nil base_path" do
       let(:edition) { create(:gone_unpublished_edition, base_path: nil) }
 

--- a/spec/presenters/queries/content_item_presenter_spec.rb
+++ b/spec/presenters/queries/content_item_presenter_spec.rb
@@ -91,7 +91,7 @@ RSpec.describe Presenters::Queries::ContentItemPresenter do
               "type" => unpublishing.type,
               "explanation" => unpublishing.explanation,
               "alternative_path" => unpublishing.alternative_path,
-              "unpublished_at" => unpublishing.unpublished_at.rfc3339,
+              "unpublished_at" => unpublishing.unpublished_at.utc.rfc3339,
             ),
           )
       end

--- a/spec/presenters/redirect_presenter_spec.rb
+++ b/spec/presenters/redirect_presenter_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Presenters::RedirectPresenter do
       end
 
       it "includes the public updated at" do
-        expect(subject[:public_updated_at]).to eq(edition.unpublishing.created_at.iso8601)
+        expect(subject[:public_updated_at]).to eq(edition.unpublishing.created_at.utc.iso8601)
       end
     end
 
@@ -34,11 +34,11 @@ RSpec.describe Presenters::RedirectPresenter do
       end
 
       it "includes the first published at" do
-        expect(subject[:first_published_at]).to eq(edition.first_published_at.iso8601)
+        expect(subject[:first_published_at]).to eq(edition.first_published_at.utc.iso8601)
       end
 
       it "includes the public updated at" do
-        expect(subject[:public_updated_at]).to eq(edition.public_updated_at.iso8601)
+        expect(subject[:public_updated_at]).to eq(edition.public_updated_at.utc.iso8601)
       end
     end
   end

--- a/spec/queries/get_content_collection_spec.rb
+++ b/spec/queries/get_content_collection_spec.rb
@@ -604,10 +604,10 @@ RSpec.describe Queries::GetContentCollection do
 
   describe "result order" do
     before do
-      create(:edition, base_path: "/c4", title: "D", public_updated_at: "2014-06-14")
-      create(:edition, base_path: "/c1", title: "A", public_updated_at: "2014-06-13")
-      create(:edition, base_path: "/c3", title: "C", public_updated_at: "2014-06-17")
-      create(:edition, base_path: "/c2", title: "B", public_updated_at: "2014-06-15")
+      create(:edition, base_path: "/c4", title: "D", public_updated_at: Time.utc(2014, 06, 14))
+      create(:edition, base_path: "/c1", title: "A", public_updated_at: Time.utc(2014, 06, 13))
+      create(:edition, base_path: "/c3", title: "C", public_updated_at: Time.utc(2014, 06, 17))
+      create(:edition, base_path: "/c2", title: "B", public_updated_at: Time.utc(2014, 06, 15))
     end
 
     it "returns editions in default order" do

--- a/spec/queries/get_content_collection_spec.rb
+++ b/spec/queries/get_content_collection_spec.rb
@@ -604,10 +604,10 @@ RSpec.describe Queries::GetContentCollection do
 
   describe "result order" do
     before do
-      create(:edition, base_path: "/c4", title: "D", public_updated_at: Time.utc(2014, 06, 14))
-      create(:edition, base_path: "/c1", title: "A", public_updated_at: Time.utc(2014, 06, 13))
-      create(:edition, base_path: "/c3", title: "C", public_updated_at: Time.utc(2014, 06, 17))
-      create(:edition, base_path: "/c2", title: "B", public_updated_at: Time.utc(2014, 06, 15))
+      create(:edition, base_path: "/c4", title: "D", public_updated_at: Time.utc(2014, 6, 14))
+      create(:edition, base_path: "/c1", title: "A", public_updated_at: Time.utc(2014, 6, 13))
+      create(:edition, base_path: "/c3", title: "C", public_updated_at: Time.utc(2014, 6, 17))
+      create(:edition, base_path: "/c2", title: "B", public_updated_at: Time.utc(2014, 6, 15))
     end
 
     it "returns editions in default order" do

--- a/spec/queries/get_expanded_links_spec.rb
+++ b/spec/queries/get_expanded_links_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe Queries::GetExpandedLinks do
 
       it "returns the data from expanded links" do
         expect(result).to match(
-          generated: updated_at.iso8601,
+          generated: updated_at.utc.iso8601,
           expanded_links: expanded_links.as_json,
         )
       end

--- a/spec/queries/get_link_changes_spec.rb
+++ b/spec/queries/get_link_changes_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe Queries::GetLinkChanges do
   describe "#as_hash" do
     it "returns the link changes with the correct data" do
-      create(:link_change, link_type: "taxons")
+      link_change = create(:link_change, link_type: "taxons")
 
       result = Queries::GetLinkChanges.new(link_types: "taxons").as_hash
 
@@ -10,6 +10,7 @@ RSpec.describe Queries::GetLinkChanges do
       expect(change.keys).to match_array(
         %i[source target link_type change user_uid created_at],
       )
+      expect(change[:created_at]).to eql(link_change.created_at.utc.iso8601)
     end
 
     it "expands the source and target" do

--- a/spec/requests/publish_intent_requests_spec.rb
+++ b/spec/requests/publish_intent_requests_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe "Publish intent requests", type: :request do
   let(:content_item) do
     {
-      publish_time: (Time.now.utc + 3.hours).iso8601,
+      publish_time: (Time.zone.now.utc + 3.hours).iso8601,
       publishing_app: "publisher",
       rendering_app: "frontend",
       routers: [

--- a/spec/requests/publish_intent_requests_spec.rb
+++ b/spec/requests/publish_intent_requests_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe "Publish intent requests", type: :request do
   let(:content_item) do
     {
-      publish_time: (Time.zone.now + 3.hours).iso8601,
+      publish_time: (Time.now.utc + 3.hours).iso8601,
       publishing_app: "publisher",
       rendering_app: "frontend",
       routers: [

--- a/spec/requests/unpublishing_spec.rb
+++ b/spec/requests/unpublishing_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe "POST /v2/content/:content_id/unpublish", type: :request do
         content_item: a_hash_including(
           withdrawn_notice: {
             explanation: "Test withdrawal",
-            withdrawn_at: Time.now.utc.iso8601,
+            withdrawn_at: Time.zone.now.utc.iso8601,
           },
         ),
       }
@@ -107,7 +107,7 @@ RSpec.describe "POST /v2/content/:content_id/unpublish", type: :request do
           base_path:,
           locale: edition.locale,
           publishing_app: edition.publishing_app,
-          public_updated_at: Time.now.utc.iso8601,
+          public_updated_at: Time.zone.now.utc.iso8601,
           first_published_at: edition.first_published_at.utc.iso8601,
           redirects: [
             {

--- a/spec/requests/unpublishing_spec.rb
+++ b/spec/requests/unpublishing_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe "POST /v2/content/:content_id/unpublish", type: :request do
         content_item: a_hash_including(
           withdrawn_notice: {
             explanation: "Test withdrawal",
-            withdrawn_at: Time.zone.now.iso8601,
+            withdrawn_at: Time.now.utc.iso8601,
           },
         ),
       }
@@ -107,8 +107,8 @@ RSpec.describe "POST /v2/content/:content_id/unpublish", type: :request do
           base_path:,
           locale: edition.locale,
           publishing_app: edition.publishing_app,
-          public_updated_at: Time.zone.now.iso8601,
-          first_published_at: edition.first_published_at.iso8601,
+          public_updated_at: Time.now.utc.iso8601,
+          first_published_at: edition.first_published_at.utc.iso8601,
           redirects: [
             {
               path: base_path,


### PR DESCRIPTION
Draft PR, because the more I think about this the less confident I am that it's the right thing to do.

This PR makes publishing API be explicit about using UTC when its turning dates into strings.

This is to allow us to be consistent in the timezone in GOV.UK apps - they should all use London, and publishing-api should be consistent with that.

_However_, now that I've implemented this, I'm not sure it really does make sense for publishing-api to have a London timezone. Because it's not user facing, it's never got a reason to turn a time into a string in the user's timezone. And because it's an API, it usually wants to render times in UTC. If there's never a case where we want to render things in the London timezone, maybe it would be better for us to say "publishing apps and frontends (which have human users) should use London as the timezone, but API-only apps should use UTC". Otherwise there's a bit of a risk of getting it wrong (e.g. doing `datetime.iso8601` instead of `datetime.utc.iso8601`). 🤔  🤔  🤔 

If we do want to have some UTC apps and some London apps, it might be that https://github.com/alphagov/govuk_app_config/pull/381 is not such a good idea after all. We could introduce something like `config.govuk_time_zone = "UTC"` to allow apps to be explicit, but maybe we'd be better off without the weirdness in the gem and just setting London explicitly instead...

Discussion very welcome 😅 
