### PR TITLE
Content modelling/add presenters for content type

### DIFF
--- a/app/presenters/content_embed/base_presenter.rb
+++ b/app/presenters/content_embed/base_presenter.rb
@@ -1,0 +1,31 @@
+module Presenters
+  module ContentEmbed
+    class BasePresenter
+      include ActionView::Helpers::TagHelper
+
+      def initialize(edition)
+        @edition = edition
+      end
+
+      def render
+        base_tag(content:)
+      end
+
+    private
+
+      def content
+        edition.title
+      end
+
+      def base_tag(content:, tag_type: :span)
+        content_tag(
+          tag_type,
+          content,
+          class: %W[content-embed content-embed__#{edition.document_type}],
+        )
+      end
+
+      attr_reader :edition, :content_type
+    end
+  end
+end

--- a/app/presenters/content_embed/email_address_presenter.rb
+++ b/app/presenters/content_embed/email_address_presenter.rb
@@ -1,0 +1,11 @@
+module Presenters
+  module ContentEmbed
+    class EmailAddressPresenter < BasePresenter
+    private
+
+      def content
+        edition.details[:email_address]
+      end
+    end
+  end
+end

--- a/app/presenters/content_embed_presenter.rb
+++ b/app/presenters/content_embed_presenter.rb
@@ -1,5 +1,9 @@
 module Presenters
   class ContentEmbedPresenter
+    CONTENT_PRESENTERS = {
+      "content_block_email_address" => ContentEmbed::EmailAddressPresenter,
+    }.freeze
+
     def initialize(edition)
       @edition = edition
     end
@@ -64,14 +68,10 @@ module Presenters
       content
     end
 
-    # This is a temporary solution to get email address content blocks working
-    # while we agree on a long-term approach that works for everything.
     def get_content_for_edition(edition)
-      if edition.document_type == "content_block_email_address"
-        edition.details[:email_address]
-      else
-        edition.title
-      end
+      CONTENT_PRESENTERS
+        .fetch(edition.document_type, ContentEmbed::BasePresenter)
+        .new(edition).render
     end
   end
 end

--- a/spec/presenters/content_embed/base_presenter_spec.rb
+++ b/spec/presenters/content_embed/base_presenter_spec.rb
@@ -1,0 +1,9 @@
+RSpec.describe Presenters::ContentEmbed::BasePresenter do
+  let(:edition) { build(:edition, document_type: "something", title: "My edition") }
+
+  it "should render with the title" do
+    presenter = described_class.new(edition)
+
+    expect(presenter.render).to eq("<span class=\"content-embed content-embed__something\">My edition</span>")
+  end
+end

--- a/spec/presenters/content_embed/email_address_presenter_spec.rb
+++ b/spec/presenters/content_embed/email_address_presenter_spec.rb
@@ -1,0 +1,10 @@
+RSpec.describe Presenters::ContentEmbed::EmailAddressPresenter do
+  let(:email_address) { "foo@example.com" }
+  let(:edition) { build(:edition, document_type: "content_block_email_address", details: { email_address: }) }
+
+  it "should render with the email address" do
+    presenter = described_class.new(edition)
+
+    expect(presenter.render).to eq("<span class=\"content-embed content-embed__content_block_email_address\">#{email_address}</span>")
+  end
+end


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
