### PR TITLE
(656) DISTINCT by `unique_session_id` for page views

### DIFF
--- a/app/services/page_views_service.rb
+++ b/app/services/page_views_service.rb
@@ -5,9 +5,9 @@ class PageViewsService
   PageView = Data.define(:path, :page_views)
   SQL = <<~SQL.freeze
     SELECT cleaned_page_location,
-    COUNT (DISTINCT ga_sessionid) as unique_pageviews FROM
+    COUNT (DISTINCT unique_session_id) as unique_pageviews FROM
     (
-      SELECT cleaned_page_location, ga_sessionid
+      SELECT cleaned_page_location, unique_session_id
       FROM `ga4-analytics-352613.flattened_dataset.partitioned_flattened_events`
       WHERE event_name = "page_view"
       AND cleaned_page_location IN UNNEST(@paths)


### PR DESCRIPTION
The data we got back was quite different from what was present in the Content Data service. After discussing with the Data team, we’ve found that DISTINCTing by the `unique_session_id` (a combination of the pseudonymous ID of a user on a particular client and the session ID generated by Google Analytics) is the right way to go.