### PR TITLE
Update docs re: updating content schemas

### DIFF
--- a/docs/content_schemas/adding-a-new-schema.md
+++ b/docs/content_schemas/adding-a-new-schema.md
@@ -16,6 +16,10 @@ Once you have completed these file add the new format to `allowed_document_types
 You can generate the corresponding schemas with the
 [`rake` task](../README.md#Rakefile).
 
+## Sample PR adding a new content schema
+
+- (Adding Content Block Email Address][https://github.com/alphagov/publishing-api/commit/f657d06ba43fcf720fad43b504692e8793bddde4]
+
 ## Examples
 
 Any new schema should also ship with a set of curated examples. These examples


### PR DESCRIPTION
These docs didn't explain the steps involved in adding new fields to the `default_format.jsonnet` schema, which we had to do when adding `content_id_alias` as a new field outside of those already declared there.

This hopefully clarifies things, in particular the need to add new methods to the `SchemaGenerator::Format` class which was hidden away.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
