### PR TITLE
Add additional GraphQL Edition Type fields

### DIFF
--- a/app/graphql/types/edition_type.rb
+++ b/app/graphql/types/edition_type.rb
@@ -2,6 +2,33 @@
 
 module Types
   class EditionType < Types::BaseObject
-    field :title, String
+    field :analytics_identifier, String
+    field :base_path, String
+    field :content_id, ID
+    field :description, String
+    field :details, GraphQL::Types::JSON, null: false
+    field :document_type, String
+    field :first_published_at, GraphQL::Types::ISO8601DateTime, null: false
+    field :locale, String, null: false
+    field :phase, String, null: false
+    field :public_updated_at, GraphQL::Types::ISO8601DateTime, null: false
+    field :publishing_app, String
+    field :publishing_request_id, String
+    field :publishing_scheduled_at, GraphQL::Types::ISO8601DateTime
+    field :rendering_app, String
+    field :scheduled_publishing_delay_seconds, Int
+    field :schema_name, String
+    field :title, String, null: false
+    field :updated_at, GraphQL::Types::ISO8601DateTime
+    field :withdrawn_notice, String
+
+    # Aliased by field methods for fields that are currently presented in the
+    # content item, but come from Content Store, so we can't provide them here
+    def not_stored_in_publishing_api
+      nil
+    end
+
+    alias_method :publishing_scheduled_at, :not_stored_in_publishing_api
+    alias_method :scheduled_publishing_delay_seconds, :not_stored_in_publishing_api
   end
 end

--- a/app/graphql/types/edition_type.rb
+++ b/app/graphql/types/edition_type.rb
@@ -2,6 +2,11 @@
 
 module Types
   class EditionType < Types::BaseObject
+    class WithdrawnNotice < Types::BaseObject
+      field :explanation, String
+      field :withdrawn_at, GraphQL::Types::ISO8601DateTime
+    end
+
     field :analytics_identifier, String
     field :base_path, String
     field :content_id, ID
@@ -20,7 +25,16 @@ module Types
     field :schema_name, String
     field :title, String, null: false
     field :updated_at, GraphQL::Types::ISO8601DateTime
-    field :withdrawn_notice, String
+    field :withdrawn_notice, WithdrawnNotice
+
+    def withdrawn_notice
+      return nil unless object.unpublishing&.withdrawal?
+
+      Presenters::EditionPresenter
+        .new(object)
+        .present
+        .fetch(:withdrawn_notice)
+    end
 
     # Aliased by field methods for fields that are currently presented in the
     # content item, but come from Content Store, so we can't provide them here

--- a/spec/graphql/types/edition_type_spec.rb
+++ b/spec/graphql/types/edition_type_spec.rb
@@ -1,0 +1,33 @@
+RSpec.describe "Types::EditionType" do
+  include GraphQL::Testing::Helpers.for(PublishingApiSchema)
+
+  describe "#withdrawn_notice" do
+    context "when the edition is withdrawn" do
+      it "returns a withdrawal notice" do
+        edition = create(:withdrawn_unpublished_edition, explanation: "for testing", unpublished_at: "2024-10-28 17:00:00.000000000 +0000")
+        expected = {
+          explanation: "for testing",
+          withdrawn_at: "2024-10-28T17:00:00Z",
+        }
+
+        expect(
+          run_graphql_field(
+            "Edition.withdrawnNotice",
+            edition,
+          ),
+        ).to eq(expected)
+      end
+    end
+
+    context "when the edition is not withdrawn" do
+      it "returns nil" do
+        expect(
+          run_graphql_field(
+            "Edition.withdrawnNotice",
+            create(:edition),
+          ),
+        ).to be_nil
+      end
+    end
+  end
+end

--- a/spec/integration/graphql_spec.rb
+++ b/spec/integration/graphql_spec.rb
@@ -1,7 +1,8 @@
 RSpec.describe "GraphQL" do
   describe "generic edition" do
     before do
-      create(:live_edition, title: "My Generic Edition", base_path: "/my/generic/edition")
+      document = create(:document, content_id: "d53db33f-d4ac-4eb3-839a-d415174eb906")
+      @edition = create(:live_edition, document:, base_path: "/my/generic/edition")
     end
 
     it "exposes generic edition fields" do
@@ -11,6 +12,27 @@ RSpec.describe "GraphQL" do
             edition(basePath: \"/my/generic/edition\") {
               ... on Edition {
                 title
+                analyticsIdentifier
+                basePath
+                contentId
+                description
+                details
+                documentType
+                firstPublishedAt
+                locale
+                phase
+                publicUpdatedAt
+                publishingApp
+                publishingRequestId
+                publishingScheduledAt
+                renderingApp
+                scheduledPublishingDelaySeconds
+                schemaName
+                updatedAt
+                withdrawnNotice {
+                  explanation
+                  withdrawnAt
+                }
               }
             }
           }",
@@ -19,12 +41,35 @@ RSpec.describe "GraphQL" do
       expected = {
         "data": {
           "edition": {
-            "title": "My Generic Edition",
+            "analyticsIdentifier": @edition.analytics_identifier,
+            "basePath": @edition.base_path,
+            "contentId": @edition.content_id,
+            "description": @edition.description,
+            "details": @edition.details,
+            "documentType": @edition.document_type,
+            "firstPublishedAt": @edition.first_published_at.iso8601,
+            "locale": @edition.locale,
+            "phase": @edition.phase,
+            "publicUpdatedAt": @edition.public_updated_at.iso8601,
+            "publishingApp": @edition.publishing_app,
+            "publishingRequestId": @edition.publishing_request_id,
+            "publishingScheduledAt": nil,
+            "renderingApp": @edition.rendering_app,
+            "scheduledPublishingDelaySeconds": nil,
+            "schemaName": @edition.schema_name,
+            "title": @edition.title,
+            "updatedAt": @edition.updated_at.iso8601,
+            "withdrawnNotice": {
+              "explanation": nil,
+              "withdrawnAt": nil,
+            },
           },
         },
-      }.to_json
+      }
 
-      expect(response.body).to eq(expected)
+      parsed_response = JSON.parse(response.body).deep_symbolize_keys
+
+      expect(parsed_response).to eq(expected)
     end
 
     it "does not expose non-generic edition fields" do


### PR DESCRIPTION
[Trello card](https://trello.com/c/e1Upvu9L/1441-add-remaining-graphql-edition-fields)

## Changes in this PR

Expands the edition type to include all the top-level properties that a content item contains, and most of the nested data. The queries sent by frontend apps will be able to pare down the data that gets sent to them from the Publishing API, but we are able to get almost all the same data as presented by the current content item if required.

The `withdrawn_notice` field has been implemented slightly differently here to how it is usually stored on a content item, in that it's now either a full object or `null` instead of the previous implementation where it was a full object or an empty object (`{}`) if one wasn't present. We've written in this way to comply with the recommended way of writing GraphQL schemas (see commit message for more details), but it will mean consumers may have to update the way they access this data.

### Fields not yet fully implemented

#### Details

Currently a generic JSON type as it's an inherently flexible object that could have a wide range of fields.

It may be worth defining more specific types and moving the `details` keys up to the top level on each type for each page being built in future. This would allow for reduced complexity in querying the required fields.

We've used JSON to keep it flexible and to allow consumers to fall back on these fields if they need to.

#### Links

Needs further work to query and present the data that is currently presented in the content item so we've left the field off for now, rather than adding a non-so-useful placeholder. We'll need to add links when we add pages that use links like the ministers index page. It would be good to figure out how we can reduce the need for full link expansion and move to a more minimal on-demand version when we tackle this piece of work.

#### `publishing_scheduled_at` and `scheduled_publishing_delay_seconds`

These are not currently available in Publishing API. They are generated in Content Store, so we just return `null` here. If we do need to serve these in future, we'd need to find a way of storing these in Publishing API, but that's definitely out of scope for now.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
