### PR TITLE
Add GraphQL roles prime minister page

### DIFF
--- a/app/controllers/graphql_controller.rb
+++ b/app/controllers/graphql_controller.rb
@@ -14,7 +14,17 @@ class GraphqlController < ApplicationController
       # Query context goes here, for example:
       # current_user: current_user,
     }
-    result = PublishingApiSchema.execute(query, variables:, context:, operation_name:)
+    result = PublishingApiSchema.execute(
+      query,
+      variables:,
+      context:,
+      operation_name:,
+    ).to_hash
+
+    if result.key?("errors")
+      logger.warn("GraphQL query result contained errors: #{result['errors']}")
+    end
+
     render json: result
   rescue StandardError => e
     raise e unless Rails.env.development?

--- a/app/graphql/types/edition_type.rb
+++ b/app/graphql/types/edition_type.rb
@@ -30,10 +30,7 @@ module Types
     def withdrawn_notice
       return nil unless object.unpublishing&.withdrawal?
 
-      Presenters::EditionPresenter
-        .new(object)
-        .present
-        .fetch(:withdrawn_notice)
+      presented_edition.fetch(:withdrawn_notice)
     end
 
     # Aliased by field methods for fields that are currently presented in the
@@ -44,5 +41,13 @@ module Types
 
     alias_method :publishing_scheduled_at, :not_stored_in_publishing_api
     alias_method :scheduled_publishing_delay_seconds, :not_stored_in_publishing_api
+
+  private
+
+    def presented_edition
+      @presented_edition ||= Presenters::EditionPresenter
+        .new(object)
+        .present
+    end
   end
 end

--- a/app/graphql/types/query_type/edition_type_or_subtype.rb
+++ b/app/graphql/types/query_type/edition_type_or_subtype.rb
@@ -3,7 +3,7 @@
 module Types
   class QueryType
     class EditionTypeOrSubtype < Types::BaseUnion
-      EDITION_TYPES = [Types::EditionType, Types::WorldIndexType].freeze
+      EDITION_TYPES = [Types::EditionType, Types::RoleType, Types::WorldIndexType].freeze
 
       possible_types(*EDITION_TYPES)
 

--- a/app/graphql/types/role_type.rb
+++ b/app/graphql/types/role_type.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+
+module Types
+  class RoleType < Types::EditionType
+    def self.document_type = "ministerial_role"
+
+    class Organisation < Types::BaseObject
+      field :base_path, String
+      field :title, String, null: false
+    end
+
+    class RoleAppointment < Types::BaseObject
+      class Person < Types::BaseObject
+        field :base_path, String
+        field :biography, String
+        field :title, String, null: false
+
+        def biography
+          Presenters::EditionPresenter
+            .new(object)
+            .present
+            .dig(:details, :body)
+            .find { |body| body[:content_type] == "text/html" }[:content]
+        end
+      end
+
+      field :ended_on, GraphQL::Types::ISO8601DateTime
+      field :person, Person
+      field :started_on, GraphQL::Types::ISO8601DateTime
+
+      def ended_on
+        object.details[:ended_on]
+      end
+
+      def person
+        Edition
+          .live
+          .joins(document: { reverse_links: :link_set })
+          .where(
+            document: { locale: "en" },
+            link_set: { content_id: object.content_id },
+            reverse_links: { link_type: "person" },
+          )
+          .first
+      end
+
+      def started_on
+        object.details[:started_on]
+      end
+    end
+
+    class Translation < Types::BaseObject
+      field :locale, String
+      field :base_path, String
+    end
+
+    field :available_translations, [Translation]
+    field :current_role_appointment, RoleAppointment
+    field :ordered_parent_organisations, [Organisation]
+    field :past_role_appointments, [RoleAppointment]
+    field :responsibilities, String
+    field :supports_historical_accounts, Boolean
+
+    def available_translations
+      Presenters::Queries::AvailableTranslations.by_edition(object)
+        .translations.fetch(:available_translations, [])
+    end
+
+    def current_role_appointment
+      Edition
+        .live
+        .joins(document: :link_set_links)
+        .where(
+          document: { locale: "en" },
+          link_set_links: { target_content_id: object.content_id, link_type: "role" },
+        )
+        .where("details ->> 'current' = 'true'")
+        .first
+    end
+
+    def ordered_parent_organisations
+      Edition
+        .live
+        .joins(document: { reverse_links: :link_set })
+        .where(
+          document: { locale: "en" },
+          link_set: { content_id: object.content_id },
+          reverse_links: { link_type: "ordered_parent_organisations" },
+        )
+    end
+
+    def past_role_appointments
+      Edition
+        .live
+        .joins(document: :link_set_links)
+        .where(
+          document: { locale: "en" },
+          link_set_links: { target_content_id: object.content_id, link_type: "role" },
+        )
+        .where("details ->> 'current' = 'false'")
+    end
+
+    def responsibilities
+      presented_edition
+        .dig(:details, :body)
+        .find { |body| body[:content_type] == "text/html" }[:content]
+    end
+
+    def supports_historical_accounts
+      object.details[:supports_historical_accounts]
+    end
+  end
+end

--- a/app/graphql/types/world_index_type.rb
+++ b/app/graphql/types/world_index_type.rb
@@ -2,6 +2,8 @@
 
 module Types
   class WorldIndexType < Types::EditionType
+    def self.document_type = "world_index"
+
     class WorldLocation < Types::BaseObject
       field :active, Boolean, null: false
       field :analytics_identifier, String
@@ -15,8 +17,6 @@ module Types
     field :body, String
     field :international_delegations, [WorldLocation], null: false
     field :world_locations, [WorldLocation], null: false
-
-    def self.document_type = "world_index"
 
     def international_delegations
       object.details[:international_delegations]

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -5,6 +5,12 @@ class Document < ApplicationRecord
   has_many :editions
   has_one :link_set, primary_key: "content_id", foreign_key: "content_id", inverse_of: :documents
   has_many :link_set_links, class_name: "Link", through: :link_set, source: :links
+  has_many :reverse_links,
+           class_name: "Link",
+           foreign_key: :target_content_id,
+           primary_key: :content_id,
+           inverse_of: :target_documents
+
   has_one :draft, -> { where(content_store: "draft") }, class_name: "Edition"
   has_one :live, -> { where(content_store: "live") }, class_name: "Edition"
   has_one :statistics_cache

--- a/spec/graphql/types/query_type/edition_type_or_subtype_spec.rb
+++ b/spec/graphql/types/query_type/edition_type_or_subtype_spec.rb
@@ -3,9 +3,11 @@ RSpec.describe "Types::QueryType::EditionTypeOrSubtype" do
     it "includes all EditionType descendants" do
       Rails.application.eager_load!
 
-      expected = [Types::EditionType, *Types::EditionType.descendants]
+      expected = [Types::EditionType, *Types::EditionType.descendants].map(&:name)
+      actual = Types::QueryType::EditionTypeOrSubtype::EDITION_TYPES.map(&:name)
+      diff = expected - actual
 
-      expect(Types::QueryType::EditionTypeOrSubtype::EDITION_TYPES.sort).to eq(expected.sort)
+      expect(diff).to be_empty
     end
   end
 

--- a/spec/integration/graphql_spec.rb
+++ b/spec/integration/graphql_spec.rb
@@ -236,4 +236,216 @@ RSpec.describe "GraphQL" do
       expect(response.body).to eq(expected)
     end
   end
+
+  describe "roles" do
+    before do
+      role = create(
+        :live_edition,
+        title: "Prime Minister",
+        document_type: "ministerial_role",
+        base_path: "/government/ministers/prime-minister",
+        details:
+        {
+          "attends_cabinet_type": nil,
+          "body": [{
+            "content_type": "text/govspeak",
+            "content": "# Prime Minister\nThe Prime Minister is the leader of His Majesty's Government",
+          }],
+          "supports_historical_accounts": true,
+        },
+      )
+      create(
+        :live_edition,
+        title: "Prime Minister Español",
+        document: create(:document, content_id: role.content_id, locale: "es"),
+        document_type: "ministerial_role",
+        base_path: "/government/ministers/prime-minister.es",
+      )
+
+      role_appointment1 = create(
+        :live_edition,
+        title: "The Rt Hon Keir Starmer - Prime Minister",
+        document_type: "role_appointment",
+        schema_name: "role_appointment",
+        details: {
+          current: true,
+          started_on: Time.zone.local(2024, 7, 5),
+        },
+      ).tap do |role_appointment|
+        person = create(
+          :live_edition,
+          title: "The Rt Hon Sir Keir Starmer KCB KC MP",
+          document_type: "person",
+          schema_name: "person",
+          base_path: "/government/people/keir-starmer",
+          details: {
+            body: [{
+              content: "Sir Keir Starmer became Prime Minister on 5 July 2024.",
+              content_type: "text/govspeak",
+            }],
+          },
+        )
+        create(
+          :link_set,
+          content_id: role_appointment.content_id,
+          links_hash: { person: [person.content_id], role: [role.content_id] },
+        )
+      end
+
+      role_appointment2 = create(
+        :live_edition,
+        title: "The Rt Hon Rishi Sunak - Prime Minister",
+        document_type: "role_appointment",
+        schema_name: "role_appointment",
+        details: {
+          current: false,
+          started_on: Time.zone.local(2022, 10, 25),
+          ended_on: Time.zone.local(2024, 7, 5),
+        },
+      ).tap do |role_appointment|
+        person = create(
+          :live_edition,
+          title: "The Rt Hon Rishi Sunak MP",
+          document_type: "person",
+          schema_name: "person",
+          base_path: "/government/people/rishi-sunak",
+          details: {
+            body: [{
+              content: "Rishi Sunak was Prime Minister between 25 October 2022 and 5 July 2024.",
+              content_type: "text/govspeak",
+            }],
+          },
+        )
+        create(
+          :link_set,
+          content_id: role_appointment.content_id,
+          links_hash: { person: [person.content_id], role: [role.content_id] },
+        )
+      end
+
+      organisation1 = create(
+        :live_edition,
+        title: "Cabinet Office",
+        document_type: "organisation",
+        schema_name: "organisation",
+        base_path: "/government/organisations/cabinet-office",
+      )
+      organisation2 = create(
+        :live_edition,
+        title: "Prime Minister's Office, 10 Downing Street",
+        document_type: "organisation",
+        schema_name: "organisation",
+        base_path: "/government/organisations/prime-ministers-office-10-downing-street",
+      )
+      create(
+        :link_set,
+        content_id: role.content_id,
+        links_hash: {
+          ordered_parent_organisations: [organisation1.content_id, organisation2.content_id],
+          role_appointments: [role_appointment1.content_id, role_appointment2.content_id],
+        },
+      )
+    end
+
+    it "exposes Role-specific fields, generic Edition fields and Role's links" do
+      post "/graphql", params: {
+        query:
+          "{
+            edition(basePath: \"/government/ministers/prime-minister\") {
+              ... on Role {
+                basePath
+                title
+                responsibilities
+                supportsHistoricalAccounts
+                locale
+
+                availableTranslations {
+                  basePath
+                  locale
+                }
+
+                currentRoleAppointment {
+                  person {
+                    ...basePersonInfo
+                    biography
+                  }
+                }
+
+                pastRoleAppointments {
+                  endedOn
+                  startedOn
+
+                  person {
+                    ...basePersonInfo
+                  }
+                }
+
+                orderedParentOrganisations {
+                  basePath
+                  title
+                }
+              }
+            }
+          }
+
+          fragment basePersonInfo on Person {
+            basePath
+            title
+          }",
+      }
+
+      expected = {
+        data: {
+          edition: {
+            availableTranslations: [
+              {
+                basePath: "/government/ministers/prime-minister",
+                locale: "en",
+              },
+              {
+                basePath: "/government/ministers/prime-minister.es",
+                locale: "es",
+              },
+            ],
+            basePath: "/government/ministers/prime-minister",
+            currentRoleAppointment: {
+              person: {
+                basePath: "/government/people/keir-starmer",
+                biography: "<p>Sir Keir Starmer became Prime Minister on 5 July 2024.</p>\n",
+                title: "The Rt Hon Sir Keir Starmer KCB KC MP",
+              },
+            },
+            locale: "en",
+            orderedParentOrganisations: [
+              {
+                basePath: "/government/organisations/cabinet-office",
+                title: "Cabinet Office",
+              },
+              {
+                basePath: "/government/organisations/prime-ministers-office-10-downing-street",
+                title: "Prime Minister's Office, 10 Downing Street",
+              },
+            ],
+            pastRoleAppointments: [
+              {
+                endedOn: "2024-07-05T00:00:00Z",
+                person: {
+                  basePath: "/government/people/rishi-sunak",
+                  title: "The Rt Hon Rishi Sunak MP",
+                },
+                startedOn: "2022-10-25T00:00:00Z",
+              },
+            ],
+            responsibilities: "<h1 id=\"prime-minister\">Prime Minister</h1>\n<p>The Prime Minister is the leader of His Majesty’s Government</p>\n",
+            supportsHistoricalAccounts: true,
+            title: "Prime Minister",
+          },
+        },
+      }
+
+      parsed_response = JSON.parse(response.body).deep_symbolize_keys
+
+      expect(parsed_response).to eq(expected)
+    end
+  end
 end


### PR DESCRIPTION
https://trello.com/c/8e6tlsKw/1445-prime-minister-page-define-revise-graphql-types-add-type-to-editiontypeorsubtype

Most of the action is in the "Introduce RoleType for GraphQL prime-minister page" commit. If it's proving difficult to review, we can always add the link fields (and their associated type definitions) incrementally over a few commits. Let me know!