### PR TITLE
Add pact test example with title

### DIFF
--- a/spec/service_consumers/pact_helper.rb
+++ b/spec/service_consumers/pact_helper.rb
@@ -681,5 +681,16 @@ Pact.provider_states_for "GDS API Adapters" do
         target_content_id: primary_publishing_organisation.content_id,
       )
     end
+
+    provider_state "a published content item exists with content_id: 19ad249e-7ac4-4aa4-8ab4-b6c5f381c043" do
+      set_up do
+        document = create(:document, content_id: "19ad249e-7ac4-4aa4-8ab4-b6c5f381c043")
+
+        create(:live_edition,
+               document:,
+               base_path: "/my-document",
+               title: "My document")
+      end
+    end
   end
 end


### PR DESCRIPTION
This adds an example document for pact tests that has a title. This will be used in the GraphQL pact tests so we have some content to return in the response.

[Trello card](https://trello.com/c/jDF1nSQ0)