### PR TITLE
Spike/look into embedding content

### DIFF
--- a/app/commands/v2/put_content.rb
+++ b/app/commands/v2/put_content.rb
@@ -87,15 +87,22 @@ module Commands
       end
 
       def create_links(edition)
-        return if payload[:links].nil?
+        links = (payload[:links] || {}).merge(fetch_embedded_content(edition))
+        return if links.empty?
 
-        payload[:links].each do |link_type, target_link_ids|
+        links.each do |link_type, target_link_ids|
           edition.links.create!(
             target_link_ids.map.with_index do |target_link_id, i|
               { link_type:, target_content_id: target_link_id, position: i }
             end,
           )
         end
+      end
+
+      def fetch_embedded_content(edition)
+        return {} if edition[:details]["body"].nil?
+
+        ContentEmbedService.new(edition[:details]["body"]).fetch_links
       end
 
       def create_redirect

--- a/app/presenters/details_presenter.rb
+++ b/app/presenters/details_presenter.rb
@@ -13,12 +13,26 @@ module Presenters
       @details ||=
         begin
           updated = recursively_transform_govspeak(content_item_details)
+          updated[:body] = render_embedded_content(updated[:body]) if updated[:body].present?
           updated[:change_history] = change_history if change_history.present?
           updated
         end
     end
 
   private
+
+    def render_embedded_content(body)
+      if body.is_a?(Array)
+        body.map do |content|
+          {
+            content_type: content[:content_type],
+            content: ContentEmbedService.new(content[:content]).render,
+          }
+        end
+      else
+        ContentEmbedService.new(body).render
+      end
+    end
 
     def govspeak_content?(value)
       wrapped = Array.wrap(value)

--- a/app/services/content_embed_service.rb
+++ b/app/services/content_embed_service.rb
@@ -1,0 +1,56 @@
+class ContentEmbedService
+  include ApplicationHelper
+
+  SUPPORTED_DOCUMENT_TYPES = %w[contact].freeze
+  UUID_REGEX = /([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/
+  EMBED_REGEX = /({{embed:(#{SUPPORTED_DOCUMENT_TYPES.join('|')}):#{UUID_REGEX}}})/
+
+  def initialize(body)
+    @body = body
+  end
+
+  def render
+    match_data = @body.scan(EMBED_REGEX)
+
+    match_data.each do |match|
+      embed_code = match[0]
+      document_type = match[1]
+      content_id = match[2]
+
+      edition = find_edition(document_type, content_id)
+      # TODO: Link Edition to document
+      replace_embed_code_with_content(embed_code, edition)
+    end
+
+    @body
+  end
+
+private
+
+  def find_edition(document_type, content_id)
+    Edition.with_document.find_by(
+      state: "published",
+      content_store: "live",
+      document_type:,
+      documents: { content_id: },
+    )
+    ## TODO: What do we do if the edition can't be found?
+  end
+
+  def replace_embed_code_with_content(embed_code, edition)
+    @body.gsub!(
+      embed_code,
+      renderer.render(partial: view_for_document_type(edition.document_type), locals: { details: edition.details }, formats: [:html]),
+    )
+  end
+
+  def renderer
+    @renderer ||= ActionController::Base
+  end
+
+  def view_for_document_type(document_type)
+    {
+      "contact" => "contacts/contact",
+    }[document_type]
+  end
+end

--- a/app/services/content_embed_service.rb
+++ b/app/services/content_embed_service.rb
@@ -6,7 +6,7 @@ class ContentEmbedService
   EMBED_REGEX = /({{embed:(#{SUPPORTED_DOCUMENT_TYPES.join('|')}):#{UUID_REGEX}}})/
 
   class EmbeddedEdition
-    attr_reader :embed_code
+    attr_reader :embed_code, :document_type, :content_id
 
     def initialize(embed_code:, document_type:, content_id:)
       @embed_code = embed_code
@@ -35,6 +35,12 @@ class ContentEmbedService
         document_type: match[1],
         content_id: match[2],
       )
+    end
+  end
+
+  def fetch_links
+    embedded_editions.group_by(&:document_type).transform_values do |items|
+      items.map(&:content_id)
     end
   end
 

--- a/app/views/contacts/_contact.erb
+++ b/app/views/contacts/_contact.erb
@@ -1,0 +1,1 @@
+<%= details[:title] %>

--- a/spec/integration/put_content/content_with_embedded_content_spec.rb
+++ b/spec/integration/put_content/content_with_embedded_content_spec.rb
@@ -1,0 +1,21 @@
+RSpec.describe "PUT /v2/content when embedded content is provided" do
+  include_context "PutContent call"
+
+  context "with embedded content" do
+    let(:contact) { create(:edition, state: "published", content_store: "live", document_type: "contact") }
+    let(:document) { create(:document) }
+    let!(:link) { document.content_id }
+
+    before do
+      payload.merge!(document_type: "press_release", schema_name: "news_article", details: { body: "{{embed:contact:#{contact.document.content_id}}}" })
+    end
+
+    it "should create links" do
+      expect {
+        put "/v2/content/#{content_id}", params: payload.to_json
+      }.to change(Link, :count).by(1)
+
+      expect(Link.find_by(target_content_id: contact.content_id)).to be
+    end
+  end
+end

--- a/spec/services/content_embed_service_spec.rb
+++ b/spec/services/content_embed_service_spec.rb
@@ -1,17 +1,40 @@
 RSpec.describe ContentEmbedService do
+  let(:contacts) do
+    [
+      create(:edition,
+             state: "published",
+             document_type: "contact",
+             content_store: "live",
+             details: { title: "Some Title" }),
+      create(:edition,
+             state: "published",
+             document_type: "contact",
+             content_store: "live",
+             details: { title: "Some other Title" }),
+    ]
+  end
+
+  describe ".embedded_editions" do
+    it "returns all editions" do
+      body = "{{embed:contact:#{contacts[0].document.content_id}}} {{embed:contact:#{contacts[1].document.content_id}}}"
+
+      embedded_editions = ContentEmbedService.new(body).embedded_editions
+
+      expect(embedded_editions[0].embed_code).to eq("{{embed:contact:#{contacts[0].document.content_id}}}")
+      expect(embedded_editions[0].edition).to eq(contacts[0])
+
+      expect(embedded_editions[1].embed_code).to eq("{{embed:contact:#{contacts[1].document.content_id}}}")
+      expect(embedded_editions[1].edition).to eq(contacts[1])
+    end
+  end
+
   describe ".render" do
     it "renders a contact" do
-      contact = create(:edition,
-                       state: "published",
-                       document_type: "contact",
-                       content_store: "live",
-                       details: { title: "Some Title" })
-
       body = <<-DOC
       <h1>Heading</h1>
 
       <p>Contact 1</p>
-      <p>{{embed:contact:#{contact.document.content_id}}}</p>
+      <p>{{embed:contact:#{contacts[0].document.content_id}}}</p>
       DOC
 
       result = ContentEmbedService.new(body).render
@@ -19,29 +42,17 @@ RSpec.describe ContentEmbedService do
         <h1>Heading</h1>
 
         <p>Contact 1</p>
-        <p>#{contact.details[:title]}</p>
+        <p>#{contacts[0].details[:title]}</p>
       DOC
 
       expect(result.gsub(/\s+/, " ")).to eq(expected.gsub(/\s+/, " "))
     end
 
     it "renders multiple contacts" do
-      contact1 = create(:edition,
-                        state: "published",
-                        document_type: "contact",
-                        content_store: "live",
-                        details: { title: "Some Title" })
-
-      contact2 = create(:edition,
-                        state: "published",
-                        document_type: "contact",
-                        content_store: "live",
-                        details: { title: "Some other Title" })
-
-      body = "{{embed:contact:#{contact1.document.content_id}}} {{embed:contact:#{contact2.document.content_id}}}"
+      body = "{{embed:contact:#{contacts[0].document.content_id}}} {{embed:contact:#{contacts[1].document.content_id}}}"
 
       result = ContentEmbedService.new(body).render
-      expected = "#{contact1.details[:title]} #{contact2.details[:title]}"
+      expected = "#{contacts[0].details[:title]} #{contacts[1].details[:title]}"
 
       expect(result).to eq(expected)
     end

--- a/spec/services/content_embed_service_spec.rb
+++ b/spec/services/content_embed_service_spec.rb
@@ -1,0 +1,49 @@
+RSpec.describe ContentEmbedService do
+  describe ".render" do
+    it "renders a contact" do
+      contact = create(:edition,
+                       state: "published",
+                       document_type: "contact",
+                       content_store: "live",
+                       details: { title: "Some Title" })
+
+      body = <<-DOC
+      <h1>Heading</h1>
+
+      <p>Contact 1</p>
+      <p>{{embed:contact:#{contact.document.content_id}}}</p>
+      DOC
+
+      result = ContentEmbedService.new(body).render
+      expected = <<-DOC
+        <h1>Heading</h1>
+
+        <p>Contact 1</p>
+        <p>#{contact.details[:title]}</p>
+      DOC
+
+      expect(result.gsub(/\s+/, " ")).to eq(expected.gsub(/\s+/, " "))
+    end
+
+    it "renders multiple contacts" do
+      contact1 = create(:edition,
+                        state: "published",
+                        document_type: "contact",
+                        content_store: "live",
+                        details: { title: "Some Title" })
+
+      contact2 = create(:edition,
+                        state: "published",
+                        document_type: "contact",
+                        content_store: "live",
+                        details: { title: "Some other Title" })
+
+      body = "{{embed:contact:#{contact1.document.content_id}}} {{embed:contact:#{contact2.document.content_id}}}"
+
+      result = ContentEmbedService.new(body).render
+      expected = "#{contact1.details[:title]} #{contact2.details[:title]}"
+
+      expect(result).to eq(expected)
+    end
+  end
+end

--- a/spec/services/content_embed_service_spec.rb
+++ b/spec/services/content_embed_service_spec.rb
@@ -28,6 +28,24 @@ RSpec.describe ContentEmbedService do
     end
   end
 
+  describe ".fetch_links" do
+    it "returns an empty hash where there are no embeds" do
+      body = "Hello world!"
+
+      links = ContentEmbedService.new(body).fetch_links
+
+      expect(links).to eq({})
+    end
+
+    it "marshals embedded editions into links" do
+      body = "{{embed:contact:#{contacts[0].document.content_id}}} {{embed:contact:#{contacts[1].document.content_id}}}"
+
+      links = ContentEmbedService.new(body).fetch_links
+
+      expect(links).to eq({ "contact" => [contacts[0].document.content_id, contacts[1].document.content_id] })
+    end
+  end
+
   describe ".render" do
     it "renders a contact" do
       body = <<-DOC


### PR DESCRIPTION
This is a (possibly quite naive) expression of how I think content embedding might work. The flow works by looking for content in the format `{{embed:CONTENT_TYPE:UUID}}` within govspeak / HTML and follows the following flow:

```mermaid
graph TD;
id1[Content sent to API]-->id2[Links extracted from content]-->id3[Govspeak transformed]-->id4[Placeholders replaced with embedded content]-->id5[Transformed content sent to Content API];
```

It currently only supports embeds in a `body` attribute, but I think we can easily make this work with any field within a content type's payload. 

Current assumption is that once the links are extracted, this makes the content a dependency on the embedded content, so when changes are made, the content is re presented for publishing. Could do with testing this assumption though.

Thoughts welcome! 👍 