### PR TITLE
Content Modelling/593 New update type for updating Content Blocks and their Host Documents

### DIFF
--- a/app/commands/v2/publish.rb
+++ b/app/commands/v2/publish.rb
@@ -11,8 +11,10 @@ module Commands
 
     private
 
+      UPDATE_TYPES_WITH_CHANGE_NOTES = %w[major content_block].freeze
+
       def publish_edition
-        delete_change_notes unless update_type == "major"
+        delete_change_notes unless UPDATE_TYPES_WITH_CHANGE_NOTES.include?(update_type)
         previous_edition.supersede if previous_edition
 
         unless edition.pathless?
@@ -137,7 +139,7 @@ module Commands
       end
 
       def valid_update_types
-        %w[major minor republish links]
+        %w[major minor republish links content_block]
       end
 
       def already_published?

--- a/app/sidekiq/downstream_live_job.rb
+++ b/app/sidekiq/downstream_live_job.rb
@@ -83,7 +83,8 @@ private
   end
 
   def enqueue_dependencies
-    DependencyResolutionJob.perform_async(
+    dependency_job_klass = @message_queue_event_type == "content_block" ? HostContentUpdateJob : DependencyResolutionJob
+    dependency_job_klass.perform_async(
       "content_store" => "Adapters::ContentStore",
       "content_id" => content_id,
       "locale" => locale,

--- a/app/sidekiq/host_content_update_job.rb
+++ b/app/sidekiq/host_content_update_job.rb
@@ -1,0 +1,18 @@
+class HostContentUpdateJob < DependencyResolutionJob
+private
+
+  def downstream_live(dependent_content_id, locale)
+    return if draft?
+
+    DownstreamLiveJob.perform_async_in_queue(
+      DownstreamLiveJob::LOW_QUEUE,
+      "content_id" => dependent_content_id,
+      "locale" => locale,
+      "message_queue_event_type" => "host_content",
+      "update_dependencies" => false,
+      "dependency_resolution_source_content_id" => content_id,
+      "source_command" => source_command,
+      "source_fields" => source_fields,
+    )
+  end
+end

--- a/docs/api.md
+++ b/docs/api.md
@@ -94,7 +94,7 @@ presented edition and [warnings](#warnings).
   - The path that this item will use on [GOV.UK](https://www.gov.uk).
 - `change_note` *(optional)*
   - Specifies the [change note](model.md#changenote).
-  - Ignored if the `update_type` is not major.
+  - Ignored if the `update_type` is not "major" or "content_block".
 - `description` *(optional)*
   - A description of the content that can be displayed publicly.
 - `details` *(conditionally required, default: {})*
@@ -213,7 +213,7 @@ will be presented in the live content store. Uses
   to "superseded".
 - For an `update_type` of "major" the `public_updated_at` field will be updated
   to the current time.
-- For an `update_type` other than "major":
+- For an `update_type` other than "major" or "content_block":
   - If it exists, the [change note](model.md#changenote) will be
     deleted, as change notes are only for major updates.
 - If the edition has a non-blank `base_path`:

--- a/docs/arch/adr-006-new-event-type-for-content-blocks.md
+++ b/docs/arch/adr-006-new-event-type-for-content-blocks.md
@@ -1,0 +1,70 @@
+# Decision Record: Add new event type to add custom dependency resolution behaviour when a Content Block is updated
+
+## Context
+
+### Existing behaviour
+
+The way content blocks are handled leans on a lot of existing functionality within the publishing platform. 
+Previously to the introduction of content blocks, documents had (and still have!) the concept of “links”, so when a 
+document is changed, this triggers the republication of all the documents that are associated with that page.
+
+A good example of this is an “Organisation” page (for example, the Cabinet Office). The Cabinet Office organisation 
+page, as well as listing some information about the organisation, also lists the ministers for that organisation.
+
+When the frontend fetches the organisation from the content store, it also gets the ministers (stored as links). 
+This information is static within the content store, so if information about those ministers changes, we need to 
+send the organisation page back to the Content Store along with the new minister information.
+
+This is done through a process known as dependency resolution. When we publish a minister, we get all that 
+minister’s dependent documents, and resend them to the content store as shown:
+
+https://gist.github.com/pezholio/3b698953ec84b569a90df331e0b7c559
+
+### Content Block requirements
+
+With content blocks, this process remains largely unchanged, when a block is changed, we fetch the dependent 
+documents and send them to the content stores. As part of the process of sending the documents to the content stores,
+we perform a find/replace to find the embed code and replace it with the actual content of the blocks.
+
+Going forward, we’d like to do a couple of things:
+
+1. If a member of the public is signed up to receive email alerts on a dependent document, we’d like to alert them 
+   when content is changed as a result of a content block within that document changing; and
+2. Add a change note in publishing apps to inform the editors and the public that the document(s) have been 
+   republished as a result of a change to a content block
+
+For email alerts, there is already a mechanism to add a `major` event type to the RabbitMQ queue when a document is 
+published and the change is a major change. This then gets picked up by the Email Alerts Service, which then 
+triggers email notifications for subscribed users.
+
+We have looked into hooking into this behaviour to “fake” a `major` event message to then trigger email alerts when 
+a dependent document is updated. This has a couple of issues:
+
+1. The code is already quite verbose, and this adds a bunch of complexities
+2. We need to reach into the payload and generate a new changenote for each dependent bit of content, which causes 
+   misdirection and is again, quite messy
+
+## Decisions
+
+We therefore suggest updating the Publishing API code to:
+1. receive a new `content_block` update type 
+2. when this update type is used, call a new Sidekiq Job to update host documents with a new `host_content` update type
+
+In the near future we will then be able to add Change Notes to the relevant Host Documents, and update the Email Alerts 
+Service to subscribe to the `host_content` event.
+
+## Consequences
+
+We believe that this will make the intent of the code clearer, as well as allow us to make changes in an incremental way.
+
+This will also enable two way communication between publishing apps, allowing users to see at a glance when content 
+blocks have triggered a change.
+
+The work to implement Change Notes will require some changes to the publishing apps themselves, as 
+well as potentially some duplication of code in each app. However, this is a good practical illustration of why we 
+are trying to reduce the number of publishing apps in the estate.
+
+We could trial this with Whitehall at first, and then expand to Mainstream, Travel Advice etc if the ideal proves 
+successful.
+
+

--- a/lib/expansion_rules.rb
+++ b/lib/expansion_rules.rb
@@ -91,6 +91,7 @@ module_function
 
   DEFAULT_FIELDS_AND_DESCRIPTION = (DEFAULT_FIELDS + [:description]).freeze
 
+  CONTENT_BLOCK_FIELDS = (DEFAULT_FIELDS + details_fields(:email_address)).freeze
   CONTACT_FIELDS = (DEFAULT_FIELDS + details_fields(:description, :title, :contact_form_links, :post_addresses, :email_addresses, :phone_numbers)).freeze
   GOVERNMENT_FIELDS = (MANDATORY_FIELDS + %i[api_path base_path document_type] + details_fields(:started_on, :ended_on, :current)).freeze
   ORGANISATION_FIELDS = (DEFAULT_FIELDS - [:public_updated_at] + details_fields(:acronym, :logo, :brand, :default_news_image, :organisation_govuk_status)).freeze
@@ -162,6 +163,8 @@ module_function
         fields: [] },
       { document_type: :contact,
         fields: CONTACT_FIELDS },
+      { document_type: :content_block_email_address,
+        fields: CONTENT_BLOCK_FIELDS },
       { document_type: :topical_event,
         fields: DEFAULT_FIELDS },
       { document_type: :organisation,

--- a/spec/commands/v2/publish_spec.rb
+++ b/spec/commands/v2/publish_spec.rb
@@ -240,13 +240,13 @@ RSpec.describe Commands::V2::Publish do
       end
 
       it "updates dependencies for Live" do
-        expect(DependencyResolutionJob).to receive(:perform_async).with("content_store" => "Adapters::ContentStore",
-                                                                        "content_id" => document.content_id,
-                                                                        "locale" => locale,
-                                                                        "orphaned_content_ids" => [],
-                                                                        "source_command" => "publish",
-                                                                        "source_document_type" => "content_block_email_address",
-                                                                        "source_fields" => [])
+        expect(HostContentUpdateJob).to receive(:perform_async).with("content_store" => "Adapters::ContentStore",
+                                                                     "content_id" => document.content_id,
+                                                                     "locale" => locale,
+                                                                     "orphaned_content_ids" => [],
+                                                                     "source_command" => "publish",
+                                                                     "source_document_type" => "content_block_email_address",
+                                                                     "source_fields" => [])
 
         described_class.call(payload)
       end

--- a/spec/commands/v2/publish_spec.rb
+++ b/spec/commands/v2/publish_spec.rb
@@ -181,6 +181,82 @@ RSpec.describe Commands::V2::Publish do
       end
     end
 
+    context "publishing a content block update" do
+      before do
+        payload[:update_type] = "content_block"
+        draft_item.update!(document_type: "content_block_email_address")
+        ChangeNote.create!(edition: draft_item)
+      end
+
+      it "changes the state of the draft item to 'published'" do
+        described_class.call(payload)
+
+        updated_draft_item = Edition.find(draft_item.id)
+        expect(updated_draft_item.state).to eq("published")
+      end
+
+      it "sends downstream asynchronously" do
+        expect(DownstreamLiveJob)
+          .to receive(:perform_async_in_queue)
+                .with(
+                  "downstream_high",
+                  {
+                    "message_queue_event_type" => "content_block",
+                    "orphaned_content_ids" => [],
+                    "content_id" => document.content_id,
+                    "locale" => locale,
+                    "update_dependencies" => true,
+                    "source_command" => "publish",
+                    "source_fields" => [],
+                  },
+                )
+
+        expect(DownstreamDraftJob)
+          .to receive(:perform_async_in_queue)
+                .with(
+                  "downstream_high",
+                  {
+                    "content_id" => document.content_id,
+                    "locale" => locale,
+                    "update_dependencies" => true,
+                    "source_command" => "publish",
+                    "source_fields" => [],
+                  },
+                )
+
+        described_class.call(payload)
+      end
+
+      it "updates dependencies for Drafts" do
+        expect(DependencyResolutionJob).to receive(:perform_async).with("content_store" => "Adapters::DraftContentStore",
+                                                                        "content_id" => document.content_id,
+                                                                        "locale" => locale,
+                                                                        "orphaned_content_ids" => [],
+                                                                        "source_command" => "publish",
+                                                                        "source_document_type" => "content_block_email_address",
+                                                                        "source_fields" => [])
+
+        described_class.call(payload)
+      end
+
+      it "updates dependencies for Live" do
+        expect(DependencyResolutionJob).to receive(:perform_async).with("content_store" => "Adapters::ContentStore",
+                                                                        "content_id" => document.content_id,
+                                                                        "locale" => locale,
+                                                                        "orphaned_content_ids" => [],
+                                                                        "source_command" => "publish",
+                                                                        "source_document_type" => "content_block_email_address",
+                                                                        "source_fields" => [])
+
+        described_class.call(payload)
+      end
+
+      it "does not delete Change Notes" do
+        described_class.call(payload)
+        expect(ChangeNote.count).to eq(1)
+      end
+    end
+
     context "dependency fields change on new publication" do
       let(:existing_base_path) { base_path }
 

--- a/spec/lib/expansion_rules_spec.rb
+++ b/spec/lib/expansion_rules_spec.rb
@@ -40,6 +40,7 @@ RSpec.describe ExpansionRules do
   describe ".expansion_fields" do
     let(:default_fields) { rules::DEFAULT_FIELDS }
     let(:contact_fields) { default_fields + [%i[details description], %i[details title], %i[details contact_form_links], %i[details post_addresses], %i[details email_addresses], %i[details phone_numbers]] }
+    let(:content_block_fields) { default_fields + [%i[details email_address]] }
     let(:organisation_fields) { default_fields - [:public_updated_at] + [%i[details acronym], %i[details logo], %i[details brand], %i[details default_news_image], %i[details organisation_govuk_status]] }
     let(:taxon_fields) { default_fields + %i[description details phase] }
     let(:default_fields_and_description) { default_fields + %i[description] }
@@ -67,6 +68,7 @@ RSpec.describe ExpansionRules do
     specify { expect(rules.expansion_fields(:parent)).to eq(default_fields) }
 
     specify { expect(rules.expansion_fields(:contact)).to eq(contact_fields) }
+    specify { expect(rules.expansion_fields(:content_block_email_address)).to eq(content_block_fields) }
     specify { expect(rules.expansion_fields(:historic_appointment)).to eq(historic_appointment_fields) }
     specify { expect(rules.expansion_fields(:fatality_notice)).to eq(fatality_notice_fields) }
     specify { expect(rules.expansion_fields(:mainstream_browse_page)).to eq(default_fields_and_description) }

--- a/spec/sidekiq/host_content_update_job_spec.rb
+++ b/spec/sidekiq/host_content_update_job_spec.rb
@@ -1,0 +1,40 @@
+RSpec.describe HostContentUpdateJob, :perform do
+  let(:content_id) { SecureRandom.uuid }
+  subject(:worker_perform) do
+    described_class.new.perform(
+      "content_id" => content_id,
+      "locale" => "en",
+      "content_store" => "Adapters::ContentStore",
+      "orphaned_content_ids" => [],
+    )
+  end
+
+  let(:dependent_content_id) { SecureRandom.uuid }
+  let(:edition_dependent) { double(:edition_dependent, call: [], content_id: dependent_content_id) }
+  let(:dependencies) do
+    [
+      [dependent_content_id, "en"],
+    ]
+  end
+
+  before do
+    allow_any_instance_of(Queries::ContentDependencies).to receive(:call).and_return(dependencies)
+  end
+
+  it "queues the Live host content for update" do
+    expect(DownstreamLiveJob).to receive(:perform_async_in_queue).with(
+      "downstream_low",
+      {
+        "content_id" => dependent_content_id,
+        "dependency_resolution_source_content_id" =>
+         content_id,
+        "locale" => "en",
+        "message_queue_event_type" => "host_content",
+        "source_command" => nil,
+        "source_fields" => [],
+        "update_dependencies" => false,
+      },
+    )
+    worker_perform
+  end
+end


### PR DESCRIPTION
For more context of the Content Block work, please see the `content_object_store` engine in Whitehall https://github.com/alphagov/whitehall/blob/3375d41d987f9790e410eeb8bc6bc79aebfc1cab/docs/adr/0004-content-object-store-added-with-a-rails-engine.md

For the long version of why we are making this change see the ADR https://github.com/alphagov/publishing-api/blob/content-modelling/593-content-block-update-type/docs/arch/adr-006-new-event-type-for-content-blocks.md 

when a Content Block is updated, we want to support features that relate to the updating of the Block and its Host Documents (Documents that have the Block in their content, currently identified as Links).

As Content Blocks are a new type of content, we think it makes sense that a new update type is issued, because we want to diverge in the near future from the existing update flow for Editions, and it semantically is a different type of update - `major`/`minor` updates do not mean anything (currently) in Content Block land.

This PR introduces two new update types:
1. `content_block` to track when a content block is being updated
2. `host_content` to track when a host document is being updated

without (yet) changing any of the functionality related to `major` updates. 

This will enable us to make changes in the near future such as adding Change Notes and listening to the update type to send emails. (as in ADR).

The work to use this type is in Whitehall PR here https://github.com/alphagov/whitehall/pull/9497 

Spike branch to show how we might create ChangeNotes in Publishing API https://github.com/alphagov/publishing-api/compare/content-modelling/spike-change-notes?expand=1

## questions

* This would mean that the `major_published_at` and `public_updated_at` fields on an Edition might not be updated correctly https://github.com/alphagov/publishing-api/blob/df7eae7b8cd1160aeda2f54c963bf08162d84c7a/app/models/edition/timestamps.rb#L43 (do we care about that?)
* Are there any other knock on effects of adding new update types?


----

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
