### PR TITLE
Content modelling/515 embedded content can appear in any field

### DIFF
--- a/app/commands/v2/put_content.rb
+++ b/app/commands/v2/put_content.rb
@@ -99,9 +99,9 @@ module Commands
       end
 
       def fetch_embedded_content(edition)
-        return [] if edition[:details]["body"].nil?
+        return [] if edition[:details].nil?
 
-        EmbeddedContentFinderService.new.fetch_linked_content_ids(edition[:details]["body"], edition.locale)
+        EmbeddedContentFinderService.new.fetch_linked_content_ids(edition[:details], edition.locale)
       end
 
       def create_redirect

--- a/app/services/embedded_content_finder_service.rb
+++ b/app/services/embedded_content_finder_service.rb
@@ -5,22 +5,26 @@ class EmbeddedContentFinderService
   UUID_REGEX = /([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/
   EMBED_REGEX = /({{embed:(#{SUPPORTED_DOCUMENT_TYPES.join('|')}):#{UUID_REGEX}}})/
 
-  def fetch_linked_content_ids(body, locale)
-    content_references = if body.is_a?(Array)
-                           body.map { |hash| find_content_references(hash["content"]) }.flatten
-                         else
-                           find_content_references(body)
-                         end
-    return [] if content_references.empty?
+  def fetch_linked_content_ids(details, locale)
+    content_references = details.values.map { |value|
+      find_content_references(value)
+    }.flatten.compact.uniq
 
     check_all_references_exist(content_references, locale)
     content_references.map(&:content_id)
   end
 
   def find_content_references(value)
-    return [] unless value.is_a?(String)
-
-    value.scan(EMBED_REGEX).map { |match| ContentReference.new(document_type: match[1], content_id: match[2], embed_code: match[0]) }.uniq
+    case value
+    when Array
+      value.map { |item| find_content_references(item) }.flatten
+    when Hash
+      value.map { |_, v| find_content_references(v) }.flatten
+    when String
+      value.scan(EMBED_REGEX).map { |match| ContentReference.new(document_type: match[1], content_id: match[2], embed_code: match[0]) }.uniq
+    else
+      []
+    end
   end
 
 private

--- a/app/services/embedded_content_finder_service.rb
+++ b/app/services/embedded_content_finder_service.rb
@@ -17,8 +17,10 @@ class EmbeddedContentFinderService
     content_references.map(&:content_id)
   end
 
-  def find_content_references(body)
-    body.scan(EMBED_REGEX).map { |match| ContentReference.new(document_type: match[1], content_id: match[2], embed_code: match[0]) }.uniq
+  def find_content_references(value)
+    return [] unless value.is_a?(String)
+
+    value.scan(EMBED_REGEX).map { |match| ContentReference.new(document_type: match[1], content_id: match[2], embed_code: match[0]) }.uniq
   end
 
 private

--- a/spec/integration/put_content/content_with_embedded_content_spec.rb
+++ b/spec/integration/put_content/content_with_embedded_content_spec.rb
@@ -20,6 +20,30 @@ RSpec.describe "PUT /v2/content when embedded content is provided" do
     end
   end
 
+  context "when embedded content is in a details field other than body" do
+    let(:first_contact) { create(:edition, state: "published", content_store: "live", document_type: "contact") }
+    let(:second_contact) { create(:edition, state: "published", content_store: "live", document_type: "contact") }
+    let(:document) { create(:document, content_id:) }
+
+    let(:payload_for_multiple_field_embeds) do
+      payload.merge!(
+        document_type: "transaction",
+        schema_name: "transaction",
+        details: {
+          downtime_message: "{{embed:contact:#{first_contact.document.content_id}}}",
+        },
+      )
+    end
+
+    it "should create a link" do
+      expect {
+        put "/v2/content/#{content_id}", params: payload_for_multiple_field_embeds.to_json
+      }.to change(Link, :count).by(1)
+
+      expect(Link.find_by(target_content_id: first_contact.content_id)).not_to be_nil
+    end
+  end
+
   context "with embedded content as an array" do
     let(:first_contact) { create(:edition, state: "published", content_store: "live", document_type: "contact") }
     let(:second_contact) { create(:edition, state: "published", content_store: "live", document_type: "contact") }

--- a/spec/presenters/content_embed_presenter_spec.rb
+++ b/spec/presenters/content_embed_presenter_spec.rb
@@ -57,6 +57,52 @@ RSpec.describe Presenters::ContentEmbedPresenter do
       end
     end
 
+    context "when body is a hash" do
+      let(:details) do
+        { body: { title: "some string with a reference: {{embed:contact:#{embedded_content_id}}}" } }
+      end
+
+      it "returns embedded content references with values from their editions" do
+        expect(described_class.new(edition).render_embedded_content(details)).to eq({
+          body: { title: "some string with a reference: VALUE" },
+        })
+      end
+    end
+
+    context "when body is a multipart document" do
+      let(:details) do
+        {
+          parts: [
+            body: [
+              {
+                content: "some string with a reference: {{embed:contact:#{embedded_content_id}}}",
+                content_type: "text/govspeak",
+              },
+            ],
+            slug: "some-slug",
+            title: "Some title",
+          ],
+        }
+      end
+
+      it "returns embedded content references with values from their editions" do
+        expect(described_class.new(edition).render_embedded_content(details)).to eq(
+          {
+            parts: [
+              body: [
+                {
+                  content: "some string with a reference: VALUE",
+                  content_type: "text/govspeak",
+                },
+              ],
+              slug: "some-slug",
+              title: "Some title",
+            ],
+          },
+        )
+      end
+    end
+
     context "when the embedded content is available in multiple locales" do
       let(:details) { { body: "some string with a reference: {{embed:contact:#{embedded_content_id}}}" } }
 

--- a/spec/presenters/content_embed_presenter_spec.rb
+++ b/spec/presenters/content_embed_presenter_spec.rb
@@ -176,5 +176,41 @@ RSpec.describe Presenters::ContentEmbedPresenter do
         })
       end
     end
+
+    context "when multiple documents are embedded in different parts of the document" do
+      let(:other_embedded_content_id) { SecureRandom.uuid }
+
+      before do
+        embedded_document = create(:document, content_id: other_embedded_content_id)
+        create(
+          :edition,
+          document: embedded_document,
+          state: "published",
+          content_store: "live",
+          document_type: "contact",
+          title: "VALUE2",
+        )
+      end
+
+      let(:links_hash) do
+        {
+          embed: [embedded_content_id, other_embedded_content_id],
+        }
+      end
+
+      let(:details) do
+        {
+          title: "title string with reference: {{embed:contact:#{other_embedded_content_id}}}",
+          body: "some string with a reference: {{embed:contact:#{embedded_content_id}}}",
+        }
+      end
+
+      it "returns embedded content references with values from their editions" do
+        expect(described_class.new(edition).render_embedded_content(details)).to eq({
+          title: "title string with reference: VALUE2",
+          body: "some string with a reference: VALUE",
+        })
+      end
+    end
   end
 end

--- a/spec/presenters/details_presenter_spec.rb
+++ b/spec/presenters/details_presenter_spec.rb
@@ -184,7 +184,7 @@ RSpec.describe Presenters::DetailsPresenter do
       end
     end
 
-    %w[body].each do |field_name|
+    %w[body downtime_message more_information].each do |field_name|
       context "when we're passed a #{field_name} with embedded content" do
         let(:embeddable_content) do
           create(:edition, state: "published", content_store: "live", document_type: "contact", title: "Some contact")

--- a/spec/services/embedded_content_finder_service_spec.rb
+++ b/spec/services/embedded_content_finder_service_spec.rb
@@ -75,4 +75,10 @@ RSpec.describe EmbeddedContentFinderService do
       expect { EmbeddedContentFinderService.new.fetch_linked_content_ids(body, Edition::DEFAULT_LOCALE) }.to raise_error(CommandError)
     end
   end
+
+  describe ".find_content_references" do
+    it "returns nil if the argument isn't a scannable string" do
+      expect { EmbeddedContentFinderService.new.find_content_references(false).to eq([]) }
+    end
+  end
 end

--- a/spec/services/embedded_content_finder_service_spec.rb
+++ b/spec/services/embedded_content_finder_service_spec.rb
@@ -23,32 +23,34 @@ RSpec.shared_examples "finds references" do |document_type|
              details: { title: "Some Title" })
     end
 
-    it "finds content references" do
-      body = "{{embed:#{document_type}:#{editions[0].content_id}}} {{embed:#{document_type}:#{editions[1].content_id}}}"
+    %w[body].each do |field_name|
+      it "finds content references" do
+        field = "{{embed:#{document_type}:#{editions[0].content_id}}} {{embed:#{document_type}:#{editions[1].content_id}}}"
 
-      links = EmbeddedContentFinderService.new.fetch_linked_content_ids(body, Edition::DEFAULT_LOCALE)
+        links = EmbeddedContentFinderService.new.fetch_linked_content_ids(field, Edition::DEFAULT_LOCALE)
 
-      expect(links).to eq([editions[0].content_id, editions[1].content_id])
-    end
+        expect(links).to eq([editions[0].content_id, editions[1].content_id])
+      end
 
-    it "finds content references when body is an array of hashes" do
-      body = [{ "content" => "{{embed:#{document_type}:#{editions[0].content_id}}} {{embed:#{document_type}:#{editions[1].content_id}}}" }]
+      it "finds content references when #{field_name} is an array of hashes" do
+        field = [{ "content" => "{{embed:#{document_type}:#{editions[0].content_id}}} {{embed:#{document_type}:#{editions[1].content_id}}}" }]
 
-      links = EmbeddedContentFinderService.new.fetch_linked_content_ids(body, Edition::DEFAULT_LOCALE)
+        links = EmbeddedContentFinderService.new.fetch_linked_content_ids(field, Edition::DEFAULT_LOCALE)
 
-      expect(links).to eq([editions[0].content_id, editions[1].content_id])
-    end
+        expect(links).to eq([editions[0].content_id, editions[1].content_id])
+      end
 
-    it "errors when given a content ID that is still draft" do
-      body = "{{embed:#{document_type}:#{draft_edition.content_id}}}"
+      it "errors when given a content ID that is still draft" do
+        field = "{{embed:#{document_type}:#{draft_edition.content_id}}}"
 
-      expect { EmbeddedContentFinderService.new.fetch_linked_content_ids(body, Edition::DEFAULT_LOCALE) }.to raise_error(CommandError)
-    end
+        expect { EmbeddedContentFinderService.new.fetch_linked_content_ids(field, Edition::DEFAULT_LOCALE) }.to raise_error(CommandError)
+      end
 
-    it "errors when given a live content ID that is not available in the current locale" do
-      body = "{{embed:#{document_type}:#{editions[0].content_id}}}"
+      it "errors when given a live content ID that is not available in the current locale" do
+        field = "{{embed:#{document_type}:#{editions[0].content_id}}}"
 
-      expect { EmbeddedContentFinderService.new.fetch_linked_content_ids(body, "foo") }.to raise_error(CommandError)
+        expect { EmbeddedContentFinderService.new.fetch_linked_content_ids(field, "foo") }.to raise_error(CommandError)
+      end
     end
   end
 end

--- a/spec/services/embedded_content_finder_service_spec.rb
+++ b/spec/services/embedded_content_finder_service_spec.rb
@@ -23,33 +23,71 @@ RSpec.shared_examples "finds references" do |document_type|
              details: { title: "Some Title" })
     end
 
-    %w[body].each do |field_name|
+    %w[body downtime_message more_information].each do |field_name|
       it "finds content references" do
-        field = "{{embed:#{document_type}:#{editions[0].content_id}}} {{embed:#{document_type}:#{editions[1].content_id}}}"
+        details = { field_name => "{{embed:#{document_type}:#{editions[0].content_id}}} {{embed:#{document_type}:#{editions[1].content_id}}}" }
 
-        links = EmbeddedContentFinderService.new.fetch_linked_content_ids(field, Edition::DEFAULT_LOCALE)
+        links = EmbeddedContentFinderService.new.fetch_linked_content_ids(details, Edition::DEFAULT_LOCALE)
 
         expect(links).to eq([editions[0].content_id, editions[1].content_id])
       end
 
       it "finds content references when #{field_name} is an array of hashes" do
-        field = [{ "content" => "{{embed:#{document_type}:#{editions[0].content_id}}} {{embed:#{document_type}:#{editions[1].content_id}}}" }]
+        details = { field_name => [{ "content" => "{{embed:#{document_type}:#{editions[0].content_id}}} {{embed:#{document_type}:#{editions[1].content_id}}}" }] }
 
-        links = EmbeddedContentFinderService.new.fetch_linked_content_ids(field, Edition::DEFAULT_LOCALE)
+        links = EmbeddedContentFinderService.new.fetch_linked_content_ids(details, Edition::DEFAULT_LOCALE)
+
+        expect(links).to eq([editions[0].content_id, editions[1].content_id])
+      end
+
+      it "finds content references when #{field_name} is a multipart document" do
+        details = {
+          field_name => [
+            {
+              body: [
+                {
+                  content: "some string with a reference: {{embed:#{document_type}:#{editions[0].content_id}}}",
+                  content_type: "text/govspeak",
+                },
+              ],
+              slug: "some-slug",
+              title: "Some title",
+            },
+            {
+              body: [
+                {
+                  content: "some string with another reference: {{embed:#{document_type}:#{editions[1].content_id}}}",
+                  content_type: "text/govspeak",
+                },
+              ],
+              slug: "some-other-slug",
+              title: "Some other title",
+            },
+          ],
+        }
+        links = EmbeddedContentFinderService.new.fetch_linked_content_ids(details, Edition::DEFAULT_LOCALE)
+
+        expect(links).to eq([editions[0].content_id, editions[1].content_id])
+      end
+
+      it "finds content references when the field is a hash" do
+        details = { field_name => { title: "{{embed:#{document_type}:#{editions[0].content_id}}}", slug: "{{embed:#{document_type}:#{editions[1].content_id}}}", current: true } }
+
+        links = EmbeddedContentFinderService.new.fetch_linked_content_ids(details, Edition::DEFAULT_LOCALE)
 
         expect(links).to eq([editions[0].content_id, editions[1].content_id])
       end
 
       it "errors when given a content ID that is still draft" do
-        field = "{{embed:#{document_type}:#{draft_edition.content_id}}}"
+        details = { field_name => "{{embed:#{document_type}:#{draft_edition.content_id}}}" }
 
-        expect { EmbeddedContentFinderService.new.fetch_linked_content_ids(field, Edition::DEFAULT_LOCALE) }.to raise_error(CommandError)
+        expect { EmbeddedContentFinderService.new.fetch_linked_content_ids(details, Edition::DEFAULT_LOCALE) }.to raise_error(CommandError)
       end
 
       it "errors when given a live content ID that is not available in the current locale" do
-        field = "{{embed:#{document_type}:#{editions[0].content_id}}}"
+        details = { field_name => "{{embed:#{document_type}:#{editions[0].content_id}}}" }
 
-        expect { EmbeddedContentFinderService.new.fetch_linked_content_ids(field, "foo") }.to raise_error(CommandError)
+        expect { EmbeddedContentFinderService.new.fetch_linked_content_ids(details, "foo") }.to raise_error(CommandError)
       end
     end
   end
@@ -62,17 +100,57 @@ RSpec.describe EmbeddedContentFinderService do
     end
 
     it "returns an empty hash where there are no embeds" do
-      body = "Hello world!"
+      details = { body: "Hello world!" }
 
-      links = EmbeddedContentFinderService.new.fetch_linked_content_ids(body, Edition::DEFAULT_LOCALE)
+      links = EmbeddedContentFinderService.new.fetch_linked_content_ids(details, Edition::DEFAULT_LOCALE)
 
       expect(links).to eq([])
     end
 
     it "errors when given a content ID that has no live editions" do
-      body = "{{embed:contact:00000000-0000-0000-0000-000000000000}}"
+      details = { body: "{{embed:contact:00000000-0000-0000-0000-000000000000}}" }
 
-      expect { EmbeddedContentFinderService.new.fetch_linked_content_ids(body, Edition::DEFAULT_LOCALE) }.to raise_error(CommandError)
+      expect { EmbeddedContentFinderService.new.fetch_linked_content_ids(details, Edition::DEFAULT_LOCALE) }.to raise_error(CommandError)
+    end
+
+    context "when the field value is an array" do
+      it "returns an empty array" do
+        details = { body: [] }
+        result = EmbeddedContentFinderService.new.fetch_linked_content_ids(details, Edition::DEFAULT_LOCALE)
+        expect(result).to eq([])
+      end
+    end
+
+    context "when the field value is a hash" do
+      it "returns an empty array" do
+        details = { body: {} }
+        result = EmbeddedContentFinderService.new.fetch_linked_content_ids(details, Edition::DEFAULT_LOCALE)
+        expect(result).to eq([])
+      end
+    end
+
+    context "when the field value is a nested hash" do
+      it "returns an empty array" do
+        details = { body: { foo: {} } }
+        result = EmbeddedContentFinderService.new.fetch_linked_content_ids(details, Edition::DEFAULT_LOCALE)
+        expect(result).to eq([])
+      end
+    end
+
+    context "when the field value is nil" do
+      it "returns an empty array" do
+        details = { body: nil }
+        result = EmbeddedContentFinderService.new.fetch_linked_content_ids(details, Edition::DEFAULT_LOCALE)
+        expect(result).to eq([])
+      end
+    end
+
+    context "when the field value is a boolean" do
+      it "returns an empty array" do
+        details = { foo: true }
+        result = EmbeddedContentFinderService.new.fetch_linked_content_ids(details, Edition::DEFAULT_LOCALE)
+        expect(result).to eq([])
+      end
     end
   end
 


### PR DESCRIPTION
# Context

We want to allow embedding content blocks into any field, rather than just `body`. This allows content blocks to be embedded in documents of all types. We've found the following documents in Mainstream that can't use embeds:

- completed transaction
- guide
- transaction

As well as the Travel Advice documents which use the field name of part.

# Changes in this PR

This change enables:

1. all fields to be scanned for embed codes on creation, so that links can be created
2. all fields to be scanned for embed codes on presentation

I've also added some additional integration tests to ensure the whole journey works end to end. This does add a little more weight to the test suite, but I think this is a reasonable tradeoff given the amount of moving parts there are.