### PR TITLE
Remove whenever gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,6 @@ gem "prometheus-client"
 gem "sentry-sidekiq"
 gem "sidekiq-scheduler"
 gem "sidekiq-unique-jobs", "< 8.0.10"
-gem "whenever", require: false
 gem "with_advisory_lock"
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -116,7 +116,6 @@ GEM
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
     chartkick (5.1.2)
-    chronic (0.10.2)
     climate_control (1.2.0)
     concurrent-ruby (1.3.4)
     connection_pool (2.4.1)
@@ -851,8 +850,6 @@ GEM
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    whenever (1.0.0)
-      chronic (>= 0.6.3)
     with_advisory_lock (5.1.0)
       activerecord (>= 6.1)
       zeitwerk (>= 2.6)
@@ -905,7 +902,6 @@ DEPENDENCIES
   timecop
   web-console
   webmock
-  whenever
   with_advisory_lock
 
 BUNDLED WITH


### PR DESCRIPTION
[Trello](https://trello.com/c/XaoSL3oM/1465-remove-whenever-gem-from-our-apps)

This was [added][1] when scheduling a Rake task to run every minute. The scheduling has since been [removed from the Publishing API code][2] but the gem was left behind

[1]: https://github.com/alphagov/publishing-api/commit/5ef5426d3112a2d75c4240b6aa51bb95fe62085c
[2]: https://github.com/alphagov/publishing-api/commit/0627f9a914b8bc468c64d848aee1b2288412b7c0

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
