### PR TITLE
add 'instructions for publishers' to Content Block schema

### DIFF
--- a/content_schemas/dist/formats/content_block_email_address/notification/schema.json
+++ b/content_schemas/dist/formats/content_block_email_address/notification/schema.json
@@ -386,6 +386,9 @@
         "email_address": {
           "type": "string",
           "format": "email"
+        },
+        "instructions_for_publishers": {
+          "$ref": "#/definitions/instructions_for_publishers"
         }
       }
     },
@@ -543,6 +546,11 @@
         "$ref": "#/definitions/guid"
       },
       "uniqueItems": true
+    },
+    "instructions_for_publishers": {
+      "description": "An internal message to be added to content blocks",
+      "type": "string",
+      "additionalProperties": false
     },
     "locale": {
       "type": "string",

--- a/content_schemas/dist/formats/content_block_email_address/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/content_block_email_address/publisher_v2/schema.json
@@ -200,6 +200,9 @@
         "email_address": {
           "type": "string",
           "format": "email"
+        },
+        "instructions_for_publishers": {
+          "$ref": "#/definitions/instructions_for_publishers"
         }
       }
     },
@@ -218,6 +221,11 @@
         "$ref": "#/definitions/guid"
       },
       "uniqueItems": true
+    },
+    "instructions_for_publishers": {
+      "description": "An internal message to be added to content blocks",
+      "type": "string",
+      "additionalProperties": false
     },
     "locale": {
       "type": "string",

--- a/content_schemas/dist/formats/content_block_postal_address/notification/schema.json
+++ b/content_schemas/dist/formats/content_block_postal_address/notification/schema.json
@@ -388,6 +388,9 @@
         "county": {
           "type": "string"
         },
+        "instructions_for_publishers": {
+          "$ref": "#/definitions/instructions_for_publishers"
+        },
         "line_1": {
           "type": "string"
         },
@@ -556,6 +559,11 @@
         "$ref": "#/definitions/guid"
       },
       "uniqueItems": true
+    },
+    "instructions_for_publishers": {
+      "description": "An internal message to be added to content blocks",
+      "type": "string",
+      "additionalProperties": false
     },
     "locale": {
       "type": "string",

--- a/content_schemas/dist/formats/content_block_postal_address/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/content_block_postal_address/publisher_v2/schema.json
@@ -202,6 +202,9 @@
         "county": {
           "type": "string"
         },
+        "instructions_for_publishers": {
+          "$ref": "#/definitions/instructions_for_publishers"
+        },
         "line_1": {
           "type": "string"
         },
@@ -231,6 +234,11 @@
         "$ref": "#/definitions/guid"
       },
       "uniqueItems": true
+    },
+    "instructions_for_publishers": {
+      "description": "An internal message to be added to content blocks",
+      "type": "string",
+      "additionalProperties": false
     },
     "locale": {
       "type": "string",

--- a/content_schemas/examples/content_block_email_address/publisher_v2/example.json
+++ b/content_schemas/examples/content_block_email_address/publisher_v2/example.json
@@ -3,9 +3,9 @@
   "schema_name": "content_block_email_address",
   "document_type": "content_block_email_address",
   "title": "Government Digital Service - General contact",
-  "description": "General contact email address for Government Digital Service",
   "content_id_alias": "gds-general",
   "details": {
+    "instructions_for_publishers": "General contact email address for Government Digital Service",
     "email_address": "foo@example.com"
   },
   "links": {

--- a/content_schemas/formats/content_block_email_address.jsonnet
+++ b/content_schemas/formats/content_block_email_address.jsonnet
@@ -1,6 +1,6 @@
 (import "shared/content_block.jsonnet") + {
   document_type: "content_block_email_address",
-  definitions: {
+  definitions: (import "shared/definitions/_content_block_manager.jsonnet") + {
     details: {
       type: "object",
       additionalProperties: false,
@@ -10,6 +10,9 @@
           type: "string",
           format: "email",
         },
+        instructions_for_publishers: {
+           "$ref": "#/definitions/instructions_for_publishers",
+        }
       },
     },
   },

--- a/content_schemas/formats/content_block_postal_address.jsonnet
+++ b/content_schemas/formats/content_block_postal_address.jsonnet
@@ -1,6 +1,6 @@
 (import "shared/content_block.jsonnet") + {
   document_type: "content_block_postal_address",
-  definitions: {
+  definitions: (import "shared/definitions/_content_block_manager.jsonnet") +  {
     details: {
       type: "object",
       additionalProperties: false,
@@ -21,6 +21,9 @@
         postcode: {
           type: "string"
         },
+        instructions_for_publishers: {
+          "$ref": "#/definitions/instructions_for_publishers",
+        }
       },
     },
   },

--- a/content_schemas/formats/shared/definitions/_content_block_manager.jsonnet
+++ b/content_schemas/formats/shared/definitions/_content_block_manager.jsonnet
@@ -1,0 +1,7 @@
+ {
+    instructions_for_publishers: {
+        description: "An internal message to be added to content blocks",
+        type: "string",
+        additionalProperties: false,
+   }
+ }


### PR DESCRIPTION
https://trello.com/c/eilOXzrP/677-add-instructions-to-publishers-to-add-edit
We want to add a field to all Content Blocks that will be a short string containing an internal-only message.

As this is a Content Block specific field, it doesn't necessarily make sense to add it to the shared `default-format`, so if I understand the schema process correctly we can only add it to the `details` key.

I think we have a couple of options:

1. (this PR currently) we add `instructions_for_publishers` to the `details` object - nothing more would need to be done, at least until we start rendering more complicated blocks. We currently only look for the `email_address` key to get block content. But it could be a concern later down the line that the field would accidentally be made available on the frontend? Maybe it could be nested under another key like `internal_metadata`? It also causes complications on the frontend when rendering (TBC)

2. we could use the existing `description` top level key on schemas. I think this could be a bit confusing for devs later down the line though, and I think `description` might be subtly different for other documents. But it would be cleaner and mean all content blocks would automatically get the field. Also less possibility of it being rendered on the frontend.


----

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
