### PR TITLE
Content-modelling/550 Return publishing app for host Editions

### DIFF
--- a/app/presenters/queries/embedded_content_presenter.rb
+++ b/app/presenters/queries/embedded_content_presenter.rb
@@ -26,6 +26,7 @@ module Presenters
             title: edition.title,
             base_path: edition.base_path,
             document_type: edition.document_type,
+            publishing_app: edition.publishing_app,
             primary_publishing_organisation: {
               content_id: edition.primary_publishing_organisation_content_id,
               title: edition.primary_publishing_organisation_title,

--- a/app/queries/get_embedded_content.rb
+++ b/app/queries/get_embedded_content.rb
@@ -29,7 +29,8 @@ module Queries
         .joins("LEFT JOIN editions AS org_editions ON org_editions.document_id = documents.id")
         .where(links: { link_type: embedded_link_type, target_content_id: })
         .select(
-          "editions.id, editions.title, editions.base_path, editions.document_type, primary_links.target_content_id AS primary_publishing_organisation_content_id",
+          "editions.id, editions.title, editions.base_path, editions.document_type, editions.publishing_app",
+          "primary_links.target_content_id AS primary_publishing_organisation_content_id",
           "org_editions.title AS primary_publishing_organisation_title",
           "org_editions.base_path AS primary_publishing_organisation_base_path",
         )

--- a/spec/integration/embedded_content_spec.rb
+++ b/spec/integration/embedded_content_spec.rb
@@ -43,6 +43,7 @@ RSpec.describe "Embedded documents" do
   context "when an edition embeds a reference to the content block" do
     it "returns details of the edition and its publishing organisation in the results" do
       host_edition = create(:live_edition,
+                            publishing_app: "whitehall",
                             details: {
                               "body" => "<p>{{embed:email_address:#{content_block.content_id}}}</p>\n",
                             },
@@ -64,6 +65,7 @@ RSpec.describe "Embedded documents" do
           "title" => host_edition.title,
           "base_path" => host_edition.base_path,
           "document_type" => host_edition.document_type,
+          "publishing_app" => host_edition.publishing_app,
           "primary_publishing_organisation" => {
             "content_id" => publishing_organisation.content_id,
             "title" => publishing_organisation.title,

--- a/spec/presenters/queries/embedded_content_presenter_spec.rb
+++ b/spec/presenters/queries/embedded_content_presenter_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe Presenters::Queries::EmbeddedContentPresenter do
               title: "foo",
               base_path: "/foo",
               document_type: "publication",
+              publishing_app: "publisher",
               primary_publishing_organisation_content_id: organisation_edition_id,
               primary_publishing_organisation_title: "bar",
               primary_publishing_organisation_base_path: "/bar")]
@@ -25,6 +26,7 @@ RSpec.describe Presenters::Queries::EmbeddedContentPresenter do
             title: "foo",
             base_path: "/foo",
             document_type: "publication",
+            publishing_app: "publisher",
             primary_publishing_organisation: {
               content_id: organisation_edition_id,
               title: "bar",

--- a/spec/queries/get_embedded_content_spec.rb
+++ b/spec/queries/get_embedded_content_spec.rb
@@ -64,7 +64,8 @@ RSpec.describe Queries::GetEmbeddedContent do
                                               links_hash: {
                                                 primary_publishing_organisation: [organisation.content_id],
                                                 embed: [target_content_id],
-                                              })
+                                              },
+                                              publishing_app: "example-app")
         draft_host_editions = create_list(:edition, 2,
                                           details: {
                                             body: "<p>{{embed:email_address:#{target_content_id}}}</p>\n",
@@ -72,7 +73,8 @@ RSpec.describe Queries::GetEmbeddedContent do
                                           links_hash: {
                                             primary_publishing_organisation: [organisation.content_id],
                                             embed: [target_content_id],
-                                          })
+                                          },
+                                          publishing_app: "another-app")
 
         _unwanted_edition = create(:live_edition)
 
@@ -86,6 +88,7 @@ RSpec.describe Queries::GetEmbeddedContent do
                  title: host_edition.title,
                  base_path: host_edition.base_path,
                  document_type: host_edition.document_type,
+                 publishing_app: host_edition.publishing_app,
                  primary_publishing_organisation_content_id: organisation.content_id,
                  primary_publishing_organisation_title: organisation.title,
                  primary_publishing_organisation_base_path: organisation.base_path)
@@ -97,6 +100,7 @@ RSpec.describe Queries::GetEmbeddedContent do
             title: edition_double.title,
             base_path: edition_double.base_path,
             document_type: edition_double.document_type,
+            publishing_app: edition_double.publishing_app,
             primary_publishing_organisation_content_id: edition_double.primary_publishing_organisation_content_id,
             primary_publishing_organisation_title: edition_double.primary_publishing_organisation_title,
             primary_publishing_organisation_base_path: edition_double.primary_publishing_organisation_base_path,


### PR DESCRIPTION
This returns the publishing app name for all host editions (Editions with Embedded content in them)

In [this previous Whitehal PR ](https://github.com/alphagov/whitehall/pull/9447)we send publish intents for host Documents of embedded content, but we hardcoded the publishing app to Whitehall - we need to see the correct publishing app for all host editions in order to send these intents.


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
