### PR TITLE
Improve link handling in content endpoint

### DIFF
--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -21,10 +21,13 @@ class Link < ApplicationRecord
       logger.warn("filter_editions called with multiple filters. These will be ANDed together in a way that probably isn't what we want. Filters were: #{filters.inspect}")
     end
 
-    scope = scope.joins(document: :link_set_links)
+    scope = scope.joins("LEFT JOIN links edition_links ON edition_links.edition_id = editions.id")
+    scope = scope.left_joins(document: :link_set_links)
 
     filters.each do |link_type, target_content_id|
-      scope = scope.where(links: { link_type:, target_content_id: })
+      scope = scope
+                .where(edition_links: { link_type:, target_content_id: })
+                .or(scope.where(links: { link_type:, target_content_id: }))
     end
 
     scope

--- a/app/queries/get_content_collection.rb
+++ b/app/queries/get_content_collection.rb
@@ -64,7 +64,7 @@ module Queries
     end
 
     def permitted_fields
-      default_fields + %w[total]
+      default_fields + %w[total link_set_links]
     end
 
     def default_fields

--- a/docs/api.md
+++ b/docs/api.md
@@ -366,14 +366,34 @@ and a state has been specified, the draft is returned.
 - `document_type` *(optional)*
   - The type of editions to return.
 - `fields[]` *(optional)*
-  - Accepts an array of: analytics_identifier, base_path,
-    content_store, description, details, document_type,
-    first_published_at, last_edited_at, major_published_at, phase,
-    public_updated_at, published_at, publishing_api_first_published_at,
-    publishing_api_last_edited_at, publishing_app, redirects, rendering_app,
-    routes, schema_name, state, title, user_facing_version, update_type
-  - Determines which fields will be returned in the response, if omitted all
-    fields will be returned.
+  - Accepts an array of: 
+    - analytics_identifier
+    - base_path
+    - content_store
+    - description
+    - details
+    - document_type
+    - first_published_at
+    - last_edited_at
+    - links
+    - link_set_links
+    - major_published_at
+    - phase
+    - public_updated_at
+    - published_at
+    - publishing_api_first_published_at
+    - publishing_api_last_edited_at
+    - publishing_app
+    - redirects
+    - rendering_app
+    - routes
+    - schema_name
+    - state
+    - title
+    - user_facing_version
+    - update_type
+  - Determines which fields will be returned in the response, if omitted all fields (with the exception of 
+  `link_set_links`) will be returned.
 - `link_*` *(optional)*
   - Accepts a content_id.
   - Used to restrict documents to those linking to another document,

--- a/spec/models/link_spec.rb
+++ b/spec/models/link_spec.rb
@@ -102,9 +102,12 @@ RSpec.describe Link do
     let(:scope) { double(:scope) }
 
     it "modifies a scope to filter linked editions" do
-      expect(scope).to receive(:joins).with(anything).and_return(scope)
-      expect(scope).to receive(:where)
-        .with(links: { link_type: "organisations", target_content_id: "12345" })
+      expect(scope).to receive(:joins).with("LEFT JOIN links edition_links ON edition_links.edition_id = editions.id").and_return(scope)
+      expect(scope).to receive(:left_joins).with(document: :link_set_links).and_return(scope)
+
+      expect(scope).to receive(:where).with(edition_links: { link_type: "organisations", target_content_id: "12345" }).and_return(scope)
+      expect(scope).to receive(:where).with(links: { link_type: "organisations", target_content_id: "12345" }).and_return(scope)
+      expect(scope).to receive(:or).with(scope)
 
       described_class.filter_editions(scope, "organisations" => "12345")
     end

--- a/spec/presenters/queries/content_item_presenter_spec.rb
+++ b/spec/presenters/queries/content_item_presenter_spec.rb
@@ -164,6 +164,46 @@ RSpec.describe Presenters::Queries::ContentItemPresenter do
         expect(result).to eq expected
       end
     end
+
+    context "with linkset links" do
+      let(:result) { described_class.present(edition, fields: %i[link_set_links]) }
+
+      context "when we have a linkset link" do
+        before do
+          link_set = create(:link_set, content_id: edition.document.content_id)
+          link_set.links.create!(link_type: "test", target_content_id: content_id)
+        end
+
+        it "presents the item including the link" do
+          expected = {
+            "link_set_links" => { "test" => [content_id] },
+          }
+          expect(result).to eq expected
+        end
+      end
+
+      context "when we have multiple linkset links" do
+        let(:other_content_id) { SecureRandom.uuid }
+        let(:and_another_content_id) { SecureRandom.uuid }
+
+        before do
+          link_set = create(:link_set, content_id: edition.document.content_id)
+          link_set.links.create!(link_type: "test", target_content_id: other_content_id)
+          link_set.links.create!(link_type: "test", target_content_id: and_another_content_id)
+          link_set.links.create!(link_type: "ers", target_content_id: content_id)
+        end
+
+        it "presents the item including the link" do
+          expected = {
+            "link_set_links" => {
+              "test" => [other_content_id, and_another_content_id],
+              "ers" => [content_id],
+            },
+          }
+          expect(result).to eq expected
+        end
+      end
+    end
   end
 
   describe "#present_many" do


### PR DESCRIPTION
The Content Modelling team have a need to list what documents have a dependency on a given content block, including the Title, Content Type and associated Organisation (this could be via `primary_publishing_organisation` or another link, such as `sponsoring_organisation` for Worldwide Organisations for example.

We initially tried creating a new endpoint (see #2822), but we've since discovered the [`GET /v2/content`](https://github.com/alphagov/publishing-api/blob/main/docs/api.md#get-v2content) endpoint does 90% of what we need to do. However, we need to make some changes to:

- Allow the `link_*` query option to support Edition links, as well as Linkset links, this is because embedded content will be stored as an Edition link
- Return Linkset links as well as Edition links in the responses - currently only Edition links are returned, which means we can't always identify the associated Organisation for a document

I did consider expanding the links at this point, but this could be a bit over the top given that Organisations are already handled in Whitehall, so as long as we have a Content ID, we should be able to fetch the associated Organisation easily.