### PR TITLE
content-modelling/562 remove draft editions from Host Content Items

### DIFF
--- a/app/queries/get_embedded_content.rb
+++ b/app/queries/get_embedded_content.rb
@@ -4,7 +4,7 @@ module Queries
 
     def initialize(target_content_id)
       self.target_content_id = target_content_id
-      self.states = %i[draft published]
+      self.states = %i[published]
     end
 
     def call

--- a/spec/factories/edition.rb
+++ b/spec/factories/edition.rb
@@ -95,9 +95,10 @@ FactoryBot.define do
     document_type { "contact" }
   end
 
-  factory :edition_with_embedded_content, parent: :edition do
+  factory :live_edition_with_embedded_content, parent: :edition do
     base_path { "/#{SecureRandom.uuid}" }
     details { { body: "{{embed:#{embedded_content_type}:#{embedded_content_id}" } }
+    state { "published" }
 
     transient do
       embedded_content_id { SecureRandom.uuid }

--- a/spec/queries/get_embedded_content_spec.rb
+++ b/spec/queries/get_embedded_content_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe Queries::GetEmbeddedContent do
     end
 
     context "when there are live and draft editions that embed the target content" do
-      it "only passes them to the presenter" do
+      it "only passes live editions to the presenter" do
         target_content_id = content_block.content_id
         published_host_editions = create_list(:live_edition, 2,
                                               details: {
@@ -66,19 +66,19 @@ RSpec.describe Queries::GetEmbeddedContent do
                                                 embed: [target_content_id],
                                               },
                                               publishing_app: "example-app")
-        draft_host_editions = create_list(:edition, 2,
-                                          details: {
-                                            body: "<p>{{embed:email_address:#{target_content_id}}}</p>\n",
-                                          },
-                                          links_hash: {
-                                            primary_publishing_organisation: [organisation.content_id],
-                                            embed: [target_content_id],
-                                          },
-                                          publishing_app: "another-app")
+        _draft_host_editions = create_list(:edition, 2,
+                                           details: {
+                                             body: "<p>{{embed:email_address:#{target_content_id}}}</p>\n",
+                                           },
+                                           links_hash: {
+                                             primary_publishing_organisation: [organisation.content_id],
+                                             embed: [target_content_id],
+                                           },
+                                           publishing_app: "another-app")
 
         _unwanted_edition = create(:live_edition)
 
-        expected_editions = published_host_editions + draft_host_editions
+        expected_editions = published_host_editions
 
         # The edition records we create in test can't be used as they are as assertions.
         # We load new fields into the Edition using the SQL Select.

--- a/spec/service_consumers/pact_helper.rb
+++ b/spec/service_consumers/pact_helper.rb
@@ -657,12 +657,12 @@ Pact.provider_states_for "GDS API Adapters" do
       reusable_edition = create(:live_edition, document: reusable_document)
 
       document = create(:document, content_id: "d66d6552-2627-4451-9dbc-cadbbd2005a1")
-      edition_with_embedded_edition = create(:edition_with_embedded_content,
-                                             document:,
-                                             embedded_content_id: reusable_edition.content_id,
-                                             title: "foo",
-                                             base_path: "/foo",
-                                             document_type: "publication")
+      live_edition_with_embedded_edition = create(:live_edition_with_embedded_content,
+                                                  document:,
+                                                  embedded_content_id: reusable_edition.content_id,
+                                                  title: "foo",
+                                                  base_path: "/foo",
+                                                  document_type: "publication")
 
       organisation_document = create(:document, content_id: "d1e7d343-9844-4246-a469-1fa4640e12ad")
       primary_publishing_organisation = create(:live_edition,
@@ -673,7 +673,7 @@ Pact.provider_states_for "GDS API Adapters" do
                                                base_path: "/bar")
       create(
         :link,
-        edition: edition_with_embedded_edition,
+        edition: live_edition_with_embedded_edition,
         link_type: :primary_publishing_organisation,
         link_set: nil,
         position: 0,


### PR DESCRIPTION
when we show users Documents that have embedded
content in them, we do not need to show draft
Editions because then the user would see
duplicates and draft Editions will not be visible
on the govuk frontend.

## Before

showing draft and published Editions, so it looks like a duplicate
![Screenshot 2024-09-20 at 11 55 55](https://github.com/user-attachments/assets/9eee9959-0f36-4adb-8ec6-cc12d8f54fac)

## After

just showing published Edition
![Screenshot 2024-09-20 at 11 55 49](https://github.com/user-attachments/assets/b6030a30-b8d9-4c80-a1ff-1cbb3a8e148a)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
