### PR TITLE
Rename date facet

### DIFF
--- a/.github/workflows/test-content-schemas-2.yml
+++ b/.github/workflows/test-content-schemas-2.yml
@@ -65,9 +65,9 @@ jobs:
 
   test-specialist-publisher:
     name: Test Specialist Publisher
-    uses: alphagov/specialist-publisher/.github/workflows/rspec.yml@main
+    uses: alphagov/specialist-publisher/.github/workflows/rspec.yml@SFO-Finder-iteration-3
     with:
-      ref: 'main'
+      ref: 'SFO-Finder-iteration-3'
       publishingApiRef: ${{ github.ref }}
 
   test-travel-advice-publisher:

--- a/content_schemas/dist/formats/specialist_document/frontend/schema.json
+++ b/content_schemas/dist/formats/specialist_document/frontend/schema.json
@@ -1878,7 +1878,7 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "sfo_case_opened_date": {
+        "sfo_case_date_announced": {
           "type": "string",
           "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
         },

--- a/content_schemas/dist/formats/specialist_document/notification/schema.json
+++ b/content_schemas/dist/formats/specialist_document/notification/schema.json
@@ -2019,7 +2019,7 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "sfo_case_opened_date": {
+        "sfo_case_date_announced": {
           "type": "string",
           "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
         },

--- a/content_schemas/dist/formats/specialist_document/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/specialist_document/publisher_v2/schema.json
@@ -1711,7 +1711,7 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "sfo_case_opened_date": {
+        "sfo_case_date_announced": {
           "type": "string",
           "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
         },

--- a/content_schemas/formats/shared/definitions/_specialist_document.jsonnet
+++ b/content_schemas/formats/shared/definitions/_specialist_document.jsonnet
@@ -1069,7 +1069,7 @@
       sfo_case_state: {
         type: "string",
       },
-      sfo_case_opened_date: {
+      sfo_case_date_announced: {
         type: "string",
         pattern: "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$",
       },


### PR DESCRIPTION
Renames a facet in the new SFO Finder specialist finder.

[Previous PR](https://github.com/alphagov/publishing-api/pull/2968)
[Trello](https://trello.com/c/E7KMeGZo/3034-specialist-finder-sfo-cases)
[Zendesk](https://govuk.zendesk.com/agent/tickets/5958029)