### PR TITLE
Create human readable content aliases on `PUT Content`

### DIFF
--- a/app/commands/v2/put_content.rb
+++ b/app/commands/v2/put_content.rb
@@ -16,6 +16,7 @@ module Commands
         edition = create_or_update_edition
         set_timestamps(edition)
 
+        create_content_id_alias
         update_content_dependencies(edition)
 
         orphaned_links = link_diff_between(
@@ -96,6 +97,19 @@ module Commands
             end,
           )
         end
+      end
+
+      def create_content_id_alias
+        content_id_alias_name = payload[:content_id_alias]
+        return unless content_id_alias_name
+
+        if (content_id_alias = ContentIdAlias.find_by(name: content_id_alias_name))
+          return if content_id_alias.content_id == payload[:content_id]
+
+          raise CommandError.new(code: 422, message: "ContentIdAlias with name \"#{content_id_alias_name}\" exists for a different content ID.")
+        end
+
+        ContentIdAlias.create!(name: content_id_alias_name, content_id: payload[:content_id])
       end
 
       def fetch_embedded_content(edition)

--- a/app/models/content_id_alias.rb
+++ b/app/models/content_id_alias.rb
@@ -1,0 +1,3 @@
+class ContentIdAlias < ApplicationRecord
+  validates :name, uniqueness: true, presence: true
+end

--- a/content_schemas/dist/formats/answer/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/answer/publisher_v2/schema.json
@@ -35,6 +35,9 @@
         "string"
       ]
     },
+    "content_id_alias": {
+      "type": "null"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },

--- a/content_schemas/dist/formats/calendar/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/calendar/publisher_v2/schema.json
@@ -35,6 +35,9 @@
         "string"
       ]
     },
+    "content_id_alias": {
+      "type": "null"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },

--- a/content_schemas/dist/formats/call_for_evidence/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/call_for_evidence/publisher_v2/schema.json
@@ -35,6 +35,9 @@
         "string"
       ]
     },
+    "content_id_alias": {
+      "type": "null"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },

--- a/content_schemas/dist/formats/case_study/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/case_study/publisher_v2/schema.json
@@ -35,6 +35,9 @@
         "string"
       ]
     },
+    "content_id_alias": {
+      "type": "null"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },

--- a/content_schemas/dist/formats/completed_transaction/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/completed_transaction/publisher_v2/schema.json
@@ -35,6 +35,9 @@
         "string"
       ]
     },
+    "content_id_alias": {
+      "type": "null"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },

--- a/content_schemas/dist/formats/consultation/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/consultation/publisher_v2/schema.json
@@ -35,6 +35,9 @@
         "string"
       ]
     },
+    "content_id_alias": {
+      "type": "null"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },

--- a/content_schemas/dist/formats/contact/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/contact/publisher_v2/schema.json
@@ -32,6 +32,9 @@
         "string"
       ]
     },
+    "content_id_alias": {
+      "type": "null"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },

--- a/content_schemas/dist/formats/content_block_email_address/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/content_block_email_address/publisher_v2/schema.json
@@ -32,6 +32,9 @@
         "string"
       ]
     },
+    "content_id_alias": {
+      "$ref": "#/definitions/content_id_alias_optional"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },
@@ -153,6 +156,20 @@
       "anyOf": [
         {
           "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "content_id_alias": {
+      "description": "Human-readable alias for a Content ID, used when embedding content. Should only be supplied when updating Content Blocks.",
+      "type": "string"
+    },
+    "content_id_alias_optional": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/content_id_alias"
         },
         {
           "type": "null"

--- a/content_schemas/dist/formats/content_block_postal_address/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/content_block_postal_address/publisher_v2/schema.json
@@ -32,6 +32,9 @@
         "string"
       ]
     },
+    "content_id_alias": {
+      "$ref": "#/definitions/content_id_alias_optional"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },
@@ -153,6 +156,20 @@
       "anyOf": [
         {
           "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "content_id_alias": {
+      "description": "Human-readable alias for a Content ID, used when embedding content. Should only be supplied when updating Content Blocks.",
+      "type": "string"
+    },
+    "content_id_alias_optional": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/content_id_alias"
         },
         {
           "type": "null"

--- a/content_schemas/dist/formats/coronavirus_landing_page/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/coronavirus_landing_page/publisher_v2/schema.json
@@ -35,6 +35,9 @@
         "string"
       ]
     },
+    "content_id_alias": {
+      "type": "null"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },

--- a/content_schemas/dist/formats/corporate_information_page/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/corporate_information_page/publisher_v2/schema.json
@@ -35,6 +35,9 @@
         "string"
       ]
     },
+    "content_id_alias": {
+      "type": "null"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },

--- a/content_schemas/dist/formats/detailed_guide/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/detailed_guide/publisher_v2/schema.json
@@ -35,6 +35,9 @@
         "string"
       ]
     },
+    "content_id_alias": {
+      "type": "null"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },

--- a/content_schemas/dist/formats/document_collection/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/document_collection/publisher_v2/schema.json
@@ -35,6 +35,9 @@
         "string"
       ]
     },
+    "content_id_alias": {
+      "type": "null"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },

--- a/content_schemas/dist/formats/email_alert_signup/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/email_alert_signup/publisher_v2/schema.json
@@ -35,6 +35,9 @@
         "string"
       ]
     },
+    "content_id_alias": {
+      "type": "null"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },

--- a/content_schemas/dist/formats/embassies_index/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/embassies_index/publisher_v2/schema.json
@@ -35,6 +35,9 @@
         "string"
       ]
     },
+    "content_id_alias": {
+      "type": "null"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },

--- a/content_schemas/dist/formats/external_content/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/external_content/publisher_v2/schema.json
@@ -33,6 +33,9 @@
         "string"
       ]
     },
+    "content_id_alias": {
+      "type": "null"
+    },
     "description": {
       "$ref": "#/definitions/description"
     },

--- a/content_schemas/dist/formats/facet/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/facet/publisher_v2/schema.json
@@ -32,6 +32,9 @@
         "string"
       ]
     },
+    "content_id_alias": {
+      "type": "null"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },

--- a/content_schemas/dist/formats/fatality_notice/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/fatality_notice/publisher_v2/schema.json
@@ -35,6 +35,9 @@
         "string"
       ]
     },
+    "content_id_alias": {
+      "type": "null"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },

--- a/content_schemas/dist/formats/field_of_operation/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/field_of_operation/publisher_v2/schema.json
@@ -35,6 +35,9 @@
         "string"
       ]
     },
+    "content_id_alias": {
+      "type": "null"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },

--- a/content_schemas/dist/formats/fields_of_operation/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/fields_of_operation/publisher_v2/schema.json
@@ -35,6 +35,9 @@
         "string"
       ]
     },
+    "content_id_alias": {
+      "type": "null"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },

--- a/content_schemas/dist/formats/finder/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/finder/publisher_v2/schema.json
@@ -35,6 +35,9 @@
         "string"
       ]
     },
+    "content_id_alias": {
+      "type": "null"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },

--- a/content_schemas/dist/formats/finder_email_signup/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/finder_email_signup/publisher_v2/schema.json
@@ -35,6 +35,9 @@
         "string"
       ]
     },
+    "content_id_alias": {
+      "type": "null"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },

--- a/content_schemas/dist/formats/generic/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/generic/publisher_v2/schema.json
@@ -35,6 +35,9 @@
         "string"
       ]
     },
+    "content_id_alias": {
+      "type": "null"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },

--- a/content_schemas/dist/formats/generic_with_external_related_links/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/generic_with_external_related_links/publisher_v2/schema.json
@@ -35,6 +35,9 @@
         "string"
       ]
     },
+    "content_id_alias": {
+      "type": "null"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },

--- a/content_schemas/dist/formats/get_involved/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/get_involved/publisher_v2/schema.json
@@ -35,6 +35,9 @@
         "string"
       ]
     },
+    "content_id_alias": {
+      "type": "null"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },

--- a/content_schemas/dist/formats/gone/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/gone/publisher_v2/schema.json
@@ -30,6 +30,9 @@
         "string"
       ]
     },
+    "content_id_alias": {
+      "type": "null"
+    },
     "description": {
       "type": "null"
     },

--- a/content_schemas/dist/formats/government/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/government/publisher_v2/schema.json
@@ -35,6 +35,9 @@
         "string"
       ]
     },
+    "content_id_alias": {
+      "type": "null"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },

--- a/content_schemas/dist/formats/guide/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/guide/publisher_v2/schema.json
@@ -35,6 +35,9 @@
         "string"
       ]
     },
+    "content_id_alias": {
+      "type": "null"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },

--- a/content_schemas/dist/formats/help_page/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/help_page/publisher_v2/schema.json
@@ -35,6 +35,9 @@
         "string"
       ]
     },
+    "content_id_alias": {
+      "type": "null"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },

--- a/content_schemas/dist/formats/historic_appointment/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/historic_appointment/publisher_v2/schema.json
@@ -35,6 +35,9 @@
         "string"
       ]
     },
+    "content_id_alias": {
+      "type": "null"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },

--- a/content_schemas/dist/formats/historic_appointments/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/historic_appointments/publisher_v2/schema.json
@@ -35,6 +35,9 @@
         "string"
       ]
     },
+    "content_id_alias": {
+      "type": "null"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },

--- a/content_schemas/dist/formats/history/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/history/publisher_v2/schema.json
@@ -35,6 +35,9 @@
         "string"
       ]
     },
+    "content_id_alias": {
+      "type": "null"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },

--- a/content_schemas/dist/formats/hmrc_manual/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/hmrc_manual/publisher_v2/schema.json
@@ -35,6 +35,9 @@
         "string"
       ]
     },
+    "content_id_alias": {
+      "type": "null"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },

--- a/content_schemas/dist/formats/hmrc_manual_section/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/hmrc_manual_section/publisher_v2/schema.json
@@ -35,6 +35,9 @@
         "string"
       ]
     },
+    "content_id_alias": {
+      "type": "null"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },

--- a/content_schemas/dist/formats/homepage/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/homepage/publisher_v2/schema.json
@@ -35,6 +35,9 @@
         "string"
       ]
     },
+    "content_id_alias": {
+      "type": "null"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },

--- a/content_schemas/dist/formats/how_government_works/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/how_government_works/publisher_v2/schema.json
@@ -35,6 +35,9 @@
         "string"
       ]
     },
+    "content_id_alias": {
+      "type": "null"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },

--- a/content_schemas/dist/formats/html_publication/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/html_publication/publisher_v2/schema.json
@@ -35,6 +35,9 @@
         "string"
       ]
     },
+    "content_id_alias": {
+      "type": "null"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },

--- a/content_schemas/dist/formats/landing_page/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/landing_page/publisher_v2/schema.json
@@ -35,6 +35,9 @@
         "string"
       ]
     },
+    "content_id_alias": {
+      "type": "null"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },

--- a/content_schemas/dist/formats/licence/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/licence/publisher_v2/schema.json
@@ -35,6 +35,9 @@
         "string"
       ]
     },
+    "content_id_alias": {
+      "type": "null"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },

--- a/content_schemas/dist/formats/link_collection/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/link_collection/publisher_v2/schema.json
@@ -32,6 +32,9 @@
         "string"
       ]
     },
+    "content_id_alias": {
+      "type": "null"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },

--- a/content_schemas/dist/formats/local_transaction/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/local_transaction/publisher_v2/schema.json
@@ -35,6 +35,9 @@
         "string"
       ]
     },
+    "content_id_alias": {
+      "type": "null"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },

--- a/content_schemas/dist/formats/mainstream_browse_page/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/mainstream_browse_page/publisher_v2/schema.json
@@ -35,6 +35,9 @@
         "string"
       ]
     },
+    "content_id_alias": {
+      "type": "null"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },

--- a/content_schemas/dist/formats/manual/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/manual/publisher_v2/schema.json
@@ -35,6 +35,9 @@
         "string"
       ]
     },
+    "content_id_alias": {
+      "type": "null"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },

--- a/content_schemas/dist/formats/manual_section/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/manual_section/publisher_v2/schema.json
@@ -35,6 +35,9 @@
         "string"
       ]
     },
+    "content_id_alias": {
+      "type": "null"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },

--- a/content_schemas/dist/formats/ministers_index/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/ministers_index/publisher_v2/schema.json
@@ -35,6 +35,9 @@
         "string"
       ]
     },
+    "content_id_alias": {
+      "type": "null"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },

--- a/content_schemas/dist/formats/need/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/need/publisher_v2/schema.json
@@ -35,6 +35,9 @@
         "string"
       ]
     },
+    "content_id_alias": {
+      "type": "null"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },

--- a/content_schemas/dist/formats/news_article/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/news_article/publisher_v2/schema.json
@@ -35,6 +35,9 @@
         "string"
       ]
     },
+    "content_id_alias": {
+      "type": "null"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },

--- a/content_schemas/dist/formats/organisation/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/organisation/publisher_v2/schema.json
@@ -35,6 +35,9 @@
         "string"
       ]
     },
+    "content_id_alias": {
+      "type": "null"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },

--- a/content_schemas/dist/formats/organisations_homepage/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/organisations_homepage/publisher_v2/schema.json
@@ -35,6 +35,9 @@
         "string"
       ]
     },
+    "content_id_alias": {
+      "type": "null"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },

--- a/content_schemas/dist/formats/person/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/person/publisher_v2/schema.json
@@ -35,6 +35,9 @@
         "string"
       ]
     },
+    "content_id_alias": {
+      "type": "null"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },

--- a/content_schemas/dist/formats/place/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/place/publisher_v2/schema.json
@@ -35,6 +35,9 @@
         "string"
       ]
     },
+    "content_id_alias": {
+      "type": "null"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },

--- a/content_schemas/dist/formats/publication/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/publication/publisher_v2/schema.json
@@ -35,6 +35,9 @@
         "string"
       ]
     },
+    "content_id_alias": {
+      "type": "null"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },

--- a/content_schemas/dist/formats/redirect/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/redirect/publisher_v2/schema.json
@@ -32,6 +32,9 @@
         "string"
       ]
     },
+    "content_id_alias": {
+      "type": "null"
+    },
     "description": {
       "type": "null"
     },

--- a/content_schemas/dist/formats/role/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/role/publisher_v2/schema.json
@@ -33,6 +33,9 @@
         "string"
       ]
     },
+    "content_id_alias": {
+      "type": "null"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },

--- a/content_schemas/dist/formats/role_appointment/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/role_appointment/publisher_v2/schema.json
@@ -32,6 +32,9 @@
         "string"
       ]
     },
+    "content_id_alias": {
+      "type": "null"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },

--- a/content_schemas/dist/formats/service_manual_guide/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/service_manual_guide/publisher_v2/schema.json
@@ -35,6 +35,9 @@
         "string"
       ]
     },
+    "content_id_alias": {
+      "type": "null"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },

--- a/content_schemas/dist/formats/service_manual_homepage/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/service_manual_homepage/publisher_v2/schema.json
@@ -35,6 +35,9 @@
         "string"
       ]
     },
+    "content_id_alias": {
+      "type": "null"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },

--- a/content_schemas/dist/formats/service_manual_service_standard/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/service_manual_service_standard/publisher_v2/schema.json
@@ -35,6 +35,9 @@
         "string"
       ]
     },
+    "content_id_alias": {
+      "type": "null"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },

--- a/content_schemas/dist/formats/service_manual_service_toolkit/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/service_manual_service_toolkit/publisher_v2/schema.json
@@ -35,6 +35,9 @@
         "string"
       ]
     },
+    "content_id_alias": {
+      "type": "null"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },

--- a/content_schemas/dist/formats/service_manual_topic/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/service_manual_topic/publisher_v2/schema.json
@@ -35,6 +35,9 @@
         "string"
       ]
     },
+    "content_id_alias": {
+      "type": "null"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },

--- a/content_schemas/dist/formats/service_sign_in/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/service_sign_in/publisher_v2/schema.json
@@ -35,6 +35,9 @@
         "string"
       ]
     },
+    "content_id_alias": {
+      "type": "null"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },

--- a/content_schemas/dist/formats/simple_smart_answer/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/simple_smart_answer/publisher_v2/schema.json
@@ -35,6 +35,9 @@
         "string"
       ]
     },
+    "content_id_alias": {
+      "type": "null"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },

--- a/content_schemas/dist/formats/smart_answer/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/smart_answer/publisher_v2/schema.json
@@ -35,6 +35,9 @@
         "string"
       ]
     },
+    "content_id_alias": {
+      "type": "null"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },

--- a/content_schemas/dist/formats/special_route/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/special_route/publisher_v2/schema.json
@@ -32,6 +32,9 @@
         "string"
       ]
     },
+    "content_id_alias": {
+      "type": "null"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },

--- a/content_schemas/dist/formats/specialist_document/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/specialist_document/publisher_v2/schema.json
@@ -35,6 +35,9 @@
         "string"
       ]
     },
+    "content_id_alias": {
+      "type": "null"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },

--- a/content_schemas/dist/formats/speech/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/speech/publisher_v2/schema.json
@@ -35,6 +35,9 @@
         "string"
       ]
     },
+    "content_id_alias": {
+      "type": "null"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },

--- a/content_schemas/dist/formats/statistical_data_set/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/statistical_data_set/publisher_v2/schema.json
@@ -35,6 +35,9 @@
         "string"
       ]
     },
+    "content_id_alias": {
+      "type": "null"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },

--- a/content_schemas/dist/formats/statistics_announcement/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/statistics_announcement/publisher_v2/schema.json
@@ -35,6 +35,9 @@
         "string"
       ]
     },
+    "content_id_alias": {
+      "type": "null"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },

--- a/content_schemas/dist/formats/step_by_step_nav/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/step_by_step_nav/publisher_v2/schema.json
@@ -35,6 +35,9 @@
         "string"
       ]
     },
+    "content_id_alias": {
+      "type": "null"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },

--- a/content_schemas/dist/formats/take_part/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/take_part/publisher_v2/schema.json
@@ -35,6 +35,9 @@
         "string"
       ]
     },
+    "content_id_alias": {
+      "type": "null"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },

--- a/content_schemas/dist/formats/taxon/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/taxon/publisher_v2/schema.json
@@ -35,6 +35,9 @@
         "string"
       ]
     },
+    "content_id_alias": {
+      "type": "null"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },

--- a/content_schemas/dist/formats/topical_event/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/topical_event/publisher_v2/schema.json
@@ -35,6 +35,9 @@
         "string"
       ]
     },
+    "content_id_alias": {
+      "type": "null"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },

--- a/content_schemas/dist/formats/topical_event_about_page/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/topical_event_about_page/publisher_v2/schema.json
@@ -35,6 +35,9 @@
         "string"
       ]
     },
+    "content_id_alias": {
+      "type": "null"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },

--- a/content_schemas/dist/formats/transaction/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/transaction/publisher_v2/schema.json
@@ -35,6 +35,9 @@
         "string"
       ]
     },
+    "content_id_alias": {
+      "type": "null"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },

--- a/content_schemas/dist/formats/travel_advice/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/travel_advice/publisher_v2/schema.json
@@ -35,6 +35,9 @@
         "string"
       ]
     },
+    "content_id_alias": {
+      "type": "null"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },

--- a/content_schemas/dist/formats/travel_advice_index/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/travel_advice_index/publisher_v2/schema.json
@@ -35,6 +35,9 @@
         "string"
       ]
     },
+    "content_id_alias": {
+      "type": "null"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },

--- a/content_schemas/dist/formats/working_group/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/working_group/publisher_v2/schema.json
@@ -35,6 +35,9 @@
         "string"
       ]
     },
+    "content_id_alias": {
+      "type": "null"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },

--- a/content_schemas/dist/formats/world_index/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/world_index/publisher_v2/schema.json
@@ -35,6 +35,9 @@
         "string"
       ]
     },
+    "content_id_alias": {
+      "type": "null"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },

--- a/content_schemas/dist/formats/world_location/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/world_location/publisher_v2/schema.json
@@ -32,6 +32,9 @@
         "string"
       ]
     },
+    "content_id_alias": {
+      "type": "null"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },

--- a/content_schemas/dist/formats/world_location_news/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/world_location_news/publisher_v2/schema.json
@@ -35,6 +35,9 @@
         "string"
       ]
     },
+    "content_id_alias": {
+      "type": "null"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },

--- a/content_schemas/dist/formats/worldwide_corporate_information_page/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/worldwide_corporate_information_page/publisher_v2/schema.json
@@ -35,6 +35,9 @@
         "string"
       ]
     },
+    "content_id_alias": {
+      "type": "null"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },

--- a/content_schemas/dist/formats/worldwide_office/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/worldwide_office/publisher_v2/schema.json
@@ -35,6 +35,9 @@
         "string"
       ]
     },
+    "content_id_alias": {
+      "type": "null"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },

--- a/content_schemas/dist/formats/worldwide_organisation/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/worldwide_organisation/publisher_v2/schema.json
@@ -35,6 +35,9 @@
         "string"
       ]
     },
+    "content_id_alias": {
+      "type": "null"
+    },
     "description": {
       "$ref": "#/definitions/description_optional"
     },

--- a/content_schemas/examples/content_block_email_address/publisher_v2/example.json
+++ b/content_schemas/examples/content_block_email_address/publisher_v2/example.json
@@ -4,6 +4,7 @@
   "document_type": "content_block_email_address",
   "title": "Government Digital Service - General contact",
   "description": "General contact email address for Government Digital Service",
+  "content_id_alias": "gds-general",
   "details": {
     "email_address": "foo@example.com"
   },

--- a/content_schemas/examples/content_block_postal_address/publisher_v2/example.json
+++ b/content_schemas/examples/content_block_postal_address/publisher_v2/example.json
@@ -4,6 +4,7 @@
   "document_type": "content_block_postal_address",
   "title": "Government Digital Service - Head office",
   "description": "The head office for Government Digital Service",
+  "content_id_alias": "gds-general",
   "details": {
     "line_1": "1 Westminster Road",
     "line_2": "Flat A",

--- a/content_schemas/formats/content_block_postal_address.jsonnet
+++ b/content_schemas/formats/content_block_postal_address.jsonnet
@@ -20,7 +20,7 @@
         },
         postcode: {
           type: "string"
-        }
+        },
       },
     },
   },

--- a/content_schemas/formats/shared/content_block.jsonnet
+++ b/content_schemas/formats/shared/content_block.jsonnet
@@ -1,5 +1,6 @@
 (import "default_format.jsonnet") + {
   base_path: "forbidden",
+  content_id_alias: "optional",
   routes: "forbidden",
   rendering_app: "forbidden",
   edition_links: (import "base_edition_links.jsonnet") +  {

--- a/content_schemas/formats/shared/default_format.jsonnet
+++ b/content_schemas/formats/shared/default_format.jsonnet
@@ -1,5 +1,6 @@
 {
   base_path: "required",
+  content_id_alias: "forbidden",
   definitions: {},
   description: "optional",
   details: "required",

--- a/content_schemas/formats/shared/definitions/content_id_alias.jsonnet
+++ b/content_schemas/formats/shared/definitions/content_id_alias.jsonnet
@@ -1,0 +1,16 @@
+{
+  content_id_alias: {
+    description: "Human-readable alias for a Content ID, used when embedding content. Should only be supplied when updating Content Blocks.",
+    type: "string",
+  },
+  content_id_alias_optional: {
+    anyOf: [
+      {
+        "$ref": "#/definitions/content_id_alias",
+      },
+      {
+        type: "null",
+      },
+    ],
+  },
+}

--- a/db/migrate/20241009141509_create_content_id_aliases.rb
+++ b/db/migrate/20241009141509_create_content_id_aliases.rb
@@ -1,0 +1,12 @@
+class CreateContentIdAliases < ActiveRecord::Migration[7.2]
+  def change
+    create_table :content_id_aliases do |t|
+      t.string :name, null: false
+      t.uuid :content_id, null: false, index: true
+
+      t.timestamps
+    end
+
+    add_index :content_id_aliases, :name, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_02_20_153403) do
+ActiveRecord::Schema[7.2].define(version: 2024_10_09_141509) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -42,6 +42,15 @@ ActiveRecord::Schema[7.1].define(version: 2024_02_20_153403) do
     t.datetime "created_at", precision: nil
     t.datetime "updated_at", precision: nil
     t.index ["edition_id"], name: "index_change_notes_on_edition_id"
+  end
+
+  create_table "content_id_aliases", force: :cascade do |t|
+    t.string "name", null: false
+    t.uuid "content_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["content_id"], name: "index_content_id_aliases_on_content_id"
+    t.index ["name"], name: "index_content_id_aliases_on_name", unique: true
   end
 
   create_table "documents", id: :serial, force: :cascade do |t|

--- a/lib/schema_generator/format.rb
+++ b/lib/schema_generator/format.rb
@@ -94,6 +94,16 @@ module SchemaGenerator
       )
     end
 
+    def content_id_alias
+      @content_id_alias ||= OptionalProperty.new(
+        property: "content_id_alias",
+        status: format_data["content_id_alias"] || "required",
+        required_definition: "content_id_alias",
+        optional_definition: "content_id_alias_optional",
+        forbidden_definition: "null",
+      )
+    end
+
     def generate_publisher?
       generate_publisher = format_data.dig("generate", "publisher")
       generate_publisher.nil? ? true : generate_publisher

--- a/lib/schema_generator/publisher_content_schema_generator.rb
+++ b/lib/schema_generator/publisher_content_schema_generator.rb
@@ -40,6 +40,7 @@ module SchemaGenerator
     def derived_properties
       {
         "base_path" => format.base_path.definition,
+        "content_id_alias" => format.content_id_alias.definition,
         "document_type" => format.document_type.definition,
         "description" => format.description.definition,
         "details" => format.details.definition,

--- a/spec/factories/content_id_alias.rb
+++ b/spec/factories/content_id_alias.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :content_id_alias do
+    sequence(:name) { |n| "friendly-id-#{n}" }
+    content_id { SecureRandom.uuid }
+  end
+end

--- a/spec/models/content_id_alias_spec.rb
+++ b/spec/models/content_id_alias_spec.rb
@@ -1,0 +1,28 @@
+RSpec.describe ContentIdAlias do
+  describe "validations" do
+    context "when name is present" do
+      subject { build(:content_id_alias, name: "my-content-id") }
+      it { is_expected.to be_valid }
+    end
+
+    context "when name only contains whitespace" do
+      subject { build(:content_id_alias, name: "     ") }
+      it { is_expected.not_to be_valid }
+    end
+
+    context "when name is an empty string" do
+      subject { build(:content_id_alias, name: "") }
+      it { is_expected.not_to be_valid }
+    end
+
+    context "when name has already been taken" do
+      before do
+        create(:content_id_alias, name: "my-content-id")
+      end
+
+      subject { build(:content_id_alias, name: "my-content-id") }
+
+      it { is_expected.not_to be_valid }
+    end
+  end
+end


### PR DESCRIPTION
[Trello card](https://trello.com/c/lgu8vhzK/1402-finish-up-friendly-id-work)

## Changes in this PR

At the moment, Publishing API uses "content ids" (UUIDs) to identify bits of content. When embedding content into the body or title of an Edition, users currently enter this content id as part of the embed code (e.g `{{embed:email:f3bbdec2-0e62-4520-a7fd-6ffd5d36e03a}}`, which is then expanded under the `embed` key of the `Edition`'s `links` attribute.

Here we introduce a human-readable alias for this content id to make it easier for content editors to embed content and make sense of this embedded string.

We're not expanding this anywhere yet, and it's an optional parameter, so this shouldn't have any impact on existing API calls or embedding of content.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
