### PR TITLE
Add support for news articles to GraphQL endpoint

### DIFF
--- a/app/graphql/types/edition_type.rb
+++ b/app/graphql/types/edition_type.rb
@@ -43,6 +43,22 @@ module Types
     alias_method :publishing_scheduled_at, :not_stored_in_publishing_api
     alias_method :scheduled_publishing_delay_seconds, :not_stored_in_publishing_api
 
+    class Translation < Types::BaseObject
+      field :locale, String
+      field :base_path, String
+    end
+
+    class EditionLinks < Types::BaseObject
+      field :available_translations, [Translation]
+
+      def available_translations
+        Presenters::Queries::AvailableTranslations.by_edition(object)
+          .translations.fetch(:available_translations, [])
+      end
+    end
+
+    field :links, EditionLinks, method: :itself
+
   private
 
     def presented_edition

--- a/app/graphql/types/edition_type.rb
+++ b/app/graphql/types/edition_type.rb
@@ -48,8 +48,65 @@ module Types
       field :base_path, String
     end
 
+    class GovernmentDetails < Types::BaseObject
+      field :current, Boolean
+    end
+
+    class GovernmentLink < Types::BaseObject
+      field :base_path, String
+      field :content_id, String
+      field :details, GovernmentDetails
+      field :title, String
+    end
+
+    class OrganisationLink < Types::BaseObject
+      field :base_path, String
+      field :content_id, String
+      field :title, String
+    end
+
+    class PersonLink < Types::BaseObject
+      field :base_path, String
+      field :content_id, String
+      field :title, String
+    end
+
+    class Taxon < Types::BaseObject
+      field :base_path, String
+      field :content_id, String
+      field :document_type, String
+      field :phase, String
+      field :title, String
+    end
+
+    class TaxonLink < Taxon
+      class TaxonLinks < Types::BaseObject
+        links_field :parent_taxons, [Taxon]
+      end
+
+      field :links, TaxonLinks, method: :itself
+    end
+
+    class TopicalEventLink < Types::BaseObject
+      field :base_path, String
+      field :content_id, String
+      field :title, String
+    end
+
+    class WorldLocationLink < Types::BaseObject
+      field :base_path, String
+      field :content_id, String
+      field :title, String
+    end
+
     class EditionLinks < Types::BaseObject
       field :available_translations, [Translation]
+      links_field :government, [GovernmentLink]
+      links_field :organisations, [OrganisationLink]
+      links_field :people, [PersonLink]
+      links_field :taxons, [TaxonLink]
+      links_field :topical_events, [TopicalEventLink]
+      links_field :world_locations, [WorldLocationLink]
 
       def available_translations
         Presenters::Queries::AvailableTranslations.by_edition(object)

--- a/app/graphql/types/edition_type.rb
+++ b/app/graphql/types/edition_type.rb
@@ -23,6 +23,7 @@ module Types
     field :rendering_app, String
     field :scheduled_publishing_delay_seconds, Int
     field :schema_name, String
+    field :state, String
     field :title, String, null: false
     field :updated_at, GraphQL::Types::ISO8601DateTime
     field :withdrawn_notice, WithdrawnNotice

--- a/app/graphql/types/ministers_index_type.rb
+++ b/app/graphql/types/ministers_index_type.rb
@@ -2,7 +2,7 @@
 
 module Types
   class MinistersIndexType < Types::EditionType
-    def self.document_type = "ministers_index"
+    def self.document_types = %w[ministers_index]
 
     class MinistersIndexPerson < Types::BaseObject
       class MinistersIndexRoleAppointment < Types::BaseObject

--- a/app/graphql/types/news_article_type.rb
+++ b/app/graphql/types/news_article_type.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Types
+  class NewsArticleType < Types::EditionType
+    def self.document_types = %w[
+      government_response
+      news_story
+      press_release
+      world_news_story
+    ]
+  end
+end

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -4,10 +4,11 @@ module Types
   class QueryType < Types::BaseObject
     field :edition, EditionTypeOrSubtype, description: "An edition or one of its subtypes" do
       argument :base_path, String
+      argument :content_store, String, required: false, default_value: "live"
     end
 
-    def edition(base_path:)
-      Edition.live.find_by(base_path:)
+    def edition(base_path:, content_store:)
+      Edition.where(content_store:).find_by(base_path:)
     end
   end
 end

--- a/app/graphql/types/query_type/edition_type_or_subtype.rb
+++ b/app/graphql/types/query_type/edition_type_or_subtype.rb
@@ -12,7 +12,7 @@ module Types
           document_type = object.document_type
 
           matching_edition_subtype = Types::EditionType.descendants.find do |edition_subtype|
-            document_type == edition_subtype.document_type
+            edition_subtype.document_types.include?(document_type)
           end
 
           matching_edition_subtype || Types::EditionType

--- a/app/graphql/types/query_type/edition_type_or_subtype.rb
+++ b/app/graphql/types/query_type/edition_type_or_subtype.rb
@@ -3,7 +3,13 @@
 module Types
   class QueryType
     class EditionTypeOrSubtype < Types::BaseUnion
-      EDITION_TYPES = [Types::EditionType, Types::RoleType, Types::WorldIndexType, Types::MinistersIndexType].freeze
+      EDITION_TYPES = [
+        Types::EditionType,
+        Types::MinistersIndexType,
+        Types::NewsArticleType,
+        Types::RoleType,
+        Types::WorldIndexType,
+      ].freeze
 
       possible_types(*EDITION_TYPES)
 

--- a/app/graphql/types/role_type.rb
+++ b/app/graphql/types/role_type.rb
@@ -2,7 +2,7 @@
 
 module Types
   class RoleType < Types::EditionType
-    def self.document_type = "ministerial_role"
+    def self.document_types = %w[ministerial_role]
 
     class Organisation < Types::BaseObject
       field :base_path, String

--- a/app/graphql/types/role_type.rb
+++ b/app/graphql/types/role_type.rb
@@ -56,11 +56,6 @@ module Types
       field :links, RoleAppointmentLinks, method: :itself
     end
 
-    class Translation < Types::BaseObject
-      field :locale, String
-      field :base_path, String
-    end
-
     class RoleDetails < Types::BaseObject
       field :body, String
       field :supports_historical_accounts, Boolean
@@ -75,15 +70,9 @@ module Types
       end
     end
 
-    class RoleLinks < Types::BaseObject
-      field :available_translations, [Translation]
+    class RoleLinks < EditionType::EditionLinks
       field :ordered_parent_organisations, [Organisation]
       field :role_appointments, [RoleAppointment]
-
-      def available_translations
-        Presenters::Queries::AvailableTranslations.by_edition(object)
-          .translations.fetch(:available_translations, [])
-      end
 
       def ordered_parent_organisations
         Edition

--- a/app/graphql/types/world_index_type.rb
+++ b/app/graphql/types/world_index_type.rb
@@ -2,7 +2,7 @@
 
 module Types
   class WorldIndexType < Types::EditionType
-    def self.document_type = "world_index"
+    def self.document_types = %w[world_index]
 
     class WorldLocation < Types::BaseObject
       field :active, Boolean, null: false

--- a/spec/graphql/types/news_article_type_spec.rb
+++ b/spec/graphql/types/news_article_type_spec.rb
@@ -1,0 +1,12 @@
+RSpec.describe Types::NewsArticleType do
+  describe ".document_types" do
+    it "defines the document types for .resolve_type to distinguish the type from the generic Edition type" do
+      expect(described_class.document_types).to eq(%w[
+        government_response
+        news_story
+        press_release
+        world_news_story
+      ])
+    end
+  end
+end

--- a/spec/graphql/types/query_type_spec.rb
+++ b/spec/graphql/types/query_type_spec.rb
@@ -1,0 +1,101 @@
+RSpec.describe Types::QueryType do
+  include GraphQL::Testing::Helpers.for(PublishingApiSchema)
+
+  describe "#edition" do
+    let(:query) do
+      <<~QUERY
+        query($basePath: String!, $contentStore: String!) {
+          edition(basePath: $basePath, contentStore: $contentStore) {
+            ... on Edition {
+              basePath
+              state
+            }
+          }
+        }
+      QUERY
+    end
+
+    context "when there is only a draft edition" do
+      let(:draft_edition) { create(:draft_edition) }
+
+      context "requesting the draft edition" do
+        it "returns the draft edition" do
+          expected_data = {
+            "basePath" => draft_edition.base_path,
+            "state" => "draft",
+          }
+
+          result = PublishingApiSchema.execute(query, variables: { basePath: draft_edition.base_path, contentStore: "draft" })
+          edition_data = result.dig("data", "edition")
+          expect(edition_data).to eq(expected_data)
+        end
+      end
+
+      context "requesting the live edition" do
+        it "returns no edition" do
+          result = PublishingApiSchema.execute(query, variables: { basePath: draft_edition.base_path, contentStore: "live" })
+          edition_data = result.dig("data", "edition")
+          expect(edition_data).to be_nil
+        end
+      end
+    end
+
+    context "when there is only a live edition" do
+      let(:live_edition) { create(:live_edition) }
+
+      context "requesting the draft edition" do
+        it "returns no edition" do
+          result = PublishingApiSchema.execute(query, variables: { basePath: live_edition.base_path, contentStore: "draft" })
+          edition_data = result.dig("data", "edition")
+          expect(edition_data).to be_nil
+        end
+      end
+
+      context "requesting the live edition" do
+        it "returns the live edition" do
+          expected_data = {
+            "basePath" => live_edition.base_path,
+            "state" => "published",
+          }
+
+          result = PublishingApiSchema.execute(query, variables: { basePath: live_edition.base_path, contentStore: "live" })
+          edition_data = result.dig("data", "edition")
+          expect(edition_data).to eq(expected_data)
+        end
+      end
+    end
+
+    context "when there is a published edition and a newer draft edition" do
+      let(:document) { create(:document) }
+      let(:base_path) { "/foo" }
+      let!(:live_edition) { create(:live_edition, document:, base_path:, user_facing_version: 1) }
+      let!(:draft_edition) { create(:draft_edition, document:, base_path:, user_facing_version: 2) }
+
+      context "requesting the draft edition" do
+        it "returns the draft edition" do
+          expected_data = {
+            "basePath" => draft_edition.base_path,
+            "state" => "draft",
+          }
+
+          result = PublishingApiSchema.execute(query, variables: { basePath: draft_edition.base_path, contentStore: "draft" })
+          edition_data = result.dig("data", "edition")
+          expect(edition_data).to eq(expected_data)
+        end
+      end
+
+      context "requesting the live edition" do
+        it "returns the live edition" do
+          expected_data = {
+            "basePath" => live_edition.base_path,
+            "state" => "published",
+          }
+
+          result = PublishingApiSchema.execute(query, variables: { basePath: live_edition.base_path, contentStore: "live" })
+          edition_data = result.dig("data", "edition")
+          expect(edition_data).to eq(expected_data)
+        end
+      end
+    end
+  end
+end

--- a/spec/graphql/types/world_index_type_spec.rb
+++ b/spec/graphql/types/world_index_type_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe "Types::WorldIndexType" do
-  describe ".document_type" do
-    it "defines a document type for .resolve_type to distinguish the type from the generic Edition type" do
-      expect(Types::WorldIndexType.document_type).to eq("world_index")
+  describe ".document_types" do
+    it "defines the document types for .resolve_type to distinguish the type from the generic Edition type" do
+      expect(Types::WorldIndexType.document_types).to eq(%w[world_index])
     end
   end
 end

--- a/spec/integration/graphql/news_article_spec.rb
+++ b/spec/integration/graphql/news_article_spec.rb
@@ -1,0 +1,210 @@
+RSpec.describe "GraphQL" do
+  describe "news article" do
+    before do
+      @edition = create(
+        :live_edition,
+        title: "Generic news article",
+        base_path: "/government/news/announcement",
+        document_type: "news_story",
+        details: {
+          body: "Some text",
+        },
+      )
+
+      @government = create(
+        :live_edition,
+        document_type: "government",
+      )
+
+      @organisation = create(
+        :live_edition,
+        document_type: "organisation",
+      )
+
+      @person = create(
+        :live_edition,
+        document_type: "person",
+      )
+
+      @topical_event = create(
+        :live_edition,
+        document_type: "topical_event",
+      )
+
+      @world_location = create(
+        :live_edition,
+        document_type: "world_location",
+      )
+
+      @parent_taxon = create(
+        :live_edition,
+        document_type: "taxon",
+      )
+
+      @child_taxon = create(
+        :live_edition,
+        document_type: "taxon",
+      )
+
+      create(:link_set,
+             content_id: @child_taxon.document.content_id,
+             links_hash: {
+               parent_taxons: [
+                 @parent_taxon.document.content_id,
+               ],
+             })
+
+      create(:link_set,
+             content_id: @edition.document.content_id,
+             links_hash: {
+               government: [
+                 @government.document.content_id,
+               ],
+               organisations: [
+                 @organisation.document.content_id,
+               ],
+               people: [
+                 @person.document.content_id,
+               ],
+               taxons: [
+                 @child_taxon.document.content_id,
+               ],
+               topical_events: [
+                 @topical_event.document.content_id,
+               ],
+               world_locations: [
+                 @world_location.document.content_id,
+               ],
+             })
+    end
+
+    it "exposes news article specific fields in addition to generic edition fields" do
+      post "/graphql", params: {
+        query: <<~QUERY,
+          {
+              edition(
+                basePath: "/government/news/announcement",
+                contentStore: "live",
+              ) {
+                ... on NewsArticle {
+                  basePath
+                  title
+                  details
+                  links {
+                    availableTranslations {
+                      basePath
+                      locale
+                    }
+                    government {
+                      details {
+                        current
+                      }
+                      title
+                    }
+                    organisations {
+                      basePath
+                      title
+                    }
+                    people {
+                      basePath
+                      title
+                    }
+                    taxons {
+                      basePath
+                      contentId
+                      title
+                      links {
+                        parentTaxons {
+                          basePath
+                          contentId
+                          title
+                        }
+                      }
+                    }
+                    topicalEvents {
+                      basePath
+                      title
+                    }
+                    worldLocations {
+                      basePath
+                      title
+                    }
+                  }
+                }
+            }
+          }
+        QUERY
+      }
+
+      expected = {
+        data: {
+          edition: {
+            basePath: @edition.base_path,
+            details: {
+              body: @edition.details[:body],
+            },
+            links: {
+              availableTranslations: [
+                {
+                  basePath: @edition.base_path,
+                  locale: @edition.locale,
+                },
+              ],
+              government: [
+                {
+                  details: {
+                    current: @government.details["current"],
+                  },
+                  title: @government.title,
+                },
+              ],
+              organisations: [
+                {
+                  basePath: @organisation.base_path,
+                  title: @organisation.title,
+                },
+              ],
+              people: [
+                {
+                  basePath: @person.base_path,
+                  title: @person.title,
+                },
+              ],
+              taxons: [
+                {
+                  basePath: @child_taxon.base_path,
+                  contentId: @child_taxon.content_id,
+                  title: @child_taxon.title,
+                  links: {
+                    parentTaxons: [
+                      {
+                        basePath: @parent_taxon.base_path,
+                        contentId: @parent_taxon.content_id,
+                        title: @parent_taxon.title,
+                      },
+                    ],
+                  },
+                },
+              ],
+              topicalEvents: [
+                {
+                  basePath: @topical_event.base_path,
+                  title: @topical_event.title,
+                },
+              ],
+              worldLocations: [
+                {
+                  basePath: @world_location.base_path,
+                  title: @world_location.title,
+                },
+              ],
+            },
+            title: @edition.title,
+          },
+        },
+      }
+
+      expect(JSON.parse(response.body).deep_symbolize_keys).to eq(expected)
+    end
+  end
+end


### PR DESCRIPTION
This allows us to retrieve news articles using a GraphQL query.

[Trello card](https://trello.com/c/RMkMvY8b)