### PR TITLE
Add `last_edited_by_editor_id` to embedded content

### DIFF
--- a/app/presenters/queries/embedded_content_presenter.rb
+++ b/app/presenters/queries/embedded_content_presenter.rb
@@ -27,6 +27,7 @@ module Presenters
             base_path: edition.base_path,
             document_type: edition.document_type,
             publishing_app: edition.publishing_app,
+            last_edited_by_editor_id: edition.last_edited_by_editor_id,
             primary_publishing_organisation: {
               content_id: edition.primary_publishing_organisation_content_id,
               title: edition.primary_publishing_organisation_title,

--- a/app/queries/get_embedded_content.rb
+++ b/app/queries/get_embedded_content.rb
@@ -29,7 +29,7 @@ module Queries
         .joins("LEFT JOIN editions AS org_editions ON org_editions.document_id = documents.id AND org_editions.state = 'published'")
         .where(links: { link_type: embedded_link_type, target_content_id: })
         .select(
-          "editions.id, editions.title, editions.base_path, editions.document_type, editions.publishing_app",
+          "editions.id, editions.title, editions.base_path, editions.document_type, editions.publishing_app, editions.last_edited_by_editor_id",
           "primary_links.target_content_id AS primary_publishing_organisation_content_id",
           "org_editions.title AS primary_publishing_organisation_title",
           "org_editions.base_path AS primary_publishing_organisation_base_path",

--- a/spec/factories/live_edition.rb
+++ b/spec/factories/live_edition.rb
@@ -5,6 +5,7 @@ FactoryBot.define do
     content_store { "live" }
     public_updated_at { "2014-05-14T13:00:06Z" }
     first_published_at { "2014-01-02T03:04:05Z" }
+    last_edited_by_editor_id { SecureRandom.uuid }
 
     transient do
       draft_version_number { 2 }

--- a/spec/integration/embedded_content_spec.rb
+++ b/spec/integration/embedded_content_spec.rb
@@ -66,6 +66,7 @@ RSpec.describe "Embedded documents" do
           "base_path" => host_edition.base_path,
           "document_type" => host_edition.document_type,
           "publishing_app" => host_edition.publishing_app,
+          "last_edited_by_editor_id" => host_edition.last_edited_by_editor_id,
           "primary_publishing_organisation" => {
             "content_id" => publishing_organisation.content_id,
             "title" => publishing_organisation.title,

--- a/spec/presenters/queries/embedded_content_presenter_spec.rb
+++ b/spec/presenters/queries/embedded_content_presenter_spec.rb
@@ -2,6 +2,7 @@ RSpec.describe Presenters::Queries::EmbeddedContentPresenter do
   describe "#present" do
     let(:organisation_edition_id) { SecureRandom.uuid }
     let(:target_edition_id) { SecureRandom.uuid }
+    let(:last_edited_by_editor_id) { SecureRandom.uuid }
 
     let(:host_editions) do
       [double("Edition",
@@ -10,6 +11,7 @@ RSpec.describe Presenters::Queries::EmbeddedContentPresenter do
               base_path: "/foo",
               document_type: "publication",
               publishing_app: "publisher",
+              last_edited_by_editor_id:,
               primary_publishing_organisation_content_id: organisation_edition_id,
               primary_publishing_organisation_title: "bar",
               primary_publishing_organisation_base_path: "/bar")]
@@ -27,6 +29,7 @@ RSpec.describe Presenters::Queries::EmbeddedContentPresenter do
             base_path: "/foo",
             document_type: "publication",
             publishing_app: "publisher",
+            last_edited_by_editor_id:,
             primary_publishing_organisation: {
               content_id: organisation_edition_id,
               title: "bar",


### PR DESCRIPTION
This will allow us to identify the last user who “touched” a piece of content, allowing Content Block Manager users to identify who last made a change to content that uses a block.