### PR TITLE
Bulk retagging mainstream content tagged to DLUHC over to MHCLG

### DIFF
--- a/lib/tasks/tmp_retagging_content.rake
+++ b/lib/tasks/tmp_retagging_content.rake
@@ -1,0 +1,30 @@
+desc "Migrate mainstream publisher docs from DLUHC to MHCLG"
+task migrate_publisher_dluhc_docs_to_mhclg: :environment do
+  dluhc_content_id = "c45c316a-a4f5-42c7-b94d-d7f1821be18e"
+  mhclg_content_id = "1390d07f-12b3-4f55-9dd5-fec5fd9e3649"
+
+  dluhc_content_ids = Edition
+    .distinct
+    .where(publishing_app: "publisher", state: %w[draft published])
+    .joins(:document)
+    .joins("INNER JOIN link_sets ON documents.content_id = link_sets.content_id")
+    .joins("INNER JOIN links ON link_sets.id = links.link_set_id")
+    .where(links: { target_content_id: dluhc_content_id, link_type: "organisations" })
+    .pluck("documents.content_id")
+    .uniq
+
+  puts "#{dluhc_content_ids.count} DLUHC documents to be migrated to MHCLG\n"
+
+  dluhc_content_ids.each do |content_id|
+    Commands::V2::PatchLinkSet.call(
+      {
+        content_id:,
+        links: {
+          organisations: [mhclg_content_id],
+        },
+      },
+    )
+
+    puts "Migrated document with content_id: #{content_id}"
+  end
+end


### PR DESCRIPTION
As part of a post-election Machinery of Government change, the Department for Levelling Up, Housing and Communities has gone back to being called the Ministry of Housing, Communities and Local Government.

One of the tasks involved is bulk retagging mainstream content that's currently tagged to DLUHC over to the new MHCLG org.

This is alternative solution to https://github.com/alphagov/publishing-api/pull/2827. Which task should be run depends - see the [slack thread](https://gds.slack.com/archives/C02PSUYE9SN/p1722519327548429)
[Trello card](https://trello.com/c/smUhCZvN/281-bulk-retagging-of-dluhc-content)

Before:
<img width="1387" alt="Screenshot 2024-08-01 at 08 16 57" src="https://github.com/user-attachments/assets/1e9e8593-ebf5-470a-896f-66ab049b9ccc">
 
After:
<img width="1364" alt="Screenshot 2024-08-01 at 08 18 14" src="https://github.com/user-attachments/assets/30216a91-9cb7-4047-9575-07fbfd601957">

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
