### PR TITLE
Add a landing page document type

### DIFF
--- a/content_schemas/allowed_document_types.yml
+++ b/content_schemas/allowed_document_types.yml
@@ -78,6 +78,7 @@
 - independent_report
 - international_development_fund
 - international_treaty
+- landing_page
 - licence
 - license_finder
 - licence_transaction

--- a/content_schemas/dist/formats/generic/frontend/schema.json
+++ b/content_schemas/dist/formats/generic/frontend/schema.json
@@ -114,6 +114,7 @@
         "independent_report",
         "international_development_fund",
         "international_treaty",
+        "landing_page",
         "licence",
         "license_finder",
         "licence_transaction",

--- a/content_schemas/dist/formats/generic/notification/schema.json
+++ b/content_schemas/dist/formats/generic/notification/schema.json
@@ -138,6 +138,7 @@
         "independent_report",
         "international_development_fund",
         "international_treaty",
+        "landing_page",
         "licence",
         "license_finder",
         "licence_transaction",

--- a/content_schemas/dist/formats/generic/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/generic/publisher_v2/schema.json
@@ -124,6 +124,7 @@
         "independent_report",
         "international_development_fund",
         "international_treaty",
+        "landing_page",
         "licence",
         "license_finder",
         "licence_transaction",

--- a/content_schemas/dist/formats/generic_with_external_related_links/frontend/schema.json
+++ b/content_schemas/dist/formats/generic_with_external_related_links/frontend/schema.json
@@ -114,6 +114,7 @@
         "independent_report",
         "international_development_fund",
         "international_treaty",
+        "landing_page",
         "licence",
         "license_finder",
         "licence_transaction",

--- a/content_schemas/dist/formats/generic_with_external_related_links/notification/schema.json
+++ b/content_schemas/dist/formats/generic_with_external_related_links/notification/schema.json
@@ -138,6 +138,7 @@
         "independent_report",
         "international_development_fund",
         "international_treaty",
+        "landing_page",
         "licence",
         "license_finder",
         "licence_transaction",

--- a/content_schemas/dist/formats/generic_with_external_related_links/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/generic_with_external_related_links/publisher_v2/schema.json
@@ -124,6 +124,7 @@
         "independent_report",
         "international_development_fund",
         "international_treaty",
+        "landing_page",
         "licence",
         "license_finder",
         "licence_transaction",


### PR DESCRIPTION
Initially this will only be usable by content items in the "generic" schemas. We haven't decided on the format these content items will have yet, so we can't build a more specific schema for them yet.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.