### PR TITLE
Fix issue with embedded content on body being an array

### DIFF
--- a/app/services/embedded_content_finder_service.rb
+++ b/app/services/embedded_content_finder_service.rb
@@ -7,7 +7,7 @@ class EmbeddedContentFinderService
 
   def fetch_linked_content_ids(body, locale)
     content_references = if body.is_a?(Array)
-                           body.map { |hash| find_content_references(hash[:content]) }.flatten
+                           body.map { |hash| find_content_references(hash["content"]) }.flatten
                          else
                            find_content_references(body)
                          end

--- a/spec/integration/put_content/content_with_embedded_content_spec.rb
+++ b/spec/integration/put_content/content_with_embedded_content_spec.rb
@@ -1,13 +1,32 @@
 RSpec.describe "PUT /v2/content when embedded content is provided" do
   include_context "PutContent call"
 
-  context "with embedded content" do
+  context "with embedded content as a string" do
     let(:first_contact) { create(:edition, state: "published", content_store: "live", document_type: "contact") }
     let(:second_contact) { create(:edition, state: "published", content_store: "live", document_type: "contact") }
     let(:document) { create(:document, content_id:) }
 
     before do
       payload.merge!(document_type: "press_release", schema_name: "news_article", details: { body: "{{embed:contact:#{first_contact.document.content_id}}} {{embed:contact:#{second_contact.document.content_id}}}" })
+    end
+
+    it "should create links" do
+      expect {
+        put "/v2/content/#{content_id}", params: payload.to_json
+      }.to change(Link, :count).by(2)
+
+      expect(Link.find_by(target_content_id: first_contact.content_id)).not_to be_nil
+      expect(Link.find_by(target_content_id: second_contact.content_id)).not_to be_nil
+    end
+  end
+
+  context "with embedded content as an array" do
+    let(:first_contact) { create(:edition, state: "published", content_store: "live", document_type: "contact") }
+    let(:second_contact) { create(:edition, state: "published", content_store: "live", document_type: "contact") }
+    let(:document) { create(:document, content_id:) }
+
+    before do
+      payload.merge!(document_type: "person", schema_name: "person", details: { body: [{ content_type: "text/govspeak", content: "{{embed:contact:#{first_contact.document.content_id}}} {{embed:contact:#{second_contact.document.content_id}}}" }] })
     end
 
     it "should create links" do

--- a/spec/services/embedded_content_finder_service_spec.rb
+++ b/spec/services/embedded_content_finder_service_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe EmbeddedContentFinderService do
     end
 
     it "finds contact references when body is an array of hashes" do
-      body = [{ content: "{{embed:contact:#{contacts[0].content_id}}} {{embed:contact:#{contacts[1].content_id}}}" }]
+      body = [{ "content" => "{{embed:contact:#{contacts[0].content_id}}} {{embed:contact:#{contacts[1].content_id}}}" }]
 
       links = EmbeddedContentFinderService.new.fetch_linked_content_ids(body, Edition::DEFAULT_LOCALE)
 


### PR DESCRIPTION
We used a symbol as the hash key for the body, when it is actually a string.

No test cases covered this scenario, so adding a relevant test too.

[Trello card](https://trello.com/c/CN92MLav)