### PR TITLE
Content modelling/417 Get embedded content by target_content_id

### DIFF
--- a/app/controllers/v2/content_items_controller.rb
+++ b/app/controllers/v2/content_items_controller.rb
@@ -21,6 +21,14 @@ module V2
       ).call
     end
 
+    def embedded
+      results = Queries::GetEmbeddedContent.new(
+        path_params[:content_id],
+      ).call
+
+      render json: results
+    end
+
     def show
       render json: Queries::GetContent.call(
         path_params[:content_id],

--- a/app/presenters/queries/embedded_content_presenter.rb
+++ b/app/presenters/queries/embedded_content_presenter.rb
@@ -1,0 +1,43 @@
+module Presenters
+  module Queries
+    class EmbeddedContentPresenter
+      def self.present(target_edition_id, host_editions)
+        new(target_edition_id, host_editions).present
+      end
+
+      def initialize(target_edition_id, host_editions)
+        self.target_edition_id = target_edition_id
+        self.host_editions = host_editions.to_a
+      end
+
+      def present
+        {
+          content_id: target_edition_id,
+          total: host_editions.count,
+          results:,
+        }
+      end
+
+      def results
+        return [] unless host_editions.any?
+
+        host_editions.map do |edition|
+          {
+            title: edition.title,
+            base_path: edition.base_path,
+            document_type: edition.document_type,
+            primary_publishing_organisation: {
+              content_id: edition.primary_publishing_organisation_content_id,
+              title: edition.primary_publishing_organisation_title,
+              base_path: edition.primary_publishing_organisation_base_path,
+            },
+          }
+        end
+      end
+
+    private
+
+      attr_accessor :target_edition_id, :host_editions
+    end
+  end
+end

--- a/app/queries/get_embedded_content.rb
+++ b/app/queries/get_embedded_content.rb
@@ -1,0 +1,39 @@
+module Queries
+  class GetEmbeddedContent
+    attr_reader :target_content_id
+
+    def initialize(target_content_id)
+      self.target_content_id = target_content_id
+    end
+
+    def call
+      if Document.find_by(content_id: target_content_id).nil?
+        message = "Could not find an edition to get embedded content for"
+        raise CommandError.new(code: 404, message:)
+      end
+
+      Presenters::Queries::EmbeddedContentPresenter.present(
+        target_content_id,
+        host_editions,
+      )
+    end
+
+  private
+
+    def host_editions
+      @host_editions ||= Edition.live
+        .joins(:links)
+        .joins("LEFT JOIN links AS primary_links ON primary_links.edition_id = editions.id AND primary_links.link_type = 'primary_publishing_organisation'")
+        .joins("LEFT JOIN documents ON documents.content_id = primary_links.target_content_id")
+        .joins("LEFT JOIN editions AS org_editions ON org_editions.document_id = documents.id")
+        .where(links: { link_type: embedded_link_type, target_content_id: })
+        .select(
+          "editions.id, editions.title, editions.base_path, editions.document_type, primary_links.target_content_id AS primary_publishing_organisation_content_id",
+          "org_editions.title AS primary_publishing_organisation_title",
+          "org_editions.base_path AS primary_publishing_organisation_base_path",
+        )
+    end
+
+    attr_writer :target_content_id
+  end
+end

--- a/app/queries/get_embedded_content.rb
+++ b/app/queries/get_embedded_content.rb
@@ -1,9 +1,10 @@
 module Queries
   class GetEmbeddedContent
-    attr_reader :target_content_id
+    attr_reader :target_content_id, :states
 
     def initialize(target_content_id)
       self.target_content_id = target_content_id
+      self.states = %i[draft published]
     end
 
     def call
@@ -21,7 +22,7 @@ module Queries
   private
 
     def host_editions
-      @host_editions ||= Edition.live
+      @host_editions ||= Edition.where(state: states)
         .joins(:links)
         .joins("LEFT JOIN links AS primary_links ON primary_links.edition_id = editions.id AND primary_links.link_type = 'primary_publishing_organisation'")
         .joins("LEFT JOIN documents ON documents.content_id = primary_links.target_content_id")
@@ -34,6 +35,10 @@ module Queries
         )
     end
 
-    attr_writer :target_content_id
+    def embedded_link_type
+      "embed"
+    end
+
+    attr_writer :target_content_id, :states
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,6 +20,7 @@ Rails.application.routes.draw do
       scope constraints: method(:content_id_constraint) do
         put "/content/:content_id", to: "content_items#put_content"
         get "/content/:content_id", to: "content_items#show"
+        get "/content/:content_id/embedded", to: "content_items#embedded"
         post "/content/:content_id/publish", to: "content_items#publish"
         post "/content/:content_id/republish", to: "content_items#republish"
         post "/content/:content_id/unpublish", to: "content_items#unpublish"

--- a/docs/api.md
+++ b/docs/api.md
@@ -16,6 +16,7 @@ message queue for other apps (e.g. `email-alert-service`) to consume.
 - [`POST /v2/content/:content_id/discard-draft`](#post-v2contentcontent_iddiscard-draft)
 - [`GET /v2/content`](#get-v2content)
 - [`GET /v2/content/:content_id`](#get-v2contentcontent_id)
+- [`GET /v2/content/:content_id/embedded`](#get-v2contentcontent_idembedded)
 - [`PATCH /v2/links/:content_id`](#patch-v2linkscontent_id)
 - [`GET /v2/links/:content_id`](#get-v2linkscontent_id)
 - [`GET /v2/expanded-links/:content_id`](#get-v2expanded-linkscontent_id)
@@ -426,6 +427,20 @@ included within the response.
 - `version` *(optional)*
   - Specify a particular edition of this document
   - If omitted the most recent edition.
+
+## `GET /v2/content/:content_id/embedded`
+
+Retrieves a summary list of any live content which has an embedded reference to
+the target `:content_id`.
+
+<!-- TODO: Include a link to how Resuable Content works here when we have it -->
+Content can include an embedded reference in its body when
+it wants to defer to a reusable piece of content, such as an email address.
+
+### Path parameters
+
+- [`content_id`](model.md#content_id)
+  - Identifies the target document for the reusable piece of content
 
 ## `PATCH /v2/links/:content_id`
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -430,8 +430,8 @@ included within the response.
 
 ## `GET /v2/content/:content_id/embedded`
 
-Retrieves a summary list of any live content which has an embedded reference to
-the target `:content_id`.
+Retrieves a summary list of any draft or published content which has an embedded
+reference to the target `:content_id`.
 
 <!-- TODO: Include a link to how Resuable Content works here when we have it -->
 Content can include an embedded reference in its body when

--- a/spec/integration/embedded_content_spec.rb
+++ b/spec/integration/embedded_content_spec.rb
@@ -1,0 +1,76 @@
+RSpec.describe "Embedded documents" do
+  let!(:publishing_organisation) do
+    create(:live_edition,
+           title: "bar",
+           document_type: "organisation",
+           schema_name: "organisation",
+           base_path: "/government/organisations/bar")
+  end
+
+  let!(:content_block) do
+    create(:live_edition,
+           title: "Foo's email address",
+           document_type: "content_block_email_address",
+           schema_name: "content_block_email_address",
+           details: {
+             "email_address" => "foo@example.com",
+           })
+  end
+
+  context "when the target edition doesn't exist" do
+    it "returns a 404" do
+      get "/v2/content/#{SecureRandom.uuid}/embedded"
+
+      expect(response.status).to eq(404)
+    end
+  end
+
+  context "when no editions embed the content block" do
+    it "returns an empty results array" do
+      unembedded_edition = create(:live_edition)
+
+      get "/v2/content/#{unembedded_edition.content_id}/embedded"
+
+      expect(response.status).to eq(200)
+      response_body = parsed_response
+
+      expect(response_body["content_id"]).to eq(unembedded_edition.content_id)
+      expect(response_body["total"]).to eq(0)
+      expect(response_body["results"]).to eq([])
+    end
+  end
+
+  context "when an edition embeds a reference to the content block" do
+    it "returns details of the edition and its publishing organisation in the results" do
+      host_edition = create(:live_edition,
+                            details: {
+                              "body" => "<p>{{embed:email_address:#{content_block.content_id}}}</p>\n",
+                            },
+                            links_hash: {
+                              primary_publishing_organisation: [publishing_organisation.content_id],
+                              embed: [content_block.content_id],
+                            })
+
+      get "/v2/content/#{content_block.content_id}/embedded"
+
+      expect(response.status).to eq(200)
+
+      response_body = parsed_response
+
+      expect(response_body["content_id"]).to eq(content_block.content_id)
+      expect(response_body["total"]).to eq(1)
+      expect(response_body["results"]).to include(
+        {
+          "title" => host_edition.title,
+          "base_path" => host_edition.base_path,
+          "document_type" => host_edition.document_type,
+          "primary_publishing_organisation" => {
+            "content_id" => publishing_organisation.content_id,
+            "title" => publishing_organisation.title,
+            "base_path" => publishing_organisation.base_path,
+          },
+        },
+      )
+    end
+  end
+end

--- a/spec/presenters/queries/embedded_content_presenter_spec.rb
+++ b/spec/presenters/queries/embedded_content_presenter_spec.rb
@@ -1,0 +1,42 @@
+RSpec.describe Presenters::Queries::EmbeddedContentPresenter do
+  describe "#present" do
+    let(:organisation_edition_id) { SecureRandom.uuid }
+    let(:target_edition_id) { SecureRandom.uuid }
+
+    let(:host_editions) do
+      [double("Edition",
+              id: "1",
+              title: "foo",
+              base_path: "/foo",
+              document_type: "publication",
+              primary_publishing_organisation_content_id: organisation_edition_id,
+              primary_publishing_organisation_title: "bar",
+              primary_publishing_organisation_base_path: "/bar")]
+    end
+
+    let(:result) { described_class.present(target_edition_id, host_editions) }
+
+    let(:expected_output) do
+      {
+        content_id: target_edition_id,
+        total: 1,
+        results: [
+          {
+            title: "foo",
+            base_path: "/foo",
+            document_type: "publication",
+            primary_publishing_organisation: {
+              content_id: organisation_edition_id,
+              title: "bar",
+              base_path: "/bar",
+            },
+          },
+        ],
+      }
+    end
+
+    it "presents attributes of host content in an array of results" do
+      expect(result).to eq(expected_output)
+    end
+  end
+end

--- a/spec/queries/get_embedded_content_spec.rb
+++ b/spec/queries/get_embedded_content_spec.rb
@@ -1,0 +1,130 @@
+RSpec.describe Queries::GetEmbeddedContent do
+  describe "#call" do
+    it "returns data prepared by the presenter" do
+      target_content_id = SecureRandom.uuid
+      allow(Document).to receive(:find_by).with(content_id: target_content_id).and_return(anything)
+
+      presenter_double = double(Presenters::Queries::EmbeddedContentPresenter)
+      expect(Presenters::Queries::EmbeddedContentPresenter).to receive(:new)
+        .with(target_content_id, kind_of(ActiveRecord::Relation))
+        .and_return(presenter_double)
+
+      stubbed_response = {}.to_json
+      expect(presenter_double).to receive(:present).and_return(stubbed_response)
+
+      result = described_class.new(target_content_id).call
+
+      expect(result).to eq(stubbed_response)
+    end
+
+    context "when the target_content_id doesn't match a Document" do
+      it "returns 404" do
+        expect { described_class.new(SecureRandom.uuid).call }.to raise_error(CommandError) do |error|
+          expect(error.code).to eq(404)
+          expect(error.message).to eq("Could not find an edition to get embedded content for")
+        end
+      end
+    end
+
+    context "when the target_content_id does not match a live edition" do
+      it "does not include it in the results" do
+        organisation = create(:live_edition,
+                              title: "bar",
+                              document_type: "organisation",
+                              schema_name: "organisation",
+                              base_path: "/government/organisations/bar")
+        content_block = create(:live_edition, document_type: "content_block_email_address",
+                                              schema_name: "content_block_email_address",
+                                              details: {
+                                                "email_address" => "foo@example.com",
+                                              })
+        target_content_id = content_block.content_id
+        _draft_edition = create(:edition, state: "draft",
+                                          details: {
+                                            body: "<p>{{embed:email_address:#{target_content_id}}}</p>\n",
+                                          },
+                                          links_hash: {
+                                            primary_publishing_organisation: [organisation.content_id],
+                                            content_block_email_address: [content_block.content_id],
+                                          })
+
+        result = described_class.new(target_content_id).call
+
+        expect(result).to eq({ content_id: target_content_id, total: 0, results: [] })
+      end
+    end
+
+    context "when the target_content is not embedded in any live editions" do
+      it "returns an empty results list" do
+        target_content_id = SecureRandom.uuid
+        allow(Document).to receive(:find_by).and_return(anything)
+
+        result = described_class.new(target_content_id).call
+
+        expect(result).to eq({ content_id: target_content_id, total: 0, results: [] })
+      end
+    end
+
+    context "when there are live editions that embed the target content" do
+      it "only passes them to the presenter" do
+        organisation = create(:live_edition,
+                              title: "bar",
+                              document_type: "organisation",
+                              schema_name: "organisation",
+                              base_path: "/government/organisations/bar")
+        content_block = create(:live_edition, document_type: "content_block_email_address",
+                                              schema_name: "content_block_email_address",
+                                              details: {
+                                                "email_address" => "foo@example.com",
+                                              })
+        target_content_id = content_block.content_id
+        host_editions = create_list(:live_edition, 2,
+                                    details: {
+                                      body: "<p>{{embed:email_address:#{target_content_id}}}</p>\n",
+                                    },
+                                    links_hash: {
+                                      primary_publishing_organisation: [organisation.content_id],
+                                      content_block_email_address: [target_content_id],
+                                    })
+        _unwanted_edition = create(:live_edition)
+
+        # The edition records we create in test can't be used as they are as assertions.
+        # We load new fields into the Edition using the SQL Select.
+        edition_doubles = host_editions.map do |host_edition|
+          double("Edition",
+                 id: host_edition.id,
+                 title: host_edition.title,
+                 base_path: host_edition.base_path,
+                 document_type: host_edition.document_type,
+                 primary_publishing_organisation_content_id: organisation.content_id,
+                 primary_publishing_organisation_title: organisation.title,
+                 primary_publishing_organisation_base_path: organisation.base_path)
+        end
+
+        expected_editions = edition_doubles.map do |edition_double|
+          have_attributes(
+            id: edition_double.id,
+            title: edition_double.title,
+            base_path: edition_double.base_path,
+            document_type: edition_double.document_type,
+            primary_publishing_organisation_content_id: edition_double.primary_publishing_organisation_content_id,
+            primary_publishing_organisation_title: edition_double.primary_publishing_organisation_title,
+            primary_publishing_organisation_base_path: edition_double.primary_publishing_organisation_base_path,
+          )
+        end
+
+        presenter_double = double(Presenters::Queries::EmbeddedContentPresenter)
+        expect(Presenters::Queries::EmbeddedContentPresenter).to receive(:new) do |_, editions|
+          editions.each_with_index do |edition, index|
+            expect(edition).to expected_editions[index]
+          end
+          presenter_double
+        end
+
+        allow(presenter_double).to receive(:present).and_return({}.to_json)
+
+        described_class.new(target_content_id).call
+      end
+    end
+  end
+end


### PR DESCRIPTION
# What does this do?

Given a `target_content_id` which is the edition of the content block/embeddable content, it will find and return any other live editions [where it has been embedded and a link set up](https://github.com/alphagov/publishing-api/pull/2813).

For The content Object store within Whitehall we only need a few fields compared to the existing `content/:id` endpoint: `title`, `base_path`, `document_type`, `target_content_id` and a couple of fields about the associated organisation.

With this data we’ll present a table that allows reusable content publishers to see where their content is currently being included.

# Why a new endpoint?

We have previously tried to use [the `/v2/content/:content_id` endpoint](https://github.com/alphagov/publishing-api/blob/main/docs/api.md#put-v2contentcontent_id). Though it includes a lot more `Edition` data than we need it also returned the publishing organisation link and gave us pagination and sorting for free. **This worked locally but on[ Integration this timed out](https://gds.slack.com/archives/C0776B04EJU/p1723559847781489) and our implementation (which is flagged off in production) is currently broken.**

We tracked down the performance problem to [a subquery used](https://github.com/alphagov/publishing-api/blob/3f4cc8523b1713aefc1e8f70950e1a81cfa56f22/app/presenters/queries/content_item_presenter.rb#L190) when the `link_set_links` `field` is passed through. [It appears we added this a few weeks ago in an effort to extend the endpoint for our purposes](https://github.com/alphagov/publishing-api/pull/2823). As a result of the data that follows I think this change should be reverted and [I'll propose it as a separate change](https://github.com/alphagov/publishing-api/pull/2847).

We did some local [benchmarking](https://ruby-doc.org/stdlib-2.7.1/libdoc/benchmark/rdoc/Benchmark.html) and found the query was slowing down notably after a few hundred thousand records:

```
2024-08-15 17:24:20 Document count: 178924
2024-08-15 17:24:20 Edition count: 178925
2024-08-15 17:24:20 Link count: 178855
                                      user            system      total          real
2024-08-15 17:24:20   0.003363   0.012408   0.015771 (  0.334085)
1.92s in the browser

2024-08-15 17:29:01 Document count: 228173
2024-08-15 17:29:01 Edition count: 228174
2024-08-15 17:29:01 Link count: 228106
                                      user            system      total          real
2024-08-15 17:29:01   0.019349   0.013283   0.032632 (  0.499379)
3.8s in the browser
```

We stopped seeding at this point as we could see that seeding more would eventually result in a timeout.

On integration the comparable data counts at the time were:

```
39_953_449 links
14_170_691 editions
1_323_401 documents 
931_902 link sets
```

It seems reasonable that there might be more than hundreds of thousands of
documents and millions of links in production. We can't find an obvious
fault in the existing subquery. Instead of risking a change to it we
create a new endpoint which does just the thing we need.

On the same data set we see a marked improvement:
```
2024-08-16 11:19:27 Document: 230366
2024-08-16 11:19:27 Edition: 230365
2024-08-16 11:19:27 Link: 230295
                                      user            system      total          real
2024-08-16 11:19:27   0.000593   0.000170   0.000763 (  0.001478)
```

A negative side effect of this is that we won't get pagination and
sorting for free.

## Naming

We continue to use the relatively new term of `embedded`. [It was the language used on the original linking work](https://github.com/alphagov/publishing-api/pull/2813) and also is what we use as our embed references: `{{embed…}}`.

We sit alongside many other endpoints and services which are named "link", "linkables", "link sets" and "link set links". Though we of course use `links` under the hood to find embedded content we try to abstract that in order to more clearly distinguish this.
