### PR TITLE
Add sidekiq ui

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -118,6 +118,14 @@ module PublishingAPI
       events_key_prefix: "events/",
     )
 
+    # This also configures session_options for use below
+    config.session_store :cookie_store, key: "_interslice_session"
+
+    # Required for all session management (regardless of session_store)
+    config.middleware.use ActionDispatch::Cookies
+
+    config.middleware.use config.session_store, config.session_options
+
     config.debug_exception_response_format = :api
 
     # Even though most GOV.UK apps use the London time_zone, publishing-api almost always wants to

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,8 @@ Rails.application.routes.draw do
     UuidValidator.valid?(request.params[:content_id])
   end
 
+  require "sidekiq/web"
+
   scope format: false do
     put "/publish-intent(/*base_path)", to: "publish_intents#create_or_update"
     get "/publish-intent(/*base_path)", to: "publish_intents#show"
@@ -47,9 +49,7 @@ Rails.application.routes.draw do
     GovukHealthcheck::SidekiqRedis,
   )
 
-  if Rails.env.development?
-    require "sidekiq/web"
-    mount Sidekiq::Web => "/sidekiq"
-  end
+  mount Sidekiq::Web => "/sidekiq"
+
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
 end

--- a/docs/admin-tasks.md
+++ b/docs/admin-tasks.md
@@ -113,3 +113,20 @@ To see all the editions that were unpublished between two times run:
 ```
 bundle exec rake "csv_report:unpublishings_by_date_range['2020-10-01 10:00', '2020-12-31 10:00']"
 ```
+
+## Viewing the Sidekiq UI
+
+We have access to the Sidekiq UI but because Publishing API doesn't have a
+frontend we have to use port forwarding to see it in our live environments.
+
+You'll need to have access to our EKS clusters before you can follow these
+instructions. There's [documentation here](https://docs.publishing.service.gov.uk/kubernetes/get-started/access-eks-cluster/#access-a-cluster-that-you-have-accessed-before) on how to do that. This means that
+you'll need full production access before you can view the Sidekiq UI.
+
+To view the UI run:
+
+```
+kubectl -n apps port-forward deployment/publishing-api 8080:8080
+```
+
+and then navigate to localhost:8080/sidekiq


### PR DESCRIPTION
This adds the sidekiq UI to publishing API. This is deliberately done in a really straightforward way. As it stands Whitehall is the only real precident for this work and work has been done there to hide sidekiq behind a permission in signon. This isn't required by publishing API though because it doesn't have a UI or any ingress channels, nor will any have to be added. Instead we'll have to use port forwarding within K8s to access the interface. This acts as the authentication layer because only those with AWS access to our clusters will be able to do that.

There was some discussion about whether we'd be able to get access to our sidekiq queues through logging or grafana, but this was seen as the lighter weight option because querying the logs is technically fairly tricky.

I've had to add the ability to have sessions as well or the sidekiq UI just won't load.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
