### PR TITLE
Optionally set an Author on an Edition

### DIFF
--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -18,6 +18,7 @@ class Edition < ApplicationRecord
     document_type
     first_published_at
     last_edited_at
+    last_edited_by_editor_id
     major_published_at
     phase
     public_updated_at

--- a/app/presenters/edition_presenter.rb
+++ b/app/presenters/edition_presenter.rb
@@ -9,6 +9,7 @@ module Presenters
       document_id
       id
       last_edited_at
+      last_edited_by_editor_id
       publishing_api_first_published_at
       major_published_at
       published_at

--- a/content_schemas/dist/formats/answer/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/answer/publisher_v2/schema.json
@@ -58,6 +58,10 @@
       "type": "string",
       "format": "date-time"
     },
+    "last_edited_by_editor_id": {
+      "description": "The UUID of the editor who edited the content.",
+      "type": "string"
+    },
     "links": {
       "type": "object",
       "additionalProperties": false,

--- a/content_schemas/dist/formats/calendar/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/calendar/publisher_v2/schema.json
@@ -58,6 +58,10 @@
       "type": "string",
       "format": "date-time"
     },
+    "last_edited_by_editor_id": {
+      "description": "The UUID of the editor who edited the content.",
+      "type": "string"
+    },
     "links": {
       "type": "object",
       "additionalProperties": false,

--- a/content_schemas/dist/formats/call_for_evidence/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/call_for_evidence/publisher_v2/schema.json
@@ -61,6 +61,10 @@
       "type": "string",
       "format": "date-time"
     },
+    "last_edited_by_editor_id": {
+      "description": "The UUID of the editor who edited the content.",
+      "type": "string"
+    },
     "links": {
       "type": "object",
       "additionalProperties": false,

--- a/content_schemas/dist/formats/case_study/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/case_study/publisher_v2/schema.json
@@ -58,6 +58,10 @@
       "type": "string",
       "format": "date-time"
     },
+    "last_edited_by_editor_id": {
+      "description": "The UUID of the editor who edited the content.",
+      "type": "string"
+    },
     "links": {
       "type": "object",
       "additionalProperties": false,

--- a/content_schemas/dist/formats/completed_transaction/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/completed_transaction/publisher_v2/schema.json
@@ -58,6 +58,10 @@
       "type": "string",
       "format": "date-time"
     },
+    "last_edited_by_editor_id": {
+      "description": "The UUID of the editor who edited the content.",
+      "type": "string"
+    },
     "links": {
       "type": "object",
       "additionalProperties": false,

--- a/content_schemas/dist/formats/consultation/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/consultation/publisher_v2/schema.json
@@ -61,6 +61,10 @@
       "type": "string",
       "format": "date-time"
     },
+    "last_edited_by_editor_id": {
+      "description": "The UUID of the editor who edited the content.",
+      "type": "string"
+    },
     "links": {
       "type": "object",
       "additionalProperties": false,

--- a/content_schemas/dist/formats/contact/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/contact/publisher_v2/schema.json
@@ -55,6 +55,10 @@
       "type": "string",
       "format": "date-time"
     },
+    "last_edited_by_editor_id": {
+      "description": "The UUID of the editor who edited the content.",
+      "type": "string"
+    },
     "links": {
       "type": "object",
       "additionalProperties": false,

--- a/content_schemas/dist/formats/content_block_email_address/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/content_block_email_address/publisher_v2/schema.json
@@ -55,6 +55,10 @@
       "type": "string",
       "format": "date-time"
     },
+    "last_edited_by_editor_id": {
+      "description": "The UUID of the editor who edited the content.",
+      "type": "string"
+    },
     "links": {
       "type": "object",
       "additionalProperties": false,

--- a/content_schemas/dist/formats/content_block_postal_address/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/content_block_postal_address/publisher_v2/schema.json
@@ -55,6 +55,10 @@
       "type": "string",
       "format": "date-time"
     },
+    "last_edited_by_editor_id": {
+      "description": "The UUID of the editor who edited the content.",
+      "type": "string"
+    },
     "links": {
       "type": "object",
       "additionalProperties": false,

--- a/content_schemas/dist/formats/coronavirus_landing_page/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/coronavirus_landing_page/publisher_v2/schema.json
@@ -58,6 +58,10 @@
       "type": "string",
       "format": "date-time"
     },
+    "last_edited_by_editor_id": {
+      "description": "The UUID of the editor who edited the content.",
+      "type": "string"
+    },
     "links": {
       "type": "object",
       "additionalProperties": false,

--- a/content_schemas/dist/formats/corporate_information_page/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/corporate_information_page/publisher_v2/schema.json
@@ -79,6 +79,10 @@
       "type": "string",
       "format": "date-time"
     },
+    "last_edited_by_editor_id": {
+      "description": "The UUID of the editor who edited the content.",
+      "type": "string"
+    },
     "links": {
       "type": "object",
       "additionalProperties": false,

--- a/content_schemas/dist/formats/detailed_guide/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/detailed_guide/publisher_v2/schema.json
@@ -58,6 +58,10 @@
       "type": "string",
       "format": "date-time"
     },
+    "last_edited_by_editor_id": {
+      "description": "The UUID of the editor who edited the content.",
+      "type": "string"
+    },
     "links": {
       "type": "object",
       "additionalProperties": false,

--- a/content_schemas/dist/formats/document_collection/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/document_collection/publisher_v2/schema.json
@@ -58,6 +58,10 @@
       "type": "string",
       "format": "date-time"
     },
+    "last_edited_by_editor_id": {
+      "description": "The UUID of the editor who edited the content.",
+      "type": "string"
+    },
     "links": {
       "type": "object",
       "additionalProperties": false,

--- a/content_schemas/dist/formats/email_alert_signup/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/email_alert_signup/publisher_v2/schema.json
@@ -58,6 +58,10 @@
       "type": "string",
       "format": "date-time"
     },
+    "last_edited_by_editor_id": {
+      "description": "The UUID of the editor who edited the content.",
+      "type": "string"
+    },
     "links": {
       "type": "object",
       "additionalProperties": false,

--- a/content_schemas/dist/formats/embassies_index/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/embassies_index/publisher_v2/schema.json
@@ -58,6 +58,10 @@
       "type": "string",
       "format": "date-time"
     },
+    "last_edited_by_editor_id": {
+      "description": "The UUID of the editor who edited the content.",
+      "type": "string"
+    },
     "links": {
       "type": "object",
       "additionalProperties": false,

--- a/content_schemas/dist/formats/external_content/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/external_content/publisher_v2/schema.json
@@ -56,6 +56,10 @@
       "type": "string",
       "format": "date-time"
     },
+    "last_edited_by_editor_id": {
+      "description": "The UUID of the editor who edited the content.",
+      "type": "string"
+    },
     "links": {
       "type": "object",
       "additionalProperties": false,

--- a/content_schemas/dist/formats/facet/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/facet/publisher_v2/schema.json
@@ -55,6 +55,10 @@
       "type": "string",
       "format": "date-time"
     },
+    "last_edited_by_editor_id": {
+      "description": "The UUID of the editor who edited the content.",
+      "type": "string"
+    },
     "links": {
       "type": "object",
       "additionalProperties": false,

--- a/content_schemas/dist/formats/fatality_notice/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/fatality_notice/publisher_v2/schema.json
@@ -58,6 +58,10 @@
       "type": "string",
       "format": "date-time"
     },
+    "last_edited_by_editor_id": {
+      "description": "The UUID of the editor who edited the content.",
+      "type": "string"
+    },
     "links": {
       "type": "object",
       "additionalProperties": false,

--- a/content_schemas/dist/formats/field_of_operation/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/field_of_operation/publisher_v2/schema.json
@@ -58,6 +58,10 @@
       "type": "string",
       "format": "date-time"
     },
+    "last_edited_by_editor_id": {
+      "description": "The UUID of the editor who edited the content.",
+      "type": "string"
+    },
     "links": {
       "type": "object",
       "additionalProperties": false,

--- a/content_schemas/dist/formats/fields_of_operation/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/fields_of_operation/publisher_v2/schema.json
@@ -58,6 +58,10 @@
       "type": "string",
       "format": "date-time"
     },
+    "last_edited_by_editor_id": {
+      "description": "The UUID of the editor who edited the content.",
+      "type": "string"
+    },
     "links": {
       "type": "object",
       "additionalProperties": false,

--- a/content_schemas/dist/formats/finder/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/finder/publisher_v2/schema.json
@@ -59,6 +59,10 @@
       "type": "string",
       "format": "date-time"
     },
+    "last_edited_by_editor_id": {
+      "description": "The UUID of the editor who edited the content.",
+      "type": "string"
+    },
     "links": {
       "type": "object",
       "additionalProperties": false,

--- a/content_schemas/dist/formats/finder_email_signup/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/finder_email_signup/publisher_v2/schema.json
@@ -58,6 +58,10 @@
       "type": "string",
       "format": "date-time"
     },
+    "last_edited_by_editor_id": {
+      "description": "The UUID of the editor who edited the content.",
+      "type": "string"
+    },
     "links": {
       "type": "object",
       "additionalProperties": false,

--- a/content_schemas/dist/formats/generic/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/generic/publisher_v2/schema.json
@@ -241,6 +241,10 @@
       "type": "string",
       "format": "date-time"
     },
+    "last_edited_by_editor_id": {
+      "description": "The UUID of the editor who edited the content.",
+      "type": "string"
+    },
     "links": {
       "type": "object",
       "additionalProperties": false,

--- a/content_schemas/dist/formats/generic_with_external_related_links/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/generic_with_external_related_links/publisher_v2/schema.json
@@ -241,6 +241,10 @@
       "type": "string",
       "format": "date-time"
     },
+    "last_edited_by_editor_id": {
+      "description": "The UUID of the editor who edited the content.",
+      "type": "string"
+    },
     "links": {
       "type": "object",
       "additionalProperties": false,

--- a/content_schemas/dist/formats/get_involved/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/get_involved/publisher_v2/schema.json
@@ -58,6 +58,10 @@
       "type": "string",
       "format": "date-time"
     },
+    "last_edited_by_editor_id": {
+      "description": "The UUID of the editor who edited the content.",
+      "type": "string"
+    },
     "links": {
       "type": "object",
       "additionalProperties": false,

--- a/content_schemas/dist/formats/gone/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/gone/publisher_v2/schema.json
@@ -53,6 +53,10 @@
       "type": "string",
       "format": "date-time"
     },
+    "last_edited_by_editor_id": {
+      "description": "The UUID of the editor who edited the content.",
+      "type": "string"
+    },
     "links": {
       "type": "object",
       "additionalProperties": false,

--- a/content_schemas/dist/formats/government/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/government/publisher_v2/schema.json
@@ -58,6 +58,10 @@
       "type": "string",
       "format": "date-time"
     },
+    "last_edited_by_editor_id": {
+      "description": "The UUID of the editor who edited the content.",
+      "type": "string"
+    },
     "links": {
       "type": "object",
       "additionalProperties": false,

--- a/content_schemas/dist/formats/guide/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/guide/publisher_v2/schema.json
@@ -58,6 +58,10 @@
       "type": "string",
       "format": "date-time"
     },
+    "last_edited_by_editor_id": {
+      "description": "The UUID of the editor who edited the content.",
+      "type": "string"
+    },
     "links": {
       "type": "object",
       "additionalProperties": false,

--- a/content_schemas/dist/formats/help_page/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/help_page/publisher_v2/schema.json
@@ -58,6 +58,10 @@
       "type": "string",
       "format": "date-time"
     },
+    "last_edited_by_editor_id": {
+      "description": "The UUID of the editor who edited the content.",
+      "type": "string"
+    },
     "links": {
       "type": "object",
       "additionalProperties": false,

--- a/content_schemas/dist/formats/historic_appointment/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/historic_appointment/publisher_v2/schema.json
@@ -58,6 +58,10 @@
       "type": "string",
       "format": "date-time"
     },
+    "last_edited_by_editor_id": {
+      "description": "The UUID of the editor who edited the content.",
+      "type": "string"
+    },
     "links": {
       "type": "object",
       "additionalProperties": false,

--- a/content_schemas/dist/formats/historic_appointments/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/historic_appointments/publisher_v2/schema.json
@@ -58,6 +58,10 @@
       "type": "string",
       "format": "date-time"
     },
+    "last_edited_by_editor_id": {
+      "description": "The UUID of the editor who edited the content.",
+      "type": "string"
+    },
     "links": {
       "type": "object",
       "additionalProperties": false,

--- a/content_schemas/dist/formats/history/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/history/publisher_v2/schema.json
@@ -58,6 +58,10 @@
       "type": "string",
       "format": "date-time"
     },
+    "last_edited_by_editor_id": {
+      "description": "The UUID of the editor who edited the content.",
+      "type": "string"
+    },
     "links": {
       "type": "object",
       "additionalProperties": false,

--- a/content_schemas/dist/formats/hmrc_manual/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/hmrc_manual/publisher_v2/schema.json
@@ -58,6 +58,10 @@
       "type": "string",
       "format": "date-time"
     },
+    "last_edited_by_editor_id": {
+      "description": "The UUID of the editor who edited the content.",
+      "type": "string"
+    },
     "links": {
       "type": "object",
       "additionalProperties": false,

--- a/content_schemas/dist/formats/hmrc_manual_section/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/hmrc_manual_section/publisher_v2/schema.json
@@ -58,6 +58,10 @@
       "type": "string",
       "format": "date-time"
     },
+    "last_edited_by_editor_id": {
+      "description": "The UUID of the editor who edited the content.",
+      "type": "string"
+    },
     "links": {
       "type": "object",
       "additionalProperties": false,

--- a/content_schemas/dist/formats/homepage/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/homepage/publisher_v2/schema.json
@@ -59,6 +59,10 @@
       "type": "string",
       "format": "date-time"
     },
+    "last_edited_by_editor_id": {
+      "description": "The UUID of the editor who edited the content.",
+      "type": "string"
+    },
     "links": {
       "type": "object",
       "additionalProperties": false,

--- a/content_schemas/dist/formats/how_government_works/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/how_government_works/publisher_v2/schema.json
@@ -58,6 +58,10 @@
       "type": "string",
       "format": "date-time"
     },
+    "last_edited_by_editor_id": {
+      "description": "The UUID of the editor who edited the content.",
+      "type": "string"
+    },
     "links": {
       "type": "object",
       "additionalProperties": false,

--- a/content_schemas/dist/formats/html_publication/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/html_publication/publisher_v2/schema.json
@@ -58,6 +58,10 @@
       "type": "string",
       "format": "date-time"
     },
+    "last_edited_by_editor_id": {
+      "description": "The UUID of the editor who edited the content.",
+      "type": "string"
+    },
     "links": {
       "type": "object",
       "additionalProperties": false,

--- a/content_schemas/dist/formats/landing_page/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/landing_page/publisher_v2/schema.json
@@ -58,6 +58,10 @@
       "type": "string",
       "format": "date-time"
     },
+    "last_edited_by_editor_id": {
+      "description": "The UUID of the editor who edited the content.",
+      "type": "string"
+    },
     "links": {
       "type": "object",
       "additionalProperties": false,

--- a/content_schemas/dist/formats/licence/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/licence/publisher_v2/schema.json
@@ -58,6 +58,10 @@
       "type": "string",
       "format": "date-time"
     },
+    "last_edited_by_editor_id": {
+      "description": "The UUID of the editor who edited the content.",
+      "type": "string"
+    },
     "links": {
       "type": "object",
       "additionalProperties": false,

--- a/content_schemas/dist/formats/link_collection/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/link_collection/publisher_v2/schema.json
@@ -55,6 +55,10 @@
       "type": "string",
       "format": "date-time"
     },
+    "last_edited_by_editor_id": {
+      "description": "The UUID of the editor who edited the content.",
+      "type": "string"
+    },
     "links": {
       "type": "object",
       "additionalProperties": false,

--- a/content_schemas/dist/formats/local_transaction/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/local_transaction/publisher_v2/schema.json
@@ -58,6 +58,10 @@
       "type": "string",
       "format": "date-time"
     },
+    "last_edited_by_editor_id": {
+      "description": "The UUID of the editor who edited the content.",
+      "type": "string"
+    },
     "links": {
       "type": "object",
       "additionalProperties": false,

--- a/content_schemas/dist/formats/mainstream_browse_page/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/mainstream_browse_page/publisher_v2/schema.json
@@ -58,6 +58,10 @@
       "type": "string",
       "format": "date-time"
     },
+    "last_edited_by_editor_id": {
+      "description": "The UUID of the editor who edited the content.",
+      "type": "string"
+    },
     "links": {
       "type": "object",
       "additionalProperties": false,

--- a/content_schemas/dist/formats/manual/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/manual/publisher_v2/schema.json
@@ -58,6 +58,10 @@
       "type": "string",
       "format": "date-time"
     },
+    "last_edited_by_editor_id": {
+      "description": "The UUID of the editor who edited the content.",
+      "type": "string"
+    },
     "links": {
       "type": "object",
       "additionalProperties": false,

--- a/content_schemas/dist/formats/manual_section/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/manual_section/publisher_v2/schema.json
@@ -58,6 +58,10 @@
       "type": "string",
       "format": "date-time"
     },
+    "last_edited_by_editor_id": {
+      "description": "The UUID of the editor who edited the content.",
+      "type": "string"
+    },
     "links": {
       "type": "object",
       "additionalProperties": false,

--- a/content_schemas/dist/formats/ministers_index/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/ministers_index/publisher_v2/schema.json
@@ -58,6 +58,10 @@
       "type": "string",
       "format": "date-time"
     },
+    "last_edited_by_editor_id": {
+      "description": "The UUID of the editor who edited the content.",
+      "type": "string"
+    },
     "links": {
       "type": "object",
       "additionalProperties": false,

--- a/content_schemas/dist/formats/need/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/need/publisher_v2/schema.json
@@ -58,6 +58,10 @@
       "type": "string",
       "format": "date-time"
     },
+    "last_edited_by_editor_id": {
+      "description": "The UUID of the editor who edited the content.",
+      "type": "string"
+    },
     "links": {
       "type": "object",
       "additionalProperties": false,

--- a/content_schemas/dist/formats/news_article/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/news_article/publisher_v2/schema.json
@@ -61,6 +61,10 @@
       "type": "string",
       "format": "date-time"
     },
+    "last_edited_by_editor_id": {
+      "description": "The UUID of the editor who edited the content.",
+      "type": "string"
+    },
     "links": {
       "type": "object",
       "additionalProperties": false,

--- a/content_schemas/dist/formats/organisation/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/organisation/publisher_v2/schema.json
@@ -58,6 +58,10 @@
       "type": "string",
       "format": "date-time"
     },
+    "last_edited_by_editor_id": {
+      "description": "The UUID of the editor who edited the content.",
+      "type": "string"
+    },
     "links": {
       "type": "object",
       "additionalProperties": false,

--- a/content_schemas/dist/formats/organisations_homepage/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/organisations_homepage/publisher_v2/schema.json
@@ -58,6 +58,10 @@
       "type": "string",
       "format": "date-time"
     },
+    "last_edited_by_editor_id": {
+      "description": "The UUID of the editor who edited the content.",
+      "type": "string"
+    },
     "links": {
       "type": "object",
       "additionalProperties": false,

--- a/content_schemas/dist/formats/person/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/person/publisher_v2/schema.json
@@ -58,6 +58,10 @@
       "type": "string",
       "format": "date-time"
     },
+    "last_edited_by_editor_id": {
+      "description": "The UUID of the editor who edited the content.",
+      "type": "string"
+    },
     "links": {
       "type": "object",
       "additionalProperties": false,

--- a/content_schemas/dist/formats/place/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/place/publisher_v2/schema.json
@@ -58,6 +58,10 @@
       "type": "string",
       "format": "date-time"
     },
+    "last_edited_by_editor_id": {
+      "description": "The UUID of the editor who edited the content.",
+      "type": "string"
+    },
     "links": {
       "type": "object",
       "additionalProperties": false,

--- a/content_schemas/dist/formats/publication/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/publication/publisher_v2/schema.json
@@ -77,6 +77,10 @@
       "type": "string",
       "format": "date-time"
     },
+    "last_edited_by_editor_id": {
+      "description": "The UUID of the editor who edited the content.",
+      "type": "string"
+    },
     "links": {
       "type": "object",
       "additionalProperties": false,

--- a/content_schemas/dist/formats/redirect/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/redirect/publisher_v2/schema.json
@@ -57,6 +57,10 @@
       "type": "string",
       "format": "date-time"
     },
+    "last_edited_by_editor_id": {
+      "description": "The UUID of the editor who edited the content.",
+      "type": "string"
+    },
     "links": {
       "type": "object",
       "additionalProperties": false,

--- a/content_schemas/dist/formats/role/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/role/publisher_v2/schema.json
@@ -68,6 +68,10 @@
       "type": "string",
       "format": "date-time"
     },
+    "last_edited_by_editor_id": {
+      "description": "The UUID of the editor who edited the content.",
+      "type": "string"
+    },
     "links": {
       "type": "object",
       "additionalProperties": false,

--- a/content_schemas/dist/formats/role_appointment/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/role_appointment/publisher_v2/schema.json
@@ -55,6 +55,10 @@
       "type": "string",
       "format": "date-time"
     },
+    "last_edited_by_editor_id": {
+      "description": "The UUID of the editor who edited the content.",
+      "type": "string"
+    },
     "links": {
       "type": "object",
       "additionalProperties": false,

--- a/content_schemas/dist/formats/service_manual_guide/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/service_manual_guide/publisher_v2/schema.json
@@ -58,6 +58,10 @@
       "type": "string",
       "format": "date-time"
     },
+    "last_edited_by_editor_id": {
+      "description": "The UUID of the editor who edited the content.",
+      "type": "string"
+    },
     "links": {
       "type": "object",
       "additionalProperties": false,

--- a/content_schemas/dist/formats/service_manual_homepage/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/service_manual_homepage/publisher_v2/schema.json
@@ -58,6 +58,10 @@
       "type": "string",
       "format": "date-time"
     },
+    "last_edited_by_editor_id": {
+      "description": "The UUID of the editor who edited the content.",
+      "type": "string"
+    },
     "links": {
       "type": "object",
       "additionalProperties": false,

--- a/content_schemas/dist/formats/service_manual_service_standard/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/service_manual_service_standard/publisher_v2/schema.json
@@ -58,6 +58,10 @@
       "type": "string",
       "format": "date-time"
     },
+    "last_edited_by_editor_id": {
+      "description": "The UUID of the editor who edited the content.",
+      "type": "string"
+    },
     "links": {
       "type": "object",
       "additionalProperties": false,

--- a/content_schemas/dist/formats/service_manual_service_toolkit/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/service_manual_service_toolkit/publisher_v2/schema.json
@@ -58,6 +58,10 @@
       "type": "string",
       "format": "date-time"
     },
+    "last_edited_by_editor_id": {
+      "description": "The UUID of the editor who edited the content.",
+      "type": "string"
+    },
     "links": {
       "type": "object",
       "additionalProperties": false,

--- a/content_schemas/dist/formats/service_manual_topic/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/service_manual_topic/publisher_v2/schema.json
@@ -58,6 +58,10 @@
       "type": "string",
       "format": "date-time"
     },
+    "last_edited_by_editor_id": {
+      "description": "The UUID of the editor who edited the content.",
+      "type": "string"
+    },
     "links": {
       "type": "object",
       "additionalProperties": false,

--- a/content_schemas/dist/formats/service_sign_in/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/service_sign_in/publisher_v2/schema.json
@@ -58,6 +58,10 @@
       "type": "string",
       "format": "date-time"
     },
+    "last_edited_by_editor_id": {
+      "description": "The UUID of the editor who edited the content.",
+      "type": "string"
+    },
     "links": {
       "type": "object",
       "additionalProperties": false,

--- a/content_schemas/dist/formats/simple_smart_answer/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/simple_smart_answer/publisher_v2/schema.json
@@ -58,6 +58,10 @@
       "type": "string",
       "format": "date-time"
     },
+    "last_edited_by_editor_id": {
+      "description": "The UUID of the editor who edited the content.",
+      "type": "string"
+    },
     "links": {
       "type": "object",
       "additionalProperties": false,

--- a/content_schemas/dist/formats/smart_answer/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/smart_answer/publisher_v2/schema.json
@@ -58,6 +58,10 @@
       "type": "string",
       "format": "date-time"
     },
+    "last_edited_by_editor_id": {
+      "description": "The UUID of the editor who edited the content.",
+      "type": "string"
+    },
     "links": {
       "type": "object",
       "additionalProperties": false,

--- a/content_schemas/dist/formats/special_route/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/special_route/publisher_v2/schema.json
@@ -58,6 +58,10 @@
       "type": "string",
       "format": "date-time"
     },
+    "last_edited_by_editor_id": {
+      "description": "The UUID of the editor who edited the content.",
+      "type": "string"
+    },
     "links": {
       "type": "object",
       "additionalProperties": false,

--- a/content_schemas/dist/formats/specialist_document/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/specialist_document/publisher_v2/schema.json
@@ -241,6 +241,10 @@
       "type": "string",
       "format": "date-time"
     },
+    "last_edited_by_editor_id": {
+      "description": "The UUID of the editor who edited the content.",
+      "type": "string"
+    },
     "links": {
       "type": "object",
       "required": [

--- a/content_schemas/dist/formats/speech/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/speech/publisher_v2/schema.json
@@ -61,6 +61,10 @@
       "type": "string",
       "format": "date-time"
     },
+    "last_edited_by_editor_id": {
+      "description": "The UUID of the editor who edited the content.",
+      "type": "string"
+    },
     "links": {
       "type": "object",
       "additionalProperties": false,

--- a/content_schemas/dist/formats/statistical_data_set/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/statistical_data_set/publisher_v2/schema.json
@@ -58,6 +58,10 @@
       "type": "string",
       "format": "date-time"
     },
+    "last_edited_by_editor_id": {
+      "description": "The UUID of the editor who edited the content.",
+      "type": "string"
+    },
     "links": {
       "type": "object",
       "additionalProperties": false,

--- a/content_schemas/dist/formats/statistics_announcement/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/statistics_announcement/publisher_v2/schema.json
@@ -62,6 +62,10 @@
       "type": "string",
       "format": "date-time"
     },
+    "last_edited_by_editor_id": {
+      "description": "The UUID of the editor who edited the content.",
+      "type": "string"
+    },
     "links": {
       "type": "object",
       "additionalProperties": false,

--- a/content_schemas/dist/formats/step_by_step_nav/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/step_by_step_nav/publisher_v2/schema.json
@@ -58,6 +58,10 @@
       "type": "string",
       "format": "date-time"
     },
+    "last_edited_by_editor_id": {
+      "description": "The UUID of the editor who edited the content.",
+      "type": "string"
+    },
     "links": {
       "type": "object",
       "additionalProperties": false,

--- a/content_schemas/dist/formats/take_part/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/take_part/publisher_v2/schema.json
@@ -58,6 +58,10 @@
       "type": "string",
       "format": "date-time"
     },
+    "last_edited_by_editor_id": {
+      "description": "The UUID of the editor who edited the content.",
+      "type": "string"
+    },
     "links": {
       "type": "object",
       "additionalProperties": false,

--- a/content_schemas/dist/formats/taxon/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/taxon/publisher_v2/schema.json
@@ -58,6 +58,10 @@
       "type": "string",
       "format": "date-time"
     },
+    "last_edited_by_editor_id": {
+      "description": "The UUID of the editor who edited the content.",
+      "type": "string"
+    },
     "links": {
       "type": "object",
       "additionalProperties": false,

--- a/content_schemas/dist/formats/topical_event/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/topical_event/publisher_v2/schema.json
@@ -58,6 +58,10 @@
       "type": "string",
       "format": "date-time"
     },
+    "last_edited_by_editor_id": {
+      "description": "The UUID of the editor who edited the content.",
+      "type": "string"
+    },
     "links": {
       "type": "object",
       "additionalProperties": false,

--- a/content_schemas/dist/formats/topical_event_about_page/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/topical_event_about_page/publisher_v2/schema.json
@@ -58,6 +58,10 @@
       "type": "string",
       "format": "date-time"
     },
+    "last_edited_by_editor_id": {
+      "description": "The UUID of the editor who edited the content.",
+      "type": "string"
+    },
     "links": {
       "type": "object",
       "additionalProperties": false,

--- a/content_schemas/dist/formats/transaction/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/transaction/publisher_v2/schema.json
@@ -58,6 +58,10 @@
       "type": "string",
       "format": "date-time"
     },
+    "last_edited_by_editor_id": {
+      "description": "The UUID of the editor who edited the content.",
+      "type": "string"
+    },
     "links": {
       "type": "object",
       "additionalProperties": false,

--- a/content_schemas/dist/formats/travel_advice/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/travel_advice/publisher_v2/schema.json
@@ -58,6 +58,10 @@
       "type": "string",
       "format": "date-time"
     },
+    "last_edited_by_editor_id": {
+      "description": "The UUID of the editor who edited the content.",
+      "type": "string"
+    },
     "links": {
       "type": "object",
       "additionalProperties": false,

--- a/content_schemas/dist/formats/travel_advice_index/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/travel_advice_index/publisher_v2/schema.json
@@ -58,6 +58,10 @@
       "type": "string",
       "format": "date-time"
     },
+    "last_edited_by_editor_id": {
+      "description": "The UUID of the editor who edited the content.",
+      "type": "string"
+    },
     "links": {
       "type": "object",
       "additionalProperties": false,

--- a/content_schemas/dist/formats/working_group/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/working_group/publisher_v2/schema.json
@@ -58,6 +58,10 @@
       "type": "string",
       "format": "date-time"
     },
+    "last_edited_by_editor_id": {
+      "description": "The UUID of the editor who edited the content.",
+      "type": "string"
+    },
     "links": {
       "type": "object",
       "additionalProperties": false,

--- a/content_schemas/dist/formats/world_index/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/world_index/publisher_v2/schema.json
@@ -58,6 +58,10 @@
       "type": "string",
       "format": "date-time"
     },
+    "last_edited_by_editor_id": {
+      "description": "The UUID of the editor who edited the content.",
+      "type": "string"
+    },
     "links": {
       "type": "object",
       "additionalProperties": false,

--- a/content_schemas/dist/formats/world_location/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/world_location/publisher_v2/schema.json
@@ -55,6 +55,10 @@
       "type": "string",
       "format": "date-time"
     },
+    "last_edited_by_editor_id": {
+      "description": "The UUID of the editor who edited the content.",
+      "type": "string"
+    },
     "links": {
       "type": "object",
       "additionalProperties": false,

--- a/content_schemas/dist/formats/world_location_news/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/world_location_news/publisher_v2/schema.json
@@ -58,6 +58,10 @@
       "type": "string",
       "format": "date-time"
     },
+    "last_edited_by_editor_id": {
+      "description": "The UUID of the editor who edited the content.",
+      "type": "string"
+    },
     "links": {
       "type": "object",
       "additionalProperties": false,

--- a/content_schemas/dist/formats/worldwide_corporate_information_page/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/worldwide_corporate_information_page/publisher_v2/schema.json
@@ -79,6 +79,10 @@
       "type": "string",
       "format": "date-time"
     },
+    "last_edited_by_editor_id": {
+      "description": "The UUID of the editor who edited the content.",
+      "type": "string"
+    },
     "links": {
       "type": "object",
       "additionalProperties": false,

--- a/content_schemas/dist/formats/worldwide_office/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/worldwide_office/publisher_v2/schema.json
@@ -58,6 +58,10 @@
       "type": "string",
       "format": "date-time"
     },
+    "last_edited_by_editor_id": {
+      "description": "The UUID of the editor who edited the content.",
+      "type": "string"
+    },
     "links": {
       "type": "object",
       "additionalProperties": false,

--- a/content_schemas/dist/formats/worldwide_organisation/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/worldwide_organisation/publisher_v2/schema.json
@@ -58,6 +58,10 @@
       "type": "string",
       "format": "date-time"
     },
+    "last_edited_by_editor_id": {
+      "description": "The UUID of the editor who edited the content.",
+      "type": "string"
+    },
     "links": {
       "type": "object",
       "additionalProperties": false,

--- a/content_schemas/formats/shared/default_properties/publisher.jsonnet
+++ b/content_schemas/formats/shared/default_properties/publisher.jsonnet
@@ -23,6 +23,10 @@
     format: "date-time",
     description: "Last time when the content received a major or minor update.",
   },
+  last_edited_by_editor_id: {
+    type: "string",
+    description: "The UUID of the editor who edited the content.",
+  },
   previous_version: {
     type: "string",
   },

--- a/db/migrate/20241017080126_add_last_edited_by_editor_id_to_editions.rb
+++ b/db/migrate/20241017080126_add_last_edited_by_editor_id_to_editions.rb
@@ -1,0 +1,5 @@
+class AddLastEditedByEditorIdToEditions < ActiveRecord::Migration[7.2]
+  def change
+    add_column :editions, :last_edited_by_editor_id, :uuid
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_10_09_141509) do
+ActiveRecord::Schema[7.2].define(version: 2024_10_17_080126) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -93,6 +93,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_10_09_141509) do
     t.jsonb "details", default: {}
     t.jsonb "routes", default: []
     t.jsonb "redirects", default: []
+    t.uuid "last_edited_by_editor_id"
     t.index ["base_path", "content_store"], name: "index_editions_on_base_path_and_content_store", unique: true
     t.index ["document_id", "content_store"], name: "index_editions_on_document_id_and_content_store", unique: true
     t.index ["document_id", "state"], name: "index_editions_on_document_id_and_state"

--- a/spec/integration/put_content/content_with_a_previous_draft_spec.rb
+++ b/spec/integration/put_content/content_with_a_previous_draft_spec.rb
@@ -52,6 +52,10 @@ RSpec.describe "PUT /v2/content when the payload is for an already drafted editi
     expect(previously_drafted_item.last_edited_at).to eq(Time.zone.now)
   end
 
+  include_examples "setting last_edited_by_editor_id" do
+    subject { previously_drafted_item.reload }
+  end
+
   context "when public_updated_at is in the payload" do
     let(:public_updated_at) { Time.zone.now }
     before do

--- a/spec/integration/put_content/new_edition_spec.rb
+++ b/spec/integration/put_content/new_edition_spec.rb
@@ -83,6 +83,8 @@ RSpec.describe "PUT /v2/content when the payload is for a brand new edition" do
     include_examples "creates a change note"
   end
 
+  include_examples "setting last_edited_by_editor_id"
+
   context "and the change history is in the details hash" do
     before do
       payload.delete(:change_note)

--- a/spec/support/shared_context/put_content_calls.rb
+++ b/spec/support/shared_context/put_content_calls.rb
@@ -22,4 +22,27 @@ RSpec.shared_context "PutContent call" do
   let(:locale) { "en" }
   let(:content_id) { SecureRandom.uuid }
   let(:change_note) { "change note" }
+
+  shared_examples "setting last_edited_by_editor_id" do
+    context "when last_edited_by_editor_id is present in the payload" do
+      let(:last_edited_by_editor_id) { SecureRandom.uuid }
+      before do
+        payload.merge!(
+          last_edited_by_editor_id:,
+        )
+      end
+
+      it "adds a last_edited_by_editor_id to the edition" do
+        put "/v2/content/#{content_id}", params: payload.to_json
+
+        expect(subject.last_edited_by_editor_id).to eq(last_edited_by_editor_id)
+      end
+    end
+
+    it "does not set a last_edited_by_editor_id by default" do
+      put "/v2/content/#{content_id}", params: payload.to_json
+
+      expect(subject.last_edited_by_editor_id).to be_nil
+    end
+  end
 end


### PR DESCRIPTION
In Content Modelling, when viewing content that is dependent of a content block, we'd like to be able to see who last edited that content, so publishers can liaise with the "owner" of that content if, for example, a change to a content block will alter the meaning of the dependent content. 

As the Content Block Manager is publishing app agnostic, we currently have no way of knowing who last touched a piece of content, as this information is only stored within the publishing app itself.

This PR adds a new `last_edited_by` field which can optionally be sent to the Publishing API. In future this will allow us to use the [Embedded Content Endpoint](https://github.com/alphagov/publishing-api/blob/main/docs/api.md#get-v2contentcontent_idembedded) to return information about authors (if it exists).

The next step will be to update the presenters in the various publishing apps - trialing with Whitehall first.