### PR TITLE
Don’t require a rendering app for content blocks

### DIFF
--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -37,6 +37,7 @@ class Edition < ApplicationRecord
 
   NON_RENDERABLE_FORMATS = %w[redirect gone].freeze
   NO_RENDERING_APP_FORMATS = %w[contact external_content role_appointment].freeze
+  CONTENT_BLOCK_PREFIX = "content_block".freeze
 
   belongs_to :document
   has_one :unpublishing
@@ -246,6 +247,10 @@ private
   end
 
   def requires_rendering_app?
-    renderable_content? && NO_RENDERING_APP_FORMATS.exclude?(document_type)
+    !is_content_block? && renderable_content? && NO_RENDERING_APP_FORMATS.exclude?(document_type)
+  end
+
+  def is_content_block?
+    document_type.start_with?(CONTENT_BLOCK_PREFIX)
   end
 end

--- a/spec/models/edition_spec.rb
+++ b/spec/models/edition_spec.rb
@@ -107,6 +107,17 @@ RSpec.describe Edition do
       end
     end
 
+    context "when the edition is a content block" do
+      GovukSchemas::Schema.schema_names.select { |schema| schema.start_with?(Edition::CONTENT_BLOCK_PREFIX) }.each do |document_type|
+        subject { build(:edition, document_type:) }
+
+        it "does not require a rendering_app" do
+          subject.rendering_app = nil
+          expect(subject).to be_valid
+        end
+      end
+    end
+
     context "when the edition is optionally 'renderable'" do
       subject { build(:edition, document_type: "contact") }
 


### PR DESCRIPTION
Content blocks won’t be rendered by a specific app, so we don’t need a rendering app to be given.