### PR TITLE
(731) Ensure only one Organisation is returned when fetching host content.

### DIFF
--- a/app/queries/get_host_content.rb
+++ b/app/queries/get_host_content.rb
@@ -122,6 +122,7 @@ module Queries
         )
         .join(TABLES[:org_documents], Arel::Nodes::OuterJoin).on(
           TABLES[:org_documents][:content_id].eq(TABLES[:primary_links][:target_content_id]),
+          TABLES[:org_documents][:locale].eq("en"),
         )
         .join(TABLES[:org_editions], Arel::Nodes::OuterJoin).on(
           TABLES[:org_editions][:document_id].eq(TABLES[:org_documents][:id]),

--- a/spec/queries/get_host_content_spec.rb
+++ b/spec/queries/get_host_content_spec.rb
@@ -106,6 +106,25 @@ RSpec.describe Queries::GetHostContent do
 
         expect(results[0].instances).to eq(2)
       end
+
+      it "returns one row per content block when an organisation has a translation" do
+        welsh_document = create(:document, locale: "cy", content_id: organisation.content_id)
+        create(:live_edition, document: welsh_document, base_path: "#{organisation.base_path}.cy")
+
+        create(:live_edition,
+               details: {
+                 body: "<p>{{embed:email_address:#{target_content_id}}}</p>\n",
+               },
+               links_hash: {
+                 primary_publishing_organisation: [organisation.content_id],
+                 embed: [target_content_id],
+               },
+               publishing_app: "example-app")
+
+        results = described_class.new(target_content_id).call
+
+        expect(results.count).to eq(1)
+      end
     end
 
     context "when there are superseded editions that embed the target content" do


### PR DESCRIPTION
When fetching host content for an organisation which has a translation, multiple rows are returned, one per translation. The updates the join statement, so we only fetch organisation documents in the `en` locale.

Trello: https://trello.com/c/QgA7LneE/731-investigate-html-documents-coming-up-twice-for-location