### PR TITLE
Allow documents links on landing pages

### DIFF
--- a/content_schemas/dist/formats/landing_page/frontend/schema.json
+++ b/content_schemas/dist/formats/landing_page/frontend/schema.json
@@ -67,6 +67,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "documents": {
+          "description": "Documents which belong underneath this landing page",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "embed": {
           "description": "Content that will be embedded within the document, using embed tags.",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -74,6 +78,11 @@
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"
+        },
+        "government": {
+          "description": "The government associated with this document",
+          "$ref": "#/definitions/frontend_links_with_base_path",
+          "maxItems": 1
         },
         "lead_organisations": {
           "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
@@ -104,7 +113,6 @@
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "organisations": {
-          "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "original_primary_publishing_organisation": {
@@ -112,9 +120,7 @@
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "parent": {
-          "description": "The parent content item.",
-          "$ref": "#/definitions/frontend_links_with_base_path",
-          "maxItems": 1
+          "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "part_of_step_navs": {
           "description": "Link type automatically added by Publishing API",
@@ -132,6 +138,9 @@
           "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path",
           "maxItems": 1
+        },
+        "related_policies": {
+          "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "related_to_step_navs": {
           "description": "Link type automatically added by Publishing API",
@@ -151,6 +160,9 @@
         },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
+        "topical_events": {
           "$ref": "#/definitions/frontend_links_with_base_path"
         }
       }

--- a/content_schemas/dist/formats/landing_page/notification/schema.json
+++ b/content_schemas/dist/formats/landing_page/notification/schema.json
@@ -85,6 +85,10 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
+        "documents": {
+          "description": "Documents which belong underneath this landing page",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "embed": {
           "description": "Content that will be embedded within the document, using embed tags.",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -92,6 +96,11 @@
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"
+        },
+        "government": {
+          "description": "The government associated with this document",
+          "$ref": "#/definitions/frontend_links_with_base_path",
+          "maxItems": 1
         },
         "lead_organisations": {
           "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
@@ -122,7 +131,6 @@
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "organisations": {
-          "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "original_primary_publishing_organisation": {
@@ -130,9 +138,7 @@
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "parent": {
-          "description": "The parent content item.",
-          "$ref": "#/definitions/frontend_links_with_base_path",
-          "maxItems": 1
+          "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "part_of_step_navs": {
           "description": "Link type automatically added by Publishing API",
@@ -150,6 +156,9 @@
           "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path",
           "maxItems": 1
+        },
+        "related_policies": {
+          "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "related_to_step_navs": {
           "description": "Link type automatically added by Publishing API",
@@ -170,6 +179,9 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
+        },
+        "topical_events": {
+          "$ref": "#/definitions/frontend_links_with_base_path"
         }
       }
     },
@@ -187,6 +199,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "documents": {
+          "description": "Documents which belong underneath this landing page",
+          "$ref": "#/definitions/guid_list"
+        },
         "embed": {
           "description": "Content that will be embedded within the document, using embed tags.",
           "$ref": "#/definitions/guid_list"
@@ -194,6 +210,11 @@
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"
+        },
+        "government": {
+          "description": "The government associated with this document",
+          "$ref": "#/definitions/guid_list",
+          "maxItems": 1
         },
         "lead_organisations": {
           "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
@@ -216,7 +237,6 @@
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
-          "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/guid_list"
         },
         "original_primary_publishing_organisation": {
@@ -224,9 +244,7 @@
           "$ref": "#/definitions/guid_list"
         },
         "parent": {
-          "description": "The parent content item.",
-          "$ref": "#/definitions/guid_list",
-          "maxItems": 1
+          "$ref": "#/definitions/guid_list"
         },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
@@ -237,12 +255,18 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
+        "related_policies": {
+          "$ref": "#/definitions/guid_list"
+        },
         "suggested_ordered_related_items": {
           "description": "Used for displaying related content on most pages, except for step-by-step and fatality notices. Links and their ordering are determined by the machine learning algorithms.",
           "$ref": "#/definitions/guid_list"
         },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
+          "$ref": "#/definitions/guid_list"
+        },
+        "topical_events": {
           "$ref": "#/definitions/guid_list"
         }
       }

--- a/content_schemas/dist/formats/landing_page/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/landing_page/publisher_v2/schema.json
@@ -66,12 +66,42 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "documents": {
+          "description": "Documents which belong underneath this landing page",
+          "$ref": "#/definitions/guid_list"
+        },
         "embed": {
           "description": "Content that will be embedded within the document, using embed tags.",
           "$ref": "#/definitions/guid_list"
         },
+        "government": {
+          "description": "The government associated with this document",
+          "$ref": "#/definitions/guid_list",
+          "maxItems": 1
+        },
+        "organisations": {
+          "$ref": "#/definitions/guid_list"
+        },
+        "original_primary_publishing_organisation": {
+          "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "parent": {
+          "$ref": "#/definitions/guid_list"
+        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "primary_publishing_organisation": {
+          "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/guid_list",
+          "maxItems": 1
+        },
+        "related_policies": {
+          "$ref": "#/definitions/guid_list"
+        },
+        "topical_events": {
           "$ref": "#/definitions/guid_list"
         }
       }

--- a/content_schemas/formats/landing_page.jsonnet
+++ b/content_schemas/formats/landing_page.jsonnet
@@ -6,5 +6,8 @@
       additionalProperties: true,
       properties: {}
     }
-  }
+  },
+  edition_links: (import "shared/whitehall_edition_links.jsonnet") + {
+    documents: "Documents which belong underneath this landing page",
+  },
 }


### PR DESCRIPTION
... and also the standard set of Whitehall links.

We want landing pages to behave pretty much the same as document collections in terms of links, so matching most of those fields.

The exception to that is taxonomy_topic_email_override, which is really specific to the retirement of specialist topics, so not relevant to landing pages. We don't need that.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
