### PR TITLE
Remove redirect_type support

### DIFF
--- a/app/validators/routes_and_redirects_validator.rb
+++ b/app/validators/routes_and_redirects_validator.rb
@@ -115,13 +115,7 @@ private
       utilised_keys = route.keys.uniq
 
       supported_keys = %i[path type]
-      if attribute == :redirects
-        supported_keys += %i[
-          destination
-          segments_mode
-          redirect_type
-        ]
-      end
+      supported_keys += %i[destination segments_mode] if attribute == :redirects
 
       utilised_keys - supported_keys
     end


### PR DESCRIPTION
Support for this has been dropped from Router API and gds-api-adapters

https://github.com/alphagov/router-api/commit/8ee0afebea1d18bb0cdd743968401b5323166723 https://github.com/alphagov/gds-api-adapters/pull/1286

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
