### PR TITLE
Content modelling/Prototype extracting documents with embedded links

### DIFF
--- a/app/commands/v2/put_content.rb
+++ b/app/commands/v2/put_content.rb
@@ -87,15 +87,22 @@ module Commands
       end
 
       def create_links(edition)
-        return if payload[:links].nil?
+        links = (payload[:links] || {}).merge(fetch_embedded_content(edition))
+        return if links.empty?
 
-        payload[:links].each do |link_type, target_link_ids|
+        links.each do |link_type, target_link_ids|
           edition.links.create!(
             target_link_ids.map.with_index do |target_link_id, i|
               { link_type:, target_content_id: target_link_id, position: i }
             end,
           )
         end
+      end
+
+      def fetch_embedded_content(edition)
+        return {} if edition[:details]["body"].nil?
+
+        ContentEmbedService.new(edition[:details]["body"]).fetch_links
       end
 
       def create_redirect

--- a/app/controllers/v2/content_items_controller.rb
+++ b/app/controllers/v2/content_items_controller.rb
@@ -21,6 +21,10 @@ module V2
       ).call
     end
 
+    def linked_items
+      render json: Queries::GetContentByEditionLink.call(path_params[:content_id])
+    end
+
     def show
       render json: Queries::GetContent.call(
         path_params[:content_id],

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -43,6 +43,8 @@ class Edition < ApplicationRecord
   has_one :unpublishing
   has_one :change_note
   has_many :links, dependent: :delete_all
+  has_one :primary_publishing_organisation_link, -> { where(link_type: "primary_publishing_organisation") }, class_name: 'Link'
+  # has_one :primary_publishing_organisation_document, through: :primary_publishing_organisation_link, source: :document
 
   scope :renderable_content, -> { where.not(document_type: NON_RENDERABLE_FORMATS) }
   scope :with_document, -> { joins(:document) }

--- a/app/presenters/details_presenter.rb
+++ b/app/presenters/details_presenter.rb
@@ -13,12 +13,26 @@ module Presenters
       @details ||=
         begin
           updated = recursively_transform_govspeak(content_item_details)
+          updated[:body] = render_embedded_content(updated[:body]) if updated[:body].present?
           updated[:change_history] = change_history if change_history.present?
           updated
         end
     end
 
   private
+
+    def render_embedded_content(body)
+      if body.is_a?(Array)
+        body.map do |content|
+          {
+            content_type: content[:content_type],
+            content: ContentEmbedService.new(content[:content]).render,
+          }
+        end
+      else
+        ContentEmbedService.new(body).render
+      end
+    end
 
     def govspeak_content?(value)
       wrapped = Array.wrap(value)

--- a/app/presenters/queries/linked_content_items_presenter.rb
+++ b/app/presenters/queries/linked_content_items_presenter.rb
@@ -24,6 +24,7 @@ module Presenters
             title: edition.title,
             base_path: edition.base_path,
             document_type: edition.document_type,
+            publishing_organisation: publishing_organisation(edition),
           }
         end
       end
@@ -32,6 +33,18 @@ module Presenters
 
       attr_accessor :editions
 
+      def publishing_organisation(edition)
+        # TODO: Remember to hande missing publishing links. I managed to create a document without a publishing organisation locally
+        # TODO: Explore making a new association to get this association more simply and efficiently
+        publishing_organisation_content_id = edition.primary_publishing_organisation_link&.target_content_id
+        organisation_edition = Document.find_by_content_id(publishing_organisation_content_id)&.live
+        return {} unless organisation_edition
+
+        {
+          title: organisation_edition&.title,
+          base_path: organisation_edition&.base_path,
+        }
+      end
     end
   end
 end

--- a/app/presenters/queries/linked_content_items_presenter.rb
+++ b/app/presenters/queries/linked_content_items_presenter.rb
@@ -1,0 +1,37 @@
+module Presenters
+  module Queries
+    # TODO: Naming of this so it fits consistently along side all the other presenters with 'link' in it
+    class LinkedContentItemsPresenter
+      def self.present(editions)
+        new(editions).present
+      end
+
+      def initialize(editions)
+        self.editions = editions
+      end
+
+      def present
+        {
+          linked_content_items:,
+        }
+      end
+
+      def linked_content_items
+        return {} unless editions.any?
+
+        editions.map do |edition|
+          {
+            title: edition.title,
+            base_path: edition.base_path,
+            document_type: edition.document_type,
+          }
+        end
+      end
+
+    private
+
+      attr_accessor :editions
+
+    end
+  end
+end

--- a/app/queries/get_content_by_edition_link.rb
+++ b/app/queries/get_content_by_edition_link.rb
@@ -1,0 +1,18 @@
+# TODO: Queries::GetLinked is similar but gets links that belong to a link set
+# like an organisation.
+# It expects one type of link_type, for our purposes we want to have any embedded link_type
+module Queries
+  module GetContentByEditionLink
+    def self.call(target_content_id)
+      editions = Edition.live
+                        .joins(:links)
+                        .where(links: { target_content_id: target_content_id }) # Can we have a link_type of "embedded"?
+                        .select("editions.id, editions.title, editions.base_path, editions.document_type")
+
+      # TODO: I tried using Presenters::Queries::ExpandedLinkSet to return each edition and expand all of its links
+      # This works although it returns much more than we need, until it tries to expand one of our embedded links.
+      # This may be an issue with the spike.
+      Presenters::Queries::LinkedContentItemsPresenter.new(editions).present
+    end
+  end
+end

--- a/app/services/content_embed_service.rb
+++ b/app/services/content_embed_service.rb
@@ -1,7 +1,7 @@
 class ContentEmbedService
   include ApplicationHelper
 
-  SUPPORTED_DOCUMENT_TYPES = %w[contact].freeze
+  SUPPORTED_DOCUMENT_TYPES = %w[contact email_address].freeze
   UUID_REGEX = /([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/
   EMBED_REGEX = /({{embed:(#{SUPPORTED_DOCUMENT_TYPES.join('|')}):#{UUID_REGEX}}})/
 

--- a/app/services/content_embed_service.rb
+++ b/app/services/content_embed_service.rb
@@ -1,0 +1,56 @@
+class ContentEmbedService
+  include ApplicationHelper
+
+  SUPPORTED_DOCUMENT_TYPES = %w[contact].freeze
+  UUID_REGEX = /([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/
+  EMBED_REGEX = /({{embed:(#{SUPPORTED_DOCUMENT_TYPES.join('|')}):#{UUID_REGEX}}})/
+
+  def initialize(body)
+    @body = body
+  end
+
+  def render
+    match_data = @body.scan(EMBED_REGEX)
+
+    match_data.each do |match|
+      embed_code = match[0]
+      document_type = match[1]
+      content_id = match[2]
+
+      edition = find_edition(document_type, content_id)
+      # TODO: Link Edition to document
+      replace_embed_code_with_content(embed_code, edition)
+    end
+
+    @body
+  end
+
+private
+
+  def find_edition(document_type, content_id)
+    Edition.with_document.find_by(
+      state: "published",
+      content_store: "live",
+      document_type:,
+      documents: { content_id: },
+    )
+    ## TODO: What do we do if the edition can't be found?
+  end
+
+  def replace_embed_code_with_content(embed_code, edition)
+    @body.gsub!(
+      embed_code,
+      renderer.render(partial: view_for_document_type(edition.document_type), locals: { details: edition.details }, formats: [:html]),
+    )
+  end
+
+  def renderer
+    @renderer ||= ActionController::Base
+  end
+
+  def view_for_document_type(document_type)
+    {
+      "contact" => "contacts/contact",
+    }[document_type]
+  end
+end

--- a/app/services/content_embed_service.rb
+++ b/app/services/content_embed_service.rb
@@ -6,7 +6,7 @@ class ContentEmbedService
   EMBED_REGEX = /({{embed:(#{SUPPORTED_DOCUMENT_TYPES.join('|')}):#{UUID_REGEX}}})/
 
   class EmbeddedEdition
-    attr_reader :embed_code
+    attr_reader :embed_code, :document_type, :content_id
 
     def initialize(embed_code:, document_type:, content_id:)
       @embed_code = embed_code
@@ -35,6 +35,12 @@ class ContentEmbedService
         document_type: match[1],
         content_id: match[2],
       )
+    end
+  end
+
+  def fetch_links
+    embedded_editions.group_by(&:document_type).transform_values do |items|
+      items.map(&:content_id)
     end
   end
 

--- a/app/views/contacts/_contact.erb
+++ b/app/views/contacts/_contact.erb
@@ -1,0 +1,1 @@
+<%= details[:title] %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,7 @@ Rails.application.routes.draw do
       scope constraints: method(:content_id_constraint) do
         put "/content/:content_id", to: "content_items#put_content"
         get "/content/:content_id", to: "content_items#show"
+        get "/content/:content_id/linked-items", to: "content_items#linked_items"
         post "/content/:content_id/publish", to: "content_items#publish"
         post "/content/:content_id/republish", to: "content_items#republish"
         post "/content/:content_id/unpublish", to: "content_items#unpublish"

--- a/spec/integration/put_content/content_with_embedded_content_spec.rb
+++ b/spec/integration/put_content/content_with_embedded_content_spec.rb
@@ -1,0 +1,21 @@
+RSpec.describe "PUT /v2/content when embedded content is provided" do
+  include_context "PutContent call"
+
+  context "with embedded content" do
+    let(:contact) { create(:edition, state: "published", content_store: "live", document_type: "contact") }
+    let(:document) { create(:document) }
+    let!(:link) { document.content_id }
+
+    before do
+      payload.merge!(document_type: "press_release", schema_name: "news_article", details: { body: "{{embed:contact:#{contact.document.content_id}}}" })
+    end
+
+    it "should create links" do
+      expect {
+        put "/v2/content/#{content_id}", params: payload.to_json
+      }.to change(Link, :count).by(1)
+
+      expect(Link.find_by(target_content_id: contact.content_id)).to be
+    end
+  end
+end

--- a/spec/services/content_embed_service_spec.rb
+++ b/spec/services/content_embed_service_spec.rb
@@ -1,17 +1,40 @@
 RSpec.describe ContentEmbedService do
+  let(:contacts) do
+    [
+      create(:edition,
+             state: "published",
+             document_type: "contact",
+             content_store: "live",
+             details: { title: "Some Title" }),
+      create(:edition,
+             state: "published",
+             document_type: "contact",
+             content_store: "live",
+             details: { title: "Some other Title" }),
+    ]
+  end
+
+  describe ".embedded_editions" do
+    it "returns all editions" do
+      body = "{{embed:contact:#{contacts[0].document.content_id}}} {{embed:contact:#{contacts[1].document.content_id}}}"
+
+      embedded_editions = ContentEmbedService.new(body).embedded_editions
+
+      expect(embedded_editions[0].embed_code).to eq("{{embed:contact:#{contacts[0].document.content_id}}}")
+      expect(embedded_editions[0].edition).to eq(contacts[0])
+
+      expect(embedded_editions[1].embed_code).to eq("{{embed:contact:#{contacts[1].document.content_id}}}")
+      expect(embedded_editions[1].edition).to eq(contacts[1])
+    end
+  end
+
   describe ".render" do
     it "renders a contact" do
-      contact = create(:edition,
-                       state: "published",
-                       document_type: "contact",
-                       content_store: "live",
-                       details: { title: "Some Title" })
-
       body = <<-DOC
       <h1>Heading</h1>
 
       <p>Contact 1</p>
-      <p>{{embed:contact:#{contact.document.content_id}}}</p>
+      <p>{{embed:contact:#{contacts[0].document.content_id}}}</p>
       DOC
 
       result = ContentEmbedService.new(body).render
@@ -19,29 +42,17 @@ RSpec.describe ContentEmbedService do
         <h1>Heading</h1>
 
         <p>Contact 1</p>
-        <p>#{contact.details[:title]}</p>
+        <p>#{contacts[0].details[:title]}</p>
       DOC
 
       expect(result.gsub(/\s+/, " ")).to eq(expected.gsub(/\s+/, " "))
     end
 
     it "renders multiple contacts" do
-      contact1 = create(:edition,
-                        state: "published",
-                        document_type: "contact",
-                        content_store: "live",
-                        details: { title: "Some Title" })
-
-      contact2 = create(:edition,
-                        state: "published",
-                        document_type: "contact",
-                        content_store: "live",
-                        details: { title: "Some other Title" })
-
-      body = "{{embed:contact:#{contact1.document.content_id}}} {{embed:contact:#{contact2.document.content_id}}}"
+      body = "{{embed:contact:#{contacts[0].document.content_id}}} {{embed:contact:#{contacts[1].document.content_id}}}"
 
       result = ContentEmbedService.new(body).render
-      expected = "#{contact1.details[:title]} #{contact2.details[:title]}"
+      expected = "#{contacts[0].details[:title]} #{contacts[1].details[:title]}"
 
       expect(result).to eq(expected)
     end

--- a/spec/services/content_embed_service_spec.rb
+++ b/spec/services/content_embed_service_spec.rb
@@ -1,0 +1,49 @@
+RSpec.describe ContentEmbedService do
+  describe ".render" do
+    it "renders a contact" do
+      contact = create(:edition,
+                       state: "published",
+                       document_type: "contact",
+                       content_store: "live",
+                       details: { title: "Some Title" })
+
+      body = <<-DOC
+      <h1>Heading</h1>
+
+      <p>Contact 1</p>
+      <p>{{embed:contact:#{contact.document.content_id}}}</p>
+      DOC
+
+      result = ContentEmbedService.new(body).render
+      expected = <<-DOC
+        <h1>Heading</h1>
+
+        <p>Contact 1</p>
+        <p>#{contact.details[:title]}</p>
+      DOC
+
+      expect(result.gsub(/\s+/, " ")).to eq(expected.gsub(/\s+/, " "))
+    end
+
+    it "renders multiple contacts" do
+      contact1 = create(:edition,
+                        state: "published",
+                        document_type: "contact",
+                        content_store: "live",
+                        details: { title: "Some Title" })
+
+      contact2 = create(:edition,
+                        state: "published",
+                        document_type: "contact",
+                        content_store: "live",
+                        details: { title: "Some other Title" })
+
+      body = "{{embed:contact:#{contact1.document.content_id}}} {{embed:contact:#{contact2.document.content_id}}}"
+
+      result = ContentEmbedService.new(body).render
+      expected = "#{contact1.details[:title]} #{contact2.details[:title]}"
+
+      expect(result).to eq(expected)
+    end
+  end
+end

--- a/spec/services/content_embed_service_spec.rb
+++ b/spec/services/content_embed_service_spec.rb
@@ -28,6 +28,24 @@ RSpec.describe ContentEmbedService do
     end
   end
 
+  describe ".fetch_links" do
+    it "returns an empty hash where there are no embeds" do
+      body = "Hello world!"
+
+      links = ContentEmbedService.new(body).fetch_links
+
+      expect(links).to eq({})
+    end
+
+    it "marshals embedded editions into links" do
+      body = "{{embed:contact:#{contacts[0].document.content_id}}} {{embed:contact:#{contacts[1].document.content_id}}}"
+
+      links = ContentEmbedService.new(body).fetch_links
+
+      expect(links).to eq({ "contact" => [contacts[0].document.content_id, contacts[1].document.content_id] })
+    end
+  end
+
   describe ".render" do
     it "renders a contact" do
       body = <<-DOC


### PR DESCRIPTION
## Context

This proposal presents a prototype by the Content Reuse team for further discussion and isn't to be merged.

Once we've collected some feedback on a number of things we still need to figure out we'll be back with a more fleshed out proposal.

## Notes

- These changes are based atop [the embedding spike branch](https://github.com/alphagov/publishing-api/pull/2794)
- [There is another prototype within Whitehall](https://github.com/alphagov/whitehall/pull/9327) that demonstrates the presentation of this information 

## Questions

- We have some careful naming decisions to make
- We are aware that there's a lot of existing logic working with links to get content in various ways. Have we missed something that may already exist for our case?
- We will likely have to consider pagination at some point, if an email address is used across a hundred pages this may grind to a halt. Can we delay this until next/later?

## Example response for new endpoint

```
{
      "linked_content_items": [
            {
                  "title": "2",
                  "base_path": "/government/publications/2",
                  "document_type": "guidance",
                  "publishing_organisation": { }
            },
            {
                  "title": "3",
                  "base_path": "/government/publications/3",
                  "document_type": "guidance",
                  "publishing_organisation": {
                        "title": "Foo",
                        "base_path": "/government/organisations/foo"
                  }
            }
      ]
}
```
