### PR TITLE
Add a shared `content_block` format

### DIFF
--- a/content_schemas/dist/formats/content_block_email_address/notification/schema.json
+++ b/content_schemas/dist/formats/content_block_email_address/notification/schema.json
@@ -85,6 +85,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -183,6 +187,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/guid_list"
+        },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"

--- a/content_schemas/dist/formats/content_block_email_address/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/content_block_email_address/publisher_v2/schema.json
@@ -56,6 +56,14 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "embed": {
+          "description": "Content that will be embedded within the document, using embed tags.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "policy_areas": {
+          "description": "A largely deprecated tag currently only used to power email alerts.",
+          "$ref": "#/definitions/guid_list"
+        },
         "primary_publishing_organisation": {
           "description": "The organisation that published the content block. Corresponds to the Edition's 'Organisation' in Whitehall, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list",

--- a/content_schemas/dist/formats/content_block_postal_address/notification/schema.json
+++ b/content_schemas/dist/formats/content_block_postal_address/notification/schema.json
@@ -147,7 +147,7 @@
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "primary_publishing_organisation": {
-          "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
+          "description": "The organisation that published the content block. Corresponds to the Edition's 'Organisation' in Whitehall, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path",
           "maxItems": 1
         },
@@ -233,7 +233,7 @@
           "$ref": "#/definitions/guid_list"
         },
         "primary_publishing_organisation": {
-          "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
+          "description": "The organisation that published the content block. Corresponds to the Edition's 'Organisation' in Whitehall, and is empty for all other publishing applications.",
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },

--- a/content_schemas/dist/formats/content_block_postal_address/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/content_block_postal_address/publisher_v2/schema.json
@@ -63,6 +63,11 @@
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
           "$ref": "#/definitions/guid_list"
+        },
+        "primary_publishing_organisation": {
+          "description": "The organisation that published the content block. Corresponds to the Edition's 'Organisation' in Whitehall, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/guid_list",
+          "maxItems": 1
         }
       }
     },

--- a/content_schemas/formats/content_block_email_address.jsonnet
+++ b/content_schemas/formats/content_block_email_address.jsonnet
@@ -1,8 +1,5 @@
-(import "shared/default_format.jsonnet") + {
+(import "shared/content_block.jsonnet") + {
   document_type: "content_block_email_address",
-  base_path: "forbidden",
-  routes: "forbidden",
-  rendering_app: "forbidden",
   definitions: {
     details: {
       type: "object",
@@ -14,12 +11,6 @@
           format: "email",
         },
       },
-    },
-  },
-  edition_links: {
-    primary_publishing_organisation: {
-       description: "The organisation that published the content block. Corresponds to the Edition's 'Organisation' in Whitehall, and is empty for all other publishing applications.",
-       maxItems: 1,
     },
   },
 }

--- a/content_schemas/formats/content_block_postal_address.jsonnet
+++ b/content_schemas/formats/content_block_postal_address.jsonnet
@@ -1,8 +1,5 @@
-(import "shared/default_format.jsonnet") + {
+(import "shared/content_block.jsonnet") + {
   document_type: "content_block_postal_address",
-  base_path: "forbidden",
-  routes: "forbidden",
-  rendering_app: "forbidden",
   definitions: {
     details: {
       type: "object",

--- a/content_schemas/formats/shared/content_block.jsonnet
+++ b/content_schemas/formats/shared/content_block.jsonnet
@@ -1,0 +1,11 @@
+(import "default_format.jsonnet") + {
+  base_path: "forbidden",
+  routes: "forbidden",
+  rendering_app: "forbidden",
+  edition_links: (import "base_edition_links.jsonnet") +  {
+    primary_publishing_organisation: {
+       description: "The organisation that published the content block. Corresponds to the Edition's 'Organisation' in Whitehall, and is empty for all other publishing applications.",
+       maxItems: 1,
+    },
+  },
+}


### PR DESCRIPTION
This allows us to share definitions across all content blocks, and define new ones more easily. There are minimal changes to the generated schemas, apart from adding some links to the Postal Address Schema, and adding the default links back to the Email Address schema (which we deleted accidentally).