### PR TITLE
Return `last_edited_at` in embedded content response

### DIFF
--- a/app/presenters/queries/embedded_content_presenter.rb
+++ b/app/presenters/queries/embedded_content_presenter.rb
@@ -28,6 +28,7 @@ module Presenters
             document_type: edition.document_type,
             publishing_app: edition.publishing_app,
             last_edited_by_editor_id: edition.last_edited_by_editor_id,
+            last_edited_at: edition.last_edited_at,
             primary_publishing_organisation: {
               content_id: edition.primary_publishing_organisation_content_id,
               title: edition.primary_publishing_organisation_title,

--- a/app/queries/get_embedded_content.rb
+++ b/app/queries/get_embedded_content.rb
@@ -29,7 +29,7 @@ module Queries
         .joins("LEFT JOIN editions AS org_editions ON org_editions.document_id = documents.id AND org_editions.state = 'published'")
         .where(links: { link_type: embedded_link_type, target_content_id: })
         .select(
-          "editions.id, editions.title, editions.base_path, editions.document_type, editions.publishing_app, editions.last_edited_by_editor_id",
+          "editions.id, editions.title, editions.base_path, editions.document_type, editions.publishing_app, editions.last_edited_by_editor_id, editions.last_edited_at",
           "primary_links.target_content_id AS primary_publishing_organisation_content_id",
           "org_editions.title AS primary_publishing_organisation_title",
           "org_editions.base_path AS primary_publishing_organisation_base_path",

--- a/spec/integration/embedded_content_spec.rb
+++ b/spec/integration/embedded_content_spec.rb
@@ -42,8 +42,10 @@ RSpec.describe "Embedded documents" do
 
   context "when an edition embeds a reference to the content block" do
     it "returns details of the edition and its publishing organisation in the results" do
+      last_edited_at = "2023-01-01T08:00:00.000Z"
       host_edition = create(:live_edition,
                             publishing_app: "whitehall",
+                            last_edited_at: Time.zone.parse(last_edited_at),
                             details: {
                               "body" => "<p>{{embed:email_address:#{content_block.content_id}}}</p>\n",
                             },
@@ -67,6 +69,7 @@ RSpec.describe "Embedded documents" do
           "document_type" => host_edition.document_type,
           "publishing_app" => host_edition.publishing_app,
           "last_edited_by_editor_id" => host_edition.last_edited_by_editor_id,
+          "last_edited_at" => last_edited_at,
           "primary_publishing_organisation" => {
             "content_id" => publishing_organisation.content_id,
             "title" => publishing_organisation.title,

--- a/spec/presenters/queries/embedded_content_presenter_spec.rb
+++ b/spec/presenters/queries/embedded_content_presenter_spec.rb
@@ -3,6 +3,7 @@ RSpec.describe Presenters::Queries::EmbeddedContentPresenter do
     let(:organisation_edition_id) { SecureRandom.uuid }
     let(:target_edition_id) { SecureRandom.uuid }
     let(:last_edited_by_editor_id) { SecureRandom.uuid }
+    let(:last_edited_at) { 2.days.ago }
 
     let(:host_editions) do
       [double("Edition",
@@ -12,6 +13,7 @@ RSpec.describe Presenters::Queries::EmbeddedContentPresenter do
               document_type: "publication",
               publishing_app: "publisher",
               last_edited_by_editor_id:,
+              last_edited_at:,
               primary_publishing_organisation_content_id: organisation_edition_id,
               primary_publishing_organisation_title: "bar",
               primary_publishing_organisation_base_path: "/bar")]
@@ -30,6 +32,7 @@ RSpec.describe Presenters::Queries::EmbeddedContentPresenter do
             document_type: "publication",
             publishing_app: "publisher",
             last_edited_by_editor_id:,
+            last_edited_at:,
             primary_publishing_organisation: {
               content_id: organisation_edition_id,
               title: "bar",


### PR DESCRIPTION
This builds on #2923 to also return the last time an edition was edited. I’ve had to change the integration tests to be a bit more verbose because of time precision shenanigans