### PR TITLE
Update Adding a new content schema docs

### DIFF
--- a/docs/content_schemas/adding-a-new-schema.md
+++ b/docs/content_schemas/adding-a-new-schema.md
@@ -26,3 +26,11 @@ Any new schema should also ship with a set of curated examples. These examples
 will be validated against the schema and can also be used by the corresponding
 frontend applications to verify that it can render examples of the schema. These
 examples should be added to the `examples/FORMAT_NAME/frontend` folder.
+
+## Ensure new content schema text can be parsed by Content Data API
+
+To ensure new content schema text can be parsed by Content Data API, it needs to be added to an  appropriate [Edition Content Parser](https://github.com/alphagov/content-data-api/tree/main/app/domain/etl/edition/content/parsers) or a new praser should be created. This ensures that content quality metrics such as word count or reading time are available in [Content Data](https://content-data.publishing.service.gov.uk).
+
+[Example of adding a new content schema to the Content Body parser](https://github.com/alphagov/content-data-api/pull/1906). 
+
+Failing to do so, will cause `Etl::Edition::Content::Parser::InvalidSchemaError` in Content Data API but basic metrics will still be available in Content Data.


### PR DESCRIPTION
To ensure that consideration has been given to how the new schema will be parsed by Content Data API.

We used to have a test for it, which if I remember correctly run in the CI ensuring the new schema is added to appropriate parser in Content Data API but it was removed in https://github.com/alphagov/content-data-api/pull/1819.

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
