### PR TITLE
(678) Allow sorting and pagination on dependent content

### DIFF
--- a/app/controllers/v2/content_items_controller.rb
+++ b/app/controllers/v2/content_items_controller.rb
@@ -25,7 +25,7 @@ module V2
       results = GetHostContentService.new(
         path_params[:content_id],
         query_params[:order],
-        query_params[:page]
+        query_params[:page],
       ).call
 
       render json: results

--- a/app/controllers/v2/content_items_controller.rb
+++ b/app/controllers/v2/content_items_controller.rb
@@ -25,6 +25,7 @@ module V2
       results = GetHostContentService.new(
         path_params[:content_id],
         query_params[:order],
+        query_params[:page]
       ).call
 
       render json: results

--- a/app/controllers/v2/content_items_controller.rb
+++ b/app/controllers/v2/content_items_controller.rb
@@ -24,6 +24,7 @@ module V2
     def embedded
       results = GetHostContentService.new(
         path_params[:content_id],
+        query_params[:order],
       ).call
 
       render json: results

--- a/app/presenters/embedded_content_presenter.rb
+++ b/app/presenters/embedded_content_presenter.rb
@@ -1,18 +1,21 @@
 module Presenters
   class EmbeddedContentPresenter
-    def self.present(target_edition_id, host_content)
-      new(target_edition_id, host_content).present
+    def self.present(target_edition_id, host_content, total, total_pages)
+      new(target_edition_id, host_content, total, total_pages).present
     end
 
-    def initialize(target_edition_id, host_content)
+    def initialize(target_edition_id, host_content, total, total_pages)
       @target_edition_id = target_edition_id
       @host_content = host_content.to_a
+      @total = total
+      @total_pages = total_pages
     end
 
     def present
       {
         content_id: target_edition_id,
-        total: host_content.count,
+        total:,
+        total_pages:,
         results:,
       }
     end
@@ -40,6 +43,6 @@ module Presenters
 
   private
 
-    attr_reader :target_edition_id, :host_content
+    attr_reader :target_edition_id, :host_content, :total, :total_pages
   end
 end

--- a/app/queries/get_embedded_content.rb
+++ b/app/queries/get_embedded_content.rb
@@ -75,7 +75,7 @@ module Queries
       (count.to_f / PER_PAGE).ceil
     end
 
-    private
+  private
 
     def paginated_query
       arel_query.take(PER_PAGE).skip(page * PER_PAGE)

--- a/app/queries/get_embedded_content.rb
+++ b/app/queries/get_embedded_content.rb
@@ -14,51 +14,79 @@ module Queries
       :unique_pageviews,
     )
 
-    SQL = <<-SQL.freeze
-        SELECT
-            editions.id,
-            editions.title,
-            editions.base_path,
-            editions.document_type,
-            editions.publishing_app,
-            editions.last_edited_by_editor_id,
-            editions.last_edited_at,
-            primary_links.target_content_id AS primary_publishing_organisation_content_id,
-            org_editions.title AS primary_publishing_organisation_title,
-            org_editions.base_path AS primary_publishing_organisation_base_path,
-            statistics_caches.unique_pageviews AS unique_pageviews
-          FROM "editions"
-            INNER JOIN "links" ON "links"."edition_id" = "editions"."id"
-            INNER JOIN "documents" ON "documents"."id" = "editions"."document_id"
-            LEFT JOIN links AS primary_links ON primary_links.edition_id = editions.id AND primary_links.link_type = 'primary_publishing_organisation'
-            LEFT JOIN documents AS org_documents ON org_documents.content_id = primary_links.target_content_id
-            LEFT JOIN editions AS org_editions ON org_editions.document_id = org_documents.id AND org_editions.state = 'published'
-            LEFT JOIN statistics_caches ON statistics_caches.document_id = documents.id
-            WHERE "editions"."state" = $1 AND "links"."link_type" = $2 AND "links"."target_content_id" = $3
-    SQL
 
     attr_reader :target_content_id, :state
 
     def initialize(target_content_id)
+    TABLES = {
+      editions: Edition.arel_table,
+      documents: Document.arel_table,
+      links: Link.arel_table,
+      primary_links: Link.arel_table.alias(:primary_links),
+      org_editions: Edition.arel_table.alias(:org_editions),
+      org_documents: Document.arel_table.alias(:org_documents),
+      statistics_caches: StatisticsCache.arel_table,
+    }.freeze
+
+    FIELDS = [
+      TABLES[:editions][:id],
+      TABLES[:editions][:title],
+      TABLES[:editions][:base_path],
+      TABLES[:editions][:document_type],
+      TABLES[:editions][:publishing_app],
+      TABLES[:editions][:last_edited_by_editor_id],
+      TABLES[:editions][:last_edited_at],
+      TABLES[:primary_links][:target_content_id].as("primary_publishing_organisation_content_id"),
+      TABLES[:org_editions][:title].as("primary_publishing_organisation_title"),
+      TABLES[:org_editions][:base_path].as("primary_publishing_organisation_base_path"),
+      TABLES[:statistics_caches][:unique_pageviews],
+    ].freeze
+
       @target_content_id = target_content_id
       @state = "published"
     end
 
     def call
-      # Prepare params to bind to the SQL query - ActiveRecord requires params to be sent as QueryAttributes,
-      # see https://api.rubyonrails.org/classes/ActiveRecord/ConnectionAdapters/DatabaseStatements.html#method-i-select_all
-      bind_params = [
-        ActiveRecord::Relation::QueryAttribute.new("state", state, ActiveRecord::Type::Text.new),
-        ActiveRecord::Relation::QueryAttribute.new("embedded_link_type", embedded_link_type, ActiveRecord::Type::Text.new),
-        ActiveRecord::Relation::QueryAttribute.new("target_content_id", target_content_id, ActiveRecord::Type::Text.new),
-      ]
-      results = ActiveRecord::Base.connection.select_all(SQL, "SQL", bind_params).to_a
+      results = ActiveRecord::Base.connection.select_all(arel_query).to_a
       results.map do |row|
         Result.new(**row)
       end
     end
 
   private
+
+    def arel_query
+      arel_joins.where(
+        TABLES[:editions][:state].eq(state)
+                                 .and(TABLES[:links][:link_type].eq(embedded_link_type))
+                                 .and(TABLES[:links][:target_content_id].eq(target_content_id)),
+      )
+    end
+
+    def arel_joins
+      TABLES[:editions]
+        .project(FIELDS)
+        .join(TABLES[:links]).on(
+          TABLES[:links][:edition_id].eq(TABLES[:editions][:id]),
+        )
+        .join(TABLES[:documents]).on(
+          TABLES[:documents][:id].eq(TABLES[:editions][:document_id]),
+        )
+        .join(TABLES[:primary_links], Arel::Nodes::OuterJoin).on(
+          TABLES[:primary_links][:edition_id].eq(TABLES[:editions][:id]),
+          TABLES[:primary_links][:link_type].eq("primary_publishing_organisation"),
+        )
+        .join(TABLES[:org_documents], Arel::Nodes::OuterJoin).on(
+          TABLES[:org_documents][:content_id].eq(TABLES[:primary_links][:target_content_id]),
+        )
+        .join(TABLES[:org_editions], Arel::Nodes::OuterJoin).on(
+          TABLES[:org_editions][:document_id].eq(TABLES[:org_documents][:id]),
+          TABLES[:org_editions][:state].eq("published"),
+        )
+        .join(TABLES[:statistics_caches], Arel::Nodes::OuterJoin).on(
+          TABLES[:statistics_caches][:document_id].eq(TABLES[:documents][:id]),
+        )
+    end
 
     def embedded_link_type
       "embed"

--- a/app/services/get_host_content_service.rb
+++ b/app/services/get_host_content_service.rb
@@ -1,7 +1,8 @@
 class GetHostContentService
-  def initialize(target_content_id, order)
+  def initialize(target_content_id, order, page)
     @target_content_id = target_content_id
     @order = order
+    @page = page.blank? ? 0 : page.to_i - 1
   end
 
   def call
@@ -18,10 +19,14 @@ class GetHostContentService
 
 private
 
-  attr_accessor :target_content_id, :order
+  attr_accessor :target_content_id, :order, :page
+
+  def query
+    @query ||= Queries::GetEmbeddedContent.new(target_content_id, order_field:, order_direction:, page:)
+  end
 
   def host_content
-    @host_content ||= Queries::GetEmbeddedContent.new(target_content_id, order_field:, order_direction:).call
+    @host_content ||= query.call
   rescue KeyError
     message = "Invalid order field: #{order}"
     raise CommandError.new(

--- a/app/services/get_host_content_service.rb
+++ b/app/services/get_host_content_service.rb
@@ -14,6 +14,8 @@ class GetHostContentService
     Presenters::EmbeddedContentPresenter.present(
       target_content_id,
       host_content,
+      query.count,
+      query.total_pages,
     )
   end
 

--- a/app/services/get_host_content_service.rb
+++ b/app/services/get_host_content_service.rb
@@ -1,8 +1,7 @@
 class GetHostContentService
-  attr_reader :target_content_id
-
-  def initialize(target_content_id)
-    self.target_content_id = target_content_id
+  def initialize(target_content_id, order)
+    @target_content_id = target_content_id
+    @order = order
   end
 
   def call
@@ -19,9 +18,33 @@ class GetHostContentService
 
 private
 
-  attr_writer :target_content_id
+  attr_accessor :target_content_id, :order
 
   def host_content
-    @host_content ||= Queries::GetEmbeddedContent.new(target_content_id).call
+    @host_content ||= Queries::GetEmbeddedContent.new(target_content_id, order_field:, order_direction:).call
+  rescue KeyError
+    message = "Invalid order field: #{order}"
+    raise CommandError.new(
+      code: 422,
+      message:,
+      error_details: {
+        error: {
+          code: 422,
+          message:,
+        },
+      },
+    )
+  end
+
+  def order_direction
+    return nil if order.blank?
+
+    order.start_with?("-") ? :desc : :asc
+  end
+
+  def order_field
+    return nil if order.blank?
+
+    (order_direction == :desc ? order[1..] : order).to_sym
   end
 end

--- a/docs/api.md
+++ b/docs/api.md
@@ -441,6 +441,15 @@ it wants to defer to a reusable piece of content, such as an email address.
 
 - [`content_id`](model.md#content_id)
   - Identifies the target document for the reusable piece of content
+  
+### Query parameters
+
+- `order` *(optional, default: "unique_pageviews")*
+  - The field to sort the results by.
+  - Returned in an ascending order unless prefixed with a hyphen, e.g.
+    "-title".
+- `page` *(optional, default: "1")*
+  - The page number of results to return
 
 ## `PATCH /v2/links/:content_id`
 

--- a/spec/integration/embedded_content_spec.rb
+++ b/spec/integration/embedded_content_spec.rb
@@ -83,6 +83,29 @@ RSpec.describe "Embedded documents" do
     end
   end
 
+  context "pagination" do
+    before do
+      create_list(:live_edition, 12,
+                 links_hash: {
+                   embed: [content_block.content_id],
+                 })
+    end
+
+    it "returns the first page by default" do
+      get "/v2/content/#{content_block.content_id}/embedded"
+      response_body = parsed_response
+
+      expect(response_body["results"].count).to eq(10)
+    end
+
+    it "allows the next page to be requested" do
+      get "/v2/content/#{content_block.content_id}/embedded?page=2"
+      response_body = parsed_response
+
+      expect(response_body["results"].count).to eq(2)
+    end
+  end
+
   context "when passing order details" do
     it "orders by title" do
       edition_1 = create(:live_edition,

--- a/spec/integration/embedded_content_spec.rb
+++ b/spec/integration/embedded_content_spec.rb
@@ -86,15 +86,17 @@ RSpec.describe "Embedded documents" do
   context "pagination" do
     before do
       create_list(:live_edition, 12,
-                 links_hash: {
-                   embed: [content_block.content_id],
-                 })
+                  links_hash: {
+                    embed: [content_block.content_id],
+                  })
     end
 
     it "returns the first page by default" do
       get "/v2/content/#{content_block.content_id}/embedded"
       response_body = parsed_response
 
+      expect(response_body["total"]).to eq(12)
+      expect(response_body["total_pages"]).to eq(2)
       expect(response_body["results"].count).to eq(10)
     end
 
@@ -102,6 +104,8 @@ RSpec.describe "Embedded documents" do
       get "/v2/content/#{content_block.content_id}/embedded?page=2"
       response_body = parsed_response
 
+      expect(response_body["total"]).to eq(12)
+      expect(response_body["total_pages"]).to eq(2)
       expect(response_body["results"].count).to eq(2)
     end
   end

--- a/spec/presenters/embedded_content_presenter_spec.rb
+++ b/spec/presenters/embedded_content_presenter_spec.rb
@@ -4,6 +4,8 @@ RSpec.describe Presenters::EmbeddedContentPresenter do
     let(:target_edition_id) { SecureRandom.uuid }
     let(:last_edited_by_editor_id) { SecureRandom.uuid }
     let(:last_edited_at) { 2.days.ago }
+    let(:total) { 222 }
+    let(:total_pages) { 23 }
 
     let(:host_editions) do
       [double("Queries::GetEmbeddedContent::Result",
@@ -20,12 +22,13 @@ RSpec.describe Presenters::EmbeddedContentPresenter do
               primary_publishing_organisation_base_path: "/bar")]
     end
 
-    let(:result) { described_class.present(target_edition_id, host_editions) }
+    let(:result) { described_class.present(target_edition_id, host_editions, total, total_pages) }
 
     let(:expected_output) do
       {
         content_id: target_edition_id,
-        total: 1,
+        total:,
+        total_pages:,
         results: [
           {
             title: "foo",

--- a/spec/queries/get_embedded_content_spec.rb
+++ b/spec/queries/get_embedded_content_spec.rb
@@ -152,5 +152,39 @@ RSpec.describe Queries::GetEmbeddedContent do
         }.and_return([])
       end
     end
+
+    context "pagination" do
+      let(:target_content_id) { SecureRandom.uuid }
+
+      before do
+        allow(ActiveRecord::Base.connection).to receive(:select_value).and_return(232)
+      end
+
+      it "returns the count" do
+        expect(described_class.new(target_content_id).count).to eq(232)
+      end
+
+      it "returns the total number of pages" do
+        expect(described_class.new(target_content_id).total_pages).to eq(24)
+      end
+
+      it "requests the first page by default" do
+        expect(ActiveRecord::Base.connection).to receive(:select_all) { |arel_query|
+          expect(arel_query.offset).to eq(0)
+          expect(arel_query.limit).to eq(Queries::GetEmbeddedContent::PER_PAGE)
+        }.and_return([])
+
+        described_class.new(target_content_id).call
+      end
+
+      it "accepts a page argument" do
+        expect(ActiveRecord::Base.connection).to receive(:select_all) { |arel_query|
+          expect(arel_query.offset).to eq(10)
+          expect(arel_query.limit).to eq(Queries::GetEmbeddedContent::PER_PAGE)
+        }.and_return([])
+
+        described_class.new(target_content_id, page: 1).call
+      end
+    end
   end
 end

--- a/spec/queries/get_embedded_content_spec.rb
+++ b/spec/queries/get_embedded_content_spec.rb
@@ -105,5 +105,52 @@ RSpec.describe Queries::GetEmbeddedContent do
         expect(results.count).to eq(0)
       end
     end
+
+    context "sorting" do
+      let(:target_content_id) { SecureRandom.uuid }
+
+      it "sorts by unique_pageviews by default" do
+        expect_sort_call_for(order_field: Queries::GetEmbeddedContent::ORDER_FIELDS[:unique_pageviews], order_direction: :asc)
+
+        described_class.new(target_content_id).call
+      end
+
+      it "allows searching in descending order with the default field" do
+        expect_sort_call_for(order_field: Queries::GetEmbeddedContent::ORDER_FIELDS[:unique_pageviews], order_direction: :desc)
+
+        described_class.new(target_content_id, order_direction: :desc).call
+      end
+
+      it "throws an error with an invalid field" do
+        expect {
+          described_class.new(target_content_id, order_field: :foo).call
+        }.to raise_error(KeyError, "Unknown order field: foo")
+      end
+
+      it "throws an error with an invalid order direction" do
+        expect {
+          described_class.new(target_content_id, order_direction: :foo).call
+        }.to raise_error(KeyError, "Unknown order direction: foo")
+      end
+
+      Queries::GetEmbeddedContent::ORDER_FIELDS.each do |key, order_field|
+        Queries::GetEmbeddedContent::ORDER_DIRECTIONS.each do |order_direction|
+          it "allows searching by #{key} #{order_direction}" do
+            expect_sort_call_for(order_field:, order_direction:)
+
+            described_class.new(target_content_id, order_field: key, order_direction:).call
+          end
+        end
+      end
+
+      def expect_sort_call_for(order_field:, order_direction:)
+        expect(ActiveRecord::Base.connection).to receive(:select_all) { |arel_query|
+          expect(arel_query.orders.length).to eq(1)
+          expect(arel_query.orders[0]).to be_a(order_direction == :asc ? Arel::Nodes::Ascending : Arel::Nodes::Descending)
+          expect(arel_query.orders[0].expr.relation.name).to eq(order_field.relation.name)
+          expect(arel_query.orders[0].expr.name).to eq(order_field.name)
+        }.and_return([])
+      end
+    end
   end
 end

--- a/spec/services/get_host_content_service_spec.rb
+++ b/spec/services/get_host_content_service_spec.rb
@@ -37,7 +37,9 @@ RSpec.describe GetHostContentService do
     context "when the target_content_id matches a Document" do
       let(:target_content_id) { SecureRandom.uuid }
       let(:host_editions_stub) { double("ActiveRecord::Relation") }
-      let(:embedded_content_stub) { double(Queries::GetEmbeddedContent, call: host_editions_stub) }
+      let(:count) { 12 }
+      let(:total_pages) { 2 }
+      let(:embedded_content_stub) { double(Queries::GetEmbeddedContent, call: host_editions_stub, count:, total_pages:) }
       let(:result_stub) { double }
 
       before do
@@ -54,6 +56,8 @@ RSpec.describe GetHostContentService do
         expect(Presenters::EmbeddedContentPresenter).to have_received(:present).with(
           target_content_id,
           host_editions_stub,
+          count,
+          total_pages,
         )
       end
 

--- a/spec/services/get_host_content_service_spec.rb
+++ b/spec/services/get_host_content_service_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe GetHostContentService do
 
     context "when the target_content_id doesn't match a Document" do
       it "returns 404" do
-        expect { described_class.new(SecureRandom.uuid).call }.to raise_error(CommandError) do |error|
+        expect { described_class.new(SecureRandom.uuid, nil).call }.to raise_error(CommandError) do |error|
           expect(error.code).to eq(404)
           expect(error.message).to eq("Could not find an edition to get embedded content for")
         end
@@ -35,19 +35,19 @@ RSpec.describe GetHostContentService do
     end
 
     context "when the target_content_id matches a Document" do
-      it "returns a presented form of the response from the query" do
-        target_content_id = SecureRandom.uuid
+      let(:target_content_id) { SecureRandom.uuid }
+      let(:host_editions_stub) { double("ActiveRecord::Relation") }
+      let(:embedded_content_stub) { double(Queries::GetEmbeddedContent, call: host_editions_stub) }
+      let(:result_stub) { double }
+
+      before do
         allow(Document).to receive(:find_by).and_return(anything)
-
-        host_editions_stub = double("ActiveRecord::Relation")
-        embedded_content_stub = double(Queries::GetEmbeddedContent, call: host_editions_stub)
-        result_stub = double
-
         allow(Queries::GetEmbeddedContent).to receive(:new).and_return(embedded_content_stub)
-
         allow(Presenters::EmbeddedContentPresenter).to receive(:present).and_return(result_stub)
+      end
 
-        result = described_class.new(target_content_id).call
+      it "returns a presented form of the response from the query" do
+        result = described_class.new(target_content_id, nil).call
 
         expect(result).to eq(result_stub)
 
@@ -55,6 +55,45 @@ RSpec.describe GetHostContentService do
           target_content_id,
           host_editions_stub,
         )
+      end
+
+      describe "ordering" do
+        it "does not send any ordering fields by default" do
+          described_class.new(target_content_id, nil).call
+
+          expect(Queries::GetEmbeddedContent).to have_received(:new).with(
+            target_content_id, order_field: nil, order_direction: nil
+          )
+        end
+
+        it "sends a field in ascending order when not preceded with a minus" do
+          described_class.new(target_content_id, "something").call
+
+          expect(Queries::GetEmbeddedContent).to have_received(:new).with(
+            target_content_id, order_field: :something, order_direction: :asc
+          )
+        end
+
+        it "sends a field in descending order when preceded with a minus" do
+          described_class.new(target_content_id, "-something").call
+
+          expect(Queries::GetEmbeddedContent).to have_received(:new).with(
+            target_content_id, order_field: :something, order_direction: :desc
+          )
+        end
+
+        describe "when the field is not valid" do
+          before do
+            allow(embedded_content_stub).to receive(:call).and_raise(KeyError)
+          end
+
+          it "returns a 422 error" do
+            expect { described_class.new(target_content_id, "something").call }.to raise_error(CommandError) do |error|
+              expect(error.code).to eq(422)
+              expect(error.message).to eq("Invalid order field: something")
+            end
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
This adds an `order` argument to sort dependent content by various fields, as well as pagination. 

We use the `order` query string param, prefixed with `-` for descending order queries, as this matches how other endpoints handle sorting