### PR TITLE
GraphQL: Use `document_type` when resolving subtypes

### DIFF
--- a/app/graphql/types/query_type/edition_type_or_subtype.rb
+++ b/app/graphql/types/query_type/edition_type_or_subtype.rb
@@ -8,27 +8,14 @@ module Types
       possible_types(*EDITION_TYPES)
 
       class << self
-        def resolve_type(_object, context)
-          base_path_argument = base_path_argument(context)
+        def resolve_type(object, _context)
+          document_type = object.document_type
 
           matching_edition_subtype = Types::EditionType.descendants.find do |edition_subtype|
-            base_path_argument == edition_subtype.base_path
+            document_type == edition_subtype.document_type
           end
 
           matching_edition_subtype || Types::EditionType
-        end
-
-      private
-
-        def base_path_argument(context)
-          context
-            .query
-            .lookahead
-            .ast_nodes.first
-            .selections.first
-            .arguments
-            .find { |argument| argument.name == "basePath" }
-            &.value
         end
       end
     end

--- a/app/graphql/types/world_index_type.rb
+++ b/app/graphql/types/world_index_type.rb
@@ -16,7 +16,7 @@ module Types
     field :international_delegations, [WorldLocation], null: false
     field :world_locations, [WorldLocation], null: false
 
-    def self.base_path = "/world"
+    def self.document_type = "world_index"
 
     def international_delegations
       object.details[:international_delegations]

--- a/spec/graphql/types/query_type/edition_type_or_subtype_spec.rb
+++ b/spec/graphql/types/query_type/edition_type_or_subtype_spec.rb
@@ -10,45 +10,26 @@ RSpec.describe "Types::QueryType::EditionTypeOrSubtype" do
   end
 
   describe ".resolve_type" do
-    context "when the basePath argument matches an Edition subtype's base path" do
+    context "when the object's `document_type` matches an Edition subtype's `document_type`" do
       it "returns the Edition subtype" do
         expect(
           Types::QueryType::EditionTypeOrSubtype.resolve_type(
+            build(:live_edition, document_type: "world_index"),
             {},
-            mock_context(base_path_argument: "/world"),
           ),
         ).to be Types::WorldIndexType
       end
     end
 
-    context "when the basePath argument does matches a base path of any Edition subtype" do
+    context "when the object's `document_type` does not match an Edition subtype's `document_type`" do
       it "returns the generic Edition type" do
         expect(
           Types::QueryType::EditionTypeOrSubtype.resolve_type(
+            build(:live_edition, document_type: "a_generic_type"),
             {},
-            mock_context(base_path_argument: "/a/generic/edition"),
           ),
         ).to be Types::EditionType
       end
     end
-  end
-
-private
-
-  def mock_context(base_path_argument:)
-    JSON.parse({
-      query: {
-        lookahead: {
-          ast_nodes: [{
-            selections: [{
-              arguments: [{
-                name: "basePath",
-                value: base_path_argument,
-              }],
-            }],
-          }],
-        },
-      },
-    }.to_json, object_class: OpenStruct)
   end
 end

--- a/spec/graphql/types/world_index_type_spec.rb
+++ b/spec/graphql/types/world_index_type_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe "Types::WorldIndexType" do
-  describe ".base_path" do
-    it "defines a base path for .resolve_type to distinguish the type from the generic Edition type" do
-      expect(Types::WorldIndexType.base_path).to eq("/world")
+  describe ".document_type" do
+    it "defines a document type for .resolve_type to distinguish the type from the generic Edition type" do
+      expect(Types::WorldIndexType.document_type).to eq("world_index")
     end
   end
 end

--- a/spec/integration/graphql_spec.rb
+++ b/spec/integration/graphql_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe "GraphQL" do
   describe "generic edition" do
     before do
       document = create(:document, content_id: "d53db33f-d4ac-4eb3-839a-d415174eb906")
-      @edition = create(:live_edition, document:, base_path: "/my/generic/edition")
+      @edition = create(:live_edition, document:, document_type: "generic_type", base_path: "/my/generic/edition")
     end
 
     it "exposes generic edition fields" do
@@ -75,6 +75,7 @@ RSpec.describe "GraphQL" do
           :withdrawn_unpublished_edition,
           base_path: "/my/withdrawn/edition",
           explanation: "for integration testing",
+          document_type: "generic_type",
           unpublished_at: "2024-10-27 17:00:00.000000000 +0000",
         )
       end
@@ -145,6 +146,7 @@ RSpec.describe "GraphQL" do
         :live_edition,
         title: "Help and services around the world",
         base_path: "/world",
+        document_type: "world_index",
         details:
         {
           "world_locations": [


### PR DESCRIPTION
[Related trello card](https://trello.com/c/8e6tlsKw/1445-prime-minister-page-define-revise-graphql-types-add-type-to-editiontypeorsubtype)

## Changes in this PR

Here we use `document_type` rather than `base_path` when determining whether to use a generic EditionType or one of its subtypes (in this case, the WorldIndexType).

The need for this came about when adding Role GraphQL types for which the `base_path` isn't a good identifier. `document_type` can refer to multiple documents, meaning there's not a single `base_path` linked to the type. For example, the `document_type` of `ministerial_role` can refer to both the prime minister and other cabinet ministers, while the base_path of `/government/ministers/prime-minister`, can only refer to one role.

This also handily simplifies the code as we don't need to mess around in GraphQL internals for the base path argument.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
