### PR TITLE
Add GraphQL world index types and query

### DIFF
--- a/app/graphql/types/edition_type.rb
+++ b/app/graphql/types/edition_type.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module Types
+  class EditionType < Types::BaseObject
+    field :title, String
+  end
+end

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -2,5 +2,12 @@
 
 module Types
   class QueryType < Types::BaseObject
+    field :edition, EditionTypeOrSubtype, description: "An edition or one of its subtypes" do
+      argument :base_path, String
+    end
+
+    def edition(base_path:)
+      Edition.live.find_by(base_path:)
+    end
   end
 end

--- a/app/graphql/types/query_type/edition_type_or_subtype.rb
+++ b/app/graphql/types/query_type/edition_type_or_subtype.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module Types
+  class QueryType
+    class EditionTypeOrSubtype < Types::BaseUnion
+      EDITION_TYPES = [Types::EditionType, Types::WorldIndexType].freeze
+
+      possible_types(*EDITION_TYPES)
+
+      class << self
+        def resolve_type(_object, context)
+          base_path_argument = base_path_argument(context)
+
+          matching_edition_subtype = Types::EditionType.descendants.find do |edition_subtype|
+            base_path_argument == edition_subtype.base_path
+          end
+
+          matching_edition_subtype || Types::EditionType
+        end
+
+      private
+
+        def base_path_argument(context)
+          context
+            .query
+            .lookahead
+            .ast_nodes.first
+            .selections.first
+            .arguments
+            .find { |argument| argument.name == "basePath" }
+            &.value
+        end
+      end
+    end
+  end
+end

--- a/app/graphql/types/world_index_type.rb
+++ b/app/graphql/types/world_index_type.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Types
+  class WorldIndexType < Types::EditionType
+    class WorldLocation < Types::BaseObject
+      field :active, Boolean, null: false
+      field :analytics_identifier, String
+      field :content_id, ID, null: false
+      field :iso2, String
+      field :name, String, null: false
+      field :slug, String, null: false
+      field :updated_at, GraphQL::Types::ISO8601DateTime, null: false
+    end
+
+    field :body, String
+    field :international_delegations, [WorldLocation], null: false
+    field :world_locations, [WorldLocation], null: false
+
+    def self.base_path = "/world"
+
+    def international_delegations
+      object.details[:international_delegations]
+    end
+
+    def world_locations
+      object.details[:world_locations]
+    end
+  end
+end

--- a/spec/graphql/types/query_type/edition_type_or_subtype_spec.rb
+++ b/spec/graphql/types/query_type/edition_type_or_subtype_spec.rb
@@ -1,0 +1,54 @@
+RSpec.describe "Types::QueryType::EditionTypeOrSubtype" do
+  describe "EDITION_TYPES" do
+    it "includes all EditionType descendants" do
+      Rails.application.eager_load!
+
+      expected = [Types::EditionType, *Types::EditionType.descendants]
+
+      expect(Types::QueryType::EditionTypeOrSubtype::EDITION_TYPES.sort).to eq(expected.sort)
+    end
+  end
+
+  describe ".resolve_type" do
+    context "when the basePath argument matches an Edition subtype's base path" do
+      it "returns the Edition subtype" do
+        expect(
+          Types::QueryType::EditionTypeOrSubtype.resolve_type(
+            {},
+            mock_context(base_path_argument: "/world"),
+          ),
+        ).to be Types::WorldIndexType
+      end
+    end
+
+    context "when the basePath argument does matches a base path of any Edition subtype" do
+      it "returns the generic Edition type" do
+        expect(
+          Types::QueryType::EditionTypeOrSubtype.resolve_type(
+            {},
+            mock_context(base_path_argument: "/a/generic/edition"),
+          ),
+        ).to be Types::EditionType
+      end
+    end
+  end
+
+private
+
+  def mock_context(base_path_argument:)
+    JSON.parse({
+      query: {
+        lookahead: {
+          ast_nodes: [{
+            selections: [{
+              arguments: [{
+                name: "basePath",
+                value: base_path_argument,
+              }],
+            }],
+          }],
+        },
+      },
+    }.to_json, object_class: OpenStruct)
+  end
+end

--- a/spec/graphql/types/world_index_type_spec.rb
+++ b/spec/graphql/types/world_index_type_spec.rb
@@ -1,0 +1,7 @@
+RSpec.describe "Types::WorldIndexType" do
+  describe ".base_path" do
+    it "defines a base path for .resolve_type to distinguish the type from the generic Edition type" do
+      expect(Types::WorldIndexType.base_path).to eq("/world")
+    end
+  end
+end

--- a/spec/integration/graphql_spec.rb
+++ b/spec/integration/graphql_spec.rb
@@ -1,0 +1,153 @@
+RSpec.describe "GraphQL" do
+  describe "generic edition" do
+    before do
+      create(:live_edition, title: "My Generic Edition", base_path: "/my/generic/edition")
+    end
+
+    it "exposes generic edition fields" do
+      post "/graphql", params: {
+        query:
+          "{
+            edition(basePath: \"/my/generic/edition\") {
+              ... on Edition {
+                title
+              }
+            }
+          }",
+      }
+
+      expected = {
+        "data": {
+          "edition": {
+            "title": "My Generic Edition",
+          },
+        },
+      }.to_json
+
+      expect(response.body).to eq(expected)
+    end
+
+    it "does not expose non-generic edition fields" do
+      post "/graphql", params: {
+        query:
+          "{
+            edition(basePath: \"/my/generic/edition\") {
+              ... on Edition {
+                worldLocations {
+                  active
+                }
+              }
+            }
+          }",
+      }
+
+      parsed_response = JSON.parse(response.body).deep_symbolize_keys
+
+      expect(parsed_response).to match(
+        {
+          errors: [
+            hash_including(
+              message: "Field 'worldLocations' doesn't exist on type 'Edition'",
+            ),
+          ],
+        },
+      )
+    end
+  end
+
+  describe "world index" do
+    before do
+      create(
+        :live_edition,
+        title: "Help and services around the world",
+        base_path: "/world",
+        details:
+        {
+          "world_locations": [
+            {
+              "active": true,
+              "analytics_identifier": "WL1",
+              "content_id": "d3b7ba48-5027-4a98-a594-1108d205dc66",
+              "iso2": "WL",
+              "name": "Test World Location",
+              "slug": "test-world-location",
+              "updated_at": "2024-10-18T14:22:38.000+01:00",
+            },
+          ],
+          "international_delegations": [
+            {
+              "active": false,
+              "analytics_identifier": "WL2",
+              "content_id": "f0313f16-e25c-4bfe-a0fc-e561833f705f",
+              "iso2": "ID",
+              "name": "Test International Delegation",
+              "slug": "test-international-delegation",
+              "updated_at": "2024-10-19T15:07:44.000+01:00",
+            },
+          ],
+        },
+      )
+    end
+
+    it "exposes world index specific fields in addition to generic edition fields" do
+      post "/graphql", params: {
+        query:
+          "fragment worldLocationInfo on WorldLocation {
+            active
+            analyticsIdentifier
+            contentId
+            name
+            slug
+            updatedAt
+          }
+
+          {
+            edition(basePath: \"/world\") {
+              ... on WorldIndex {
+                title
+
+                worldLocations {
+                  ...worldLocationInfo
+                }
+
+                internationalDelegations {
+                  ...worldLocationInfo
+                }
+              }
+            }
+          }",
+      }
+
+      expected = {
+        "data": {
+          "edition": {
+            "title": "Help and services around the world",
+            "worldLocations": [
+              {
+                "active": true,
+                "analyticsIdentifier": "WL1",
+                "contentId": "d3b7ba48-5027-4a98-a594-1108d205dc66",
+                "name": "Test World Location",
+                "slug": "test-world-location",
+                "updatedAt": "2024-10-18T14:22:38+01:00",
+              },
+            ],
+            "internationalDelegations": [
+              {
+                "active": false,
+                "analyticsIdentifier": "WL2",
+                "contentId": "f0313f16-e25c-4bfe-a0fc-e561833f705f",
+                "name": "Test International Delegation",
+                "slug": "test-international-delegation",
+                "updatedAt": "2024-10-19T15:07:44+01:00",
+              },
+            ],
+          },
+
+        },
+      }.to_json
+
+      expect(response.body).to eq(expected)
+    end
+  end
+end


### PR DESCRIPTION
[Trello card](https://trello.com/c/XRH0sRDE/1430-write-graphql-types-and-query-required-for-world-page)

Closes #2929, closes #2930 

This is a more stripped-down-version of #2930, which added a few extra fields to the EditionType. As there's a fair bit more thought required for adding those fields, I felt it would help us get things unblocked slightly if we leave those extra fields for now and add them in future branches.

These new types will allow us to get the data the frontend Collections app needs to render the gov.uk/world page using the GraphQL endpoint.

As mentioned, the `EditionType` here is very minimal, to make this change as small as possible. We'll be adding additional fields to this in upcoming branches, but these extra fields aren't really necessary for the majority of the `/world` page in of itself, and there's a fair bit of complexity involved in some of the Edition fields e.g. Links that needs further thought.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
