### PR TITLE
Revert changes to test content schemas

### DIFF
--- a/.github/workflows/test-content-schemas-2.yml
+++ b/.github/workflows/test-content-schemas-2.yml
@@ -65,9 +65,9 @@ jobs:
 
   test-specialist-publisher:
     name: Test Specialist Publisher
-    uses: alphagov/specialist-publisher/.github/workflows/rspec.yml@SFO-Finder-iteration-3
+    uses: alphagov/specialist-publisher/.github/workflows/rspec.yml@main
     with:
-      ref: 'SFO-Finder-iteration-3'
+      ref: 'main'
       publishingApiRef: ${{ github.ref }}
 
   test-travel-advice-publisher:


### PR DESCRIPTION
We changed these in order to allow merging some changes in publishing api and specialist publisher. We are now reverting to main.

[PR that introduced the change](https://github.com/alphagov/publishing-api/pull/3000)
