### PR TITLE
Add `embed` to all content schemas

### DIFF
--- a/content_schemas/dist/formats/answer/frontend/schema.json
+++ b/content_schemas/dist/formats/answer/frontend/schema.json
@@ -67,6 +67,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/content_schemas/dist/formats/answer/notification/schema.json
+++ b/content_schemas/dist/formats/answer/notification/schema.json
@@ -85,6 +85,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -183,6 +187,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/guid_list"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/dist/formats/answer/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/answer/publisher_v2/schema.json
@@ -59,6 +59,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/guid_list"
+        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/dist/formats/calendar/frontend/schema.json
+++ b/content_schemas/dist/formats/calendar/frontend/schema.json
@@ -67,6 +67,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/content_schemas/dist/formats/calendar/notification/schema.json
+++ b/content_schemas/dist/formats/calendar/notification/schema.json
@@ -85,6 +85,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -183,6 +187,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/guid_list"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/dist/formats/calendar/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/calendar/publisher_v2/schema.json
@@ -59,6 +59,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/guid_list"
+        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/dist/formats/call_for_evidence/frontend/schema.json
+++ b/content_schemas/dist/formats/call_for_evidence/frontend/schema.json
@@ -70,6 +70,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/content_schemas/dist/formats/call_for_evidence/notification/schema.json
+++ b/content_schemas/dist/formats/call_for_evidence/notification/schema.json
@@ -88,6 +88,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -202,6 +206,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/guid_list"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/dist/formats/call_for_evidence/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/call_for_evidence/publisher_v2/schema.json
@@ -62,6 +62,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/guid_list"
+        },
         "government": {
           "description": "The government associated with this document",
           "$ref": "#/definitions/guid_list",

--- a/content_schemas/dist/formats/case_study/frontend/schema.json
+++ b/content_schemas/dist/formats/case_study/frontend/schema.json
@@ -67,6 +67,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/content_schemas/dist/formats/case_study/notification/schema.json
+++ b/content_schemas/dist/formats/case_study/notification/schema.json
@@ -85,6 +85,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -197,6 +201,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/guid_list"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/dist/formats/case_study/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/case_study/publisher_v2/schema.json
@@ -59,6 +59,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/guid_list"
+        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/dist/formats/completed_transaction/frontend/schema.json
+++ b/content_schemas/dist/formats/completed_transaction/frontend/schema.json
@@ -67,6 +67,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/content_schemas/dist/formats/completed_transaction/notification/schema.json
+++ b/content_schemas/dist/formats/completed_transaction/notification/schema.json
@@ -85,6 +85,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -183,6 +187,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/guid_list"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/dist/formats/completed_transaction/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/completed_transaction/publisher_v2/schema.json
@@ -59,6 +59,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/guid_list"
+        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/dist/formats/consultation/frontend/schema.json
+++ b/content_schemas/dist/formats/consultation/frontend/schema.json
@@ -70,6 +70,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/content_schemas/dist/formats/consultation/notification/schema.json
+++ b/content_schemas/dist/formats/consultation/notification/schema.json
@@ -88,6 +88,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -202,6 +206,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/guid_list"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/dist/formats/consultation/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/consultation/publisher_v2/schema.json
@@ -62,6 +62,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/guid_list"
+        },
         "government": {
           "description": "The government associated with this document",
           "$ref": "#/definitions/guid_list",

--- a/content_schemas/dist/formats/contact/frontend/schema.json
+++ b/content_schemas/dist/formats/contact/frontend/schema.json
@@ -67,6 +67,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/content_schemas/dist/formats/contact/notification/schema.json
+++ b/content_schemas/dist/formats/contact/notification/schema.json
@@ -85,6 +85,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -189,6 +193,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/guid_list"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/dist/formats/contact/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/contact/publisher_v2/schema.json
@@ -56,6 +56,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/guid_list"
+        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/dist/formats/content_block_email_address/notification/schema.json
+++ b/content_schemas/dist/formats/content_block_email_address/notification/schema.json
@@ -85,6 +85,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -183,6 +187,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/guid_list"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/dist/formats/content_block_email_address/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/content_block_email_address/publisher_v2/schema.json
@@ -56,6 +56,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/guid_list"
+        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/dist/formats/content_block_postal_address/notification/schema.json
+++ b/content_schemas/dist/formats/content_block_postal_address/notification/schema.json
@@ -85,6 +85,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -183,6 +187,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/guid_list"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/dist/formats/content_block_postal_address/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/content_block_postal_address/publisher_v2/schema.json
@@ -56,6 +56,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/guid_list"
+        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/dist/formats/coronavirus_landing_page/frontend/schema.json
+++ b/content_schemas/dist/formats/coronavirus_landing_page/frontend/schema.json
@@ -67,6 +67,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/content_schemas/dist/formats/coronavirus_landing_page/notification/schema.json
+++ b/content_schemas/dist/formats/coronavirus_landing_page/notification/schema.json
@@ -85,6 +85,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -183,6 +187,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/guid_list"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/dist/formats/coronavirus_landing_page/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/coronavirus_landing_page/publisher_v2/schema.json
@@ -59,6 +59,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/guid_list"
+        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/dist/formats/detailed_guide/frontend/schema.json
+++ b/content_schemas/dist/formats/detailed_guide/frontend/schema.json
@@ -67,6 +67,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/content_schemas/dist/formats/detailed_guide/notification/schema.json
+++ b/content_schemas/dist/formats/detailed_guide/notification/schema.json
@@ -85,6 +85,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -197,6 +201,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/guid_list"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/dist/formats/detailed_guide/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/detailed_guide/publisher_v2/schema.json
@@ -59,6 +59,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/guid_list"
+        },
         "government": {
           "description": "The government associated with this document",
           "$ref": "#/definitions/guid_list",

--- a/content_schemas/dist/formats/document_collection/frontend/schema.json
+++ b/content_schemas/dist/formats/document_collection/frontend/schema.json
@@ -70,6 +70,10 @@
         "documents": {
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/content_schemas/dist/formats/document_collection/notification/schema.json
+++ b/content_schemas/dist/formats/document_collection/notification/schema.json
@@ -88,6 +88,10 @@
         "documents": {
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -206,6 +210,10 @@
       "additionalProperties": false,
       "properties": {
         "documents": {
+          "$ref": "#/definitions/guid_list"
+        },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
           "$ref": "#/definitions/guid_list"
         },
         "finder": {

--- a/content_schemas/dist/formats/document_collection/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/document_collection/publisher_v2/schema.json
@@ -62,6 +62,10 @@
         "documents": {
           "$ref": "#/definitions/guid_list"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/guid_list"
+        },
         "government": {
           "description": "The government associated with this document",
           "$ref": "#/definitions/guid_list",

--- a/content_schemas/dist/formats/email_alert_signup/frontend/schema.json
+++ b/content_schemas/dist/formats/email_alert_signup/frontend/schema.json
@@ -67,6 +67,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/content_schemas/dist/formats/email_alert_signup/notification/schema.json
+++ b/content_schemas/dist/formats/email_alert_signup/notification/schema.json
@@ -85,6 +85,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -183,6 +187,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/guid_list"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/dist/formats/email_alert_signup/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/email_alert_signup/publisher_v2/schema.json
@@ -59,6 +59,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/guid_list"
+        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/dist/formats/embassies_index/frontend/schema.json
+++ b/content_schemas/dist/formats/embassies_index/frontend/schema.json
@@ -67,6 +67,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/content_schemas/dist/formats/embassies_index/notification/schema.json
+++ b/content_schemas/dist/formats/embassies_index/notification/schema.json
@@ -85,6 +85,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -183,6 +187,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/guid_list"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/dist/formats/embassies_index/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/embassies_index/publisher_v2/schema.json
@@ -59,6 +59,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/guid_list"
+        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/dist/formats/facet/frontend/schema.json
+++ b/content_schemas/dist/formats/facet/frontend/schema.json
@@ -67,6 +67,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/content_schemas/dist/formats/facet/notification/schema.json
+++ b/content_schemas/dist/formats/facet/notification/schema.json
@@ -85,6 +85,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -183,6 +187,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/guid_list"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/dist/formats/facet/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/facet/publisher_v2/schema.json
@@ -56,6 +56,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/guid_list"
+        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/dist/formats/fatality_notice/frontend/schema.json
+++ b/content_schemas/dist/formats/fatality_notice/frontend/schema.json
@@ -67,6 +67,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "field_of_operation": {
           "$ref": "#/definitions/frontend_links_with_base_path",
           "maxItems": 1

--- a/content_schemas/dist/formats/fatality_notice/notification/schema.json
+++ b/content_schemas/dist/formats/fatality_notice/notification/schema.json
@@ -85,6 +85,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "field_of_operation": {
           "$ref": "#/definitions/frontend_links_with_base_path",
           "maxItems": 1
@@ -195,6 +199,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/guid_list"
+        },
         "field_of_operation": {
           "$ref": "#/definitions/guid_list",
           "maxItems": 1,

--- a/content_schemas/dist/formats/fatality_notice/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/fatality_notice/publisher_v2/schema.json
@@ -59,6 +59,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/guid_list"
+        },
         "field_of_operation": {
           "$ref": "#/definitions/guid_list",
           "maxItems": 1,

--- a/content_schemas/dist/formats/field_of_operation/frontend/schema.json
+++ b/content_schemas/dist/formats/field_of_operation/frontend/schema.json
@@ -67,6 +67,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "fatality_notices": {
           "description": "Fatality notices for this field of operation",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/content_schemas/dist/formats/field_of_operation/notification/schema.json
+++ b/content_schemas/dist/formats/field_of_operation/notification/schema.json
@@ -85,6 +85,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "fatality_notices": {
           "description": "Fatality notices for this field of operation",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -187,6 +191,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/guid_list"
+        },
         "fatality_notices": {
           "description": "Fatality notices for this field of operation",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/dist/formats/field_of_operation/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/field_of_operation/publisher_v2/schema.json
@@ -59,6 +59,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/guid_list"
+        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/dist/formats/fields_of_operation/frontend/schema.json
+++ b/content_schemas/dist/formats/fields_of_operation/frontend/schema.json
@@ -67,6 +67,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "fields_of_operation": {
           "description": "Link to an individual field of operation",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/content_schemas/dist/formats/fields_of_operation/notification/schema.json
+++ b/content_schemas/dist/formats/fields_of_operation/notification/schema.json
@@ -85,6 +85,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "fields_of_operation": {
           "description": "Link to an individual field of operation",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -187,6 +191,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/guid_list"
+        },
         "fields_of_operation": {
           "description": "Link to an individual field of operation",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/dist/formats/fields_of_operation/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/fields_of_operation/publisher_v2/schema.json
@@ -59,6 +59,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/guid_list"
+        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/dist/formats/finder/frontend/schema.json
+++ b/content_schemas/dist/formats/finder/frontend/schema.json
@@ -70,6 +70,10 @@
         "email_alert_signup": {
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/content_schemas/dist/formats/finder/notification/schema.json
+++ b/content_schemas/dist/formats/finder/notification/schema.json
@@ -88,6 +88,10 @@
         "email_alert_signup": {
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -193,6 +197,10 @@
           "$ref": "#/definitions/guid_list"
         },
         "email_alert_signup": {
+          "$ref": "#/definitions/guid_list"
+        },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
           "$ref": "#/definitions/guid_list"
         },
         "finder": {

--- a/content_schemas/dist/formats/finder/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/finder/publisher_v2/schema.json
@@ -60,6 +60,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/guid_list"
+        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/dist/formats/finder_email_signup/frontend/schema.json
+++ b/content_schemas/dist/formats/finder_email_signup/frontend/schema.json
@@ -67,6 +67,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/content_schemas/dist/formats/finder_email_signup/notification/schema.json
+++ b/content_schemas/dist/formats/finder_email_signup/notification/schema.json
@@ -85,6 +85,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -185,6 +189,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/guid_list"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/dist/formats/finder_email_signup/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/finder_email_signup/publisher_v2/schema.json
@@ -59,6 +59,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/guid_list"
+        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/dist/formats/generic/frontend/schema.json
+++ b/content_schemas/dist/formats/generic/frontend/schema.json
@@ -248,6 +248,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/content_schemas/dist/formats/generic/notification/schema.json
+++ b/content_schemas/dist/formats/generic/notification/schema.json
@@ -266,6 +266,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -364,6 +368,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/guid_list"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/dist/formats/generic/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/generic/publisher_v2/schema.json
@@ -240,6 +240,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/guid_list"
+        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/dist/formats/generic_with_external_related_links/frontend/schema.json
+++ b/content_schemas/dist/formats/generic_with_external_related_links/frontend/schema.json
@@ -248,6 +248,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/content_schemas/dist/formats/generic_with_external_related_links/notification/schema.json
+++ b/content_schemas/dist/formats/generic_with_external_related_links/notification/schema.json
@@ -266,6 +266,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -364,6 +368,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/guid_list"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/dist/formats/generic_with_external_related_links/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/generic_with_external_related_links/publisher_v2/schema.json
@@ -240,6 +240,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/guid_list"
+        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/dist/formats/get_involved/frontend/schema.json
+++ b/content_schemas/dist/formats/get_involved/frontend/schema.json
@@ -67,6 +67,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/content_schemas/dist/formats/get_involved/notification/schema.json
+++ b/content_schemas/dist/formats/get_involved/notification/schema.json
@@ -85,6 +85,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -187,6 +191,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/guid_list"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/dist/formats/get_involved/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/get_involved/publisher_v2/schema.json
@@ -59,6 +59,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/guid_list"
+        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/dist/formats/government/frontend/schema.json
+++ b/content_schemas/dist/formats/government/frontend/schema.json
@@ -67,6 +67,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/content_schemas/dist/formats/government/notification/schema.json
+++ b/content_schemas/dist/formats/government/notification/schema.json
@@ -85,6 +85,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -183,6 +187,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/guid_list"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/dist/formats/government/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/government/publisher_v2/schema.json
@@ -59,6 +59,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/guid_list"
+        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/dist/formats/guide/frontend/schema.json
+++ b/content_schemas/dist/formats/guide/frontend/schema.json
@@ -67,6 +67,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/content_schemas/dist/formats/guide/notification/schema.json
+++ b/content_schemas/dist/formats/guide/notification/schema.json
@@ -85,6 +85,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -183,6 +187,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/guid_list"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/dist/formats/guide/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/guide/publisher_v2/schema.json
@@ -59,6 +59,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/guid_list"
+        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/dist/formats/help_page/frontend/schema.json
+++ b/content_schemas/dist/formats/help_page/frontend/schema.json
@@ -67,6 +67,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/content_schemas/dist/formats/help_page/notification/schema.json
+++ b/content_schemas/dist/formats/help_page/notification/schema.json
@@ -85,6 +85,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -183,6 +187,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/guid_list"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/dist/formats/help_page/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/help_page/publisher_v2/schema.json
@@ -59,6 +59,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/guid_list"
+        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/dist/formats/historic_appointment/frontend/schema.json
+++ b/content_schemas/dist/formats/historic_appointment/frontend/schema.json
@@ -67,6 +67,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/content_schemas/dist/formats/historic_appointment/notification/schema.json
+++ b/content_schemas/dist/formats/historic_appointment/notification/schema.json
@@ -85,6 +85,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -187,6 +191,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/guid_list"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/dist/formats/historic_appointment/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/historic_appointment/publisher_v2/schema.json
@@ -59,6 +59,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/guid_list"
+        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/dist/formats/historic_appointments/frontend/schema.json
+++ b/content_schemas/dist/formats/historic_appointments/frontend/schema.json
@@ -67,6 +67,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/content_schemas/dist/formats/historic_appointments/notification/schema.json
+++ b/content_schemas/dist/formats/historic_appointments/notification/schema.json
@@ -85,6 +85,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -187,6 +191,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/guid_list"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/dist/formats/historic_appointments/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/historic_appointments/publisher_v2/schema.json
@@ -59,6 +59,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/guid_list"
+        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/dist/formats/history/frontend/schema.json
+++ b/content_schemas/dist/formats/history/frontend/schema.json
@@ -67,6 +67,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/content_schemas/dist/formats/history/notification/schema.json
+++ b/content_schemas/dist/formats/history/notification/schema.json
@@ -85,6 +85,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -183,6 +187,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/guid_list"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/dist/formats/history/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/history/publisher_v2/schema.json
@@ -59,6 +59,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/guid_list"
+        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/dist/formats/hmrc_manual/frontend/schema.json
+++ b/content_schemas/dist/formats/hmrc_manual/frontend/schema.json
@@ -67,6 +67,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/content_schemas/dist/formats/hmrc_manual/notification/schema.json
+++ b/content_schemas/dist/formats/hmrc_manual/notification/schema.json
@@ -85,6 +85,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -183,6 +187,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/guid_list"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/dist/formats/hmrc_manual/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/hmrc_manual/publisher_v2/schema.json
@@ -59,6 +59,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/guid_list"
+        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/dist/formats/hmrc_manual_section/frontend/schema.json
+++ b/content_schemas/dist/formats/hmrc_manual_section/frontend/schema.json
@@ -67,6 +67,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/content_schemas/dist/formats/hmrc_manual_section/notification/schema.json
+++ b/content_schemas/dist/formats/hmrc_manual_section/notification/schema.json
@@ -85,6 +85,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -183,6 +187,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/guid_list"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/dist/formats/hmrc_manual_section/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/hmrc_manual_section/publisher_v2/schema.json
@@ -59,6 +59,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/guid_list"
+        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/dist/formats/homepage/frontend/schema.json
+++ b/content_schemas/dist/formats/homepage/frontend/schema.json
@@ -68,6 +68,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "level_one_taxons": {
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/content_schemas/dist/formats/homepage/notification/schema.json
+++ b/content_schemas/dist/formats/homepage/notification/schema.json
@@ -86,6 +86,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "level_one_taxons": {
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -138,6 +142,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/guid_list"
+        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/dist/formats/homepage/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/homepage/publisher_v2/schema.json
@@ -60,6 +60,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/guid_list"
+        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/dist/formats/how_government_works/frontend/schema.json
+++ b/content_schemas/dist/formats/how_government_works/frontend/schema.json
@@ -71,6 +71,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/content_schemas/dist/formats/how_government_works/notification/schema.json
+++ b/content_schemas/dist/formats/how_government_works/notification/schema.json
@@ -89,6 +89,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -189,6 +193,10 @@
       "properties": {
         "current_prime_minister": {
           "description": "Link to the person page for the current prime minister",
+          "$ref": "#/definitions/guid_list"
+        },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
           "$ref": "#/definitions/guid_list"
         },
         "finder": {

--- a/content_schemas/dist/formats/how_government_works/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/how_government_works/publisher_v2/schema.json
@@ -59,6 +59,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/guid_list"
+        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/dist/formats/html_publication/frontend/schema.json
+++ b/content_schemas/dist/formats/html_publication/frontend/schema.json
@@ -67,6 +67,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/content_schemas/dist/formats/html_publication/notification/schema.json
+++ b/content_schemas/dist/formats/html_publication/notification/schema.json
@@ -85,6 +85,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -185,6 +189,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/guid_list"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/dist/formats/html_publication/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/html_publication/publisher_v2/schema.json
@@ -59,6 +59,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/guid_list"
+        },
         "government": {
           "description": "The government associated with this document",
           "$ref": "#/definitions/guid_list",

--- a/content_schemas/dist/formats/licence/frontend/schema.json
+++ b/content_schemas/dist/formats/licence/frontend/schema.json
@@ -67,6 +67,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/content_schemas/dist/formats/licence/notification/schema.json
+++ b/content_schemas/dist/formats/licence/notification/schema.json
@@ -85,6 +85,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -183,6 +187,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/guid_list"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/dist/formats/licence/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/licence/publisher_v2/schema.json
@@ -59,6 +59,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/guid_list"
+        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/dist/formats/link_collection/frontend/schema.json
+++ b/content_schemas/dist/formats/link_collection/frontend/schema.json
@@ -67,6 +67,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/content_schemas/dist/formats/link_collection/notification/schema.json
+++ b/content_schemas/dist/formats/link_collection/notification/schema.json
@@ -85,6 +85,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -183,6 +187,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/guid_list"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/dist/formats/link_collection/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/link_collection/publisher_v2/schema.json
@@ -56,6 +56,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/guid_list"
+        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/dist/formats/local_transaction/frontend/schema.json
+++ b/content_schemas/dist/formats/local_transaction/frontend/schema.json
@@ -67,6 +67,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/content_schemas/dist/formats/local_transaction/notification/schema.json
+++ b/content_schemas/dist/formats/local_transaction/notification/schema.json
@@ -85,6 +85,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -183,6 +187,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/guid_list"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/dist/formats/local_transaction/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/local_transaction/publisher_v2/schema.json
@@ -59,6 +59,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/guid_list"
+        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/dist/formats/mainstream_browse_page/frontend/schema.json
+++ b/content_schemas/dist/formats/mainstream_browse_page/frontend/schema.json
@@ -72,6 +72,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/content_schemas/dist/formats/mainstream_browse_page/notification/schema.json
+++ b/content_schemas/dist/formats/mainstream_browse_page/notification/schema.json
@@ -90,6 +90,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -203,6 +207,10 @@
           "description": "The top-level browse page which is active",
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
+        },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/guid_list"
         },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",

--- a/content_schemas/dist/formats/mainstream_browse_page/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/mainstream_browse_page/publisher_v2/schema.json
@@ -59,6 +59,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/guid_list"
+        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/dist/formats/manual/frontend/schema.json
+++ b/content_schemas/dist/formats/manual/frontend/schema.json
@@ -66,6 +66,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/content_schemas/dist/formats/manual/notification/schema.json
+++ b/content_schemas/dist/formats/manual/notification/schema.json
@@ -84,6 +84,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -185,6 +189,10 @@
       "additionalProperties": false,
       "properties": {
         "available_translations": {
+          "$ref": "#/definitions/guid_list"
+        },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
           "$ref": "#/definitions/guid_list"
         },
         "finder": {

--- a/content_schemas/dist/formats/manual/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/manual/publisher_v2/schema.json
@@ -59,6 +59,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/guid_list"
+        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/dist/formats/manual_section/frontend/schema.json
+++ b/content_schemas/dist/formats/manual_section/frontend/schema.json
@@ -66,6 +66,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/content_schemas/dist/formats/manual_section/notification/schema.json
+++ b/content_schemas/dist/formats/manual_section/notification/schema.json
@@ -84,6 +84,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -185,6 +189,10 @@
       "additionalProperties": false,
       "properties": {
         "available_translations": {
+          "$ref": "#/definitions/guid_list"
+        },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
           "$ref": "#/definitions/guid_list"
         },
         "finder": {

--- a/content_schemas/dist/formats/manual_section/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/manual_section/publisher_v2/schema.json
@@ -59,6 +59,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/guid_list"
+        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/dist/formats/ministers_index/frontend/schema.json
+++ b/content_schemas/dist/formats/ministers_index/frontend/schema.json
@@ -67,6 +67,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/content_schemas/dist/formats/ministers_index/notification/schema.json
+++ b/content_schemas/dist/formats/ministers_index/notification/schema.json
@@ -85,6 +85,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -215,6 +219,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/guid_list"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/dist/formats/ministers_index/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/ministers_index/publisher_v2/schema.json
@@ -59,6 +59,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/guid_list"
+        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/dist/formats/need/frontend/schema.json
+++ b/content_schemas/dist/formats/need/frontend/schema.json
@@ -67,6 +67,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/content_schemas/dist/formats/need/notification/schema.json
+++ b/content_schemas/dist/formats/need/notification/schema.json
@@ -85,6 +85,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -183,6 +187,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/guid_list"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/dist/formats/need/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/need/publisher_v2/schema.json
@@ -59,6 +59,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/guid_list"
+        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/dist/formats/news_article/frontend/schema.json
+++ b/content_schemas/dist/formats/news_article/frontend/schema.json
@@ -70,6 +70,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/content_schemas/dist/formats/news_article/notification/schema.json
+++ b/content_schemas/dist/formats/news_article/notification/schema.json
@@ -88,6 +88,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -214,6 +218,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/guid_list"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/dist/formats/news_article/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/news_article/publisher_v2/schema.json
@@ -62,6 +62,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/guid_list"
+        },
         "government": {
           "description": "The government associated with this document",
           "$ref": "#/definitions/guid_list",

--- a/content_schemas/dist/formats/organisation/frontend/schema.json
+++ b/content_schemas/dist/formats/organisation/frontend/schema.json
@@ -67,6 +67,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/content_schemas/dist/formats/organisation/notification/schema.json
+++ b/content_schemas/dist/formats/organisation/notification/schema.json
@@ -85,6 +85,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -239,6 +243,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/guid_list"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/dist/formats/organisation/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/organisation/publisher_v2/schema.json
@@ -59,6 +59,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/guid_list"
+        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/dist/formats/organisations_homepage/frontend/schema.json
+++ b/content_schemas/dist/formats/organisations_homepage/frontend/schema.json
@@ -67,6 +67,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/content_schemas/dist/formats/organisations_homepage/notification/schema.json
+++ b/content_schemas/dist/formats/organisations_homepage/notification/schema.json
@@ -85,6 +85,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -183,6 +187,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/guid_list"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/dist/formats/organisations_homepage/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/organisations_homepage/publisher_v2/schema.json
@@ -59,6 +59,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/guid_list"
+        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/dist/formats/person/frontend/schema.json
+++ b/content_schemas/dist/formats/person/frontend/schema.json
@@ -67,6 +67,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/content_schemas/dist/formats/person/notification/schema.json
+++ b/content_schemas/dist/formats/person/notification/schema.json
@@ -85,6 +85,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -183,6 +187,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/guid_list"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/dist/formats/person/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/person/publisher_v2/schema.json
@@ -59,6 +59,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/guid_list"
+        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/dist/formats/place/frontend/schema.json
+++ b/content_schemas/dist/formats/place/frontend/schema.json
@@ -67,6 +67,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/content_schemas/dist/formats/place/notification/schema.json
+++ b/content_schemas/dist/formats/place/notification/schema.json
@@ -85,6 +85,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -183,6 +187,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/guid_list"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/dist/formats/place/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/place/publisher_v2/schema.json
@@ -59,6 +59,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/guid_list"
+        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/dist/formats/publication/frontend/schema.json
+++ b/content_schemas/dist/formats/publication/frontend/schema.json
@@ -86,6 +86,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/content_schemas/dist/formats/publication/notification/schema.json
+++ b/content_schemas/dist/formats/publication/notification/schema.json
@@ -104,6 +104,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -224,6 +228,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/guid_list"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/dist/formats/publication/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/publication/publisher_v2/schema.json
@@ -78,6 +78,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/guid_list"
+        },
         "government": {
           "description": "The government associated with this document",
           "$ref": "#/definitions/guid_list",

--- a/content_schemas/dist/formats/role/frontend/schema.json
+++ b/content_schemas/dist/formats/role/frontend/schema.json
@@ -79,6 +79,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/content_schemas/dist/formats/role/notification/schema.json
+++ b/content_schemas/dist/formats/role/notification/schema.json
@@ -97,6 +97,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -204,6 +208,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/guid_list"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/dist/formats/role/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/role/publisher_v2/schema.json
@@ -69,6 +69,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/guid_list"
+        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/dist/formats/role_appointment/frontend/schema.json
+++ b/content_schemas/dist/formats/role_appointment/frontend/schema.json
@@ -67,6 +67,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/content_schemas/dist/formats/role_appointment/notification/schema.json
+++ b/content_schemas/dist/formats/role_appointment/notification/schema.json
@@ -85,6 +85,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -191,6 +195,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/guid_list"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/dist/formats/role_appointment/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/role_appointment/publisher_v2/schema.json
@@ -56,6 +56,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/guid_list"
+        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/dist/formats/service_manual_guide/frontend/schema.json
+++ b/content_schemas/dist/formats/service_manual_guide/frontend/schema.json
@@ -71,6 +71,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/content_schemas/dist/formats/service_manual_guide/notification/schema.json
+++ b/content_schemas/dist/formats/service_manual_guide/notification/schema.json
@@ -89,6 +89,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -193,6 +197,10 @@
       "properties": {
         "content_owners": {
           "description": "References a page of a GDS community responsible for maintaining the guide e.g. Agile delivery community, Design community",
+          "$ref": "#/definitions/guid_list"
+        },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
           "$ref": "#/definitions/guid_list"
         },
         "finder": {

--- a/content_schemas/dist/formats/service_manual_guide/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/service_manual_guide/publisher_v2/schema.json
@@ -59,6 +59,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/guid_list"
+        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/dist/formats/service_manual_homepage/frontend/schema.json
+++ b/content_schemas/dist/formats/service_manual_homepage/frontend/schema.json
@@ -67,6 +67,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/content_schemas/dist/formats/service_manual_homepage/notification/schema.json
+++ b/content_schemas/dist/formats/service_manual_homepage/notification/schema.json
@@ -85,6 +85,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -183,6 +187,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/guid_list"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/dist/formats/service_manual_homepage/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/service_manual_homepage/publisher_v2/schema.json
@@ -59,6 +59,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/guid_list"
+        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/dist/formats/service_manual_service_standard/frontend/schema.json
+++ b/content_schemas/dist/formats/service_manual_service_standard/frontend/schema.json
@@ -71,6 +71,10 @@
           "description": "References an email alert signup page for the service standard",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/content_schemas/dist/formats/service_manual_service_standard/notification/schema.json
+++ b/content_schemas/dist/formats/service_manual_service_standard/notification/schema.json
@@ -89,6 +89,10 @@
           "description": "References an email alert signup page for the service standard",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -189,6 +193,10 @@
       "properties": {
         "email_alert_signup": {
           "description": "References an email alert signup page for the service standard",
+          "$ref": "#/definitions/guid_list"
+        },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
           "$ref": "#/definitions/guid_list"
         },
         "finder": {

--- a/content_schemas/dist/formats/service_manual_service_standard/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/service_manual_service_standard/publisher_v2/schema.json
@@ -59,6 +59,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/guid_list"
+        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/dist/formats/service_manual_service_toolkit/frontend/schema.json
+++ b/content_schemas/dist/formats/service_manual_service_toolkit/frontend/schema.json
@@ -67,6 +67,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/content_schemas/dist/formats/service_manual_service_toolkit/notification/schema.json
+++ b/content_schemas/dist/formats/service_manual_service_toolkit/notification/schema.json
@@ -85,6 +85,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -183,6 +187,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/guid_list"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/dist/formats/service_manual_service_toolkit/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/service_manual_service_toolkit/publisher_v2/schema.json
@@ -59,6 +59,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/guid_list"
+        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/dist/formats/service_manual_topic/frontend/schema.json
+++ b/content_schemas/dist/formats/service_manual_topic/frontend/schema.json
@@ -75,6 +75,10 @@
           "description": "References an email alert signup page for this topic",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/content_schemas/dist/formats/service_manual_topic/notification/schema.json
+++ b/content_schemas/dist/formats/service_manual_topic/notification/schema.json
@@ -93,6 +93,10 @@
           "description": "References an email alert signup page for this topic",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -201,6 +205,10 @@
         },
         "email_alert_signup": {
           "description": "References an email alert signup page for this topic",
+          "$ref": "#/definitions/guid_list"
+        },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
           "$ref": "#/definitions/guid_list"
         },
         "finder": {

--- a/content_schemas/dist/formats/service_manual_topic/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/service_manual_topic/publisher_v2/schema.json
@@ -59,6 +59,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/guid_list"
+        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/dist/formats/service_sign_in/frontend/schema.json
+++ b/content_schemas/dist/formats/service_sign_in/frontend/schema.json
@@ -67,6 +67,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/content_schemas/dist/formats/service_sign_in/notification/schema.json
+++ b/content_schemas/dist/formats/service_sign_in/notification/schema.json
@@ -85,6 +85,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -183,6 +187,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/guid_list"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/dist/formats/service_sign_in/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/service_sign_in/publisher_v2/schema.json
@@ -59,6 +59,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/guid_list"
+        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/dist/formats/simple_smart_answer/frontend/schema.json
+++ b/content_schemas/dist/formats/simple_smart_answer/frontend/schema.json
@@ -67,6 +67,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/content_schemas/dist/formats/simple_smart_answer/notification/schema.json
+++ b/content_schemas/dist/formats/simple_smart_answer/notification/schema.json
@@ -85,6 +85,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -183,6 +187,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/guid_list"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/dist/formats/simple_smart_answer/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/simple_smart_answer/publisher_v2/schema.json
@@ -59,6 +59,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/guid_list"
+        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/dist/formats/smart_answer/frontend/schema.json
+++ b/content_schemas/dist/formats/smart_answer/frontend/schema.json
@@ -67,6 +67,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/content_schemas/dist/formats/smart_answer/notification/schema.json
+++ b/content_schemas/dist/formats/smart_answer/notification/schema.json
@@ -85,6 +85,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -183,6 +187,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/guid_list"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/dist/formats/smart_answer/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/smart_answer/publisher_v2/schema.json
@@ -59,6 +59,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/guid_list"
+        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/dist/formats/special_route/frontend/schema.json
+++ b/content_schemas/dist/formats/special_route/frontend/schema.json
@@ -70,6 +70,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/content_schemas/dist/formats/special_route/notification/schema.json
+++ b/content_schemas/dist/formats/special_route/notification/schema.json
@@ -88,6 +88,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -186,6 +190,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/guid_list"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/dist/formats/special_route/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/special_route/publisher_v2/schema.json
@@ -59,6 +59,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/guid_list"
+        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/dist/formats/speech/frontend/schema.json
+++ b/content_schemas/dist/formats/speech/frontend/schema.json
@@ -70,6 +70,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/content_schemas/dist/formats/speech/notification/schema.json
+++ b/content_schemas/dist/formats/speech/notification/schema.json
@@ -88,6 +88,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -213,6 +217,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/guid_list"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/dist/formats/speech/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/speech/publisher_v2/schema.json
@@ -62,6 +62,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/guid_list"
+        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/dist/formats/statistical_data_set/frontend/schema.json
+++ b/content_schemas/dist/formats/statistical_data_set/frontend/schema.json
@@ -67,6 +67,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/content_schemas/dist/formats/statistical_data_set/notification/schema.json
+++ b/content_schemas/dist/formats/statistical_data_set/notification/schema.json
@@ -85,6 +85,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -187,6 +191,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/guid_list"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/dist/formats/statistical_data_set/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/statistical_data_set/publisher_v2/schema.json
@@ -59,6 +59,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/guid_list"
+        },
         "organisations": {
           "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/dist/formats/statistics_announcement/frontend/schema.json
+++ b/content_schemas/dist/formats/statistics_announcement/frontend/schema.json
@@ -71,6 +71,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/content_schemas/dist/formats/statistics_announcement/notification/schema.json
+++ b/content_schemas/dist/formats/statistics_announcement/notification/schema.json
@@ -89,6 +89,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -186,6 +190,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/guid_list"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/dist/formats/statistics_announcement/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/statistics_announcement/publisher_v2/schema.json
@@ -63,6 +63,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/guid_list"
+        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/dist/formats/step_by_step_nav/frontend/schema.json
+++ b/content_schemas/dist/formats/step_by_step_nav/frontend/schema.json
@@ -67,6 +67,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "level_one_taxons": {
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/content_schemas/dist/formats/step_by_step_nav/notification/schema.json
+++ b/content_schemas/dist/formats/step_by_step_nav/notification/schema.json
@@ -85,6 +85,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "level_one_taxons": {
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -145,6 +149,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/guid_list"
+        },
         "pages_part_of_step_nav": {
           "description": "A list of content that should be navigable via this step by step journey",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/dist/formats/step_by_step_nav/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/step_by_step_nav/publisher_v2/schema.json
@@ -59,6 +59,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/guid_list"
+        },
         "pages_part_of_step_nav": {
           "description": "A list of content that should be navigable via this step by step journey",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/dist/formats/take_part/frontend/schema.json
+++ b/content_schemas/dist/formats/take_part/frontend/schema.json
@@ -67,6 +67,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/content_schemas/dist/formats/take_part/notification/schema.json
+++ b/content_schemas/dist/formats/take_part/notification/schema.json
@@ -85,6 +85,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -183,6 +187,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/guid_list"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/dist/formats/take_part/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/take_part/publisher_v2/schema.json
@@ -59,6 +59,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/guid_list"
+        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/dist/formats/taxon/frontend/schema.json
+++ b/content_schemas/dist/formats/taxon/frontend/schema.json
@@ -71,6 +71,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/content_schemas/dist/formats/taxon/notification/schema.json
+++ b/content_schemas/dist/formats/taxon/notification/schema.json
@@ -89,6 +89,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -197,6 +201,10 @@
       "properties": {
         "associated_taxons": {
           "description": "A list of associated taxons whose children should be included as children of this taxon",
+          "$ref": "#/definitions/guid_list"
+        },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
           "$ref": "#/definitions/guid_list"
         },
         "finder": {

--- a/content_schemas/dist/formats/taxon/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/taxon/publisher_v2/schema.json
@@ -63,6 +63,10 @@
           "description": "A list of associated taxons whose children should be included as children of this taxon",
           "$ref": "#/definitions/guid_list"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/guid_list"
+        },
         "parent_taxons": {
           "description": "The list of taxon parents.",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/dist/formats/topical_event/frontend/schema.json
+++ b/content_schemas/dist/formats/topical_event/frontend/schema.json
@@ -67,6 +67,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/content_schemas/dist/formats/topical_event/notification/schema.json
+++ b/content_schemas/dist/formats/topical_event/notification/schema.json
@@ -85,6 +85,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -183,6 +187,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/guid_list"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/dist/formats/topical_event/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/topical_event/publisher_v2/schema.json
@@ -59,6 +59,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/guid_list"
+        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/dist/formats/topical_event_about_page/frontend/schema.json
+++ b/content_schemas/dist/formats/topical_event_about_page/frontend/schema.json
@@ -67,6 +67,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/content_schemas/dist/formats/topical_event_about_page/notification/schema.json
+++ b/content_schemas/dist/formats/topical_event_about_page/notification/schema.json
@@ -85,6 +85,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -183,6 +187,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/guid_list"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/dist/formats/topical_event_about_page/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/topical_event_about_page/publisher_v2/schema.json
@@ -59,6 +59,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/guid_list"
+        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/dist/formats/transaction/frontend/schema.json
+++ b/content_schemas/dist/formats/transaction/frontend/schema.json
@@ -67,6 +67,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/content_schemas/dist/formats/transaction/notification/schema.json
+++ b/content_schemas/dist/formats/transaction/notification/schema.json
@@ -85,6 +85,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -183,6 +187,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/guid_list"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/dist/formats/transaction/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/transaction/publisher_v2/schema.json
@@ -59,6 +59,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/guid_list"
+        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/dist/formats/travel_advice/frontend/schema.json
+++ b/content_schemas/dist/formats/travel_advice/frontend/schema.json
@@ -67,6 +67,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/content_schemas/dist/formats/travel_advice/notification/schema.json
+++ b/content_schemas/dist/formats/travel_advice/notification/schema.json
@@ -85,6 +85,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -186,6 +190,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/guid_list"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/dist/formats/travel_advice/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/travel_advice/publisher_v2/schema.json
@@ -59,6 +59,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/guid_list"
+        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/dist/formats/travel_advice_index/frontend/schema.json
+++ b/content_schemas/dist/formats/travel_advice_index/frontend/schema.json
@@ -67,6 +67,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/content_schemas/dist/formats/travel_advice_index/notification/schema.json
+++ b/content_schemas/dist/formats/travel_advice_index/notification/schema.json
@@ -85,6 +85,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -186,6 +190,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/guid_list"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/dist/formats/travel_advice_index/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/travel_advice_index/publisher_v2/schema.json
@@ -59,6 +59,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/guid_list"
+        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/dist/formats/working_group/frontend/schema.json
+++ b/content_schemas/dist/formats/working_group/frontend/schema.json
@@ -67,6 +67,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/content_schemas/dist/formats/working_group/notification/schema.json
+++ b/content_schemas/dist/formats/working_group/notification/schema.json
@@ -85,6 +85,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -183,6 +187,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/guid_list"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/dist/formats/working_group/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/working_group/publisher_v2/schema.json
@@ -59,6 +59,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/guid_list"
+        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/dist/formats/world_index/frontend/schema.json
+++ b/content_schemas/dist/formats/world_index/frontend/schema.json
@@ -67,6 +67,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/content_schemas/dist/formats/world_index/notification/schema.json
+++ b/content_schemas/dist/formats/world_index/notification/schema.json
@@ -85,6 +85,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -183,6 +187,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/guid_list"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/dist/formats/world_index/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/world_index/publisher_v2/schema.json
@@ -59,6 +59,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/guid_list"
+        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/dist/formats/world_location/frontend/schema.json
+++ b/content_schemas/dist/formats/world_location/frontend/schema.json
@@ -67,6 +67,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "featured_policies": {
           "description": "Featured policies primarily for use with Whitehall organisations",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/content_schemas/dist/formats/world_location/notification/schema.json
+++ b/content_schemas/dist/formats/world_location/notification/schema.json
@@ -85,6 +85,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "featured_policies": {
           "description": "Featured policies primarily for use with Whitehall organisations",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -187,6 +191,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/guid_list"
+        },
         "featured_policies": {
           "description": "Featured policies primarily for use with Whitehall organisations",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/dist/formats/world_location/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/world_location/publisher_v2/schema.json
@@ -56,6 +56,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/guid_list"
+        },
         "featured_policies": {
           "description": "Featured policies primarily for use with Whitehall organisations",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/dist/formats/world_location_news/frontend/schema.json
+++ b/content_schemas/dist/formats/world_location_news/frontend/schema.json
@@ -67,6 +67,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/content_schemas/dist/formats/world_location_news/notification/schema.json
+++ b/content_schemas/dist/formats/world_location_news/notification/schema.json
@@ -85,6 +85,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -191,6 +195,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/guid_list"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/dist/formats/world_location_news/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/world_location_news/publisher_v2/schema.json
@@ -59,6 +59,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/guid_list"
+        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/dist/formats/worldwide_corporate_information_page/frontend/schema.json
+++ b/content_schemas/dist/formats/worldwide_corporate_information_page/frontend/schema.json
@@ -88,6 +88,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/content_schemas/dist/formats/worldwide_corporate_information_page/notification/schema.json
+++ b/content_schemas/dist/formats/worldwide_corporate_information_page/notification/schema.json
@@ -106,6 +106,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -208,6 +212,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/guid_list"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/dist/formats/worldwide_corporate_information_page/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/worldwide_corporate_information_page/publisher_v2/schema.json
@@ -80,6 +80,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/guid_list"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/guid_list",

--- a/content_schemas/dist/formats/worldwide_office/frontend/schema.json
+++ b/content_schemas/dist/formats/worldwide_office/frontend/schema.json
@@ -71,6 +71,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/content_schemas/dist/formats/worldwide_office/notification/schema.json
+++ b/content_schemas/dist/formats/worldwide_office/notification/schema.json
@@ -89,6 +89,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -193,6 +197,10 @@
       "properties": {
         "contact": {
           "description": "Contact details for this Worldwide Office",
+          "$ref": "#/definitions/guid_list"
+        },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
           "$ref": "#/definitions/guid_list"
         },
         "finder": {

--- a/content_schemas/dist/formats/worldwide_office/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/worldwide_office/publisher_v2/schema.json
@@ -63,6 +63,10 @@
           "description": "Contact details for this Worldwide Office",
           "$ref": "#/definitions/guid_list"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/guid_list"
+        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/guid_list",

--- a/content_schemas/dist/formats/worldwide_organisation/frontend/schema.json
+++ b/content_schemas/dist/formats/worldwide_organisation/frontend/schema.json
@@ -75,6 +75,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/content_schemas/dist/formats/worldwide_organisation/notification/schema.json
+++ b/content_schemas/dist/formats/worldwide_organisation/notification/schema.json
@@ -93,6 +93,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -229,6 +233,10 @@
         },
         "corporate_information_pages": {
           "description": "Corporate information pages for this Worldwide Organisation",
+          "$ref": "#/definitions/guid_list"
+        },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
           "$ref": "#/definitions/guid_list"
         },
         "finder": {

--- a/content_schemas/dist/formats/worldwide_organisation/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/worldwide_organisation/publisher_v2/schema.json
@@ -67,6 +67,10 @@
           "description": "Corporate information pages for this Worldwide Organisation",
           "$ref": "#/definitions/guid_list"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/guid_list"
+        },
         "home_page_offices": {
           "description": "The offices, other than the main office, to be shown on the home page of this Worldwide Organisation",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/formats/shared/base_edition_links.jsonnet
+++ b/content_schemas/formats/shared/base_edition_links.jsonnet
@@ -1,3 +1,4 @@
 {
+  embed: "Content that will be embedded within the document, using embed tags.",
   policy_areas: "A largely deprecated tag currently only used to power email alerts.",
 }


### PR DESCRIPTION
This will allow us to store embedded content as a link on documents.

[Trello card](https://trello.com/c/CN92MLav)