### PR TITLE
add `instructions_to_publishers` to schemas

### DIFF
--- a/content_schemas/dist/formats/answer/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/answer/publisher_v2/schema.json
@@ -53,6 +53,9 @@
     "first_published_at": {
       "$ref": "#/definitions/first_published_at"
     },
+    "instructions_to_publishers": {
+      "type": "null"
+    },
     "last_edited_at": {
       "description": "Last time when the content received a major or minor update.",
       "type": "string",

--- a/content_schemas/dist/formats/calendar/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/calendar/publisher_v2/schema.json
@@ -53,6 +53,9 @@
     "first_published_at": {
       "$ref": "#/definitions/first_published_at"
     },
+    "instructions_to_publishers": {
+      "type": "null"
+    },
     "last_edited_at": {
       "description": "Last time when the content received a major or minor update.",
       "type": "string",

--- a/content_schemas/dist/formats/call_for_evidence/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/call_for_evidence/publisher_v2/schema.json
@@ -56,6 +56,9 @@
     "first_published_at": {
       "$ref": "#/definitions/first_published_at"
     },
+    "instructions_to_publishers": {
+      "type": "null"
+    },
     "last_edited_at": {
       "description": "Last time when the content received a major or minor update.",
       "type": "string",

--- a/content_schemas/dist/formats/case_study/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/case_study/publisher_v2/schema.json
@@ -53,6 +53,9 @@
     "first_published_at": {
       "$ref": "#/definitions/first_published_at"
     },
+    "instructions_to_publishers": {
+      "type": "null"
+    },
     "last_edited_at": {
       "description": "Last time when the content received a major or minor update.",
       "type": "string",

--- a/content_schemas/dist/formats/completed_transaction/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/completed_transaction/publisher_v2/schema.json
@@ -53,6 +53,9 @@
     "first_published_at": {
       "$ref": "#/definitions/first_published_at"
     },
+    "instructions_to_publishers": {
+      "type": "null"
+    },
     "last_edited_at": {
       "description": "Last time when the content received a major or minor update.",
       "type": "string",

--- a/content_schemas/dist/formats/consultation/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/consultation/publisher_v2/schema.json
@@ -56,6 +56,9 @@
     "first_published_at": {
       "$ref": "#/definitions/first_published_at"
     },
+    "instructions_to_publishers": {
+      "type": "null"
+    },
     "last_edited_at": {
       "description": "Last time when the content received a major or minor update.",
       "type": "string",

--- a/content_schemas/dist/formats/contact/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/contact/publisher_v2/schema.json
@@ -50,6 +50,9 @@
     "first_published_at": {
       "$ref": "#/definitions/first_published_at"
     },
+    "instructions_to_publishers": {
+      "type": "null"
+    },
     "last_edited_at": {
       "description": "Last time when the content received a major or minor update.",
       "type": "string",

--- a/content_schemas/dist/formats/content_block_email_address/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/content_block_email_address/publisher_v2/schema.json
@@ -50,6 +50,9 @@
     "first_published_at": {
       "$ref": "#/definitions/first_published_at"
     },
+    "instructions_to_publishers": {
+      "$ref": "#/definitions/instructions_to_publishers_optional"
+    },
     "last_edited_at": {
       "description": "Last time when the content received a major or minor update.",
       "type": "string",
@@ -218,6 +221,16 @@
         "$ref": "#/definitions/guid"
       },
       "uniqueItems": true
+    },
+    "instructions_to_publishers_optional": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/content_id_alias"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "locale": {
       "type": "string",

--- a/content_schemas/dist/formats/content_block_postal_address/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/content_block_postal_address/publisher_v2/schema.json
@@ -50,6 +50,9 @@
     "first_published_at": {
       "$ref": "#/definitions/first_published_at"
     },
+    "instructions_to_publishers": {
+      "$ref": "#/definitions/instructions_to_publishers_optional"
+    },
     "last_edited_at": {
       "description": "Last time when the content received a major or minor update.",
       "type": "string",
@@ -231,6 +234,16 @@
         "$ref": "#/definitions/guid"
       },
       "uniqueItems": true
+    },
+    "instructions_to_publishers_optional": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/content_id_alias"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "locale": {
       "type": "string",

--- a/content_schemas/dist/formats/coronavirus_landing_page/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/coronavirus_landing_page/publisher_v2/schema.json
@@ -53,6 +53,9 @@
     "first_published_at": {
       "$ref": "#/definitions/first_published_at"
     },
+    "instructions_to_publishers": {
+      "type": "null"
+    },
     "last_edited_at": {
       "description": "Last time when the content received a major or minor update.",
       "type": "string",

--- a/content_schemas/dist/formats/corporate_information_page/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/corporate_information_page/publisher_v2/schema.json
@@ -74,6 +74,9 @@
     "first_published_at": {
       "$ref": "#/definitions/first_published_at"
     },
+    "instructions_to_publishers": {
+      "type": "null"
+    },
     "last_edited_at": {
       "description": "Last time when the content received a major or minor update.",
       "type": "string",

--- a/content_schemas/dist/formats/detailed_guide/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/detailed_guide/publisher_v2/schema.json
@@ -53,6 +53,9 @@
     "first_published_at": {
       "$ref": "#/definitions/first_published_at"
     },
+    "instructions_to_publishers": {
+      "type": "null"
+    },
     "last_edited_at": {
       "description": "Last time when the content received a major or minor update.",
       "type": "string",

--- a/content_schemas/dist/formats/document_collection/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/document_collection/publisher_v2/schema.json
@@ -53,6 +53,9 @@
     "first_published_at": {
       "$ref": "#/definitions/first_published_at"
     },
+    "instructions_to_publishers": {
+      "type": "null"
+    },
     "last_edited_at": {
       "description": "Last time when the content received a major or minor update.",
       "type": "string",

--- a/content_schemas/dist/formats/email_alert_signup/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/email_alert_signup/publisher_v2/schema.json
@@ -53,6 +53,9 @@
     "first_published_at": {
       "$ref": "#/definitions/first_published_at"
     },
+    "instructions_to_publishers": {
+      "type": "null"
+    },
     "last_edited_at": {
       "description": "Last time when the content received a major or minor update.",
       "type": "string",

--- a/content_schemas/dist/formats/embassies_index/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/embassies_index/publisher_v2/schema.json
@@ -53,6 +53,9 @@
     "first_published_at": {
       "$ref": "#/definitions/first_published_at"
     },
+    "instructions_to_publishers": {
+      "type": "null"
+    },
     "last_edited_at": {
       "description": "Last time when the content received a major or minor update.",
       "type": "string",

--- a/content_schemas/dist/formats/external_content/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/external_content/publisher_v2/schema.json
@@ -51,6 +51,9 @@
     "first_published_at": {
       "$ref": "#/definitions/first_published_at"
     },
+    "instructions_to_publishers": {
+      "type": "null"
+    },
     "last_edited_at": {
       "description": "Last time when the content received a major or minor update.",
       "type": "string",

--- a/content_schemas/dist/formats/facet/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/facet/publisher_v2/schema.json
@@ -50,6 +50,9 @@
     "first_published_at": {
       "$ref": "#/definitions/first_published_at"
     },
+    "instructions_to_publishers": {
+      "type": "null"
+    },
     "last_edited_at": {
       "description": "Last time when the content received a major or minor update.",
       "type": "string",

--- a/content_schemas/dist/formats/fatality_notice/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/fatality_notice/publisher_v2/schema.json
@@ -53,6 +53,9 @@
     "first_published_at": {
       "$ref": "#/definitions/first_published_at"
     },
+    "instructions_to_publishers": {
+      "type": "null"
+    },
     "last_edited_at": {
       "description": "Last time when the content received a major or minor update.",
       "type": "string",

--- a/content_schemas/dist/formats/field_of_operation/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/field_of_operation/publisher_v2/schema.json
@@ -53,6 +53,9 @@
     "first_published_at": {
       "$ref": "#/definitions/first_published_at"
     },
+    "instructions_to_publishers": {
+      "type": "null"
+    },
     "last_edited_at": {
       "description": "Last time when the content received a major or minor update.",
       "type": "string",

--- a/content_schemas/dist/formats/fields_of_operation/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/fields_of_operation/publisher_v2/schema.json
@@ -53,6 +53,9 @@
     "first_published_at": {
       "$ref": "#/definitions/first_published_at"
     },
+    "instructions_to_publishers": {
+      "type": "null"
+    },
     "last_edited_at": {
       "description": "Last time when the content received a major or minor update.",
       "type": "string",

--- a/content_schemas/dist/formats/finder/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/finder/publisher_v2/schema.json
@@ -54,6 +54,9 @@
     "first_published_at": {
       "$ref": "#/definitions/first_published_at"
     },
+    "instructions_to_publishers": {
+      "type": "null"
+    },
     "last_edited_at": {
       "description": "Last time when the content received a major or minor update.",
       "type": "string",

--- a/content_schemas/dist/formats/finder_email_signup/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/finder_email_signup/publisher_v2/schema.json
@@ -53,6 +53,9 @@
     "first_published_at": {
       "$ref": "#/definitions/first_published_at"
     },
+    "instructions_to_publishers": {
+      "type": "null"
+    },
     "last_edited_at": {
       "description": "Last time when the content received a major or minor update.",
       "type": "string",

--- a/content_schemas/dist/formats/generic/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/generic/publisher_v2/schema.json
@@ -237,6 +237,9 @@
     "first_published_at": {
       "$ref": "#/definitions/first_published_at"
     },
+    "instructions_to_publishers": {
+      "type": "null"
+    },
     "last_edited_at": {
       "description": "Last time when the content received a major or minor update.",
       "type": "string",

--- a/content_schemas/dist/formats/generic_with_external_related_links/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/generic_with_external_related_links/publisher_v2/schema.json
@@ -237,6 +237,9 @@
     "first_published_at": {
       "$ref": "#/definitions/first_published_at"
     },
+    "instructions_to_publishers": {
+      "type": "null"
+    },
     "last_edited_at": {
       "description": "Last time when the content received a major or minor update.",
       "type": "string",

--- a/content_schemas/dist/formats/get_involved/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/get_involved/publisher_v2/schema.json
@@ -53,6 +53,9 @@
     "first_published_at": {
       "$ref": "#/definitions/first_published_at"
     },
+    "instructions_to_publishers": {
+      "type": "null"
+    },
     "last_edited_at": {
       "description": "Last time when the content received a major or minor update.",
       "type": "string",

--- a/content_schemas/dist/formats/gone/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/gone/publisher_v2/schema.json
@@ -48,6 +48,9 @@
     "first_published_at": {
       "$ref": "#/definitions/first_published_at"
     },
+    "instructions_to_publishers": {
+      "type": "null"
+    },
     "last_edited_at": {
       "description": "Last time when the content received a major or minor update.",
       "type": "string",

--- a/content_schemas/dist/formats/government/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/government/publisher_v2/schema.json
@@ -53,6 +53,9 @@
     "first_published_at": {
       "$ref": "#/definitions/first_published_at"
     },
+    "instructions_to_publishers": {
+      "type": "null"
+    },
     "last_edited_at": {
       "description": "Last time when the content received a major or minor update.",
       "type": "string",

--- a/content_schemas/dist/formats/guide/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/guide/publisher_v2/schema.json
@@ -53,6 +53,9 @@
     "first_published_at": {
       "$ref": "#/definitions/first_published_at"
     },
+    "instructions_to_publishers": {
+      "type": "null"
+    },
     "last_edited_at": {
       "description": "Last time when the content received a major or minor update.",
       "type": "string",

--- a/content_schemas/dist/formats/help_page/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/help_page/publisher_v2/schema.json
@@ -53,6 +53,9 @@
     "first_published_at": {
       "$ref": "#/definitions/first_published_at"
     },
+    "instructions_to_publishers": {
+      "type": "null"
+    },
     "last_edited_at": {
       "description": "Last time when the content received a major or minor update.",
       "type": "string",

--- a/content_schemas/dist/formats/historic_appointment/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/historic_appointment/publisher_v2/schema.json
@@ -53,6 +53,9 @@
     "first_published_at": {
       "$ref": "#/definitions/first_published_at"
     },
+    "instructions_to_publishers": {
+      "type": "null"
+    },
     "last_edited_at": {
       "description": "Last time when the content received a major or minor update.",
       "type": "string",

--- a/content_schemas/dist/formats/historic_appointments/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/historic_appointments/publisher_v2/schema.json
@@ -53,6 +53,9 @@
     "first_published_at": {
       "$ref": "#/definitions/first_published_at"
     },
+    "instructions_to_publishers": {
+      "type": "null"
+    },
     "last_edited_at": {
       "description": "Last time when the content received a major or minor update.",
       "type": "string",

--- a/content_schemas/dist/formats/history/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/history/publisher_v2/schema.json
@@ -53,6 +53,9 @@
     "first_published_at": {
       "$ref": "#/definitions/first_published_at"
     },
+    "instructions_to_publishers": {
+      "type": "null"
+    },
     "last_edited_at": {
       "description": "Last time when the content received a major or minor update.",
       "type": "string",

--- a/content_schemas/dist/formats/hmrc_manual/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/hmrc_manual/publisher_v2/schema.json
@@ -53,6 +53,9 @@
     "first_published_at": {
       "$ref": "#/definitions/first_published_at"
     },
+    "instructions_to_publishers": {
+      "type": "null"
+    },
     "last_edited_at": {
       "description": "Last time when the content received a major or minor update.",
       "type": "string",

--- a/content_schemas/dist/formats/hmrc_manual_section/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/hmrc_manual_section/publisher_v2/schema.json
@@ -53,6 +53,9 @@
     "first_published_at": {
       "$ref": "#/definitions/first_published_at"
     },
+    "instructions_to_publishers": {
+      "type": "null"
+    },
     "last_edited_at": {
       "description": "Last time when the content received a major or minor update.",
       "type": "string",

--- a/content_schemas/dist/formats/homepage/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/homepage/publisher_v2/schema.json
@@ -54,6 +54,9 @@
     "first_published_at": {
       "$ref": "#/definitions/first_published_at"
     },
+    "instructions_to_publishers": {
+      "type": "null"
+    },
     "last_edited_at": {
       "description": "Last time when the content received a major or minor update.",
       "type": "string",

--- a/content_schemas/dist/formats/how_government_works/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/how_government_works/publisher_v2/schema.json
@@ -53,6 +53,9 @@
     "first_published_at": {
       "$ref": "#/definitions/first_published_at"
     },
+    "instructions_to_publishers": {
+      "type": "null"
+    },
     "last_edited_at": {
       "description": "Last time when the content received a major or minor update.",
       "type": "string",

--- a/content_schemas/dist/formats/html_publication/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/html_publication/publisher_v2/schema.json
@@ -53,6 +53,9 @@
     "first_published_at": {
       "$ref": "#/definitions/first_published_at"
     },
+    "instructions_to_publishers": {
+      "type": "null"
+    },
     "last_edited_at": {
       "description": "Last time when the content received a major or minor update.",
       "type": "string",

--- a/content_schemas/dist/formats/landing_page/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/landing_page/publisher_v2/schema.json
@@ -53,6 +53,9 @@
     "first_published_at": {
       "$ref": "#/definitions/first_published_at"
     },
+    "instructions_to_publishers": {
+      "type": "null"
+    },
     "last_edited_at": {
       "description": "Last time when the content received a major or minor update.",
       "type": "string",

--- a/content_schemas/dist/formats/licence/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/licence/publisher_v2/schema.json
@@ -53,6 +53,9 @@
     "first_published_at": {
       "$ref": "#/definitions/first_published_at"
     },
+    "instructions_to_publishers": {
+      "type": "null"
+    },
     "last_edited_at": {
       "description": "Last time when the content received a major or minor update.",
       "type": "string",

--- a/content_schemas/dist/formats/link_collection/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/link_collection/publisher_v2/schema.json
@@ -50,6 +50,9 @@
     "first_published_at": {
       "$ref": "#/definitions/first_published_at"
     },
+    "instructions_to_publishers": {
+      "type": "null"
+    },
     "last_edited_at": {
       "description": "Last time when the content received a major or minor update.",
       "type": "string",

--- a/content_schemas/dist/formats/local_transaction/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/local_transaction/publisher_v2/schema.json
@@ -53,6 +53,9 @@
     "first_published_at": {
       "$ref": "#/definitions/first_published_at"
     },
+    "instructions_to_publishers": {
+      "type": "null"
+    },
     "last_edited_at": {
       "description": "Last time when the content received a major or minor update.",
       "type": "string",

--- a/content_schemas/dist/formats/mainstream_browse_page/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/mainstream_browse_page/publisher_v2/schema.json
@@ -53,6 +53,9 @@
     "first_published_at": {
       "$ref": "#/definitions/first_published_at"
     },
+    "instructions_to_publishers": {
+      "type": "null"
+    },
     "last_edited_at": {
       "description": "Last time when the content received a major or minor update.",
       "type": "string",

--- a/content_schemas/dist/formats/manual/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/manual/publisher_v2/schema.json
@@ -53,6 +53,9 @@
     "first_published_at": {
       "$ref": "#/definitions/first_published_at"
     },
+    "instructions_to_publishers": {
+      "type": "null"
+    },
     "last_edited_at": {
       "description": "Last time when the content received a major or minor update.",
       "type": "string",

--- a/content_schemas/dist/formats/manual_section/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/manual_section/publisher_v2/schema.json
@@ -53,6 +53,9 @@
     "first_published_at": {
       "$ref": "#/definitions/first_published_at"
     },
+    "instructions_to_publishers": {
+      "type": "null"
+    },
     "last_edited_at": {
       "description": "Last time when the content received a major or minor update.",
       "type": "string",

--- a/content_schemas/dist/formats/ministers_index/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/ministers_index/publisher_v2/schema.json
@@ -53,6 +53,9 @@
     "first_published_at": {
       "$ref": "#/definitions/first_published_at"
     },
+    "instructions_to_publishers": {
+      "type": "null"
+    },
     "last_edited_at": {
       "description": "Last time when the content received a major or minor update.",
       "type": "string",

--- a/content_schemas/dist/formats/need/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/need/publisher_v2/schema.json
@@ -53,6 +53,9 @@
     "first_published_at": {
       "$ref": "#/definitions/first_published_at"
     },
+    "instructions_to_publishers": {
+      "type": "null"
+    },
     "last_edited_at": {
       "description": "Last time when the content received a major or minor update.",
       "type": "string",

--- a/content_schemas/dist/formats/news_article/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/news_article/publisher_v2/schema.json
@@ -56,6 +56,9 @@
     "first_published_at": {
       "$ref": "#/definitions/first_published_at"
     },
+    "instructions_to_publishers": {
+      "type": "null"
+    },
     "last_edited_at": {
       "description": "Last time when the content received a major or minor update.",
       "type": "string",

--- a/content_schemas/dist/formats/organisation/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/organisation/publisher_v2/schema.json
@@ -53,6 +53,9 @@
     "first_published_at": {
       "$ref": "#/definitions/first_published_at"
     },
+    "instructions_to_publishers": {
+      "type": "null"
+    },
     "last_edited_at": {
       "description": "Last time when the content received a major or minor update.",
       "type": "string",

--- a/content_schemas/dist/formats/organisations_homepage/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/organisations_homepage/publisher_v2/schema.json
@@ -53,6 +53,9 @@
     "first_published_at": {
       "$ref": "#/definitions/first_published_at"
     },
+    "instructions_to_publishers": {
+      "type": "null"
+    },
     "last_edited_at": {
       "description": "Last time when the content received a major or minor update.",
       "type": "string",

--- a/content_schemas/dist/formats/person/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/person/publisher_v2/schema.json
@@ -53,6 +53,9 @@
     "first_published_at": {
       "$ref": "#/definitions/first_published_at"
     },
+    "instructions_to_publishers": {
+      "type": "null"
+    },
     "last_edited_at": {
       "description": "Last time when the content received a major or minor update.",
       "type": "string",

--- a/content_schemas/dist/formats/place/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/place/publisher_v2/schema.json
@@ -53,6 +53,9 @@
     "first_published_at": {
       "$ref": "#/definitions/first_published_at"
     },
+    "instructions_to_publishers": {
+      "type": "null"
+    },
     "last_edited_at": {
       "description": "Last time when the content received a major or minor update.",
       "type": "string",

--- a/content_schemas/dist/formats/publication/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/publication/publisher_v2/schema.json
@@ -72,6 +72,9 @@
     "first_published_at": {
       "$ref": "#/definitions/first_published_at"
     },
+    "instructions_to_publishers": {
+      "type": "null"
+    },
     "last_edited_at": {
       "description": "Last time when the content received a major or minor update.",
       "type": "string",

--- a/content_schemas/dist/formats/redirect/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/redirect/publisher_v2/schema.json
@@ -52,6 +52,9 @@
     "first_published_at": {
       "$ref": "#/definitions/first_published_at"
     },
+    "instructions_to_publishers": {
+      "type": "null"
+    },
     "last_edited_at": {
       "description": "Last time when the content received a major or minor update.",
       "type": "string",

--- a/content_schemas/dist/formats/role/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/role/publisher_v2/schema.json
@@ -63,6 +63,9 @@
     "first_published_at": {
       "$ref": "#/definitions/first_published_at"
     },
+    "instructions_to_publishers": {
+      "type": "null"
+    },
     "last_edited_at": {
       "description": "Last time when the content received a major or minor update.",
       "type": "string",

--- a/content_schemas/dist/formats/role_appointment/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/role_appointment/publisher_v2/schema.json
@@ -50,6 +50,9 @@
     "first_published_at": {
       "$ref": "#/definitions/first_published_at"
     },
+    "instructions_to_publishers": {
+      "type": "null"
+    },
     "last_edited_at": {
       "description": "Last time when the content received a major or minor update.",
       "type": "string",

--- a/content_schemas/dist/formats/service_manual_guide/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/service_manual_guide/publisher_v2/schema.json
@@ -53,6 +53,9 @@
     "first_published_at": {
       "$ref": "#/definitions/first_published_at"
     },
+    "instructions_to_publishers": {
+      "type": "null"
+    },
     "last_edited_at": {
       "description": "Last time when the content received a major or minor update.",
       "type": "string",

--- a/content_schemas/dist/formats/service_manual_homepage/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/service_manual_homepage/publisher_v2/schema.json
@@ -53,6 +53,9 @@
     "first_published_at": {
       "$ref": "#/definitions/first_published_at"
     },
+    "instructions_to_publishers": {
+      "type": "null"
+    },
     "last_edited_at": {
       "description": "Last time when the content received a major or minor update.",
       "type": "string",

--- a/content_schemas/dist/formats/service_manual_service_standard/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/service_manual_service_standard/publisher_v2/schema.json
@@ -53,6 +53,9 @@
     "first_published_at": {
       "$ref": "#/definitions/first_published_at"
     },
+    "instructions_to_publishers": {
+      "type": "null"
+    },
     "last_edited_at": {
       "description": "Last time when the content received a major or minor update.",
       "type": "string",

--- a/content_schemas/dist/formats/service_manual_service_toolkit/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/service_manual_service_toolkit/publisher_v2/schema.json
@@ -53,6 +53,9 @@
     "first_published_at": {
       "$ref": "#/definitions/first_published_at"
     },
+    "instructions_to_publishers": {
+      "type": "null"
+    },
     "last_edited_at": {
       "description": "Last time when the content received a major or minor update.",
       "type": "string",

--- a/content_schemas/dist/formats/service_manual_topic/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/service_manual_topic/publisher_v2/schema.json
@@ -53,6 +53,9 @@
     "first_published_at": {
       "$ref": "#/definitions/first_published_at"
     },
+    "instructions_to_publishers": {
+      "type": "null"
+    },
     "last_edited_at": {
       "description": "Last time when the content received a major or minor update.",
       "type": "string",

--- a/content_schemas/dist/formats/service_sign_in/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/service_sign_in/publisher_v2/schema.json
@@ -53,6 +53,9 @@
     "first_published_at": {
       "$ref": "#/definitions/first_published_at"
     },
+    "instructions_to_publishers": {
+      "type": "null"
+    },
     "last_edited_at": {
       "description": "Last time when the content received a major or minor update.",
       "type": "string",

--- a/content_schemas/dist/formats/simple_smart_answer/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/simple_smart_answer/publisher_v2/schema.json
@@ -53,6 +53,9 @@
     "first_published_at": {
       "$ref": "#/definitions/first_published_at"
     },
+    "instructions_to_publishers": {
+      "type": "null"
+    },
     "last_edited_at": {
       "description": "Last time when the content received a major or minor update.",
       "type": "string",

--- a/content_schemas/dist/formats/smart_answer/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/smart_answer/publisher_v2/schema.json
@@ -53,6 +53,9 @@
     "first_published_at": {
       "$ref": "#/definitions/first_published_at"
     },
+    "instructions_to_publishers": {
+      "type": "null"
+    },
     "last_edited_at": {
       "description": "Last time when the content received a major or minor update.",
       "type": "string",

--- a/content_schemas/dist/formats/special_route/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/special_route/publisher_v2/schema.json
@@ -53,6 +53,9 @@
     "first_published_at": {
       "$ref": "#/definitions/first_published_at"
     },
+    "instructions_to_publishers": {
+      "type": "null"
+    },
     "last_edited_at": {
       "description": "Last time when the content received a major or minor update.",
       "type": "string",

--- a/content_schemas/dist/formats/specialist_document/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/specialist_document/publisher_v2/schema.json
@@ -237,6 +237,9 @@
     "first_published_at": {
       "$ref": "#/definitions/first_published_at"
     },
+    "instructions_to_publishers": {
+      "type": "null"
+    },
     "last_edited_at": {
       "description": "Last time when the content received a major or minor update.",
       "type": "string",

--- a/content_schemas/dist/formats/speech/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/speech/publisher_v2/schema.json
@@ -56,6 +56,9 @@
     "first_published_at": {
       "$ref": "#/definitions/first_published_at"
     },
+    "instructions_to_publishers": {
+      "type": "null"
+    },
     "last_edited_at": {
       "description": "Last time when the content received a major or minor update.",
       "type": "string",

--- a/content_schemas/dist/formats/statistical_data_set/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/statistical_data_set/publisher_v2/schema.json
@@ -53,6 +53,9 @@
     "first_published_at": {
       "$ref": "#/definitions/first_published_at"
     },
+    "instructions_to_publishers": {
+      "type": "null"
+    },
     "last_edited_at": {
       "description": "Last time when the content received a major or minor update.",
       "type": "string",

--- a/content_schemas/dist/formats/statistics_announcement/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/statistics_announcement/publisher_v2/schema.json
@@ -57,6 +57,9 @@
     "first_published_at": {
       "$ref": "#/definitions/first_published_at"
     },
+    "instructions_to_publishers": {
+      "type": "null"
+    },
     "last_edited_at": {
       "description": "Last time when the content received a major or minor update.",
       "type": "string",

--- a/content_schemas/dist/formats/step_by_step_nav/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/step_by_step_nav/publisher_v2/schema.json
@@ -53,6 +53,9 @@
     "first_published_at": {
       "$ref": "#/definitions/first_published_at"
     },
+    "instructions_to_publishers": {
+      "type": "null"
+    },
     "last_edited_at": {
       "description": "Last time when the content received a major or minor update.",
       "type": "string",

--- a/content_schemas/dist/formats/take_part/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/take_part/publisher_v2/schema.json
@@ -53,6 +53,9 @@
     "first_published_at": {
       "$ref": "#/definitions/first_published_at"
     },
+    "instructions_to_publishers": {
+      "type": "null"
+    },
     "last_edited_at": {
       "description": "Last time when the content received a major or minor update.",
       "type": "string",

--- a/content_schemas/dist/formats/taxon/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/taxon/publisher_v2/schema.json
@@ -53,6 +53,9 @@
     "first_published_at": {
       "$ref": "#/definitions/first_published_at"
     },
+    "instructions_to_publishers": {
+      "type": "null"
+    },
     "last_edited_at": {
       "description": "Last time when the content received a major or minor update.",
       "type": "string",

--- a/content_schemas/dist/formats/topical_event/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/topical_event/publisher_v2/schema.json
@@ -53,6 +53,9 @@
     "first_published_at": {
       "$ref": "#/definitions/first_published_at"
     },
+    "instructions_to_publishers": {
+      "type": "null"
+    },
     "last_edited_at": {
       "description": "Last time when the content received a major or minor update.",
       "type": "string",

--- a/content_schemas/dist/formats/topical_event_about_page/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/topical_event_about_page/publisher_v2/schema.json
@@ -53,6 +53,9 @@
     "first_published_at": {
       "$ref": "#/definitions/first_published_at"
     },
+    "instructions_to_publishers": {
+      "type": "null"
+    },
     "last_edited_at": {
       "description": "Last time when the content received a major or minor update.",
       "type": "string",

--- a/content_schemas/dist/formats/transaction/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/transaction/publisher_v2/schema.json
@@ -53,6 +53,9 @@
     "first_published_at": {
       "$ref": "#/definitions/first_published_at"
     },
+    "instructions_to_publishers": {
+      "type": "null"
+    },
     "last_edited_at": {
       "description": "Last time when the content received a major or minor update.",
       "type": "string",

--- a/content_schemas/dist/formats/travel_advice/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/travel_advice/publisher_v2/schema.json
@@ -53,6 +53,9 @@
     "first_published_at": {
       "$ref": "#/definitions/first_published_at"
     },
+    "instructions_to_publishers": {
+      "type": "null"
+    },
     "last_edited_at": {
       "description": "Last time when the content received a major or minor update.",
       "type": "string",

--- a/content_schemas/dist/formats/travel_advice_index/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/travel_advice_index/publisher_v2/schema.json
@@ -53,6 +53,9 @@
     "first_published_at": {
       "$ref": "#/definitions/first_published_at"
     },
+    "instructions_to_publishers": {
+      "type": "null"
+    },
     "last_edited_at": {
       "description": "Last time when the content received a major or minor update.",
       "type": "string",

--- a/content_schemas/dist/formats/working_group/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/working_group/publisher_v2/schema.json
@@ -53,6 +53,9 @@
     "first_published_at": {
       "$ref": "#/definitions/first_published_at"
     },
+    "instructions_to_publishers": {
+      "type": "null"
+    },
     "last_edited_at": {
       "description": "Last time when the content received a major or minor update.",
       "type": "string",

--- a/content_schemas/dist/formats/world_index/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/world_index/publisher_v2/schema.json
@@ -53,6 +53,9 @@
     "first_published_at": {
       "$ref": "#/definitions/first_published_at"
     },
+    "instructions_to_publishers": {
+      "type": "null"
+    },
     "last_edited_at": {
       "description": "Last time when the content received a major or minor update.",
       "type": "string",

--- a/content_schemas/dist/formats/world_location/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/world_location/publisher_v2/schema.json
@@ -50,6 +50,9 @@
     "first_published_at": {
       "$ref": "#/definitions/first_published_at"
     },
+    "instructions_to_publishers": {
+      "type": "null"
+    },
     "last_edited_at": {
       "description": "Last time when the content received a major or minor update.",
       "type": "string",

--- a/content_schemas/dist/formats/world_location_news/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/world_location_news/publisher_v2/schema.json
@@ -53,6 +53,9 @@
     "first_published_at": {
       "$ref": "#/definitions/first_published_at"
     },
+    "instructions_to_publishers": {
+      "type": "null"
+    },
     "last_edited_at": {
       "description": "Last time when the content received a major or minor update.",
       "type": "string",

--- a/content_schemas/dist/formats/worldwide_corporate_information_page/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/worldwide_corporate_information_page/publisher_v2/schema.json
@@ -74,6 +74,9 @@
     "first_published_at": {
       "$ref": "#/definitions/first_published_at"
     },
+    "instructions_to_publishers": {
+      "type": "null"
+    },
     "last_edited_at": {
       "description": "Last time when the content received a major or minor update.",
       "type": "string",

--- a/content_schemas/dist/formats/worldwide_office/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/worldwide_office/publisher_v2/schema.json
@@ -53,6 +53,9 @@
     "first_published_at": {
       "$ref": "#/definitions/first_published_at"
     },
+    "instructions_to_publishers": {
+      "type": "null"
+    },
     "last_edited_at": {
       "description": "Last time when the content received a major or minor update.",
       "type": "string",

--- a/content_schemas/dist/formats/worldwide_organisation/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/worldwide_organisation/publisher_v2/schema.json
@@ -53,6 +53,9 @@
     "first_published_at": {
       "$ref": "#/definitions/first_published_at"
     },
+    "instructions_to_publishers": {
+      "type": "null"
+    },
     "last_edited_at": {
       "description": "Last time when the content received a major or minor update.",
       "type": "string",

--- a/content_schemas/examples/content_block_email_address/publisher_v2/example.json
+++ b/content_schemas/examples/content_block_email_address/publisher_v2/example.json
@@ -3,7 +3,7 @@
   "schema_name": "content_block_email_address",
   "document_type": "content_block_email_address",
   "title": "Government Digital Service - General contact",
-  "description": "General contact email address for Government Digital Service",
+  "instructions_to_publishers": "General contact email address for Government Digital Service",
   "content_id_alias": "gds-general",
   "details": {
     "email_address": "foo@example.com"

--- a/content_schemas/formats/shared/content_block.jsonnet
+++ b/content_schemas/formats/shared/content_block.jsonnet
@@ -1,6 +1,7 @@
 (import "default_format.jsonnet") + {
   base_path: "forbidden",
   content_id_alias: "optional",
+  instructions_to_publishers: "optional",
   routes: "forbidden",
   rendering_app: "forbidden",
   edition_links: (import "base_edition_links.jsonnet") +  {

--- a/content_schemas/formats/shared/default_format.jsonnet
+++ b/content_schemas/formats/shared/default_format.jsonnet
@@ -7,6 +7,7 @@
   document_type: null,
   edition_links: import "base_edition_links.jsonnet",
   frontend_content_id: "required",
+  instructions_to_publishers: "forbidden",
   links: import "base_links.jsonnet",
   redirects: "forbidden",
   rendering_app: "required",

--- a/content_schemas/formats/shared/definitions/instructions_to_publishers.jsonnet
+++ b/content_schemas/formats/shared/definitions/instructions_to_publishers.jsonnet
@@ -1,0 +1,16 @@
+{
+  instructions_to_publishers: {
+    description: "Internal message to add context to a Content Block. Should only be supplied for Content Blocks.",
+    type: "string",
+  },
+  instructions_to_publishers_optional: {
+    anyOf: [
+      {
+        "$ref": "#/definitions/content_id_alias",
+      },
+      {
+        type: "null",
+      },
+    ],
+  },
+}

--- a/lib/schema_generator/format.rb
+++ b/lib/schema_generator/format.rb
@@ -104,6 +104,16 @@ module SchemaGenerator
       )
     end
 
+    def instructions_to_publishers
+      @instructions_to_publishers ||= OptionalProperty.new(
+        property: "instructions_to_publishers",
+        status: format_data["instructions_to_publishers"] || "optional",
+        required_definition: "instructions_to_publishers",
+        optional_definition: "instructions_to_publishers_optional",
+        forbidden_definition: "null",
+      )
+    end
+
     def generate_publisher?
       generate_publisher = format_data.dig("generate", "publisher")
       generate_publisher.nil? ? true : generate_publisher

--- a/lib/schema_generator/publisher_content_schema_generator.rb
+++ b/lib/schema_generator/publisher_content_schema_generator.rb
@@ -44,6 +44,7 @@ module SchemaGenerator
         "document_type" => format.document_type.definition,
         "description" => format.description.definition,
         "details" => format.details.definition,
+        "instructions_to_publishers" => format.instructions_to_publishers.definition,
         "links" => links,
         "redirects" => format.redirects.definition,
         "rendering_app" => format.rendering_app.definition,


### PR DESCRIPTION
We want to add a field to all Content Blocks that
will be a short string containing an internal-only message.

This adds the field `instructions_for_publishers`
to a shared default schema file, and then sets it
as optional on content blocks.

Although this is a Content Block specific field,
it did not make sense to include it in the
`details` object because we are using that schema
for all custom public-facing fields on a block. We have already set precedent for adding Content
Block specific top level fields with
`content_id_alias`.

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
