### PR TITLE
Add Content Block Postal Address type

### DIFF
--- a/content_schemas/allowed_document_types.yml
+++ b/content_schemas/allowed_document_types.yml
@@ -23,6 +23,7 @@
 - closed_consultation
 - cma_case
 - content_block_email_address
+- content_block_postal_address
 - complaints_procedure
 - completed_transaction
 - consultation

--- a/content_schemas/dist/formats/content_block_postal_address/notification/schema.json
+++ b/content_schemas/dist/formats/content_block_postal_address/notification/schema.json
@@ -32,7 +32,7 @@
       "$ref": "#/definitions/analytics_identifier"
     },
     "base_path": {
-      "$ref": "#/definitions/absolute_path"
+      "type": "null"
     },
     "content_id": {
       "$ref": "#/definitions/guid"
@@ -58,187 +58,7 @@
     "document_type": {
       "type": "string",
       "enum": [
-        "aaib_report",
-        "about",
-        "about_our_services",
-        "accessible_documents_policy",
-        "access_and_opening",
-        "ai_assurance_portfolio_technique",
-        "algorithmic_transparency_record",
-        "ambassador_role",
-        "animal_disease_case",
-        "answer",
-        "asylum_support_decision",
-        "authored_article",
-        "board_member_role",
-        "business_finance_support_scheme",
-        "calendar",
-        "call_for_evidence",
-        "call_for_evidence_outcome",
-        "case_study",
-        "chief_professional_officer_role",
-        "chief_scientific_officer_role",
-        "chief_scientific_advisor_role",
-        "closed_call_for_evidence",
-        "closed_consultation",
-        "cma_case",
-        "content_block_email_address",
-        "content_block_postal_address",
-        "complaints_procedure",
-        "completed_transaction",
-        "consultation",
-        "consultation_outcome",
-        "contact",
-        "coronavirus_landing_page",
-        "corporate_report",
-        "correspondence",
-        "countryside_stewardship_grant",
-        "decision",
-        "deputy_head_of_mission_role",
-        "detailed_guide",
-        "document_collection",
-        "drcf_digital_markets_research",
-        "drug_safety_update",
-        "email_alert_signup",
-        "embassies_index",
-        "employment_appeal_tribunal_decision",
-        "employment_tribunal_decision",
-        "equality_and_diversity",
-        "esi_fund",
-        "export_health_certificate",
-        "external_content",
-        "facet",
-        "farming_grant",
-        "fatality_notice",
-        "field_of_operation",
-        "fields_of_operation",
-        "finder",
-        "finder_email_signup",
-        "flood_and_coastal_erosion_risk_management_research_report",
-        "foi_release",
-        "form",
-        "get_involved",
-        "gone",
-        "government",
-        "government_response",
-        "governor_role",
-        "guidance",
-        "guide",
-        "help_page",
-        "high_commissioner_role",
-        "historic_appointment",
-        "historic_appointments",
-        "history",
-        "hmrc_manual",
-        "hmrc_manual_section",
-        "homepage",
-        "how_government_works",
-        "html_publication",
-        "impact_assessment",
-        "independent_report",
-        "international_development_fund",
-        "international_treaty",
-        "licence",
-        "license_finder",
-        "licence_transaction",
-        "link_collection",
-        "local_transaction",
-        "maib_report",
-        "mainstream_browse_page",
-        "marine_equipment_approved_recommendation",
-        "manual",
-        "manual_section",
-        "map",
-        "marine_notice",
-        "media_enquiries",
-        "medical_safety_alert",
-        "membership",
-        "military_role",
-        "ministerial_role",
-        "ministers_index",
-        "modern_slavery_statement",
-        "national",
-        "national_statistics",
-        "national_statistics_announcement",
-        "need",
-        "news_story",
-        "notice",
-        "official",
-        "official_statistics",
-        "official_statistics_announcement",
-        "open_call_for_evidence",
-        "open_consultation",
-        "oral_statement",
-        "organisation",
-        "our_energy_use",
-        "our_governance",
-        "person",
-        "personal_information_charter",
-        "petitions_and_campaigns",
-        "place",
-        "policy_paper",
-        "press_release",
-        "procurement",
-        "product_safety_alert_report_recall",
-        "promotional",
-        "protected_food_drink_name",
-        "publication_scheme",
-        "raib_report",
-        "recruitment",
-        "redirect",
-        "regulation",
-        "research",
-        "research_for_development_output",
-        "residential_property_tribunal_decision",
-        "role_appointment",
-        "search",
-        "service_manual_guide",
-        "service_manual_homepage",
-        "service_manual_service_standard",
-        "service_manual_service_toolkit",
-        "service_manual_topic",
-        "service_sign_in",
-        "service_standard_report",
-        "services_and_information",
-        "simple_smart_answer",
-        "smart_answer",
-        "social_media_use",
-        "special_representative_role",
-        "special_route",
-        "speech",
-        "staff_update",
-        "standard",
-        "statistical_data_set",
-        "statistics",
-        "statistics_announcement",
-        "statutory_guidance",
-        "statutory_instrument",
-        "step_by_step_nav",
-        "substitute",
-        "take_part",
-        "tax_tribunal_decision",
-        "taxon",
-        "terms_of_reference",
-        "topical_event",
-        "topical_event_about_page",
-        "traffic_commissioner_regulatory_decision",
-        "traffic_commissioner_role",
-        "transaction",
-        "transparency",
-        "travel_advice",
-        "travel_advice_index",
-        "utaac_decision",
-        "vanish",
-        "welsh_language_scheme",
-        "working_group",
-        "world_index",
-        "world_location",
-        "world_location_news",
-        "world_news_story",
-        "worldwide_office_staff_role",
-        "worldwide_office",
-        "worldwide_organisation",
-        "written_statement"
+        "content_block_postal_address"
       ]
     },
     "email_document_supertype": {
@@ -459,15 +279,17 @@
       "items": {}
     },
     "rendering_app": {
-      "$ref": "#/definitions/rendering_app"
+      "type": "null"
     },
     "routes": {
-      "$ref": "#/definitions/routes"
+      "type": "array",
+      "additionalItems": false,
+      "items": {}
     },
     "schema_name": {
       "type": "string",
       "enum": [
-        "generic"
+        "content_block_postal_address"
       ]
     },
     "search_user_need_document_supertype": {
@@ -545,10 +367,30 @@
     },
     "details": {
       "type": "object",
+      "required": [
+        "line_1",
+        "town_or_city",
+        "postcode"
+      ],
       "additionalProperties": false,
       "properties": {
         "change_history": {
           "$ref": "#/definitions/change_history"
+        },
+        "county": {
+          "type": "string"
+        },
+        "line_1": {
+          "type": "string"
+        },
+        "line_2": {
+          "type": "string"
+        },
+        "postcode": {
+          "type": "string"
+        },
+        "town_or_city": {
+          "type": "string"
         }
       }
     },
@@ -834,59 +676,6 @@
           "type": "null"
         }
       ]
-    },
-    "rendering_app": {
-      "description": "The application that renders this item.",
-      "type": "string",
-      "enum": [
-        "account-api",
-        "calculators",
-        "calendars",
-        "collections",
-        "content-store",
-        "email-alert-frontend",
-        "email-campaign-frontend",
-        "feedback",
-        "finder-frontend",
-        "frontend",
-        "government-frontend",
-        "info-frontend",
-        "performanceplatform-big-screen-view",
-        "rummager",
-        "search-api",
-        "smartanswers",
-        "spotlight",
-        "static",
-        "tariff",
-        "whitehall-admin",
-        "whitehall-frontend"
-      ]
-    },
-    "route": {
-      "type": "object",
-      "required": [
-        "path",
-        "type"
-      ],
-      "additionalProperties": false,
-      "properties": {
-        "path": {
-          "type": "string"
-        },
-        "type": {
-          "enum": [
-            "prefix",
-            "exact"
-          ]
-        }
-      }
-    },
-    "routes": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/route"
-      },
-      "minItems": 1
     },
     "title": {
       "type": "string"

--- a/content_schemas/dist/formats/content_block_postal_address/publisher_v2/links.json
+++ b/content_schemas/dist/formats/content_block_postal_address/publisher_v2/links.json
@@ -1,0 +1,86 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "bulk_publishing": {
+      "type": "boolean"
+    },
+    "links": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "finder": {
+          "description": "Powers links from content back to finders the content is surfaced on",
+          "$ref": "#/definitions/guid_list"
+        },
+        "lead_organisations": {
+          "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "mainstream_browse_pages": {
+          "description": "Powers the /browse section of the site. These are known as sections in some legacy apps.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "meets_user_needs": {
+          "description": "The user needs this piece of content meets.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "ordered_related_items": {
+          "description": "Related items, can be any page on GOV.UK. Mostly used for mainstream content to power the sidebar. Ordering of the links is determined by the editor in Content Tagger.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "ordered_related_items_overrides": {
+          "description": "Related items, can be any page on GOV.UK. Overrides 'more like this' automatically generated links in the beta navigation.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "organisations": {
+          "description": "All organisations linked to this content item. This should include lead organisations.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "parent": {
+          "description": "The parent content item.",
+          "$ref": "#/definitions/guid_list",
+          "maxItems": 1
+        },
+        "policy_areas": {
+          "description": "A largely deprecated tag currently only used to power email alerts.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "primary_publishing_organisation": {
+          "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/guid_list",
+          "maxItems": 1
+        },
+        "suggested_ordered_related_items": {
+          "description": "Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "taxons": {
+          "description": "Prototype-stage taxonomy label for this content item",
+          "$ref": "#/definitions/guid_list"
+        }
+      }
+    },
+    "previous_version": {
+      "type": "string"
+    }
+  },
+  "definitions": {
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    }
+  }
+}

--- a/content_schemas/dist/formats/content_block_postal_address/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/content_block_postal_address/publisher_v2/schema.json
@@ -1,0 +1,329 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "required": [
+    "details",
+    "document_type",
+    "publishing_app",
+    "schema_name",
+    "title"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "access_limited": {
+      "$ref": "#/definitions/access_limited"
+    },
+    "analytics_identifier": {
+      "$ref": "#/definitions/analytics_identifier"
+    },
+    "auth_bypass_ids": {
+      "description": "A list of ids that will allow access to this item for non-authenticated users",
+      "$ref": "#/definitions/guid_list"
+    },
+    "base_path": {
+      "type": "null"
+    },
+    "bulk_publishing": {
+      "type": "boolean"
+    },
+    "change_note": {
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    "description": {
+      "$ref": "#/definitions/description_optional"
+    },
+    "details": {
+      "$ref": "#/definitions/details"
+    },
+    "document_type": {
+      "type": "string",
+      "enum": [
+        "content_block_postal_address"
+      ]
+    },
+    "first_published_at": {
+      "$ref": "#/definitions/first_published_at"
+    },
+    "last_edited_at": {
+      "description": "Last time when the content received a major or minor update.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "links": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "policy_areas": {
+          "description": "A largely deprecated tag currently only used to power email alerts.",
+          "$ref": "#/definitions/guid_list"
+        }
+      }
+    },
+    "locale": {
+      "$ref": "#/definitions/locale"
+    },
+    "need_ids": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "phase": {
+      "description": "The service design phase of this content item - https://www.gov.uk/service-manual/phases",
+      "type": "string",
+      "enum": [
+        "alpha",
+        "beta",
+        "live"
+      ]
+    },
+    "previous_version": {
+      "type": "string"
+    },
+    "public_updated_at": {
+      "$ref": "#/definitions/public_updated_at"
+    },
+    "publishing_app": {
+      "$ref": "#/definitions/publishing_app_name"
+    },
+    "redirects": {
+      "type": "array",
+      "additionalItems": false,
+      "items": {}
+    },
+    "rendering_app": {
+      "type": "null"
+    },
+    "routes": {
+      "type": "array",
+      "additionalItems": false,
+      "items": {}
+    },
+    "schema_name": {
+      "type": "string",
+      "enum": [
+        "content_block_postal_address"
+      ]
+    },
+    "title": {
+      "$ref": "#/definitions/title"
+    },
+    "update_type": {
+      "$ref": "#/definitions/update_type"
+    }
+  },
+  "definitions": {
+    "description": {
+      "type": "string"
+    },
+    "access_limited": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "auth_bypass_ids": {
+          "description": "Deprecated: auth_bypass_ids should be sent as a separate field",
+          "$ref": "#/definitions/guid_list"
+        },
+        "organisations": {
+          "description": "A list of organisation content ids permitted access to this item",
+          "$ref": "#/definitions/guid_list"
+        },
+        "users": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "analytics_identifier": {
+      "description": "A short identifier we send to Google Analytics for multi-valued fields. This means we avoid the truncated values we would get if we sent the path or slug of eg organisations.",
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "description_optional": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/description"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "details": {
+      "type": "object",
+      "required": [
+        "line_1",
+        "town_or_city",
+        "postcode"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "county": {
+          "type": "string"
+        },
+        "line_1": {
+          "type": "string"
+        },
+        "line_2": {
+          "type": "string"
+        },
+        "postcode": {
+          "type": "string"
+        },
+        "town_or_city": {
+          "type": "string"
+        }
+      }
+    },
+    "first_published_at": {
+      "description": "The date the content was first published.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "guid": {
+      "type": "string",
+      "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[1-5][a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$"
+    },
+    "guid_list": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/guid"
+      },
+      "uniqueItems": true
+    },
+    "locale": {
+      "type": "string",
+      "enum": [
+        "ar",
+        "az",
+        "be",
+        "bg",
+        "bn",
+        "cs",
+        "cy",
+        "da",
+        "de",
+        "dr",
+        "el",
+        "en",
+        "es",
+        "es-419",
+        "et",
+        "fa",
+        "fi",
+        "fr",
+        "gd",
+        "gu",
+        "he",
+        "hi",
+        "hr",
+        "hu",
+        "hy",
+        "id",
+        "is",
+        "it",
+        "ja",
+        "ka",
+        "kk",
+        "ko",
+        "lt",
+        "lv",
+        "ms",
+        "mt",
+        "ne",
+        "nl",
+        "no",
+        "pa",
+        "pa-pk",
+        "pl",
+        "ps",
+        "pt",
+        "ro",
+        "ru",
+        "si",
+        "sk",
+        "sl",
+        "so",
+        "sq",
+        "sr",
+        "sv",
+        "sw",
+        "ta",
+        "th",
+        "tk",
+        "tr",
+        "uk",
+        "ur",
+        "uz",
+        "vi",
+        "yi",
+        "zh",
+        "zh-hk",
+        "zh-tw"
+      ]
+    },
+    "public_updated_at": {
+      "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",
+      "type": "string",
+      "format": "date-time"
+    },
+    "publishing_app_name": {
+      "description": "The application that published this item.",
+      "type": "string",
+      "enum": [
+        "account-api",
+        "calculators",
+        "calendars",
+        "collections-publisher",
+        "contacts",
+        "content-publisher",
+        "content-tagger",
+        "email-alert-frontend",
+        "external-link-tracker",
+        "feedback",
+        "frontend",
+        "government-frontend",
+        "hmrc-manuals-api",
+        "local-links-manager",
+        "manuals-publisher",
+        "maslow",
+        "performanceplatform-big-screen-view",
+        "publisher",
+        "rummager",
+        "search-admin",
+        "search-api",
+        "service-manual-publisher",
+        "share-sale-publisher",
+        "short-url-manager",
+        "smartanswers",
+        "special-route-publisher",
+        "specialist-publisher",
+        "static",
+        "tariff",
+        "travel-advice-publisher",
+        "whitehall"
+      ]
+    },
+    "title": {
+      "type": "string"
+    },
+    "update_type": {
+      "enum": [
+        "major",
+        "minor",
+        "republish"
+      ]
+    }
+  }
+}

--- a/content_schemas/dist/formats/generic/frontend/schema.json
+++ b/content_schemas/dist/formats/generic/frontend/schema.json
@@ -59,6 +59,7 @@
         "closed_consultation",
         "cma_case",
         "content_block_email_address",
+        "content_block_postal_address",
         "complaints_procedure",
         "completed_transaction",
         "consultation",

--- a/content_schemas/dist/formats/generic/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/generic/publisher_v2/schema.json
@@ -69,6 +69,7 @@
         "closed_consultation",
         "cma_case",
         "content_block_email_address",
+        "content_block_postal_address",
         "complaints_procedure",
         "completed_transaction",
         "consultation",

--- a/content_schemas/dist/formats/generic_with_external_related_links/frontend/schema.json
+++ b/content_schemas/dist/formats/generic_with_external_related_links/frontend/schema.json
@@ -59,6 +59,7 @@
         "closed_consultation",
         "cma_case",
         "content_block_email_address",
+        "content_block_postal_address",
         "complaints_procedure",
         "completed_transaction",
         "consultation",

--- a/content_schemas/dist/formats/generic_with_external_related_links/notification/schema.json
+++ b/content_schemas/dist/formats/generic_with_external_related_links/notification/schema.json
@@ -83,6 +83,7 @@
         "closed_consultation",
         "cma_case",
         "content_block_email_address",
+        "content_block_postal_address",
         "complaints_procedure",
         "completed_transaction",
         "consultation",

--- a/content_schemas/dist/formats/generic_with_external_related_links/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/generic_with_external_related_links/publisher_v2/schema.json
@@ -69,6 +69,7 @@
         "closed_consultation",
         "cma_case",
         "content_block_email_address",
+        "content_block_postal_address",
         "complaints_procedure",
         "completed_transaction",
         "consultation",

--- a/content_schemas/examples/content_block_postal_address/publisher_v2/example.json
+++ b/content_schemas/examples/content_block_postal_address/publisher_v2/example.json
@@ -1,0 +1,15 @@
+{
+  "locale": "en",
+  "schema_name": "content_block_postal_address",
+  "document_type": "content_block_postal_address",
+  "title": "Government Digital Service - Head office",
+  "description": "The head office for Government Digital Service",
+  "details": {
+    "line_1": "1 Westminster Road",
+    "line_2": "Flat A",
+    "town_or_city": "London",
+    "county": "Greater London",
+    "postcode": "W1A 2BC"
+  },
+  "publishing_app": "whitehall"
+}

--- a/content_schemas/formats/content_block_postal_address.jsonnet
+++ b/content_schemas/formats/content_block_postal_address.jsonnet
@@ -1,0 +1,30 @@
+(import "shared/default_format.jsonnet") + {
+  document_type: "content_block_postal_address",
+  base_path: "forbidden",
+  routes: "forbidden",
+  rendering_app: "forbidden",
+  definitions: {
+    details: {
+      type: "object",
+      additionalProperties: false,
+      required: ["line_1", "town_or_city", "postcode"],
+      properties: {
+        line_1: {
+          type: "string",
+        },
+        line_2: {
+          type: "string",
+        },
+        town_or_city: {
+          type: "string",
+        },
+        county: {
+          type: "string",
+        },
+        postcode: {
+          type: "string"
+        }
+      },
+    },
+  },
+}


### PR DESCRIPTION
The Content Modelling Team are working on a spike to add the ability to publishing reusable pieces of content (“Content Blocks”) via Whitehall. This adds a simple initial schema to help us work with a type of postal address.

There is an existing `post_addresses` object in the `contact` schema which is shaped slightly differently - I thought it better to go with the shape that GDS currently suggestions in their docs https://design-system.service.gov.uk/patterns/addresses/ to make it easier for our creation forms to comply with GDS standards.

We could add/change these fields in the future.

Things to note:
* The schema generation seems to order fields alphabetically, so the actual schema served to our frontend puts `County` as the first field 🤔 
