### PR TITLE
Add temporary rake task to remove old whitehall-frontend rendered editions

### DIFF
--- a/lib/tasks/data_hygiene.rake
+++ b/lib/tasks/data_hygiene.rake
@@ -19,6 +19,22 @@ namespace :data_hygiene do
     end
   end
 
+  desc "Unpublish remaining whitehall-frontend rendered editions"
+  task unpublish_whitehall_frontend: :environent do
+    whitehall_frontend_documents = Edition
+                                    .where(state: "published", rendering_app: "whitehall-frontend")
+                                    .map { |edition| edition.document.content_id }
+
+    whitehall_frontend_documents.each do |content_id|
+      Commands::V2::Unpublish.call(
+        {
+          content_id: content_id,
+          type: "gone",
+        },
+      )
+    end
+  end
+
   desc "Check the status of a document whether it's in Content Store or Router."
   task :document_status_check, %i[content_id locale] => :environment do |_, args|
     document = Document.find_by!(args.to_hash)


### PR DESCRIPTION
Add temporary rake task to remove old whitehall-frontend rendered editions.

Some of these are still kicking around in content-store and need to be removed.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
