### PR TITLE
Add favicon special route for frontend

### DIFF
--- a/lib/data/special_routes.yaml
+++ b/lib/data/special_routes.yaml
@@ -245,3 +245,10 @@
   :additional_routes:
     - :base_path: "/when-do-the-clocks-change.json"
       :type: "exact"
+
+- :content_id: "5fc8b4bc-f899-4d4e-ae10-f9beeb172f50"
+  :base_path: "/favicon.ico"
+  :title: "Favicon"
+  :rendering_app: "frontend"
+  :description: "The favicon is the image displayed in locations such as the browser tabs."
+  :override_existing: true


### PR DESCRIPTION
Frontend now handles favicons, (https://github.com/alphagov/frontend/pull/4241) so add a special route to point /favicon.ico there

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
