### PR TITLE
Add 'opened date' to SFO finder

### DIFF
--- a/content_schemas/dist/formats/specialist_document/frontend/schema.json
+++ b/content_schemas/dist/formats/specialist_document/frontend/schema.json
@@ -1878,6 +1878,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "sfo_case_opened_date": {
+          "type": "string",
+          "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
+        },
         "sfo_case_state": {
           "type": "string"
         }

--- a/content_schemas/dist/formats/specialist_document/notification/schema.json
+++ b/content_schemas/dist/formats/specialist_document/notification/schema.json
@@ -2019,6 +2019,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "sfo_case_opened_date": {
+          "type": "string",
+          "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
+        },
         "sfo_case_state": {
           "type": "string"
         }

--- a/content_schemas/dist/formats/specialist_document/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/specialist_document/publisher_v2/schema.json
@@ -1708,6 +1708,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "sfo_case_opened_date": {
+          "type": "string",
+          "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
+        },
         "sfo_case_state": {
           "type": "string"
         }

--- a/content_schemas/formats/shared/definitions/_specialist_document.jsonnet
+++ b/content_schemas/formats/shared/definitions/_specialist_document.jsonnet
@@ -1069,6 +1069,10 @@
       sfo_case_state: {
         type: "string",
       },
+      sfo_case_opened_date: {
+        type: "string",
+        pattern: "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$",
+      },
     },
   },
   statutory_instrument_metadata: {


### PR DESCRIPTION
Adds an additional facet to the new to SFO Finder specialist finder. As per documentation found [here](https://docs.publishing.service.gov.uk/repos/specialist-publisher/creating-editing-and-removing-specialist-document-types-and-finders.html#editing-a-specialist-document-type)

[First PR](https://github.com/alphagov/publishing-api/pull/2943)
[Trello](https://trello.com/c/E7KMeGZo/3034-specialist-finder-sfo-cases)
[Zendesk](https://govuk.zendesk.com/agent/tickets/5958029)