### PR TITLE
Temporarily pin ruby version to 3.3.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-ARG ruby_version=3.3
+# TODO: unpin obsolete base image once https://github.com/alphagov/govuk-ruby-images/issues/96 is resolved
+ARG ruby_version=3.3.1
 ARG base_image=ghcr.io/alphagov/govuk-ruby-base:$ruby_version
 ARG builder_image=ghcr.io/alphagov/govuk-ruby-builder:$ruby_version
 


### PR DESCRIPTION
Deployments to integration are currently broken due to the `jsonnet` gem
failing to install.

We believe this is due to an issue with recent govuk-ruby-builder
images, and using 3.3.3 (the latest patch at time of writing) causes the
`jsonnet` gem to fail to install. This is currently being investigated
but I'm pinning Ruby back to 3.3.1 to unblock deployments.

Issue open here: https://github.com/alphagov/govuk-ruby-images/issues/96

[Relevant slack conversation](https://gds.slack.com/archives/C013F737737/p1719399161016749)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
