### PR TITLE
Use libjsonnet from the base image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
-# TODO: unpin obsolete base image once https://github.com/alphagov/govuk-ruby-images/issues/96 is resolved
-ARG ruby_version=3.3.1
+ARG ruby_version=3.3
 ARG base_image=ghcr.io/alphagov/govuk-ruby-base:$ruby_version
 ARG builder_image=ghcr.io/alphagov/govuk-ruby-builder:$ruby_version
 
@@ -8,7 +7,7 @@ FROM --platform=$TARGETPLATFORM $builder_image AS builder
 
 WORKDIR $APP_HOME
 COPY Gemfile* .ruby-version ./
-RUN bundle install
+RUN JSONNET_USE_SYSTEM_LIBRARIES=1 bundle install
 COPY . .
 RUN bootsnap precompile --gemfile .
 


### PR DESCRIPTION
https://github.com/yugui/ruby-jsonnet/ appears to be unmaintained and pins an obsolete version of libjsonnet++ which doesn't compile with g++13 (which we recently switched to in govuk-ruby-images because it's the default C++ compiler in Ubuntu 24.04).

Thankfully the ruby-jsonnet build has an option to tell it not to try to build its own obsolete version of libjsonnet and use a preinstalled one.

As a bonus side-effect, this speeds up the build because we no longer have to build libjsonnet++.

Tested: `bundle install` succeeds with https://github.com/alphagov/govuk-ruby-images/pull/97

Rollout: needs alphagov/govuk-ruby-images#97 to have [landed](https://github.com/alphagov/govuk-ruby-images/actions/runs/9682506418) on ghcr.io.