### PR TITLE
(700) Return rollup data in `host-content` endpoint

### DIFF
--- a/app/presenters/host_content_presenter.rb
+++ b/app/presenters/host_content_presenter.rb
@@ -1,14 +1,15 @@
 module Presenters
   class HostContentPresenter
-    def self.present(target_edition_id, host_content, total, total_pages)
-      new(target_edition_id, host_content, total, total_pages).present
+    def self.present(target_edition_id, host_content, total, total_pages, rollup)
+      new(target_edition_id, host_content, total, total_pages, rollup).present
     end
 
-    def initialize(target_edition_id, host_content, total, total_pages)
+    def initialize(target_edition_id, host_content, total, total_pages, rollup)
       @target_edition_id = target_edition_id
       @host_content = host_content.to_a
       @total = total
       @total_pages = total_pages
+      @rollup = rollup
     end
 
     def present
@@ -16,6 +17,7 @@ module Presenters
         content_id: target_edition_id,
         total:,
         total_pages:,
+        rollup:,
         results:,
       }
     end
@@ -44,6 +46,15 @@ module Presenters
     end
 
   private
+
+    def rollup
+      {
+        views: @rollup.views,
+        locations: @rollup.locations,
+        instances: @rollup.instances,
+        organisations: @rollup.organisations,
+      }.transform_values(&:to_i)
+    end
 
     attr_reader :target_edition_id, :host_content, :total, :total_pages
   end

--- a/app/queries/get_host_content.rb
+++ b/app/queries/get_host_content.rb
@@ -29,17 +29,17 @@ module Queries
     }.freeze
 
     FIELDS = [
-      { field: TABLES[:editions][:id], included_in_group?: true },
-      { field: TABLES[:editions][:title], included_in_group?: true },
-      { field: TABLES[:editions][:base_path], included_in_group?: true },
-      { field: TABLES[:editions][:document_type], included_in_group?: true },
-      { field: TABLES[:editions][:publishing_app], included_in_group?: true },
-      { field: TABLES[:editions][:last_edited_by_editor_id], included_in_group?: true },
-      { field: TABLES[:editions][:last_edited_at], included_in_group?: true },
+      { field: TABLES[:editions][:id], alias: "id", included_in_group?: true },
+      { field: TABLES[:editions][:title], alias: "title", included_in_group?: true },
+      { field: TABLES[:editions][:base_path], alias: "base_path", included_in_group?: true },
+      { field: TABLES[:editions][:document_type], alias: "document_type", included_in_group?: true },
+      { field: TABLES[:editions][:publishing_app], alias: "publishing_app", included_in_group?: true },
+      { field: TABLES[:editions][:last_edited_by_editor_id], alias: "last_edited_by_editor_id", included_in_group?: true },
+      { field: TABLES[:editions][:last_edited_at], alias: "last_edited_at", included_in_group?: true },
       { field: TABLES[:primary_links][:target_content_id], alias: "primary_publishing_organisation_content_id", included_in_group?: true },
       { field: TABLES[:org_editions][:title], alias: "primary_publishing_organisation_title", included_in_group?: true },
       { field: TABLES[:org_editions][:base_path], alias: "primary_publishing_organisation_base_path", included_in_group?: true },
-      { field: TABLES[:statistics_caches][:unique_pageviews], included_in_group?: true },
+      { field: TABLES[:statistics_caches][:unique_pageviews], alias: "unique_pageviews", included_in_group?: true },
       { field: TABLES[:documents][:content_id], alias: "host_content_id", included_in_group?: true },
       { field: TABLES[:editions][:id].count, alias: "instances", included_in_group?: false },
     ].freeze
@@ -100,7 +100,7 @@ module Queries
     end
 
     def select_fields
-      FIELDS.map { |f| f[:alias].present? ? f[:field].as(f[:alias]) : f[:field] }
+      FIELDS.map { |f| f[:field].as(f[:alias]) }
     end
 
     def group_fields

--- a/app/services/get_host_content_service.rb
+++ b/app/services/get_host_content_service.rb
@@ -17,6 +17,7 @@ class GetHostContentService
       host_content,
       query.count,
       query.total_pages,
+      query.rollup,
     )
   end
 

--- a/spec/presenters/host_content_presenter_spec.rb
+++ b/spec/presenters/host_content_presenter_spec.rb
@@ -25,13 +25,27 @@ RSpec.describe Presenters::HostContentPresenter do
               instances: 1)]
     end
 
-    let(:result) { described_class.present(target_edition_id, host_editions, total, total_pages) }
+    let(:rollup) do
+      double("Queries::GetHostContent::Rollup",
+             views: "123",
+             locations: 1,
+             instances: 4.0,
+             organisations: 2)
+    end
+
+    let(:result) { described_class.present(target_edition_id, host_editions, total, total_pages, rollup) }
 
     let(:expected_output) do
       {
         content_id: target_edition_id,
         total:,
         total_pages:,
+        rollup: {
+          views: 123,
+          locations: 1,
+          instances: 4,
+          organisations: 2,
+        },
         results: [
           {
             title: "foo",
@@ -55,6 +69,25 @@ RSpec.describe Presenters::HostContentPresenter do
 
     it "presents attributes of host content in an array of results" do
       expect(result).to eq(expected_output)
+    end
+
+    context "when any rollup values are not present" do
+      let(:rollup) do
+        double("Queries::GetHostContent::Rollup",
+               views: nil,
+               locations: nil,
+               instances: "",
+               organisations: nil)
+      end
+
+      it "returns zeroes for those values" do
+        expect(result[:rollup]).to eq({
+          views: 0,
+          locations: 0,
+          instances: 0,
+          organisations: 0,
+        })
+      end
     end
   end
 end

--- a/spec/services/get_host_content_service_spec.rb
+++ b/spec/services/get_host_content_service_spec.rb
@@ -39,7 +39,8 @@ RSpec.describe GetHostContentService do
       let(:host_editions_stub) { double("ActiveRecord::Relation") }
       let(:count) { 12 }
       let(:total_pages) { 2 }
-      let(:embedded_content_stub) { double(Queries::GetHostContent, call: host_editions_stub, count:, total_pages:) }
+      let(:rollup_stub) { double(Queries::GetHostContent::Rollup) }
+      let(:embedded_content_stub) { double(Queries::GetHostContent, call: host_editions_stub, count:, total_pages:, rollup: rollup_stub) }
       let(:result_stub) { double }
 
       before do
@@ -58,6 +59,7 @@ RSpec.describe GetHostContentService do
           host_editions_stub,
           count,
           total_pages,
+          rollup_stub,
         )
       end
 


### PR DESCRIPTION
Trello card: https://trello.com/c/eJTfFnFN/700-create-rollup-for-view-page

This updates the `host-content` endpoint to return a "rollup" of summed / counted data. The fields are:

* Views - the sum total of all pageviews for host documents
* Locations - the total count of all host documents
* Instances - the sum total of all the times the block has been used across all host documents
* Organisations - the number of unique organisations using the content block