### PR TITLE
Add new values in stage facet for service standard reports finder

### DIFF
--- a/content_schemas/dist/formats/specialist_document/frontend/schema.json
+++ b/content_schemas/dist/formats/specialist_document/frontend/schema.json
@@ -3684,11 +3684,14 @@
           "enum": [
             "alpha",
             "alpha-reassessment",
+            "alpha-amber-evidence-review",
             "beta",
             "beta-reassessment",
+            "beta-amber-evidence-review",
             "live",
             "live-reassessment",
-            "live-review"
+            "live-review",
+            "live-amber-evidence-review"
           ]
         }
       }

--- a/content_schemas/dist/formats/specialist_document/notification/schema.json
+++ b/content_schemas/dist/formats/specialist_document/notification/schema.json
@@ -3825,11 +3825,14 @@
           "enum": [
             "alpha",
             "alpha-reassessment",
+            "alpha-amber-evidence-review",
             "beta",
             "beta-reassessment",
+            "beta-amber-evidence-review",
             "live",
             "live-reassessment",
-            "live-review"
+            "live-review",
+            "live-amber-evidence-review"
           ]
         }
       }

--- a/content_schemas/dist/formats/specialist_document/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/specialist_document/publisher_v2/schema.json
@@ -3507,11 +3507,14 @@
           "enum": [
             "alpha",
             "alpha-reassessment",
+            "alpha-amber-evidence-review",
             "beta",
             "beta-reassessment",
+            "beta-amber-evidence-review",
             "live",
             "live-reassessment",
-            "live-review"
+            "live-review",
+            "live-amber-evidence-review"
           ]
         }
       }

--- a/content_schemas/formats/shared/definitions/_specialist_document.jsonnet
+++ b/content_schemas/formats/shared/definitions/_specialist_document.jsonnet
@@ -3021,11 +3021,14 @@
         enum: [
           "alpha",
           "alpha-reassessment",
+          "alpha-amber-evidence-review",
           "beta",
           "beta-reassessment",
+          "beta-amber-evidence-review",
           "live",
           "live-reassessment",
           "live-review",
+          "live-amber-evidence-review",
         ],
       },
       service_provider: {


### PR DESCRIPTION
CDDO would like to update the [Service Standards Reports](https://www.gov.uk/service-standard-reports) finder.

All they’ve asked for so far is to add one more drop-down option.

I’ve asked them to raise a Zendesk Ticket.

Zendesk ticket: https://govuk.zendesk.com/agent/tickets/5905154

https://trello.com/c/sImB9Gm7/2810-update-service-standards-reports-finder

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
