### PR TITLE
(679) Get the number of instances on a page

### DIFF
--- a/app/controllers/v2/content_items_controller.rb
+++ b/app/controllers/v2/content_items_controller.rb
@@ -22,7 +22,7 @@ module V2
     end
 
     def embedded
-      results = GetHostContentService.new(
+      results = GetEmbeddedContentService.new(
         path_params[:content_id],
         query_params[:order],
         query_params[:page],

--- a/app/presenters/embedded_content_presenter.rb
+++ b/app/presenters/embedded_content_presenter.rb
@@ -32,6 +32,7 @@ module Presenters
           last_edited_by_editor_id: edition.last_edited_by_editor_id,
           last_edited_at: edition.last_edited_at,
           unique_pageviews: edition.unique_pageviews,
+          instances: edition.instances,
           primary_publishing_organisation: {
             content_id: edition.primary_publishing_organisation_content_id,
             title: edition.primary_publishing_organisation_title,

--- a/app/services/embedded_content_finder_service.rb
+++ b/app/services/embedded_content_finder_service.rb
@@ -8,20 +8,20 @@ class EmbeddedContentFinderService
   def fetch_linked_content_ids(details, locale)
     content_references = details.values.map { |value|
       find_content_references(value)
-    }.flatten.compact.uniq
+    }.flatten.compact
 
-    check_all_references_exist(content_references, locale)
+    check_all_references_exist(content_references.uniq, locale)
     content_references.map(&:content_id)
   end
 
   def find_content_references(value)
     case value
     when Array
-      value.map { |item| find_content_references(item) }.flatten
+      value.map { |item| find_content_references(item) }.flatten.uniq
     when Hash
-      value.map { |_, v| find_content_references(v) }.flatten
+      value.map { |_, v| find_content_references(v) }.flatten.uniq
     when String
-      value.scan(EMBED_REGEX).map { |match| ContentReference.new(document_type: match[1], content_id: match[2], embed_code: match[0]) }.uniq
+      value.scan(EMBED_REGEX).map { |match| ContentReference.new(document_type: match[1], content_id: match[2], embed_code: match[0]) }
     else
       []
     end

--- a/app/services/get_embedded_content_service.rb
+++ b/app/services/get_embedded_content_service.rb
@@ -1,4 +1,4 @@
-class GetHostContentService
+class GetEmbeddedContentService
   def initialize(target_content_id, order, page, per_page)
     @target_content_id = target_content_id
     @order = order

--- a/spec/presenters/embedded_content_presenter_spec.rb
+++ b/spec/presenters/embedded_content_presenter_spec.rb
@@ -19,7 +19,8 @@ RSpec.describe Presenters::EmbeddedContentPresenter do
               unique_pageviews: 123,
               primary_publishing_organisation_content_id: organisation_edition_id,
               primary_publishing_organisation_title: "bar",
-              primary_publishing_organisation_base_path: "/bar")]
+              primary_publishing_organisation_base_path: "/bar",
+              instances: 1)]
     end
 
     let(:result) { described_class.present(target_edition_id, host_editions, total, total_pages) }
@@ -38,6 +39,7 @@ RSpec.describe Presenters::EmbeddedContentPresenter do
             last_edited_by_editor_id:,
             last_edited_at:,
             unique_pageviews: 123,
+            instances: 1,
             primary_publishing_organisation: {
               content_id: organisation_edition_id,
               title: "bar",

--- a/spec/services/embedded_content_finder_service_spec.rb
+++ b/spec/services/embedded_content_finder_service_spec.rb
@@ -32,6 +32,14 @@ RSpec.shared_examples "finds references" do |document_type|
         expect(links).to eq([editions[0].content_id, editions[1].content_id])
       end
 
+      it "returns duplicates when there is more than one content reference in the field" do
+        details = { field_name => "{{embed:#{document_type}:#{editions[0].content_id}}} {{embed:#{document_type}:#{editions[0].content_id}}} {{embed:#{document_type}:#{editions[1].content_id}}}" }
+
+        links = EmbeddedContentFinderService.new.fetch_linked_content_ids(details, Edition::DEFAULT_LOCALE)
+
+        expect(links).to eq([editions[0].content_id, editions[0].content_id, editions[1].content_id])
+      end
+
       it "finds content references when #{field_name} is an array of hashes" do
         details = { field_name => [{ "content" => "{{embed:#{document_type}:#{editions[0].content_id}}} {{embed:#{document_type}:#{editions[1].content_id}}}" }] }
 
@@ -47,6 +55,10 @@ RSpec.shared_examples "finds references" do |document_type|
               body: [
                 {
                   content: "some string with a reference: {{embed:#{document_type}:#{editions[0].content_id}}}",
+                  content_type: "text/html",
+                },
+                {
+                  content: "some string with a reference: {{embed:#{document_type}:#{editions[0].content_id}}}",
                   content_type: "text/govspeak",
                 },
               ],
@@ -55,6 +67,10 @@ RSpec.shared_examples "finds references" do |document_type|
             },
             {
               body: [
+                {
+                  content: "some string with another reference: {{embed:#{document_type}:#{editions[1].content_id}}}",
+                  content_type: "text/html",
+                },
                 {
                   content: "some string with another reference: {{embed:#{document_type}:#{editions[1].content_id}}}",
                   content_type: "text/govspeak",

--- a/spec/services/get_embedded_content_service_spec.rb
+++ b/spec/services/get_embedded_content_service_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe GetHostContentService do
+RSpec.describe GetEmbeddedContentService do
   describe "#call" do
     let(:organisation) do
       edition_params = {


### PR DESCRIPTION
This allows us to identify the amount of times an instance is used within a document. We've had to make some tweaks to ensure any duplicate links are not removed, so we are able to count the amount of times the link is used, but this seems to work without any issue.