### PR TITLE
Move factory to live edition factory file

### DIFF
--- a/spec/factories/edition.rb
+++ b/spec/factories/edition.rb
@@ -94,16 +94,4 @@ FactoryBot.define do
     schema_name { "contact" }
     document_type { "contact" }
   end
-
-  factory :live_edition_with_embedded_content, parent: :edition do
-    base_path { "/#{SecureRandom.uuid}" }
-    details { { body: "{{embed:#{embedded_content_type}:#{embedded_content_id}" } }
-    state { "published" }
-
-    transient do
-      embedded_content_id { SecureRandom.uuid }
-      embedded_content_type { "content_block_email_address" }
-      links_hash { { embed: [embedded_content_id] } }
-    end
-  end
 end

--- a/spec/factories/live_edition.rb
+++ b/spec/factories/live_edition.rb
@@ -29,6 +29,17 @@ FactoryBot.define do
       with_draft
     end
 
+    trait :with_embedded_content do
+      base_path { "/#{SecureRandom.uuid}" }
+      details { { body: "{{embed:#{embedded_content_type}:#{embedded_content_id}" } }
+
+      transient do
+        embedded_content_id { SecureRandom.uuid }
+        embedded_content_type { "content_block_email_address" }
+        links_hash { { embed: [embedded_content_id] } }
+      end
+    end
+
     after(:create) do |live_edition, evaluator|
       unless evaluator.published_at
         live_edition.update!(published_at: live_edition.created_at)

--- a/spec/service_consumers/pact_helper.rb
+++ b/spec/service_consumers/pact_helper.rb
@@ -657,7 +657,8 @@ Pact.provider_states_for "GDS API Adapters" do
       reusable_edition = create(:live_edition, document: reusable_document)
 
       document = create(:document, content_id: "d66d6552-2627-4451-9dbc-cadbbd2005a1")
-      live_edition_with_embedded_edition = create(:live_edition_with_embedded_content,
+      live_edition_with_embedded_edition = create(:live_edition,
+                                                  :with_embedded_content,
                                                   document:,
                                                   embedded_content_id: reusable_edition.content_id,
                                                   title: "foo",


### PR DESCRIPTION
This looks like it belongs in the live edition factory, not the edition factory. The fact that live editions have their own factory is a little unusual and probably led to this misplacement

I've also changed it to be a trait rather than a specific factory. I'm not sure that the distinction in how they're used is clear, but `with_***` sounds trait-like

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
