### PR TITLE
Add SFO case specialist document type

### DIFF
--- a/content_schemas/allowed_document_types.yml
+++ b/content_schemas/allowed_document_types.yml
@@ -142,6 +142,7 @@
 - service_sign_in
 - service_standard_report
 - services_and_information
+- sfo_case
 - simple_smart_answer
 - smart_answer
 - social_media_use

--- a/content_schemas/dist/formats/generic/frontend/schema.json
+++ b/content_schemas/dist/formats/generic/frontend/schema.json
@@ -178,6 +178,7 @@
         "service_sign_in",
         "service_standard_report",
         "services_and_information",
+        "sfo_case",
         "simple_smart_answer",
         "smart_answer",
         "social_media_use",

--- a/content_schemas/dist/formats/generic/notification/schema.json
+++ b/content_schemas/dist/formats/generic/notification/schema.json
@@ -202,6 +202,7 @@
         "service_sign_in",
         "service_standard_report",
         "services_and_information",
+        "sfo_case",
         "simple_smart_answer",
         "smart_answer",
         "social_media_use",

--- a/content_schemas/dist/formats/generic/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/generic/publisher_v2/schema.json
@@ -191,6 +191,7 @@
         "service_sign_in",
         "service_standard_report",
         "services_and_information",
+        "sfo_case",
         "simple_smart_answer",
         "smart_answer",
         "social_media_use",

--- a/content_schemas/dist/formats/generic_with_external_related_links/frontend/schema.json
+++ b/content_schemas/dist/formats/generic_with_external_related_links/frontend/schema.json
@@ -178,6 +178,7 @@
         "service_sign_in",
         "service_standard_report",
         "services_and_information",
+        "sfo_case",
         "simple_smart_answer",
         "smart_answer",
         "social_media_use",

--- a/content_schemas/dist/formats/generic_with_external_related_links/notification/schema.json
+++ b/content_schemas/dist/formats/generic_with_external_related_links/notification/schema.json
@@ -202,6 +202,7 @@
         "service_sign_in",
         "service_standard_report",
         "services_and_information",
+        "sfo_case",
         "simple_smart_answer",
         "smart_answer",
         "social_media_use",

--- a/content_schemas/dist/formats/generic_with_external_related_links/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/generic_with_external_related_links/publisher_v2/schema.json
@@ -191,6 +191,7 @@
         "service_sign_in",
         "service_standard_report",
         "services_and_information",
+        "sfo_case",
         "simple_smart_answer",
         "smart_answer",
         "social_media_use",

--- a/content_schemas/dist/formats/specialist_document/frontend/schema.json
+++ b/content_schemas/dist/formats/specialist_document/frontend/schema.json
@@ -178,6 +178,7 @@
         "service_sign_in",
         "service_standard_report",
         "services_and_information",
+        "sfo_case",
         "simple_smart_answer",
         "smart_answer",
         "social_media_use",
@@ -677,6 +678,9 @@
         },
         {
           "$ref": "#/definitions/service_standard_report_metadata"
+        },
+        {
+          "$ref": "#/definitions/sfo_case_metadata"
         },
         {
           "$ref": "#/definitions/statutory_instrument_metadata"
@@ -1866,6 +1870,15 @@
           "$ref": "#/definitions/guid"
         },
         "stage": {
+          "type": "string"
+        }
+      }
+    },
+    "sfo_case_metadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "case_state": {
           "type": "string"
         }
       }

--- a/content_schemas/dist/formats/specialist_document/notification/schema.json
+++ b/content_schemas/dist/formats/specialist_document/notification/schema.json
@@ -202,6 +202,7 @@
         "service_sign_in",
         "service_standard_report",
         "services_and_information",
+        "sfo_case",
         "simple_smart_answer",
         "smart_answer",
         "social_media_use",
@@ -765,6 +766,9 @@
         },
         {
           "$ref": "#/definitions/service_standard_report_metadata"
+        },
+        {
+          "$ref": "#/definitions/sfo_case_metadata"
         },
         {
           "$ref": "#/definitions/statutory_instrument_metadata"
@@ -2007,6 +2011,15 @@
           "$ref": "#/definitions/guid"
         },
         "stage": {
+          "type": "string"
+        }
+      }
+    },
+    "sfo_case_metadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "case_state": {
           "type": "string"
         }
       }

--- a/content_schemas/dist/formats/specialist_document/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/specialist_document/publisher_v2/schema.json
@@ -191,6 +191,7 @@
         "service_sign_in",
         "service_standard_report",
         "services_and_information",
+        "sfo_case",
         "simple_smart_answer",
         "smart_answer",
         "social_media_use",
@@ -608,6 +609,9 @@
         },
         {
           "$ref": "#/definitions/service_standard_report_metadata"
+        },
+        {
+          "$ref": "#/definitions/sfo_case_metadata"
         },
         {
           "$ref": "#/definitions/statutory_instrument_metadata"
@@ -1696,6 +1700,15 @@
           "$ref": "#/definitions/guid"
         },
         "stage": {
+          "type": "string"
+        }
+      }
+    },
+    "sfo_case_metadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "case_state": {
           "type": "string"
         }
       }

--- a/content_schemas/formats/shared/definitions/_specialist_document.jsonnet
+++ b/content_schemas/formats/shared/definitions/_specialist_document.jsonnet
@@ -90,6 +90,9 @@
         "$ref": "#/definitions/service_standard_report_metadata",
       },
       {
+        "$ref": "#/definitions/sfo_case_metadata",
+      },
+      {
         "$ref": "#/definitions/statutory_instrument_metadata",
       },
       {
@@ -1056,6 +1059,15 @@
       },
       service_provider: {
         "$ref": "#/definitions/guid",
+      },
+    },
+  },
+  sfo_case_metadata: {
+    type: "object",
+    additionalProperties: false,
+    properties: {
+      case_state: {
+        type: "string",
       },
     },
   },


### PR DESCRIPTION
This document type has been requested by the Serious Fraud Office. The finder will enable users to find fraud, bribery and corruption cases investigated by the SFO. 

[Docs for adding a specialist document type](https://docs.publishing.service.gov.uk/repos/specialist-publisher/creating-editing-and-removing-specialist-document-types-and-finders.html)

[Trello](https://trello.com/c/E7KMeGZo/3034-specialist-finder-sfo-cases)