### PR TITLE
Bulk retagging content tagged to DLUHC over to MHCLG - preserving multiple organisations

### DIFF
--- a/lib/tasks/tmp_retaggiing_content_multiple_orgs.rake
+++ b/lib/tasks/tmp_retaggiing_content_multiple_orgs.rake
@@ -1,0 +1,33 @@
+desc "Migrate mainstream publisher docs from DLUHC to MHCLG"
+task migrate_publisher_dluhc_docs_to_mhclg: :environment do
+  dluhc_content_id = "c45c316a-a4f5-42c7-b94d-d7f1821be18e"
+  mhclg_content_id = "1390d07f-12b3-4f55-9dd5-fec5fd9e3649"
+
+  dluhc_content_ids = Edition
+    .distinct
+    .where(publishing_app: "publisher", state: %w[draft published])
+    .joins(:document)
+    .joins("INNER JOIN link_sets ON documents.content_id = link_sets.content_id")
+    .joins("INNER JOIN links ON link_sets.id = links.link_set_id")
+    .where(links: { target_content_id: dluhc_content_id, link_type: "organisations" })
+    .pluck("documents.content_id")
+    .uniq
+
+  puts "#{dluhc_content_ids.count} DLUHC documents to be migrated to MHCLG\n"
+
+  dluhc_content_ids.each do |content_id|
+    document = Document.find_by(content_id:)
+    new_link = Link.find_by(target_content_id: mhclg_content_id)
+    updated_organisations = document.link_set.links.where(link_type: "organisations").map { |link| link.target_content_id == dluhc_content_id ? new_link : link }.pluck("target_content_id")
+    Commands::V2::PatchLinkSet.call(
+      {
+        content_id:,
+        links: {
+          organisations: updated_organisations,
+        },
+      },
+    )
+
+    puts "Migrated document with content_id: #{document.content_id}"
+  end
+end


### PR DESCRIPTION
As part of a post-election Machinery of Government change, the Department for Levelling Up, Housing and Communities has gone back to being called the Ministry of Housing, Communities and Local Government.

One of the tasks involved is bulk retagging mainstream content that's currently tagged to DLUHC over to the new MHCLG org.

This is alternative solution to https://github.com/alphagov/publishing-api/pull/2821 - this time preserving all other tagged organisations. Which task should be run depends - see the [slack thread](https://gds.slack.com/archives/C02PSUYE9SN/p1722519327548429)

[Trello card](https://trello.com/c/smUhCZvN/281-bulk-retagging-of-dluhc-content)

Before:
<img width="1361" alt="Screenshot 2024-08-02 at 09 41 19" src="https://github.com/user-attachments/assets/cb869bec-0cbb-4a1b-be05-d99c22e6900b">

After:
<img width="1430" alt="Screenshot 2024-08-02 at 10 30 44" src="https://github.com/user-attachments/assets/083f013c-0c59-4db2-995f-c953cf7cf452">

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
