### PR TITLE
Point test-frontend job to correct test file

### DIFF
--- a/.github/workflows/test-content-schemas-1.yml
+++ b/.github/workflows/test-content-schemas-1.yml
@@ -93,7 +93,7 @@ jobs:
 
   test-frontend:
     name: Test Frontend
-    uses: alphagov/frontend/.github/workflows/minitest.yml@main
+    uses: alphagov/frontend/.github/workflows/rspec.yml@main
     with:
       ref: 'main'
       publishingApiRef: ${{ github.ref }}


### PR DESCRIPTION
Frontend has migrated from minitest to rspec recently, causing the `test-content-schemas-1.yml` workflow to be invalid. These changes point to the correct `rspec` file.
