### PR TITLE
Add asset_manager_id to file attachments 

### DIFF
--- a/content_schemas/dist/formats/call_for_evidence/frontend/schema.json
+++ b/content_schemas/dist/formats/call_for_evidence/frontend/schema.json
@@ -773,6 +773,9 @@
             "alternative_format_contact_email": {
               "type": "string"
             },
+            "asset_manager_id": {
+              "type": "string"
+            },
             "attachment_type": {
               "type": "string",
               "enum": [

--- a/content_schemas/dist/formats/call_for_evidence/notification/schema.json
+++ b/content_schemas/dist/formats/call_for_evidence/notification/schema.json
@@ -897,6 +897,9 @@
             "alternative_format_contact_email": {
               "type": "string"
             },
+            "asset_manager_id": {
+              "type": "string"
+            },
             "attachment_type": {
               "type": "string",
               "enum": [

--- a/content_schemas/dist/formats/call_for_evidence/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/call_for_evidence/publisher_v2/schema.json
@@ -586,6 +586,9 @@
             "alternative_format_contact_email": {
               "type": "string"
             },
+            "asset_manager_id": {
+              "type": "string"
+            },
             "attachment_type": {
               "type": "string",
               "enum": [

--- a/content_schemas/dist/formats/consultation/frontend/schema.json
+++ b/content_schemas/dist/formats/consultation/frontend/schema.json
@@ -790,6 +790,9 @@
             "alternative_format_contact_email": {
               "type": "string"
             },
+            "asset_manager_id": {
+              "type": "string"
+            },
             "attachment_type": {
               "type": "string",
               "enum": [

--- a/content_schemas/dist/formats/consultation/notification/schema.json
+++ b/content_schemas/dist/formats/consultation/notification/schema.json
@@ -914,6 +914,9 @@
             "alternative_format_contact_email": {
               "type": "string"
             },
+            "asset_manager_id": {
+              "type": "string"
+            },
             "attachment_type": {
               "type": "string",
               "enum": [

--- a/content_schemas/dist/formats/consultation/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/consultation/publisher_v2/schema.json
@@ -603,6 +603,9 @@
             "alternative_format_contact_email": {
               "type": "string"
             },
+            "asset_manager_id": {
+              "type": "string"
+            },
             "attachment_type": {
               "type": "string",
               "enum": [

--- a/content_schemas/dist/formats/corporate_information_page/frontend/schema.json
+++ b/content_schemas/dist/formats/corporate_information_page/frontend/schema.json
@@ -381,6 +381,9 @@
         "alternative_format_contact_email": {
           "type": "string"
         },
+        "asset_manager_id": {
+          "type": "string"
+        },
         "attachment_type": {
           "type": "string",
           "enum": [

--- a/content_schemas/dist/formats/corporate_information_page/notification/schema.json
+++ b/content_schemas/dist/formats/corporate_information_page/notification/schema.json
@@ -476,6 +476,9 @@
         "alternative_format_contact_email": {
           "type": "string"
         },
+        "asset_manager_id": {
+          "type": "string"
+        },
         "attachment_type": {
           "type": "string",
           "enum": [

--- a/content_schemas/dist/formats/corporate_information_page/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/corporate_information_page/publisher_v2/schema.json
@@ -316,6 +316,9 @@
         "alternative_format_contact_email": {
           "type": "string"
         },
+        "asset_manager_id": {
+          "type": "string"
+        },
         "attachment_type": {
           "type": "string",
           "enum": [

--- a/content_schemas/dist/formats/detailed_guide/frontend/schema.json
+++ b/content_schemas/dist/formats/detailed_guide/frontend/schema.json
@@ -404,6 +404,9 @@
         "alternative_format_contact_email": {
           "type": "string"
         },
+        "asset_manager_id": {
+          "type": "string"
+        },
         "attachment_type": {
           "type": "string",
           "enum": [

--- a/content_schemas/dist/formats/detailed_guide/notification/schema.json
+++ b/content_schemas/dist/formats/detailed_guide/notification/schema.json
@@ -509,6 +509,9 @@
         "alternative_format_contact_email": {
           "type": "string"
         },
+        "asset_manager_id": {
+          "type": "string"
+        },
         "attachment_type": {
           "type": "string",
           "enum": [

--- a/content_schemas/dist/formats/detailed_guide/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/detailed_guide/publisher_v2/schema.json
@@ -343,6 +343,9 @@
         "alternative_format_contact_email": {
           "type": "string"
         },
+        "asset_manager_id": {
+          "type": "string"
+        },
         "attachment_type": {
           "type": "string",
           "enum": [

--- a/content_schemas/dist/formats/manual_section/frontend/schema.json
+++ b/content_schemas/dist/formats/manual_section/frontend/schema.json
@@ -339,6 +339,9 @@
         "alternative_format_contact_email": {
           "type": "string"
         },
+        "asset_manager_id": {
+          "type": "string"
+        },
         "attachment_type": {
           "type": "string",
           "enum": [

--- a/content_schemas/dist/formats/manual_section/notification/schema.json
+++ b/content_schemas/dist/formats/manual_section/notification/schema.json
@@ -435,6 +435,9 @@
         "alternative_format_contact_email": {
           "type": "string"
         },
+        "asset_manager_id": {
+          "type": "string"
+        },
         "attachment_type": {
           "type": "string",
           "enum": [

--- a/content_schemas/dist/formats/manual_section/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/manual_section/publisher_v2/schema.json
@@ -235,6 +235,9 @@
         "alternative_format_contact_email": {
           "type": "string"
         },
+        "asset_manager_id": {
+          "type": "string"
+        },
         "attachment_type": {
           "type": "string",
           "enum": [

--- a/content_schemas/dist/formats/news_article/frontend/schema.json
+++ b/content_schemas/dist/formats/news_article/frontend/schema.json
@@ -378,6 +378,9 @@
         "alternative_format_contact_email": {
           "type": "string"
         },
+        "asset_manager_id": {
+          "type": "string"
+        },
         "attachment_type": {
           "type": "string",
           "enum": [

--- a/content_schemas/dist/formats/news_article/notification/schema.json
+++ b/content_schemas/dist/formats/news_article/notification/schema.json
@@ -497,6 +497,9 @@
         "alternative_format_contact_email": {
           "type": "string"
         },
+        "asset_manager_id": {
+          "type": "string"
+        },
         "attachment_type": {
           "type": "string",
           "enum": [

--- a/content_schemas/dist/formats/news_article/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/news_article/publisher_v2/schema.json
@@ -305,6 +305,9 @@
         "alternative_format_contact_email": {
           "type": "string"
         },
+        "asset_manager_id": {
+          "type": "string"
+        },
         "attachment_type": {
           "type": "string",
           "enum": [

--- a/content_schemas/dist/formats/publication/frontend/schema.json
+++ b/content_schemas/dist/formats/publication/frontend/schema.json
@@ -727,6 +727,9 @@
             "alternative_format_contact_email": {
               "type": "string"
             },
+            "asset_manager_id": {
+              "type": "string"
+            },
             "attachment_type": {
               "type": "string",
               "enum": [

--- a/content_schemas/dist/formats/publication/notification/schema.json
+++ b/content_schemas/dist/formats/publication/notification/schema.json
@@ -857,6 +857,9 @@
             "alternative_format_contact_email": {
               "type": "string"
             },
+            "asset_manager_id": {
+              "type": "string"
+            },
             "attachment_type": {
               "type": "string",
               "enum": [

--- a/content_schemas/dist/formats/publication/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/publication/publisher_v2/schema.json
@@ -540,6 +540,9 @@
             "alternative_format_contact_email": {
               "type": "string"
             },
+            "asset_manager_id": {
+              "type": "string"
+            },
             "attachment_type": {
               "type": "string",
               "enum": [

--- a/content_schemas/dist/formats/specialist_document/frontend/schema.json
+++ b/content_schemas/dist/formats/specialist_document/frontend/schema.json
@@ -1959,6 +1959,9 @@
         "alternative_format_contact_email": {
           "type": "string"
         },
+        "asset_manager_id": {
+          "type": "string"
+        },
         "attachment_type": {
           "type": "string",
           "enum": [

--- a/content_schemas/dist/formats/specialist_document/notification/schema.json
+++ b/content_schemas/dist/formats/specialist_document/notification/schema.json
@@ -2100,6 +2100,9 @@
         "alternative_format_contact_email": {
           "type": "string"
         },
+        "asset_manager_id": {
+          "type": "string"
+        },
         "attachment_type": {
           "type": "string",
           "enum": [

--- a/content_schemas/dist/formats/specialist_document/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/specialist_document/publisher_v2/schema.json
@@ -1792,6 +1792,9 @@
         "alternative_format_contact_email": {
           "type": "string"
         },
+        "asset_manager_id": {
+          "type": "string"
+        },
         "attachment_type": {
           "type": "string",
           "enum": [

--- a/content_schemas/dist/formats/statistical_data_set/frontend/schema.json
+++ b/content_schemas/dist/formats/statistical_data_set/frontend/schema.json
@@ -602,6 +602,9 @@
             "alternative_format_contact_email": {
               "type": "string"
             },
+            "asset_manager_id": {
+              "type": "string"
+            },
             "attachment_type": {
               "type": "string",
               "enum": [

--- a/content_schemas/dist/formats/statistical_data_set/notification/schema.json
+++ b/content_schemas/dist/formats/statistical_data_set/notification/schema.json
@@ -714,6 +714,9 @@
             "alternative_format_contact_email": {
               "type": "string"
             },
+            "asset_manager_id": {
+              "type": "string"
+            },
             "attachment_type": {
               "type": "string",
               "enum": [

--- a/content_schemas/dist/formats/statistical_data_set/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/statistical_data_set/publisher_v2/schema.json
@@ -402,6 +402,9 @@
             "alternative_format_contact_email": {
               "type": "string"
             },
+            "asset_manager_id": {
+              "type": "string"
+            },
             "attachment_type": {
               "type": "string",
               "enum": [

--- a/content_schemas/dist/formats/travel_advice/frontend/schema.json
+++ b/content_schemas/dist/formats/travel_advice/frontend/schema.json
@@ -390,6 +390,9 @@
         "alternative_format_contact_email": {
           "type": "string"
         },
+        "asset_manager_id": {
+          "type": "string"
+        },
         "attachment_type": {
           "type": "string",
           "enum": [

--- a/content_schemas/dist/formats/travel_advice/notification/schema.json
+++ b/content_schemas/dist/formats/travel_advice/notification/schema.json
@@ -484,6 +484,9 @@
         "alternative_format_contact_email": {
           "type": "string"
         },
+        "asset_manager_id": {
+          "type": "string"
+        },
         "attachment_type": {
           "type": "string",
           "enum": [

--- a/content_schemas/dist/formats/travel_advice/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/travel_advice/publisher_v2/schema.json
@@ -284,6 +284,9 @@
         "alternative_format_contact_email": {
           "type": "string"
         },
+        "asset_manager_id": {
+          "type": "string"
+        },
         "attachment_type": {
           "type": "string",
           "enum": [

--- a/content_schemas/dist/formats/working_group/frontend/schema.json
+++ b/content_schemas/dist/formats/working_group/frontend/schema.json
@@ -322,6 +322,9 @@
         "alternative_format_contact_email": {
           "type": "string"
         },
+        "asset_manager_id": {
+          "type": "string"
+        },
         "attachment_type": {
           "type": "string",
           "enum": [

--- a/content_schemas/dist/formats/working_group/notification/schema.json
+++ b/content_schemas/dist/formats/working_group/notification/schema.json
@@ -413,6 +413,9 @@
         "alternative_format_contact_email": {
           "type": "string"
         },
+        "asset_manager_id": {
+          "type": "string"
+        },
         "attachment_type": {
           "type": "string",
           "enum": [

--- a/content_schemas/dist/formats/working_group/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/working_group/publisher_v2/schema.json
@@ -219,6 +219,9 @@
         "alternative_format_contact_email": {
           "type": "string"
         },
+        "asset_manager_id": {
+          "type": "string"
+        },
         "attachment_type": {
           "type": "string",
           "enum": [

--- a/content_schemas/formats/shared/definitions/asset_links.jsonnet
+++ b/content_schemas/formats/shared/definitions/asset_links.jsonnet
@@ -1,6 +1,7 @@
 local FileAttachmentAssetProperties = {
   accessible: { type: "boolean", },
   alternative_format_contact_email: { type: "string", },
+  asset_manager_id: { type: "string", },
   attachment_type: { type: "string", enum: ["file"], },
   content_type: { type: "string", },
   file_size: { type: "integer", },


### PR DESCRIPTION
Currently, the properties in the file attachment properties are insufficient to make a request to asset manager from the server to fetch the asset.

The API client wants to be called like this:

    GdsApi.asset_manager.media(asset_maanger_id, filename)

... but we don't have an asset_manager_id, we only have url (which include the id we want), and a bunch of other fields which don't. We shouldn't have to parse URLs to find IDs.

We get away with this because in most cases where we're using file assets, we redirect the user to the full asset URL (so we don't need to fetch it on the server side).

The one example I'm aware of where we do need to request assets on the server side is CSV previews, and we've ended up with a pretty wild workaround in that case. Specifically, we route some requests to the assets domains (e.g. assets.publishing.service.gov.uk) to frontend.  This way, the preview_url ends up being served by frontend itself. This means the URL gets parsed by Rails' routing logic, and we end up with the ID in a param which we can use to call asset manager: see https://github.com/alphagov/frontend/blob/8b075a3e26d775ad97b6b473ddaa22386e07cad2/app/controllers/csv_preview_controller.rb#L27

We'll need a corresponding commit in Whitehall (and maybe other publishing apps, if they have attachments?) to start sending this new field through to the API. It's optional, so this shouldn't break anything in the meantime.

EDIT: This description has been updated by @unoduetre to not include details which are no longer relevant.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

