### PR TITLE
add `primary_publishing_organisation` to Content Block Email

### DIFF
--- a/content_schemas/dist/formats/content_block_email_address/notification/schema.json
+++ b/content_schemas/dist/formats/content_block_email_address/notification/schema.json
@@ -85,10 +85,6 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "embed": {
-          "description": "Content that will be embedded within the document, using embed tags.",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -147,7 +143,7 @@
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "primary_publishing_organisation": {
-          "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
+          "description": "The organisation that published the content block. Corresponds to the Edition's 'Organisation' in Whitehall, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path",
           "maxItems": 1
         },
@@ -187,10 +183,6 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "embed": {
-          "description": "Content that will be embedded within the document, using embed tags.",
-          "$ref": "#/definitions/guid_list"
-        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"
@@ -233,7 +225,7 @@
           "$ref": "#/definitions/guid_list"
         },
         "primary_publishing_organisation": {
-          "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
+          "description": "The organisation that published the content block. Corresponds to the Edition's 'Organisation' in Whitehall, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },

--- a/content_schemas/dist/formats/content_block_email_address/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/content_block_email_address/publisher_v2/schema.json
@@ -56,13 +56,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "embed": {
-          "description": "Content that will be embedded within the document, using embed tags.",
-          "$ref": "#/definitions/guid_list"
-        },
-        "policy_areas": {
-          "description": "A largely deprecated tag currently only used to power email alerts.",
-          "$ref": "#/definitions/guid_list"
+        "primary_publishing_organisation": {
+          "description": "The organisation that published the content block. Corresponds to the Edition's 'Organisation' in Whitehall, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/guid_list",
+          "maxItems": 1
         }
       }
     },

--- a/content_schemas/examples/content_block_email_address/publisher_v2/example.json
+++ b/content_schemas/examples/content_block_email_address/publisher_v2/example.json
@@ -7,5 +7,10 @@
   "details": {
     "email_address": "foo@example.com"
   },
+  "links": {
+    "primary_publishing_organisation": [
+      "dcc907d6-433c-42df-9ffb-d9c68be5dc4d"
+    ]
+  },
   "publishing_app": "whitehall"
 }

--- a/content_schemas/formats/content_block_email_address.jsonnet
+++ b/content_schemas/formats/content_block_email_address.jsonnet
@@ -16,4 +16,10 @@
       },
     },
   },
+  edition_links: {
+    primary_publishing_organisation: {
+       description: "The organisation that published the content block. Corresponds to the Edition's 'Organisation' in Whitehall, and is empty for all other publishing applications.",
+       maxItems: 1,
+    },
+  },
 }


### PR DESCRIPTION
We would like to associate a primary organisation with a Content Block Email Address, on the Edition level.
This adds the field to the schema to make this possible.

Once this is added we can send the `primary_publishing_organisation` as a `link` when we publish a Content Block edition - the WIP PR is here https://github.com/alphagov/whitehall/pull/9338 

Questions:

* Because this has been added under `edition_links`, when this is sent to the Publishing API a `Link` between the `Edition`'s content_id and the `Organisation`'s content_id. This seems to follow other models like the [News Article.](https://github.com/alphagov/publishing-api/blob/9c2e19da5a091a6416aba2e3b8f8f39c1dfa03c5/content_schemas/formats/news_article.jsonnet) But there is also an `organisation` type of `Links` that are connected with `Documents` - Should we stick with Edition-level relationship at the moment, assuming that for Content Blocks that makes sense for now? E.g. one version of an Edition could have a different Organisation to another version of the Edition
