### PR TITLE
(656) Update pageviews when publishing content with embeds

### DIFF
--- a/app/commands/v2/publish.rb
+++ b/app/commands/v2/publish.rb
@@ -241,6 +241,12 @@ module Commands
           queue,
           live_worker_params,
         )
+
+        UpdateStatisticsCacheForDocumentIdJob.perform_async(edition.document.id) if has_embedded_content?
+      end
+
+      def has_embedded_content?
+        edition.links.map(&:link_type).include?("embed")
       end
 
       def live_worker_params

--- a/app/sidekiq/update_statistics_cache_for_document_id_job.rb
+++ b/app/sidekiq/update_statistics_cache_for_document_id_job.rb
@@ -1,0 +1,26 @@
+class UpdateStatisticsCacheForDocumentIdJob
+  include Sidekiq::Job
+
+  def perform(document_id)
+    document = Document.find(document_id)
+    base_path = document.live.base_path
+
+    Rails.logger.info("Fetching page views for #{base_path}")
+    result = PageViewsService.new(paths: [base_path]).call
+                             .find { |r| r.path == base_path }
+
+    if result.nil?
+      Rails.logger.info("No data found for #{base_path} - skipping")
+      return
+    end
+
+    Rails.logger.info("Updating statistics for #{base_path}")
+    StatisticsCache.upsert(
+      {
+        document_id: document.id,
+        unique_pageviews: result.page_views,
+      },
+      unique_by: [:document_id],
+    )
+  end
+end

--- a/spec/commands/v2/publish_spec.rb
+++ b/spec/commands/v2/publish_spec.rb
@@ -179,6 +179,26 @@ RSpec.describe Commands::V2::Publish do
           expect(edition.major_published_at).to eq(major_published_at)
         end
       end
+
+      context "and the edition has embedded content" do
+        before do
+          draft_item.links.create!({ link_type: "embed", target_content_id: SecureRandom.uuid })
+        end
+
+        it "queues a job to update the statistics cache" do
+          expect(UpdateStatisticsCacheForDocumentIdJob).to receive(:perform_async).with(draft_item.document.id)
+
+          described_class.call(payload)
+        end
+      end
+
+      context "and the edition does not have embedded content" do
+        it "does not queue a job to update the statistics cache" do
+          expect(UpdateStatisticsCacheForDocumentIdJob).not_to receive(:perform_async)
+
+          described_class.call(payload)
+        end
+      end
     end
 
     context "publishing a content block update" do

--- a/spec/integration/publishing_content_spec.rb
+++ b/spec/integration/publishing_content_spec.rb
@@ -1,0 +1,55 @@
+RSpec.describe "POST /v2/content/:content_id/publish" do
+  let(:content_id) { SecureRandom.uuid }
+  let!(:draft_item) do
+    create(
+      :draft_edition,
+      document: create(:document, content_id:),
+      base_path: "/foo",
+    )
+  end
+
+  before do
+    allow(PublishingAPI.service(:queue_publisher)).to receive(:send_message)
+    stub_request(:put, "http://draft-content-store.dev.gov.uk/content#{draft_item.base_path}")
+      .to_return(status: 200)
+    stub_request(:put, "http://content-store.dev.gov.uk/content#{draft_item.base_path}")
+      .to_return(status: 200)
+  end
+
+  context "when a draft item has embedded content" do
+    let(:mock_page_view) do
+      PageViewsService::PageView.new(path: draft_item.base_path, page_views: 123)
+    end
+    let(:mock_page_views_service) { double(PageViewsService, call: [mock_page_view]) }
+
+    before do
+      draft_item.links.create!({ link_type: "embed", target_content_id: SecureRandom.uuid })
+    end
+
+    it "creates a statistics cache item" do
+      expect(PageViewsService).to receive(:new).and_return(mock_page_views_service)
+
+      post "/v2/content/#{content_id}/publish", params: {}.to_json
+
+      expect(response).to be_ok, response.body
+
+      cache_item = draft_item.document.reload.statistics_cache
+
+      expect(cache_item).not_to be_nil
+      expect(cache_item.document_id).to eq(draft_item.document.id)
+      expect(cache_item.unique_pageviews).to eq(mock_page_view.page_views)
+    end
+  end
+
+  context "when there is no embedded content associated with the item" do
+    it "does not create a statistics cache item" do
+      post "/v2/content/#{content_id}/publish", params: {}.to_json
+
+      expect(response).to be_ok, response.body
+
+      cache_item = draft_item.document.reload.statistics_cache
+
+      expect(cache_item).to be_nil
+    end
+  end
+end

--- a/spec/sidekiq/update_statistics_cache_for_document_id_job_spec.rb
+++ b/spec/sidekiq/update_statistics_cache_for_document_id_job_spec.rb
@@ -1,0 +1,57 @@
+RSpec.describe UpdateStatisticsCacheForDocumentIdJob, :perform do
+  let(:document) { edition.document }
+  let(:edition) { create(:live_edition, document: create(:document)) }
+  let(:mock_page_view) do
+    PageViewsService::PageView.new(path: document.live.base_path, page_views: 123)
+  end
+  let(:mock_page_views_service) { double(PageViewsService, call: [mock_page_view]) }
+
+  before do
+    allow(PageViewsService).to receive(:new).and_return(mock_page_views_service)
+    allow(Rails.logger).to receive(:info)
+  end
+
+  it "creates a statistics cache for the document if one does not exist" do
+    expect { described_class.new.perform(document.id) }.to change { StatisticsCache.count }.by(1)
+
+    statistics_cache = document.reload.statistics_cache
+
+    expect(statistics_cache).not_to be_nil
+    expect(statistics_cache&.document&.id).to eq(document.id)
+    expect(statistics_cache&.unique_pageviews).to eq(mock_page_view.page_views)
+  end
+
+  it "updates a statistics cache if one already exists for the document" do
+    create(:statistics_cache, document:, unique_pageviews: 999)
+    expect { described_class.new.perform(document.id) }.to change { StatisticsCache.count }.by(0)
+
+    statistics_cache = document.reload.statistics_cache
+
+    expect(statistics_cache).not_to be_nil
+    expect(statistics_cache&.document&.id).to eq(document.id)
+    expect(statistics_cache&.unique_pageviews).to eq(mock_page_view.page_views)
+  end
+
+  context "if there is no data available" do
+    let(:mock_page_views_service) { double(PageViewsService, call: []) }
+
+    it "does nothing and logs a message" do
+      expect { described_class.new.perform(document.id) }.to change { StatisticsCache.count }.by(0)
+
+      expect(Rails.logger).to have_received(:info).with("No data found for #{document.live.base_path} - skipping")
+    end
+  end
+
+  context "if there is no data returned for the document" do
+    # This shouldn't happen, but we should at least add a test, just in case we get back incorrect data for some reason
+    let(:mock_page_view) do
+      PageViewsService::PageView.new(path: "/something-else", page_views: 123)
+    end
+
+    it "does nothing and logs a message" do
+      expect { described_class.new.perform(document.id) }.to change { StatisticsCache.count }.by(0)
+
+      expect(Rails.logger).to have_received(:info).with("No data found for #{document.live.base_path} - skipping")
+    end
+  end
+end


### PR DESCRIPTION
This follows on from #2957 to ensure the statistics for a content item that uses embeds get updated on publish. This is particularly useful when a page uses embeds for the first time, so there's minimal delay between the block being used and the page views showing in the Content Block Manager.