### PR TITLE
Content modelling/558 investigate email notifications for the public

### DIFF
--- a/app/workers/dependency_resolution_worker.rb
+++ b/app/workers/dependency_resolution_worker.rb
@@ -9,6 +9,8 @@ class DependencyResolutionWorker
 
     send_source_stats
 
+    Rails.logger.info("Found #{dependencies.count} dependencies")
+
     dependencies.each do |(content_id, locale)|
       send_downstream(content_id, locale)
     end
@@ -68,7 +70,7 @@ private
   end
 
   def dependencies
-    Queries::ContentDependencies.new(
+    @dependencies ||= Queries::ContentDependencies.new(
       content_id:,
       locale:,
       content_stores:,

--- a/app/workers/downstream_live_worker.rb
+++ b/app/workers/downstream_live_worker.rb
@@ -138,7 +138,7 @@ private
   def broadcast_to_message_queue(payload, event_type)
     Rails.logger.info(
       "DownstreamLiveWorker#perform:" \
-        "Broadcasting #{content_id}@#{payload_version} to message queue as type #{event_type}",
+        "Broadcasting `#{edition.title}` #{content_id}@#{payload_version} to message queue as type #{event_type}",
     )
     DownstreamService.broadcast_to_message_queue(payload, event_type)
   end

--- a/app/workers/downstream_live_worker.rb
+++ b/app/workers/downstream_live_worker.rb
@@ -111,6 +111,7 @@ private
   end
 
   def create_republication_change_note
+    edition.public_updated_at = Time.zone.now
     edition.details = edition.details.merge(
       "change_history" => [{
         "note" => "#{dependency_resolution_source_content.document_type.titleize} #{dependency_resolution_source_content.title} changed",

--- a/spec/integration/embeddable_content_spec.rb
+++ b/spec/integration/embeddable_content_spec.rb
@@ -1,0 +1,33 @@
+RSpec.describe "Publishing changes to embeddable content" do
+  EmbeddedContentFinderService::SUPPORTED_DOCUMENT_TYPES.each do |document_type|
+    context "with a #{document_type} document type" do
+      let(:document) { create(:document) }
+      let!(:live_embeddable_edition) { create(:live_edition, document_type:, document:) }
+      let!(:draft_embeddable_edition) { create(:draft_edition, user_facing_version: 2, document_type:, document:) }
+
+      let(:editions) { create_list(:edition, 2, state: "published", content_store: "live") }
+
+      before do
+        stub_request(:put, %r{.*content-store.*/content/.*})
+        allow(PublishingAPI.service(:queue_publisher)).to receive(:send_message)
+
+        editions.each do |edition|
+          edition.links.create!(
+            { link_type: "embed", target_content_id: document.content_id },
+          )
+        end
+      end
+
+      it "creates a `major` event message and creates a change note for all dependent content" do
+        post "/v2/content/#{document.content_id}/publish", params: { locale: "en", update_type: "major" }.to_json
+
+        editions.each do |edition|
+          expect(PublishingAPI.service(:queue_publisher)).to have_received(:send_message).with(
+            a_hash_including({ content_id: edition.content_id, details: a_hash_including({ change_history: [a_hash_including(note: "#{live_embeddable_edition.document_type.titleize} #{live_embeddable_edition.title} changed")] }) }),
+            { event_type: "major" },
+          )
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
