### PR TITLE
Override time_zone to be UTC in publishing-api

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -119,5 +119,13 @@ module PublishingAPI
     )
 
     config.debug_exception_response_format = :api
+
+    # Even though most GOV.UK apps use the London time_zone, publishing-api almost always wants to
+    # present times in UTC, so we set that as the default time_zone
+    initializer "publishing_api.configure_timezone",
+                after: "govuk_app_config.configure_timezone",
+                before: "active_support.initialize_time_zone" do
+      config.time_zone = "UTC"
+    end
   end
 end


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
