### PR TITLE
add content id to host documents

### DIFF
--- a/app/presenters/embedded_content_presenter.rb
+++ b/app/presenters/embedded_content_presenter.rb
@@ -33,6 +33,7 @@ module Presenters
           last_edited_at: edition.last_edited_at,
           unique_pageviews: edition.unique_pageviews,
           instances: edition.instances,
+          host_content_id: edition.host_content_id,
           primary_publishing_organisation: {
             content_id: edition.primary_publishing_organisation_content_id,
             title: edition.primary_publishing_organisation_title,

--- a/app/queries/get_embedded_content.rb
+++ b/app/queries/get_embedded_content.rb
@@ -8,6 +8,7 @@ module Queries
       :publishing_app,
       :last_edited_by_editor_id,
       :last_edited_at,
+      :host_content_id,
       :primary_publishing_organisation_content_id,
       :primary_publishing_organisation_title,
       :primary_publishing_organisation_base_path,
@@ -39,6 +40,7 @@ module Queries
       { field: TABLES[:org_editions][:title], alias: "primary_publishing_organisation_title", included_in_group?: true },
       { field: TABLES[:org_editions][:base_path], alias: "primary_publishing_organisation_base_path", included_in_group?: true },
       { field: TABLES[:statistics_caches][:unique_pageviews], included_in_group?: true },
+      { field: TABLES[:documents][:content_id], alias: "host_content_id", included_in_group?: true },
       { field: TABLES[:editions][:id].count, alias: "instances", included_in_group?: false },
     ].freeze
 

--- a/spec/integration/embedded_content_spec.rb
+++ b/spec/integration/embedded_content_spec.rb
@@ -72,6 +72,7 @@ RSpec.describe "Embedded documents" do
           "last_edited_at" => last_edited_at,
           "unique_pageviews" => statistics_cache.unique_pageviews,
           "instances" => 1,
+          "host_content_id" => host_edition.content_id,
           "primary_publishing_organisation" => {
             "content_id" => publishing_organisation.content_id,
             "title" => publishing_organisation.title,

--- a/spec/presenters/embedded_content_presenter_spec.rb
+++ b/spec/presenters/embedded_content_presenter_spec.rb
@@ -3,6 +3,7 @@ RSpec.describe Presenters::EmbeddedContentPresenter do
     let(:organisation_edition_id) { SecureRandom.uuid }
     let(:target_edition_id) { SecureRandom.uuid }
     let(:last_edited_by_editor_id) { SecureRandom.uuid }
+    let(:host_content_id) { SecureRandom.uuid }
     let(:last_edited_at) { 2.days.ago }
     let(:total) { 222 }
     let(:total_pages) { 23 }
@@ -17,6 +18,7 @@ RSpec.describe Presenters::EmbeddedContentPresenter do
               last_edited_by_editor_id:,
               last_edited_at:,
               unique_pageviews: 123,
+              host_content_id:,
               primary_publishing_organisation_content_id: organisation_edition_id,
               primary_publishing_organisation_title: "bar",
               primary_publishing_organisation_base_path: "/bar",
@@ -40,6 +42,7 @@ RSpec.describe Presenters::EmbeddedContentPresenter do
             last_edited_at:,
             unique_pageviews: 123,
             instances: 1,
+            host_content_id: host_content_id,
             primary_publishing_organisation: {
               content_id: organisation_edition_id,
               title: "bar",

--- a/spec/queries/get_embedded_content_spec.rb
+++ b/spec/queries/get_embedded_content_spec.rb
@@ -82,6 +82,7 @@ RSpec.describe Queries::GetEmbeddedContent do
           expect(results[i].base_path).to eq(host_edition.base_path)
           expect(results[i].document_type).to eq(host_edition.document_type)
           expect(results[i].publishing_app).to eq(host_edition.publishing_app)
+          expect(results[i].host_content_id).to eq(host_edition.content_id)
           expect(results[i].primary_publishing_organisation_content_id).to eq(organisation.content_id)
           expect(results[i].primary_publishing_organisation_title).to eq(organisation.title)
           expect(results[i].primary_publishing_organisation_base_path).to eq(organisation.base_path)


### PR DESCRIPTION
We will need this Content ID on the Content Block
Manager frontend, to get preview content here
https://github.com/alphagov/whitehall/pull/9640

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
