### PR TITLE
Move special route publisher

### DIFF
--- a/content_schemas/dist/formats/answer/frontend/schema.json
+++ b/content_schemas/dist/formats/answer/frontend/schema.json
@@ -573,7 +573,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/answer/notification/schema.json
+++ b/content_schemas/dist/formats/answer/notification/schema.json
@@ -700,7 +700,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/answer/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/answer/publisher_v2/schema.json
@@ -353,7 +353,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/calendar/frontend/schema.json
+++ b/content_schemas/dist/formats/calendar/frontend/schema.json
@@ -543,7 +543,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/calendar/notification/schema.json
+++ b/content_schemas/dist/formats/calendar/notification/schema.json
@@ -651,7 +651,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/calendar/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/calendar/publisher_v2/schema.json
@@ -304,7 +304,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/call_for_evidence/frontend/schema.json
+++ b/content_schemas/dist/formats/call_for_evidence/frontend/schema.json
@@ -964,7 +964,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/call_for_evidence/notification/schema.json
+++ b/content_schemas/dist/formats/call_for_evidence/notification/schema.json
@@ -1088,7 +1088,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/call_for_evidence/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/call_for_evidence/publisher_v2/schema.json
@@ -767,7 +767,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/case_study/frontend/schema.json
+++ b/content_schemas/dist/formats/case_study/frontend/schema.json
@@ -679,7 +679,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/case_study/notification/schema.json
+++ b/content_schemas/dist/formats/case_study/notification/schema.json
@@ -801,7 +801,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/case_study/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/case_study/publisher_v2/schema.json
@@ -450,7 +450,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/completed_transaction/frontend/schema.json
+++ b/content_schemas/dist/formats/completed_transaction/frontend/schema.json
@@ -651,7 +651,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/completed_transaction/notification/schema.json
+++ b/content_schemas/dist/formats/completed_transaction/notification/schema.json
@@ -759,7 +759,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/completed_transaction/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/completed_transaction/publisher_v2/schema.json
@@ -412,7 +412,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/consultation/frontend/schema.json
+++ b/content_schemas/dist/formats/consultation/frontend/schema.json
@@ -981,7 +981,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/consultation/notification/schema.json
+++ b/content_schemas/dist/formats/consultation/notification/schema.json
@@ -1105,7 +1105,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/consultation/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/consultation/publisher_v2/schema.json
@@ -784,7 +784,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/contact/frontend/schema.json
+++ b/content_schemas/dist/formats/contact/frontend/schema.json
@@ -774,7 +774,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/contact/notification/schema.json
+++ b/content_schemas/dist/formats/contact/notification/schema.json
@@ -898,7 +898,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/contact/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/contact/publisher_v2/schema.json
@@ -536,7 +536,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/content_block_email_address/notification/schema.json
+++ b/content_schemas/dist/formats/content_block_email_address/notification/schema.json
@@ -653,7 +653,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/content_block_email_address/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/content_block_email_address/publisher_v2/schema.json
@@ -303,7 +303,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/content_block_postal_address/notification/schema.json
+++ b/content_schemas/dist/formats/content_block_postal_address/notification/schema.json
@@ -666,7 +666,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/content_block_postal_address/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/content_block_postal_address/publisher_v2/schema.json
@@ -316,7 +316,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/coronavirus_landing_page/frontend/schema.json
+++ b/content_schemas/dist/formats/coronavirus_landing_page/frontend/schema.json
@@ -536,7 +536,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/coronavirus_landing_page/notification/schema.json
+++ b/content_schemas/dist/formats/coronavirus_landing_page/notification/schema.json
@@ -644,7 +644,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/coronavirus_landing_page/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/coronavirus_landing_page/publisher_v2/schema.json
@@ -296,7 +296,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/corporate_information_page/frontend/schema.json
+++ b/content_schemas/dist/formats/corporate_information_page/frontend/schema.json
@@ -720,7 +720,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/corporate_information_page/notification/schema.json
+++ b/content_schemas/dist/formats/corporate_information_page/notification/schema.json
@@ -832,7 +832,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/corporate_information_page/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/corporate_information_page/publisher_v2/schema.json
@@ -519,7 +519,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/detailed_guide/frontend/schema.json
+++ b/content_schemas/dist/formats/detailed_guide/frontend/schema.json
@@ -806,7 +806,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/detailed_guide/notification/schema.json
+++ b/content_schemas/dist/formats/detailed_guide/notification/schema.json
@@ -928,7 +928,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/detailed_guide/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/detailed_guide/publisher_v2/schema.json
@@ -609,7 +609,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/document_collection/frontend/schema.json
+++ b/content_schemas/dist/formats/document_collection/frontend/schema.json
@@ -675,7 +675,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/document_collection/notification/schema.json
+++ b/content_schemas/dist/formats/document_collection/notification/schema.json
@@ -805,7 +805,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/document_collection/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/document_collection/publisher_v2/schema.json
@@ -472,7 +472,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/email_alert_signup/frontend/schema.json
+++ b/content_schemas/dist/formats/email_alert_signup/frontend/schema.json
@@ -607,7 +607,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/email_alert_signup/notification/schema.json
+++ b/content_schemas/dist/formats/email_alert_signup/notification/schema.json
@@ -715,7 +715,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/email_alert_signup/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/email_alert_signup/publisher_v2/schema.json
@@ -368,7 +368,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/embassies_index/frontend/schema.json
+++ b/content_schemas/dist/formats/embassies_index/frontend/schema.json
@@ -622,7 +622,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/embassies_index/notification/schema.json
+++ b/content_schemas/dist/formats/embassies_index/notification/schema.json
@@ -730,7 +730,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/embassies_index/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/embassies_index/publisher_v2/schema.json
@@ -383,7 +383,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/external_content/notification/schema.json
+++ b/content_schemas/dist/formats/external_content/notification/schema.json
@@ -530,7 +530,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/external_content/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/external_content/publisher_v2/schema.json
@@ -291,7 +291,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/facet/frontend/schema.json
+++ b/content_schemas/dist/formats/facet/frontend/schema.json
@@ -609,7 +609,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/facet/notification/schema.json
+++ b/content_schemas/dist/formats/facet/notification/schema.json
@@ -727,7 +727,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/facet/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/facet/publisher_v2/schema.json
@@ -377,7 +377,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/fatality_notice/frontend/schema.json
+++ b/content_schemas/dist/formats/fatality_notice/frontend/schema.json
@@ -588,7 +588,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/fatality_notice/notification/schema.json
+++ b/content_schemas/dist/formats/fatality_notice/notification/schema.json
@@ -709,7 +709,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/fatality_notice/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/fatality_notice/publisher_v2/schema.json
@@ -387,7 +387,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/field_of_operation/frontend/schema.json
+++ b/content_schemas/dist/formats/field_of_operation/frontend/schema.json
@@ -540,7 +540,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/field_of_operation/notification/schema.json
+++ b/content_schemas/dist/formats/field_of_operation/notification/schema.json
@@ -652,7 +652,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/field_of_operation/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/field_of_operation/publisher_v2/schema.json
@@ -296,7 +296,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/fields_of_operation/frontend/schema.json
+++ b/content_schemas/dist/formats/fields_of_operation/frontend/schema.json
@@ -540,7 +540,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/fields_of_operation/notification/schema.json
+++ b/content_schemas/dist/formats/fields_of_operation/notification/schema.json
@@ -652,7 +652,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/fields_of_operation/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/fields_of_operation/publisher_v2/schema.json
@@ -296,7 +296,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/finder/frontend/schema.json
+++ b/content_schemas/dist/formats/finder/frontend/schema.json
@@ -923,7 +923,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/finder/notification/schema.json
+++ b/content_schemas/dist/formats/finder/notification/schema.json
@@ -1040,7 +1040,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/finder/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/finder/publisher_v2/schema.json
@@ -679,7 +679,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/finder_email_signup/frontend/schema.json
+++ b/content_schemas/dist/formats/finder_email_signup/frontend/schema.json
@@ -690,7 +690,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/finder_email_signup/notification/schema.json
+++ b/content_schemas/dist/formats/finder_email_signup/notification/schema.json
@@ -800,7 +800,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/finder_email_signup/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/finder_email_signup/publisher_v2/schema.json
@@ -449,7 +449,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/generic/frontend/schema.json
+++ b/content_schemas/dist/formats/generic/frontend/schema.json
@@ -718,7 +718,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/generic/notification/schema.json
+++ b/content_schemas/dist/formats/generic/notification/schema.json
@@ -826,7 +826,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/generic/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/generic/publisher_v2/schema.json
@@ -478,7 +478,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/generic_with_external_related_links/frontend/schema.json
+++ b/content_schemas/dist/formats/generic_with_external_related_links/frontend/schema.json
@@ -744,7 +744,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/generic_with_external_related_links/notification/schema.json
+++ b/content_schemas/dist/formats/generic_with_external_related_links/notification/schema.json
@@ -852,7 +852,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/generic_with_external_related_links/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/generic_with_external_related_links/publisher_v2/schema.json
@@ -505,7 +505,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/get_involved/frontend/schema.json
+++ b/content_schemas/dist/formats/get_involved/frontend/schema.json
@@ -630,7 +630,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/get_involved/notification/schema.json
+++ b/content_schemas/dist/formats/get_involved/notification/schema.json
@@ -742,7 +742,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/get_involved/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/get_involved/publisher_v2/schema.json
@@ -387,7 +387,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/gone/frontend/schema.json
+++ b/content_schemas/dist/formats/gone/frontend/schema.json
@@ -488,7 +488,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/gone/notification/schema.json
+++ b/content_schemas/dist/formats/gone/notification/schema.json
@@ -514,7 +514,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/gone/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/gone/publisher_v2/schema.json
@@ -293,7 +293,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/government/frontend/schema.json
+++ b/content_schemas/dist/formats/government/frontend/schema.json
@@ -550,7 +550,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/government/notification/schema.json
+++ b/content_schemas/dist/formats/government/notification/schema.json
@@ -658,7 +658,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/government/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/government/publisher_v2/schema.json
@@ -311,7 +311,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/guide/frontend/schema.json
+++ b/content_schemas/dist/formats/guide/frontend/schema.json
@@ -602,7 +602,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/guide/notification/schema.json
+++ b/content_schemas/dist/formats/guide/notification/schema.json
@@ -729,7 +729,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/guide/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/guide/publisher_v2/schema.json
@@ -382,7 +382,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/help_page/frontend/schema.json
+++ b/content_schemas/dist/formats/help_page/frontend/schema.json
@@ -573,7 +573,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/help_page/notification/schema.json
+++ b/content_schemas/dist/formats/help_page/notification/schema.json
@@ -700,7 +700,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/help_page/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/help_page/publisher_v2/schema.json
@@ -353,7 +353,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/historic_appointment/frontend/schema.json
+++ b/content_schemas/dist/formats/historic_appointment/frontend/schema.json
@@ -583,7 +583,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/historic_appointment/notification/schema.json
+++ b/content_schemas/dist/formats/historic_appointment/notification/schema.json
@@ -695,7 +695,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/historic_appointment/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/historic_appointment/publisher_v2/schema.json
@@ -340,7 +340,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/historic_appointments/frontend/schema.json
+++ b/content_schemas/dist/formats/historic_appointments/frontend/schema.json
@@ -620,7 +620,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/historic_appointments/notification/schema.json
+++ b/content_schemas/dist/formats/historic_appointments/notification/schema.json
@@ -732,7 +732,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/historic_appointments/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/historic_appointments/publisher_v2/schema.json
@@ -377,7 +377,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/history/frontend/schema.json
+++ b/content_schemas/dist/formats/history/frontend/schema.json
@@ -542,7 +542,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/history/notification/schema.json
+++ b/content_schemas/dist/formats/history/notification/schema.json
@@ -650,7 +650,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/history/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/history/publisher_v2/schema.json
@@ -303,7 +303,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/hmrc_manual/frontend/schema.json
+++ b/content_schemas/dist/formats/hmrc_manual/frontend/schema.json
@@ -658,7 +658,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/hmrc_manual/notification/schema.json
+++ b/content_schemas/dist/formats/hmrc_manual/notification/schema.json
@@ -766,7 +766,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/hmrc_manual/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/hmrc_manual/publisher_v2/schema.json
@@ -419,7 +419,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/hmrc_manual_section/frontend/schema.json
+++ b/content_schemas/dist/formats/hmrc_manual_section/frontend/schema.json
@@ -662,7 +662,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/hmrc_manual_section/notification/schema.json
+++ b/content_schemas/dist/formats/hmrc_manual_section/notification/schema.json
@@ -770,7 +770,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/hmrc_manual_section/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/hmrc_manual_section/publisher_v2/schema.json
@@ -423,7 +423,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/homepage/frontend/schema.json
+++ b/content_schemas/dist/formats/homepage/frontend/schema.json
@@ -490,7 +490,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/homepage/notification/schema.json
+++ b/content_schemas/dist/formats/homepage/notification/schema.json
@@ -552,7 +552,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/homepage/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/homepage/publisher_v2/schema.json
@@ -296,7 +296,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/how_government_works/frontend/schema.json
+++ b/content_schemas/dist/formats/how_government_works/frontend/schema.json
@@ -598,7 +598,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/how_government_works/notification/schema.json
+++ b/content_schemas/dist/formats/how_government_works/notification/schema.json
@@ -710,7 +710,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/how_government_works/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/how_government_works/publisher_v2/schema.json
@@ -355,7 +355,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/html_publication/frontend/schema.json
+++ b/content_schemas/dist/formats/html_publication/frontend/schema.json
@@ -637,7 +637,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/html_publication/notification/schema.json
+++ b/content_schemas/dist/formats/html_publication/notification/schema.json
@@ -747,7 +747,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/html_publication/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/html_publication/publisher_v2/schema.json
@@ -416,7 +416,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/licence/frontend/schema.json
+++ b/content_schemas/dist/formats/licence/frontend/schema.json
@@ -592,7 +592,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/licence/notification/schema.json
+++ b/content_schemas/dist/formats/licence/notification/schema.json
@@ -719,7 +719,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/licence/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/licence/publisher_v2/schema.json
@@ -372,7 +372,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/link_collection/frontend/schema.json
+++ b/content_schemas/dist/formats/link_collection/frontend/schema.json
@@ -555,7 +555,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/link_collection/notification/schema.json
+++ b/content_schemas/dist/formats/link_collection/notification/schema.json
@@ -671,7 +671,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/link_collection/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/link_collection/publisher_v2/schema.json
@@ -321,7 +321,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/local_transaction/frontend/schema.json
+++ b/content_schemas/dist/formats/local_transaction/frontend/schema.json
@@ -665,7 +665,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/local_transaction/notification/schema.json
+++ b/content_schemas/dist/formats/local_transaction/notification/schema.json
@@ -792,7 +792,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/local_transaction/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/local_transaction/publisher_v2/schema.json
@@ -445,7 +445,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/mainstream_browse_page/frontend/schema.json
+++ b/content_schemas/dist/formats/mainstream_browse_page/frontend/schema.json
@@ -575,7 +575,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/mainstream_browse_page/notification/schema.json
+++ b/content_schemas/dist/formats/mainstream_browse_page/notification/schema.json
@@ -692,7 +692,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/mainstream_browse_page/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/mainstream_browse_page/publisher_v2/schema.json
@@ -313,7 +313,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/manual/frontend/schema.json
+++ b/content_schemas/dist/formats/manual/frontend/schema.json
@@ -652,7 +652,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/manual/notification/schema.json
+++ b/content_schemas/dist/formats/manual/notification/schema.json
@@ -784,7 +784,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/manual/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/manual/publisher_v2/schema.json
@@ -431,7 +431,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/manual_section/frontend/schema.json
+++ b/content_schemas/dist/formats/manual_section/frontend/schema.json
@@ -660,7 +660,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/manual_section/notification/schema.json
+++ b/content_schemas/dist/formats/manual_section/notification/schema.json
@@ -792,7 +792,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/manual_section/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/manual_section/publisher_v2/schema.json
@@ -439,7 +439,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/ministers_index/frontend/schema.json
+++ b/content_schemas/dist/formats/ministers_index/frontend/schema.json
@@ -578,7 +578,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/ministers_index/notification/schema.json
+++ b/content_schemas/dist/formats/ministers_index/notification/schema.json
@@ -718,7 +718,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/ministers_index/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/ministers_index/publisher_v2/schema.json
@@ -307,7 +307,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/need/frontend/schema.json
+++ b/content_schemas/dist/formats/need/frontend/schema.json
@@ -603,7 +603,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/need/notification/schema.json
+++ b/content_schemas/dist/formats/need/notification/schema.json
@@ -711,7 +711,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/need/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/need/publisher_v2/schema.json
@@ -364,7 +364,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/news_article/frontend/schema.json
+++ b/content_schemas/dist/formats/news_article/frontend/schema.json
@@ -742,7 +742,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/news_article/notification/schema.json
+++ b/content_schemas/dist/formats/news_article/notification/schema.json
@@ -878,7 +878,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/news_article/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/news_article/publisher_v2/schema.json
@@ -533,7 +533,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/organisation/frontend/schema.json
+++ b/content_schemas/dist/formats/organisation/frontend/schema.json
@@ -1092,7 +1092,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/organisation/notification/schema.json
+++ b/content_schemas/dist/formats/organisation/notification/schema.json
@@ -1256,7 +1256,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/organisation/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/organisation/publisher_v2/schema.json
@@ -797,7 +797,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/organisations_homepage/frontend/schema.json
+++ b/content_schemas/dist/formats/organisations_homepage/frontend/schema.json
@@ -624,7 +624,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/organisations_homepage/notification/schema.json
+++ b/content_schemas/dist/formats/organisations_homepage/notification/schema.json
@@ -732,7 +732,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/organisations_homepage/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/organisations_homepage/publisher_v2/schema.json
@@ -385,7 +385,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/person/frontend/schema.json
+++ b/content_schemas/dist/formats/person/frontend/schema.json
@@ -610,7 +610,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/person/notification/schema.json
+++ b/content_schemas/dist/formats/person/notification/schema.json
@@ -737,7 +737,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/person/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/person/publisher_v2/schema.json
@@ -390,7 +390,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/place/frontend/schema.json
+++ b/content_schemas/dist/formats/place/frontend/schema.json
@@ -582,7 +582,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/place/notification/schema.json
+++ b/content_schemas/dist/formats/place/notification/schema.json
@@ -709,7 +709,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/place/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/place/publisher_v2/schema.json
@@ -362,7 +362,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/publication/frontend/schema.json
+++ b/content_schemas/dist/formats/publication/frontend/schema.json
@@ -914,7 +914,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/publication/notification/schema.json
+++ b/content_schemas/dist/formats/publication/notification/schema.json
@@ -1044,7 +1044,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/publication/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/publication/publisher_v2/schema.json
@@ -717,7 +717,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/redirect/frontend/schema.json
+++ b/content_schemas/dist/formats/redirect/frontend/schema.json
@@ -450,7 +450,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/redirect/notification/schema.json
+++ b/content_schemas/dist/formats/redirect/notification/schema.json
@@ -463,7 +463,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/redirect/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/redirect/publisher_v2/schema.json
@@ -268,7 +268,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/role/frontend/schema.json
+++ b/content_schemas/dist/formats/role/frontend/schema.json
@@ -608,7 +608,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/role/notification/schema.json
+++ b/content_schemas/dist/formats/role/notification/schema.json
@@ -754,7 +754,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/role/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/role/publisher_v2/schema.json
@@ -387,7 +387,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/role_appointment/frontend/schema.json
+++ b/content_schemas/dist/formats/role_appointment/frontend/schema.json
@@ -561,7 +561,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/role_appointment/notification/schema.json
+++ b/content_schemas/dist/formats/role_appointment/notification/schema.json
@@ -687,7 +687,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/role_appointment/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/role_appointment/publisher_v2/schema.json
@@ -321,7 +321,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/service_manual_guide/frontend/schema.json
+++ b/content_schemas/dist/formats/service_manual_guide/frontend/schema.json
@@ -594,7 +594,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/service_manual_guide/notification/schema.json
+++ b/content_schemas/dist/formats/service_manual_guide/notification/schema.json
@@ -710,7 +710,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/service_manual_guide/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/service_manual_guide/publisher_v2/schema.json
@@ -371,7 +371,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/service_manual_homepage/frontend/schema.json
+++ b/content_schemas/dist/formats/service_manual_homepage/frontend/schema.json
@@ -536,7 +536,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/service_manual_homepage/notification/schema.json
+++ b/content_schemas/dist/formats/service_manual_homepage/notification/schema.json
@@ -644,7 +644,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/service_manual_homepage/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/service_manual_homepage/publisher_v2/schema.json
@@ -296,7 +296,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/service_manual_service_standard/frontend/schema.json
+++ b/content_schemas/dist/formats/service_manual_service_standard/frontend/schema.json
@@ -552,7 +552,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/service_manual_service_standard/notification/schema.json
+++ b/content_schemas/dist/formats/service_manual_service_standard/notification/schema.json
@@ -664,7 +664,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/service_manual_service_standard/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/service_manual_service_standard/publisher_v2/schema.json
@@ -309,7 +309,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/service_manual_service_toolkit/frontend/schema.json
+++ b/content_schemas/dist/formats/service_manual_service_toolkit/frontend/schema.json
@@ -585,7 +585,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/service_manual_service_toolkit/notification/schema.json
+++ b/content_schemas/dist/formats/service_manual_service_toolkit/notification/schema.json
@@ -693,7 +693,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/service_manual_service_toolkit/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/service_manual_service_toolkit/publisher_v2/schema.json
@@ -346,7 +346,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/service_manual_topic/frontend/schema.json
+++ b/content_schemas/dist/formats/service_manual_topic/frontend/schema.json
@@ -565,7 +565,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/service_manual_topic/notification/schema.json
+++ b/content_schemas/dist/formats/service_manual_topic/notification/schema.json
@@ -678,7 +678,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/service_manual_topic/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/service_manual_topic/publisher_v2/schema.json
@@ -307,7 +307,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/service_sign_in/frontend/schema.json
+++ b/content_schemas/dist/formats/service_sign_in/frontend/schema.json
@@ -627,7 +627,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/service_sign_in/notification/schema.json
+++ b/content_schemas/dist/formats/service_sign_in/notification/schema.json
@@ -754,7 +754,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/service_sign_in/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/service_sign_in/publisher_v2/schema.json
@@ -407,7 +407,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/simple_smart_answer/frontend/schema.json
+++ b/content_schemas/dist/formats/simple_smart_answer/frontend/schema.json
@@ -635,7 +635,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/simple_smart_answer/notification/schema.json
+++ b/content_schemas/dist/formats/simple_smart_answer/notification/schema.json
@@ -762,7 +762,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/simple_smart_answer/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/simple_smart_answer/publisher_v2/schema.json
@@ -415,7 +415,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/smart_answer/frontend/schema.json
+++ b/content_schemas/dist/formats/smart_answer/frontend/schema.json
@@ -572,7 +572,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/smart_answer/notification/schema.json
+++ b/content_schemas/dist/formats/smart_answer/notification/schema.json
@@ -680,7 +680,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/smart_answer/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/smart_answer/publisher_v2/schema.json
@@ -333,7 +333,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/special_route/frontend/schema.json
+++ b/content_schemas/dist/formats/special_route/frontend/schema.json
@@ -509,7 +509,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/special_route/notification/schema.json
+++ b/content_schemas/dist/formats/special_route/notification/schema.json
@@ -617,7 +617,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/special_route/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/special_route/publisher_v2/schema.json
@@ -291,7 +291,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/specialist_document/frontend/schema.json
+++ b/content_schemas/dist/formats/specialist_document/frontend/schema.json
@@ -3188,7 +3188,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/specialist_document/notification/schema.json
+++ b/content_schemas/dist/formats/specialist_document/notification/schema.json
@@ -3312,7 +3312,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/specialist_document/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/specialist_document/publisher_v2/schema.json
@@ -3005,7 +3005,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/speech/frontend/schema.json
+++ b/content_schemas/dist/formats/speech/frontend/schema.json
@@ -698,7 +698,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/speech/notification/schema.json
+++ b/content_schemas/dist/formats/speech/notification/schema.json
@@ -833,7 +833,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/speech/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/speech/publisher_v2/schema.json
@@ -456,7 +456,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/statistical_data_set/frontend/schema.json
+++ b/content_schemas/dist/formats/statistical_data_set/frontend/schema.json
@@ -793,7 +793,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/statistical_data_set/notification/schema.json
+++ b/content_schemas/dist/formats/statistical_data_set/notification/schema.json
@@ -905,7 +905,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/statistical_data_set/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/statistical_data_set/publisher_v2/schema.json
@@ -583,7 +583,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/statistics_announcement/frontend/schema.json
+++ b/content_schemas/dist/formats/statistics_announcement/frontend/schema.json
@@ -575,7 +575,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/statistics_announcement/notification/schema.json
+++ b/content_schemas/dist/formats/statistics_announcement/notification/schema.json
@@ -682,7 +682,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/statistics_announcement/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/statistics_announcement/publisher_v2/schema.json
@@ -337,7 +337,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/step_by_step_nav/frontend/schema.json
+++ b/content_schemas/dist/formats/step_by_step_nav/frontend/schema.json
@@ -552,7 +552,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/step_by_step_nav/notification/schema.json
+++ b/content_schemas/dist/formats/step_by_step_nav/notification/schema.json
@@ -641,7 +641,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/step_by_step_nav/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/step_by_step_nav/publisher_v2/schema.json
@@ -382,7 +382,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/substitute/notification/schema.json
+++ b/content_schemas/dist/formats/substitute/notification/schema.json
@@ -463,7 +463,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/take_part/frontend/schema.json
+++ b/content_schemas/dist/formats/take_part/frontend/schema.json
@@ -600,7 +600,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/take_part/notification/schema.json
+++ b/content_schemas/dist/formats/take_part/notification/schema.json
@@ -708,7 +708,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/take_part/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/take_part/publisher_v2/schema.json
@@ -361,7 +361,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/taxon/frontend/schema.json
+++ b/content_schemas/dist/formats/taxon/frontend/schema.json
@@ -562,7 +562,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/taxon/notification/schema.json
+++ b/content_schemas/dist/formats/taxon/notification/schema.json
@@ -682,7 +682,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/taxon/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/taxon/publisher_v2/schema.json
@@ -319,7 +319,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/topical_event/frontend/schema.json
+++ b/content_schemas/dist/formats/topical_event/frontend/schema.json
@@ -678,7 +678,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/topical_event/notification/schema.json
+++ b/content_schemas/dist/formats/topical_event/notification/schema.json
@@ -786,7 +786,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/topical_event/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/topical_event/publisher_v2/schema.json
@@ -439,7 +439,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/topical_event_about_page/frontend/schema.json
+++ b/content_schemas/dist/formats/topical_event_about_page/frontend/schema.json
@@ -550,7 +550,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/topical_event_about_page/notification/schema.json
+++ b/content_schemas/dist/formats/topical_event_about_page/notification/schema.json
@@ -658,7 +658,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/topical_event_about_page/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/topical_event_about_page/publisher_v2/schema.json
@@ -311,7 +311,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/transaction/frontend/schema.json
+++ b/content_schemas/dist/formats/transaction/frontend/schema.json
@@ -646,7 +646,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/transaction/notification/schema.json
+++ b/content_schemas/dist/formats/transaction/notification/schema.json
@@ -773,7 +773,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/transaction/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/transaction/publisher_v2/schema.json
@@ -426,7 +426,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/travel_advice/frontend/schema.json
+++ b/content_schemas/dist/formats/travel_advice/frontend/schema.json
@@ -728,7 +728,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/travel_advice/notification/schema.json
+++ b/content_schemas/dist/formats/travel_advice/notification/schema.json
@@ -858,7 +858,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/travel_advice/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/travel_advice/publisher_v2/schema.json
@@ -505,7 +505,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/travel_advice_index/frontend/schema.json
+++ b/content_schemas/dist/formats/travel_advice_index/frontend/schema.json
@@ -560,7 +560,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/travel_advice_index/notification/schema.json
+++ b/content_schemas/dist/formats/travel_advice_index/notification/schema.json
@@ -671,7 +671,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/travel_advice_index/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/travel_advice_index/publisher_v2/schema.json
@@ -318,7 +318,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/vanish/notification/schema.json
+++ b/content_schemas/dist/formats/vanish/notification/schema.json
@@ -463,7 +463,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/working_group/frontend/schema.json
+++ b/content_schemas/dist/formats/working_group/frontend/schema.json
@@ -606,7 +606,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/working_group/notification/schema.json
+++ b/content_schemas/dist/formats/working_group/notification/schema.json
@@ -714,7 +714,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/working_group/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/working_group/publisher_v2/schema.json
@@ -367,7 +367,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/world_index/frontend/schema.json
+++ b/content_schemas/dist/formats/world_index/frontend/schema.json
@@ -643,7 +643,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/world_index/notification/schema.json
+++ b/content_schemas/dist/formats/world_index/notification/schema.json
@@ -751,7 +751,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/world_index/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/world_index/publisher_v2/schema.json
@@ -404,7 +404,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/world_location/frontend/schema.json
+++ b/content_schemas/dist/formats/world_location/frontend/schema.json
@@ -582,7 +582,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/world_location/notification/schema.json
+++ b/content_schemas/dist/formats/world_location/notification/schema.json
@@ -704,7 +704,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/world_location/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/world_location/publisher_v2/schema.json
@@ -350,7 +350,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/world_location_news/frontend/schema.json
+++ b/content_schemas/dist/formats/world_location_news/frontend/schema.json
@@ -674,7 +674,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/world_location_news/notification/schema.json
+++ b/content_schemas/dist/formats/world_location_news/notification/schema.json
@@ -790,7 +790,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/world_location_news/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/world_location_news/publisher_v2/schema.json
@@ -427,7 +427,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/worldwide_corporate_information_page/frontend/schema.json
+++ b/content_schemas/dist/formats/worldwide_corporate_information_page/frontend/schema.json
@@ -568,7 +568,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/worldwide_corporate_information_page/notification/schema.json
+++ b/content_schemas/dist/formats/worldwide_corporate_information_page/notification/schema.json
@@ -680,7 +680,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/worldwide_corporate_information_page/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/worldwide_corporate_information_page/publisher_v2/schema.json
@@ -334,7 +334,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/worldwide_office/frontend/schema.json
+++ b/content_schemas/dist/formats/worldwide_office/frontend/schema.json
@@ -582,7 +582,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/worldwide_office/notification/schema.json
+++ b/content_schemas/dist/formats/worldwide_office/notification/schema.json
@@ -698,7 +698,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/worldwide_office/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/worldwide_office/publisher_v2/schema.json
@@ -348,7 +348,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/worldwide_organisation/frontend/schema.json
+++ b/content_schemas/dist/formats/worldwide_organisation/frontend/schema.json
@@ -803,7 +803,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/worldwide_organisation/notification/schema.json
+++ b/content_schemas/dist/formats/worldwide_organisation/notification/schema.json
@@ -955,7 +955,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/dist/formats/worldwide_organisation/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/worldwide_organisation/publisher_v2/schema.json
@@ -568,7 +568,7 @@
         "share-sale-publisher",
         "short-url-manager",
         "smartanswers",
-        "special-route-publisher",
+        "publishing-api",
         "specialist-publisher",
         "static",
         "tariff",

--- a/content_schemas/examples/homepage/frontend/homepage_with_popular_links_on_govuk.json
+++ b/content_schemas/examples/homepage/frontend/homepage_with_popular_links_on_govuk.json
@@ -954,7 +954,7 @@
   "locale": "en",
   "phase": "live",
   "public_updated_at": "2023-06-28T10:32:34+01:00",
-  "publishing_app": "special-route-publisher",
+  "publishing_app": "publishing-api",
   "publishing_request_id": "21-1687944754.231-10.13.31.76-382",
   "publishing_scheduled_at": null,
   "rendering_app": "frontend",

--- a/content_schemas/formats/shared/definitions/publishing_app.jsonnet
+++ b/content_schemas/formats/shared/definitions/publishing_app.jsonnet
@@ -28,7 +28,7 @@
       "share-sale-publisher",
       "short-url-manager",
       "smartanswers",
-      "special-route-publisher",
+      "publishing-api",
       "specialist-publisher",
       "static",
       "tariff",

--- a/docs/admin-tasks.md
+++ b/docs/admin-tasks.md
@@ -96,6 +96,55 @@ bundle exec rake expanded_links:populate_by_document_type['document-type']
 bundle exec rake expanded_links:truncate
 ```
 
+## Publishing special routes
+
+Special routes are content items that have to be put into publishing-api / content-store so that routes
+can be created for them in router-api's database (this includes things like assets that have to be available
+at route or hardcoded pages). The routes are described in lib/data/special_routes.yaml and lib/data/homepage.yaml
+
+* To publish the homepage special route
+```
+bundle exec rake publish_homepage
+```
+
+* To publish all special routes (except homepage)
+```
+bundle exec rake publish_special_routes
+```
+
+* To publish all special routes for one application
+```
+bundle exec rake publish_special_routes[frontend]
+```
+
+* To publish one route
+```
+bundle exec rake publish_one_special_route[/base-path]
+```
+
+* To unpublish one route so that it will return Gone
+```
+bundle exec rake unpublish_one_special_route[/base-path]
+```
+
+* To unpublish one route so that it will return Redirect
+```
+bundle exec rake unpublish_one_special_route[/base-path,/new-base-path]
+```
+
+### Adding new special routes
+
+Add an entry to /lib/data/special_routes.yaml, for example:
+
+```
+- :content_id: 'c1f08359-21f7-49c1-8811-54bf6690b6a3'
+  :base_path: '/account/home'
+  :title: 'Account home page'
+  :rendering_app: 'frontend'
+```
+
+You can generate a new value for `content_id` by running `SecureRandom.uuid` in a ruby console.
+
 ## Generating CSV reports of publishings and unpublishing by date range
 
 There are two tasks provided which create CSV reports of publishings and

--- a/lib/data/homepage.yaml
+++ b/lib/data/homepage.yaml
@@ -1,0 +1,10 @@
+- :content_id: "f3bbdec2-0e62-4520-a7fd-6ffd5d36e03a"
+  :base_path: "/"
+  :document_type: "homepage"
+  :title: "GOV.UK homepage"
+  :rendering_app: "frontend"
+  :links:
+    :organisations:
+      - "af07d5a5-df63-4ddc-9383-6a666845ebe9"
+    :primary_publishing_organisation:
+      - "af07d5a5-df63-4ddc-9383-6a666845ebe9"

--- a/lib/data/special_routes.yaml
+++ b/lib/data/special_routes.yaml
@@ -1,0 +1,236 @@
+- :content_id: "c1f08359-21f7-49c1-8811-54bf6690b6a3"
+  :base_path: "/account/home"
+  :title: "Account home page"
+  :rendering_app: "frontend"
+
+- :content_id: "e5098fc2-ad79-4c6f-882b-410831c12f60"
+  :base_path: "/account/saved-pages/add"
+  :title: "Save a page"
+  :rendering_app: "frontend"
+
+- :content_id: "3aeaeb46-b3c5-449b-8a3b-2753ffef3c9f"
+  :base_path: "/account/saved-pages/remove"
+  :title: "Remove a saved page"
+  :rendering_app: "frontend"
+
+- :content_id: "16ca5ac1-7df5-4137-9f83-0270fcfc8bb5"
+  :base_path: "/api/content"
+  :title: "Content API"
+  :description: "API exposing all content on GOV.UK."
+  :type: "prefix"
+  :rendering_app: "content-store"
+
+- :content_id: "ac47f738-b6c3-4369-8d22-ce143c947442"
+  :base_path: "/government/history/past-chancellors"
+  :title: "Past Chancellors of the Exchequer"
+  :rendering_app: "collections"
+  :links:
+    :parent:
+      - "db95a864-874f-4f50-a483-352a5bc7ba18"
+
+- :content_id: "e46b25e9-d47f-4b93-8466-682b73627db3"
+  :base_path: "/government/history/past-foreign-secretaries"
+  :title: "Past Foreign Secretaries"
+  :type: "prefix"
+  :rendering_app: "collections"
+  :links:
+    :parent:
+      - "db95a864-874f-4f50-a483-352a5bc7ba18"
+
+- :content_id: "5a0ca87e-0e91-4d4c-bd26-29feb24f98ab"
+  :base_path: "/government/uploads"
+  :title: "Government Uploads"
+  :description: "Handles redirects for /government/uploads path for asset manager"
+  :type: "prefix"
+  :rendering_app: "government-frontend"
+
+- :content_id: "cdcad470-21c6-4e19-b644-9e499de1ad12"
+  :base_path: "/media"
+  :title: "Government Uploads"
+  :description: "Handles redirects for /media/:id/:filename path for asset manager"
+  :type: "prefix"
+  :rendering_app: "government-frontend"
+
+- :content_id: "c3b020bf-bc77-4213-afa2-b45eac30f2dc"
+  :base_path: "/search/consultations"
+  :title: "Policy papers and consultations"
+  :rendering_app: "finder-frontend"
+
+- :content_id: "e38cc2da-cea5-4585-9aaa-454c109a51e0"
+  :base_path: "/search/statistics-announcements"
+  :title: "Research and statistics"
+  :rendering_app: "finder-frontend"
+
+- :content_id: "eb56dbca-be0b-4381-8dac-0c9de8a3ed7e"
+  :base_path: "/search/latest"
+  :title: "Search"
+  :rendering_app: "finder-frontend"
+
+- :content_id: "f04c45a7-c20b-4f66-a485-dc997a6a3b6d"
+  :base_path: "/sign-in/callback"
+  :title: "Sign In to GOV.UK (OAuth Callback)"
+  :rendering_app: "frontend"
+
+- :content_id: "7ee16fff-900d-4f5d-bd0a-62fdaa1ad3b6"
+  :base_path: "/sign-out"
+  :title: "Sign Out from GOV.UK"
+  :rendering_app: "frontend"
+
+
+- :content_id: "caf90fb7-11e3-4f8e-9a5d-b83283c91533"
+  :base_path: "/tour"
+  :title: "GOV.UK introductory page"
+  :description: "A description of the various sections of GOV.UK and their uses."
+  :rendering_app: "frontend"
+
+- :content_id: "3c7060f7-9efa-47be-bd36-0326f3fa4f04"
+  :base_path: "/help"
+  :title: "Help using GOV.UK"
+  :description: "Find out about GOV.UK, including the use of cookies, accessibility of the site, the privacy notice and terms and conditions of use."
+  :links:
+    :ordered_related_items:
+      - "58b05bc2-fde5-4a0b-af73-8edc532674f8"
+  :rendering_app: "frontend"
+
+- :content_id: "a4d4e755-3d75-4b19-b120-a638a6d79ba8"
+  :base_path: "/help/ab-testing"
+  :title: "A/B testing on GOV.UK"
+  :description: "This page is being used internally by GOV.UK to make sure A/B testing works."
+  :rendering_app: "frontend"
+
+- :content_id: "220f39ad-d4ad-4b0c-9d40-6c417a1341c0"
+  :base_path: "/help/cookies"
+  :title: "Cookies on GOV.UK"
+  :description: "You can choose which cookies you're happy for GOV.UK to use."
+  :rendering_app: "frontend"
+
+- :content_id: "3c991cea-cdee-4e58-b8d1-d38e7c0e6327"
+  :base_path: "/random"
+  :title: "GOV.UK random page"
+  :rendering_app: "frontend"
+
+- :content_id: "9a86495d-663f-46f8-b4ce-fc9153579338"
+  :base_path: "/roadmap"
+  :title: "GOV.UK Roadmap"
+  :description: "This is GOV.UK's current roadmap. We plan to update it again in the new financial year."
+  :rendering_app: "frontend"
+
+- :content_id: "622fda2b-5fa6-4c84-bc3b-22cd3ff08828"
+  :base_path: "/find-local-council"
+  :title: "Find your local council"
+  :description: "Find your local authority in England, Wales, Scotland and Northern Ireland"
+  :rendering_app: "frontend"
+  :type: "prefix"
+
+- :content_id: "6e92af59-3a73-4db6-b58b-740a02b229d0"
+  :base_path: "/humans.txt"
+  :title: "humans.txt"
+  :description: "In opposition to robots.txt, humans.txt provides information about GOV.UK to interested readers, such as developers interested in joining GDS."
+  :rendering_app: "static"
+  :override_existing: true
+
+- :content_id: "e3bf851b-5df7-441b-8813-f0ec849da35f"
+  :base_path: "/email-signup"
+  :title: "Get email alerts"
+  :description: "Allows users to subscribe to email alerts"
+  :rendering_app: "email-alert-frontend"
+  :override_existing: true
+
+- :content_id: "eb5fad51-f346-4365-be4a-ebc1b25b88f8"
+  :base_path: "/email-signup/confirm"
+  :title: "Get email alerts"
+  :description: "Confirmation page for users subscribing to email alerts"
+  :rendering_app: "email-alert-frontend"
+  :override_existing: true
+
+- :content_id: "ea8a4639-fd68-4e09-8886-dc4c8f4dab7a"
+  :base_path: "/email/unsubscribe"
+  :title: "Email unsubscribe"
+  :description: "Prefix route to allow users to unsubscribe from emails"
+  :rendering_app: "email-alert-frontend"
+  :type: "prefix"
+  :override_existing: true
+
+- :content_id: "1773511a-b3c9-4f37-8692-91a718d5b6ae"
+  :base_path: "/email/subscriptions"
+  :title: "Email - create subscription"
+  :description: "Prefix route to allow users to create email subscriptions"
+  :rendering_app: "email-alert-frontend"
+  :type: "prefix"
+  :override_existing: true
+
+- :content_id: "889e5a6f-d63b-4e10-8ffb-8d3959453285"
+  :base_path: "/email/authenticate"
+  :title: "Email - authenticate"
+  :description: "Prefix route to allow authentication for email subscription management"
+  :rendering_app: "email-alert-frontend"
+  :type: "prefix"
+  :override_existing: true
+
+- :content_id: "fb2f116f-09d2-4861-99d7-b6ea8168fe5d"
+  :base_path: "/email/manage"
+  :title: "Email - manage"
+  :description: "Prefix route to allow email subscription management"
+  :rendering_app: "email-alert-frontend"
+  :type: "prefix"
+  :override_existing: true
+
+- :content_id: "58b05bc2-fde5-4a0b-af73-8edc532674f8"
+  :base_path: "/contact"
+  :title: "Government contacts"
+  :description: "Prefix route for contacts"
+  :rendering_app: "feedback"
+  :type: "prefix"
+  :override_existing: true
+
+- :content_id: "58f79dbd-e57f-4ab2-ae96-96df5767d1b2"
+  :document_type: "calendar"
+  :schema: "calendar"
+  :base_path: "/bank-holidays"
+  :title: "UK bank holidays"
+  :description: "Find out when bank holidays are in England, Wales, Scotland and Northern Ireland - including past and future bank holidays"
+  :rendering_app: "frontend"
+  :type: "prefix"
+  :update_type: "minor"
+  :override_existing: true
+  :links:
+    :primary_publishing_organisation:
+      - "af07d5a5-df63-4ddc-9383-6a666845ebe9"
+  :additional_routes:
+    - :base_path: "/bank-holidays.json"
+      :type: "exact"
+
+- :content_id: "58f79dbd-e57f-4ab2-ae96-96df5767d1b2"
+  :document_type: "calendar"
+  :schema: "calendar"
+  :locale: "cy"
+  :base_path: "/gwyliau-banc"
+  :title: "Gwyliau banc y DU"
+  :description: "Dysgwch pryd mae gwyliau'r banc yng Nghymru, Lloegr, yr Alban a Gogledd Iwerddon - gan gynnwys gwyliau banc yn y gorffennol a'r dyfodol"
+  :rendering_app: "frontend"
+  :type: "prefix"
+  :update_type: "minor"
+  :override_existing: true
+  :links:
+    :primary_publishing_organisation:
+      - "af07d5a5-df63-4ddc-9383-6a666845ebe9"
+  :additional_routes:
+    - :base_path: "/gwyliau-banc.json"
+      :type: "exact"
+
+- :content_id: "41c78b38-f70e-4729-815b-680f9b90db30"
+  :document_type: "calendar"
+  :schema: "calendar"
+  :base_path: "/when-do-the-clocks-change"
+  :title: "When do the clocks change?"
+  :description: "Dates when the clocks go back or forward - includes British Summer Time, Greenwich Mean Time"
+  :rendering_app: "frontend"
+  :type: "prefix"
+  :update_type: "minor"
+  :override_existing: true
+  :links:
+    :primary_publishing_organisation:
+      - "af07d5a5-df63-4ddc-9383-6a666845ebe9"
+  :additional_routes:
+    - :base_path: "/when-do-the-clocks-change.json"
+      :type: "exact"

--- a/lib/tasks/special_route_publisher.rb
+++ b/lib/tasks/special_route_publisher.rb
@@ -1,0 +1,107 @@
+module Tasks
+  class SpecialRoutePublisher
+    def self.publish_special_routes
+      new.publish_routes(load_special_routes)
+    end
+
+    def self.publish_special_routes_for_app(app_name)
+      routes = load_special_routes.filter { |r| r[:rendering_app] == app_name }
+
+      if routes.any?
+        new.publish_routes(routes)
+      else
+        Rails.logger.info("No routes for #{app_name} in lib/data/special_routes.yaml")
+      end
+    end
+
+    def self.publish_one_route(base_path)
+      route = load_special_routes.find { |r| r[:base_path] == base_path }
+
+      if route
+        new.publish_routes([route])
+      else
+        Rails.logger.info("Route needs to be added to /lib/data/special_routes.yaml")
+      end
+    end
+
+    def self.unpublish_one_route(base_path, alternative_path = nil)
+      route = load_special_routes.find { |r| r[:base_path] == base_path }
+
+      if route && alternative_path
+        Commands::V2::Unpublish.call({ content_id: route.fetch(:content_id), type: "redirect", alternative_path: })
+      elsif route
+        Commands::V2::Unpublish.call({ content_id: route.fetch(:content_id), type: "gone" })
+      else
+        Rails.logger.info("Route needs to be added to /lib/data/special_routes.yaml")
+      end
+    end
+
+    def self.publish_homepage
+      new.publish_routes(load_homepage)
+    end
+
+    def publish_route(route)
+      routes = get_routes(route)
+
+      routes.each { |r| Rails.logger.info("Publishing #{r[:type]} route #{r[:path]}, routing to #{route.fetch(:rendering_app)}...") }
+
+      content_id = route.fetch(:content_id)
+
+      # Always request a path reservation before publishing the special route,
+      # with the flag to override any existing publishing app.
+      # This allows for routes that were previously published by other apps to
+      # be added to `special_routes.yaml` and "just work".
+      # Commands::ReservePath.call(path_item)
+      Commands::ReservePath.call({
+        base_path: route.fetch(:base_path),
+        publishing_app: "publishing-api",
+        override_existing: true,
+      })
+
+      Commands::V2::PutContent.call({
+        content_id:,
+        base_path: route.fetch(:base_path),
+        document_type: route.fetch(:document_type, "special_route"),
+        schema_name: route.fetch(:document_type, "special_route"),
+        title: route.fetch(:title),
+        description: route.fetch(:description, ""),
+        locale: route.fetch(:locale, "en"),
+        details: {},
+        routes:,
+        publishing_app: "publishing-api",
+        rendering_app: route.fetch(:rendering_app),
+        public_updated_at: Time.zone.now.iso8601,
+        update_type: route.fetch(:update_type, "major"),
+      })
+
+      if route[:links]
+        Commands::V2::PatchLinkSet.call({ content_id:, links: route[:links] })
+      end
+
+      Commands::V2::Publish.call({ content_id:, update_type: nil, locale: route.fetch(:locale, "en") })
+    end
+
+    def get_routes(route)
+      routes = [
+        {
+          path: route.fetch(:base_path),
+          type: route.fetch(:type, "exact"),
+        },
+      ]
+
+      routes + route.fetch(:additional_routes, []).map { |ar| { path: ar[:base_path], type: ar.fetch(:type, "exact") } }
+    end
+
+    def publish_routes(routes)
+      routes.each { |r| publish_route(r) }
+    end
+
+    def self.load_special_routes
+      YAML.load_file(Rails.root.join("lib/data/special_routes.yaml"))
+    end
+
+    def self.load_homepage
+      YAML.load_file(Rails.root.join("lib/data/homepage.yaml"))
+    end
+  end
+end

--- a/lib/tasks/special_routes.rake
+++ b/lib/tasks/special_routes.rake
@@ -1,0 +1,24 @@
+desc "Publish special routes (except the homepage)"
+task publish_special_routes: :environment do
+  Tasks::SpecialRoutePublisher.publish_special_routes
+end
+
+desc "Publish all special routes for a single application"
+task :publish_special_routes_for_app, [:app_name] => :environment do |_, args|
+  Tasks::SpecialRoutePublisher.publish_special_routes_for_app(args.app_name)
+end
+
+desc "Publish a single special route"
+task :publish_one_special_route, [:base_path] => :environment do |_, args|
+  Tasks::SpecialRoutePublisher.publish_one_route(args.base_path)
+end
+
+desc "Unpublish a single special route, with a type of 'gone' or 'redirect'"
+task :unpublish_one_special_route, %i[base_path alternative_path] => :environment do |_, args|
+  Tasks::SpecialRoutePublisher.unpublish_one_route(args.base_path, args.alternative_path)
+end
+
+desc "Publish the homepage"
+task publish_homepage: :environment do
+  Tasks::SpecialRoutePublisher.publish_homepage
+end

--- a/spec/fixtures/homepage.yaml
+++ b/spec/fixtures/homepage.yaml
@@ -1,0 +1,10 @@
+- :content_id: "f3bbdec2-0e62-4520-a7fd-6ffd5d36e03a"
+  :base_path: "/"
+  :document_type: "homepage"
+  :title: "GOV.UK homepage"
+  :rendering_app: "frontend"
+  :links:
+    :organisations:
+      - "af07d5a5-df63-4ddc-9383-6a666845ebe9"
+    :primary_publishing_organisation:
+      - "af07d5a5-df63-4ddc-9383-6a666845ebe9"

--- a/spec/fixtures/special_routes.yaml
+++ b/spec/fixtures/special_routes.yaml
@@ -1,0 +1,16 @@
+- :content_id: "c1f08359-21f7-49c1-8811-54bf6690b6a3"
+  :base_path: "/account/home"
+  :title: "Account home page"
+  :rendering_app: "frontend"
+
+- :content_id: "e5098fc2-ad79-4c6f-882b-410831c12f60"
+  :base_path: "/account/saved-pages/add"
+  :title: "Save a page"
+  :rendering_app: "frontend"
+
+- :content_id: "cdcad470-21c6-4e19-b644-9e499de1ad12"
+  :base_path: "/media"
+  :title: "Government Uploads"
+  :description: "Handles redirects for /media/:id/:filename path for asset manager"
+  :type: "prefix"
+  :rendering_app: "government-frontend"

--- a/spec/lib/tasks/special_route_publisher_spec.rb
+++ b/spec/lib/tasks/special_route_publisher_spec.rb
@@ -1,0 +1,66 @@
+RSpec.describe Tasks::SpecialRoutePublisher do
+  let(:content_id) { "f3bbdec2-0e62-4520-a7fd-6ffd5d36e03a" }
+
+  before do
+    stub_request(:put, %r{.*content-store.*/content/.*})
+  end
+
+  describe "#publish_route" do
+    it "sets the rendering app" do
+      described_class.new.publish_route(content_id:, base_path: "/", title: "Hello", rendering_app: "frontend")
+
+      expect(Edition.first.rendering_app).to eq("frontend")
+    end
+
+    context "without a specific locale" do
+      it "defaults to english" do
+        described_class.new.publish_route(content_id:, base_path: "/", title: "Hello", rendering_app: "frontend")
+
+        expect(Edition.first.locale).to eq("en")
+      end
+    end
+
+    context "with a specific locale" do
+      it "uses the specified locale" do
+        described_class.new.publish_route(content_id:, base_path: "/", title: "Hello", rendering_app: "frontend", locale: "cy")
+
+        expect(Edition.first.locale).to eq("cy")
+      end
+    end
+
+    context "with additional routes" do
+      let(:additional_routes) { [base_path: "/homepage.json", type: "exact"] }
+
+      it "calls the Publishing API with all routes specified for the item" do
+        described_class.new.publish_route(content_id:, base_path: "/", title: "Hello", rendering_app: "frontend", additional_routes:)
+
+        expect(Edition.first.routes).to eq(
+          [
+            { path: "/", type: "exact" },
+            { path: "/homepage.json", type: "exact" },
+          ],
+        )
+      end
+    end
+
+    context "with links" do
+      let(:links) do
+        {
+          organisations: %w[af07d5a5-df63-4ddc-9383-6a666845ebea],
+          primary_publishing_organisation: %w[af07d5a5-df63-4ddc-9383-6a666845ebe9],
+        }
+      end
+
+      it "adds the links" do
+        described_class.new.publish_route(content_id:, base_path: "/", title: "Hello", rendering_app: "frontend", links:)
+
+        link_set = Edition.first.document.link_set
+        expect(link_set).not_to be_nil
+        expect(link_set.links.first.link_type).to eq("organisations")
+        expect(link_set.links.first.target_content_id).to eq("af07d5a5-df63-4ddc-9383-6a666845ebea")
+        expect(link_set.links.second.link_type).to eq("primary_publishing_organisation")
+        expect(link_set.links.second.target_content_id).to eq("af07d5a5-df63-4ddc-9383-6a666845ebe9")
+      end
+    end
+  end
+end

--- a/spec/lib/tasks/special_routes_spec.rb
+++ b/spec/lib/tasks/special_routes_spec.rb
@@ -1,0 +1,135 @@
+RSpec.describe "Rake tasks for publishing special routes" do
+  context "with special routes data" do
+    let(:stdout) { double(:stdout, puts: nil) }
+
+    before do
+      stub_request(:put, %r{.*content-store.*/content/.*})
+    end
+
+    let(:replacement_special_routes_file) do
+      YAML.load_file(Rails.root.join("spec/fixtures/special_routes.yaml"))
+    end
+
+    before do
+      original_special_routes_path = Rails.root.join("lib/data/special_routes.yaml")
+      allow(YAML).to receive(:load_file).with(original_special_routes_path).and_return(replacement_special_routes_file)
+    end
+
+    describe "publish_special_routes" do
+      before do
+        Rake::Task["publish_special_routes"].reenable
+      end
+
+      it "publishes the special routes" do
+        Rake::Task["publish_special_routes"].invoke
+
+        expect(Document.count).to eq(3)
+        expect(Edition.count).to eq(3)
+      end
+    end
+
+    describe "publish_special_routes_for_app" do
+      before do
+        Rake::Task["publish_special_routes_for_app"].reenable
+      end
+
+      it "publishes the special routes for one particular app without publishing others" do
+        Rake::Task["publish_special_routes_for_app"].invoke("government-frontend")
+
+        expect(Document.count).to eq(1)
+        expect(Edition.count).to eq(1)
+        edition = Edition.where(title: "Government Uploads").first
+        expect(edition).not_to be_nil
+      end
+
+      it "returns a message if there are no routes for that app" do
+        expect(Rails.logger).to receive(:info).with(/No routes for finder-frontend in lib\/data\/special_routes.yaml/)
+
+        Rake::Task["publish_special_routes_for_app"].invoke("finder-frontend")
+
+        expect(Document.count).to eq(0)
+      end
+    end
+
+    describe "publish_one_special_route" do
+      before do
+        Rake::Task["publish_one_special_route"].reenable
+      end
+
+      it "publishes one special route" do
+        Rake::Task["publish_one_special_route"].invoke("/account/saved-pages/add")
+
+        expect(Document.count).to eq(1)
+        expect(Edition.count).to eq(1)
+        edition = Edition.where(title: "Save a page").first
+        expect(edition).not_to be_nil
+      end
+
+      it "returns a message if there are no records for that path" do
+        expect(Rails.logger).to receive(:info).with(/Route needs to be added to \/lib\/data\/special_routes.yaml/)
+
+        Rake::Task["publish_one_special_route"].invoke("/account/saved-pages/remove")
+
+        expect(Document.count).to eq(0)
+      end
+    end
+
+    describe "unpublish_one_special_route" do
+      before do
+        Rake::Task["publish_one_special_route"].reenable
+        Rake::Task["publish_one_special_route"].invoke("/media")
+        Rake::Task["unpublish_one_special_route"].reenable
+      end
+
+      it "unpublishes one special route" do
+        expect(Edition.first.state).to eq("published")
+
+        Rake::Task["unpublish_one_special_route"].invoke("/media")
+
+        expect(Edition.first.state).to eq("unpublished")
+      end
+
+      it "unpublishes one special route with a redirect" do
+        expect(Edition.first.state).to eq("published")
+
+        Rake::Task["unpublish_one_special_route"].invoke("/media", "/media2")
+
+        expect(Edition.first.state).to eq("unpublished")
+      end
+
+      it "returns a message if there are no records for that path" do
+        expect(Edition.first.state).to eq("published")
+        expect(Rails.logger).to receive(:info).with(/Route needs to be added to \/lib\/data\/special_routes.yaml/)
+
+        Rake::Task["unpublish_one_special_route"].invoke("/account/saved-pages/remove")
+
+        expect(Edition.first.state).to eq("published")
+      end
+    end
+  end
+
+  context "with homepage data" do
+    before do
+      stub_request(:put, %r{.*content-store.*/content/.*})
+      Rake::Task["publish_homepage"].reenable
+    end
+
+    let(:replacement_homepage_file) do
+      YAML.load_file(Rails.root.join("spec/fixtures/homepage.yaml"))
+    end
+
+    before do
+      original_homepage_path = Rails.root.join("lib/data/homepage.yaml")
+      allow(YAML).to receive(:load_file).with(original_homepage_path).and_return(replacement_homepage_file)
+    end
+
+    it "publishes the special routes" do
+      Rake::Task["publish_homepage"].invoke
+
+      expect(Document.count).to eq(1)
+      expect(Edition.count).to eq(1)
+      edition = Edition.where(title: "GOV.UK homepage").first
+      expect(edition).not_to be_nil
+    end
+  end
+end


### PR DESCRIPTION
Move special-route-publisher rake tasks into publishing-api, as per https://github.com/alphagov/special-route-publisher/issues/260 . This is the first half of the move suggested in that issue - simply moving the task from a separate repo into publishing-api, and converting it to use the in-built Command class calls rather than calling through the API. Once this is complete special-route-publisher can be retired, and at our leisure we can complete the second half of the suggestions in the issue (publishing the special routes if necessary on deploy rather than having to explicitly call the tasks).

https://trello.com/c/9rOxWNnD/396-retire-special-route-publisher

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
