### PR TITLE
(562) Ensure only live organisations appear in join

### DIFF
--- a/app/queries/get_embedded_content.rb
+++ b/app/queries/get_embedded_content.rb
@@ -26,7 +26,7 @@ module Queries
         .joins(:links)
         .joins("LEFT JOIN links AS primary_links ON primary_links.edition_id = editions.id AND primary_links.link_type = 'primary_publishing_organisation'")
         .joins("LEFT JOIN documents ON documents.content_id = primary_links.target_content_id")
-        .joins("LEFT JOIN editions AS org_editions ON org_editions.document_id = documents.id")
+        .joins("LEFT JOIN editions AS org_editions ON org_editions.document_id = documents.id AND org_editions.state = 'published'")
         .where(links: { link_type: embedded_link_type, target_content_id: })
         .select(
           "editions.id, editions.title, editions.base_path, editions.document_type, editions.publishing_app",

--- a/spec/queries/get_embedded_content_spec.rb
+++ b/spec/queries/get_embedded_content_spec.rb
@@ -1,11 +1,19 @@
 RSpec.describe Queries::GetEmbeddedContent do
   describe "#call" do
     let(:organisation) do
-      create(:live_edition,
-             title: "bar",
-             document_type: "organisation",
-             schema_name: "organisation",
-             base_path: "/government/organisations/bar")
+      edition_params = {
+        title: "bar",
+        document: create(:document),
+        document_type: "organisation",
+        schema_name: "organisation",
+        base_path: "/government/organisations/bar",
+      }
+
+      create(:superseded_edition, **edition_params)
+      live_edition = create(:live_edition, **edition_params.merge({ user_facing_version: 2 }))
+      create(:draft_edition, **edition_params.merge({ user_facing_version: 3 }))
+
+      live_edition
     end
 
     let(:content_block) do


### PR DESCRIPTION
When embedded content has a primary publication organisation, the JOIN was pulling in all draft and superseded editions in, resulting in duplicate rows (so if an organisation has 400 superseded editions and 1 live edition we get 401 rows!). This alters the JOIN to only pull in the live edition of a primary publishing organisation, meaning we only get one row per embedded content.

I’ve also updated the tests to create draft and superseded editions for the organisation, so we can ensure that we have a test suite that better represents reality.