### PR TITLE
(678) Add per page argument

### DIFF
--- a/app/controllers/v2/content_items_controller.rb
+++ b/app/controllers/v2/content_items_controller.rb
@@ -26,6 +26,7 @@ module V2
         path_params[:content_id],
         query_params[:order],
         query_params[:page],
+        query_params[:per_page],
       ).call
 
       render json: results

--- a/app/queries/get_embedded_content.rb
+++ b/app/queries/get_embedded_content.rb
@@ -14,7 +14,7 @@ module Queries
       :unique_pageviews,
     )
 
-    PER_PAGE = 10
+    DEFAULT_PER_PAGE = 10
 
     TABLES = {
       editions: Edition.arel_table,
@@ -50,14 +50,15 @@ module Queries
 
     ORDER_DIRECTIONS = %i[asc desc].freeze
 
-    attr_reader :target_content_id, :state, :order_field, :order_direction, :page
+    attr_reader :target_content_id, :state, :order_field, :order_direction, :page, :per_page
 
-    def initialize(target_content_id, order_field: nil, order_direction: nil, page: nil)
+    def initialize(target_content_id, order_field: nil, order_direction: nil, page: nil, per_page: nil)
       @target_content_id = target_content_id
       @state = "published"
       @order_direction = ORDER_DIRECTIONS.include?(order_direction || :asc) ? order_direction : raise(KeyError, "Unknown order direction: #{order_direction}")
       @order_field = ORDER_FIELDS.fetch(order_field || :unique_pageviews) { |k| raise KeyError, "Unknown order field: #{k}" }
       @page = page || 0
+      @per_page = per_page || DEFAULT_PER_PAGE
     end
 
     def call
@@ -72,13 +73,13 @@ module Queries
     end
 
     def total_pages
-      (count.to_f / PER_PAGE).ceil
+      (count.to_f / per_page).ceil
     end
 
   private
 
     def paginated_query
-      arel_query.take(PER_PAGE).skip(page * PER_PAGE)
+      arel_query.take(per_page).skip(page * per_page)
     end
 
     def arel_query

--- a/app/services/get_host_content_service.rb
+++ b/app/services/get_host_content_service.rb
@@ -1,8 +1,9 @@
 class GetHostContentService
-  def initialize(target_content_id, order, page)
+  def initialize(target_content_id, order, page, per_page)
     @target_content_id = target_content_id
     @order = order
     @page = page.blank? ? 0 : page.to_i - 1
+    @per_page = per_page.blank? ? nil : per_page.to_i
   end
 
   def call
@@ -21,10 +22,10 @@ class GetHostContentService
 
 private
 
-  attr_accessor :target_content_id, :order, :page
+  attr_accessor :target_content_id, :order, :page, :per_page
 
   def query
-    @query ||= Queries::GetEmbeddedContent.new(target_content_id, order_field:, order_direction:, page:)
+    @query ||= Queries::GetEmbeddedContent.new(target_content_id, order_field:, order_direction:, page:, per_page:)
   end
 
   def host_content

--- a/spec/integration/embedded_content_spec.rb
+++ b/spec/integration/embedded_content_spec.rb
@@ -108,6 +108,15 @@ RSpec.describe "Embedded documents" do
       expect(response_body["total_pages"]).to eq(2)
       expect(response_body["results"].count).to eq(2)
     end
+
+    it "allows a per_page argument to be passed" do
+      get "/v2/content/#{content_block.content_id}/embedded?per_page=1"
+      response_body = parsed_response
+
+      expect(response_body["total"]).to eq(12)
+      expect(response_body["total_pages"]).to eq(12)
+      expect(response_body["results"].count).to eq(1)
+    end
   end
 
   context "when passing order details" do

--- a/spec/queries/get_embedded_content_spec.rb
+++ b/spec/queries/get_embedded_content_spec.rb
@@ -171,7 +171,7 @@ RSpec.describe Queries::GetEmbeddedContent do
       it "requests the first page by default" do
         expect(ActiveRecord::Base.connection).to receive(:select_all) { |arel_query|
           expect(arel_query.offset).to eq(0)
-          expect(arel_query.limit).to eq(Queries::GetEmbeddedContent::PER_PAGE)
+          expect(arel_query.limit).to eq(Queries::GetEmbeddedContent::DEFAULT_PER_PAGE)
         }.and_return([])
 
         described_class.new(target_content_id).call
@@ -180,10 +180,35 @@ RSpec.describe Queries::GetEmbeddedContent do
       it "accepts a page argument" do
         expect(ActiveRecord::Base.connection).to receive(:select_all) { |arel_query|
           expect(arel_query.offset).to eq(10)
-          expect(arel_query.limit).to eq(Queries::GetEmbeddedContent::PER_PAGE)
+          expect(arel_query.limit).to eq(Queries::GetEmbeddedContent::DEFAULT_PER_PAGE)
         }.and_return([])
 
         described_class.new(target_content_id, page: 1).call
+      end
+
+      it "accepts a per_page argument" do
+        expect(ActiveRecord::Base.connection).to receive(:select_all) { |arel_query|
+          expect(arel_query.offset).to eq(0)
+          expect(arel_query.limit).to eq(1)
+        }.and_return([])
+
+        described_class.new(target_content_id, per_page: 1).call
+      end
+
+      it "accepts a per_page and page argument" do
+        expect(ActiveRecord::Base.connection).to receive(:select_all) { |arel_query|
+          expect(arel_query.offset).to eq(5)
+          expect(arel_query.limit).to eq(5)
+        }.and_return([])
+
+        described_class.new(target_content_id, per_page: 5, page: 1).call
+
+        expect(ActiveRecord::Base.connection).to receive(:select_all) { |arel_query|
+          expect(arel_query.offset).to eq(10)
+          expect(arel_query.limit).to eq(5)
+        }.and_return([])
+
+        described_class.new(target_content_id, per_page: 5, page: 2).call
       end
     end
   end

--- a/spec/service_consumers/pact_helper.rb
+++ b/spec/service_consumers/pact_helper.rb
@@ -693,4 +693,31 @@ Pact.provider_states_for "GDS API Adapters" do
       end
     end
   end
+
+  provider_state "multiple content items exist that embed the reusable content (content_id: bed722e6-db68-43e5-9079-063f623335a7)" do
+    set_up do
+      reusable_document = create(:document, content_id: "bed722e6-db68-43e5-9079-063f623335a7")
+      reusable_edition = create(:live_edition, document: reusable_document)
+
+      uuids = %w[
+        2ebc85e8-cb0d-47c8-8afb-332a0c3c043c
+        243ea112-5b33-4526-8512-e8f4cb7aeb6b
+        216bffa5-34ff-4392-9ff1-30b5c835280a
+        9d7babcd-d426-411a-98d5-45a5fac1db0c
+        f6a2e129-8d39-48af-9841-8fa539fb931b
+        5f4037e9-3acb-4f7f-9e5b-d9ac0a658445
+        a1f8cfad-ac6d-439a-afc3-d848fbfca107
+        011bd950-5a39-4a4a-ac9f-b7a5cac7590d
+        0cd440c4-9d05-4019-a510-562081145ba7
+        eced5e73-bdc8-4eb9-8a04-b330521df533
+        61f0f8d1-63e3-4181-8245-614339f81e00
+        3d5ac28e-77f0-4939-bf64-ab8dad3f6643
+      ]
+
+      uuids.each_with_index do |uuid, i|
+        document = create(:document, content_id: uuid)
+        create(:live_edition, :with_embedded_content, document:, embedded_content_id: reusable_edition.content_id, base_path: "/embedded-content-#{i}")
+      end
+    end
+  end
 end


### PR DESCRIPTION
This adds a `per_page` argument to the embedded content endpoint, as well as adding some improved setup to the Pact provider tests that should fix the broken gds-api-adapters Pact tests