### PR TITLE
Support email address content blocks

### DIFF
--- a/app/presenters/content_embed_presenter.rb
+++ b/app/presenters/content_embed_presenter.rb
@@ -44,11 +44,21 @@ module Presenters
         embed_code = embedded_content_references_by_content_id[embedded_edition.content_id].embed_code
         content = content.gsub(
           embed_code,
-          embedded_edition.title,
+          get_content_for_edition(embedded_edition),
         )
       end
 
       content
+    end
+
+    # This is a temporary solution to get email address content blocks working
+    # while we agree on a long-term approach that works for everything.
+    def get_content_for_edition(edition)
+      if edition.document_type == "content_block_email_address"
+        edition.details[:email_address]
+      else
+        edition.title
+      end
     end
   end
 end

--- a/app/services/embedded_content_finder_service.rb
+++ b/app/services/embedded_content_finder_service.rb
@@ -1,7 +1,7 @@
 class EmbeddedContentFinderService
   ContentReference = Data.define(:document_type, :content_id, :embed_code)
 
-  SUPPORTED_DOCUMENT_TYPES = %w[contact].freeze
+  SUPPORTED_DOCUMENT_TYPES = %w[contact content_block_email_address].freeze
   UUID_REGEX = /([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/
   EMBED_REGEX = /({{embed:(#{SUPPORTED_DOCUMENT_TYPES.join('|')}):#{UUID_REGEX}}})/
 

--- a/spec/presenters/content_embed_presenter_spec.rb
+++ b/spec/presenters/content_embed_presenter_spec.rb
@@ -6,10 +6,13 @@ RSpec.describe Presenters::ContentEmbedPresenter do
       :edition,
       document:,
       details: details.deep_stringify_keys,
-      links_hash: {
-        embed: [embedded_content_id],
-      },
+      links_hash:,
     )
+  end
+  let(:links_hash) do
+    {
+      embed: [embedded_content_id],
+    }
   end
   let(:details) { {} }
 
@@ -95,6 +98,36 @@ RSpec.describe Presenters::ContentEmbedPresenter do
             body: "some string with a reference: VALUE",
           })
         end
+      end
+    end
+
+    context "when the document is an email address" do
+      let(:embedded_document) { create(:document) }
+      let(:links_hash) do
+        {
+          embed: [embedded_document.content_id],
+        }
+      end
+
+      before do
+        create(
+          :edition,
+          document: embedded_document,
+          state: "published",
+          content_store: "live",
+          document_type: "content_block_email_address",
+          details: {
+            email_address: "foo@example.com",
+          },
+        )
+      end
+
+      let(:details) { { body: "some string with a reference: {{embed:content_block_email_address:#{embedded_document.content_id}}}" } }
+
+      it "returns an email address" do
+        expect(described_class.new(edition).render_embedded_content(details)).to eq({
+          body: "some string with a reference: foo@example.com",
+        })
       end
     end
   end

--- a/spec/services/embedded_content_finder_service_spec.rb
+++ b/spec/services/embedded_content_finder_service_spec.rb
@@ -1,27 +1,64 @@
-RSpec.describe EmbeddedContentFinderService do
-  let(:contacts) do
-    [
-      create(:edition,
-             state: "published",
-             document_type: "contact",
-             content_store: "live",
-             details: { title: "Some Title" }),
-      create(:edition,
-             state: "published",
-             document_type: "contact",
-             content_store: "live",
-             details: { title: "Some other Title" }),
-    ]
-  end
-  let(:draft_contact) do
-    create(:edition,
-           state: "draft",
-           document_type: "contact",
-           content_store: "live",
-           details: { title: "Some Title" })
-  end
+RSpec.shared_examples "finds references" do |document_type|
+  describe "when content is a #{document_type}" do
+    let(:editions) do
+      [
+        create(:edition,
+               state: "published",
+               document_type:,
+               content_store: "live",
+               details: { title: "Some Title" }),
+        create(:edition,
+               state: "published",
+               document_type:,
+               content_store: "live",
+               details: { title: "Some other Title" }),
+      ]
+    end
 
+    let(:draft_edition) do
+      create(:edition,
+             state: "draft",
+             document_type:,
+             content_store: "live",
+             details: { title: "Some Title" })
+    end
+
+    it "finds content references" do
+      body = "{{embed:#{document_type}:#{editions[0].content_id}}} {{embed:#{document_type}:#{editions[1].content_id}}}"
+
+      links = EmbeddedContentFinderService.new.fetch_linked_content_ids(body, Edition::DEFAULT_LOCALE)
+
+      expect(links).to eq([editions[0].content_id, editions[1].content_id])
+    end
+
+    it "finds content references when body is an array of hashes" do
+      body = [{ "content" => "{{embed:#{document_type}:#{editions[0].content_id}}} {{embed:#{document_type}:#{editions[1].content_id}}}" }]
+
+      links = EmbeddedContentFinderService.new.fetch_linked_content_ids(body, Edition::DEFAULT_LOCALE)
+
+      expect(links).to eq([editions[0].content_id, editions[1].content_id])
+    end
+
+    it "errors when given a content ID that is still draft" do
+      body = "{{embed:#{document_type}:#{draft_edition.content_id}}}"
+
+      expect { EmbeddedContentFinderService.new.fetch_linked_content_ids(body, Edition::DEFAULT_LOCALE) }.to raise_error(CommandError)
+    end
+
+    it "errors when given a live content ID that is not available in the current locale" do
+      body = "{{embed:#{document_type}:#{editions[0].content_id}}}"
+
+      expect { EmbeddedContentFinderService.new.fetch_linked_content_ids(body, "foo") }.to raise_error(CommandError)
+    end
+  end
+end
+
+RSpec.describe EmbeddedContentFinderService do
   describe ".fetch_linked_content_ids" do
+    EmbeddedContentFinderService::SUPPORTED_DOCUMENT_TYPES.each do |document_type|
+      include_examples "finds references", document_type
+    end
+
     it "returns an empty hash where there are no embeds" do
       body = "Hello world!"
 
@@ -30,38 +67,10 @@ RSpec.describe EmbeddedContentFinderService do
       expect(links).to eq([])
     end
 
-    it "finds contact references" do
-      body = "{{embed:contact:#{contacts[0].content_id}}} {{embed:contact:#{contacts[1].content_id}}}"
-
-      links = EmbeddedContentFinderService.new.fetch_linked_content_ids(body, Edition::DEFAULT_LOCALE)
-
-      expect(links).to eq([contacts[0].content_id, contacts[1].content_id])
-    end
-
-    it "finds contact references when body is an array of hashes" do
-      body = [{ "content" => "{{embed:contact:#{contacts[0].content_id}}} {{embed:contact:#{contacts[1].content_id}}}" }]
-
-      links = EmbeddedContentFinderService.new.fetch_linked_content_ids(body, Edition::DEFAULT_LOCALE)
-
-      expect(links).to eq([contacts[0].content_id, contacts[1].content_id])
-    end
-
     it "errors when given a content ID that has no live editions" do
       body = "{{embed:contact:00000000-0000-0000-0000-000000000000}}"
 
       expect { EmbeddedContentFinderService.new.fetch_linked_content_ids(body, Edition::DEFAULT_LOCALE) }.to raise_error(CommandError)
-    end
-
-    it "errors when given a content ID that is still draft" do
-      body = "{{embed:contact:#{draft_contact.content_id}}}"
-
-      expect { EmbeddedContentFinderService.new.fetch_linked_content_ids(body, Edition::DEFAULT_LOCALE) }.to raise_error(CommandError)
-    end
-
-    it "errors when given a live content ID that is not available in the current locale" do
-      body = "{{embed:contact:#{contacts[0].content_id}}}"
-
-      expect { EmbeddedContentFinderService.new.fetch_linked_content_ids(body, "foo") }.to raise_error(CommandError)
     end
   end
 end


### PR DESCRIPTION
This builds on the work in #2813 to allow support for Email Address content blocks. It also adds a simple conditional in the `ContentEmbedPresenter` to return the email address rather than the title. There will be scope to make this smarter in future, but this allows us to demonstrate the concept.