### PR TITLE
(763) Filter host content by content ID

### DIFF
--- a/app/controllers/v2/content_items_controller.rb
+++ b/app/controllers/v2/content_items_controller.rb
@@ -32,6 +32,15 @@ module V2
       render json: results
     end
 
+    def host_content_item
+      results = GetHostContentItemService.new(
+        path_params[:content_id],
+        path_params[:host_content_id],
+      ).call
+
+      render json: results
+    end
+
     def show
       render json: Queries::GetContent.call(
         path_params[:content_id],

--- a/app/presenters/host_content_item_presenter.rb
+++ b/app/presenters/host_content_item_presenter.rb
@@ -1,0 +1,32 @@
+module Presenters
+  class HostContentItemPresenter
+    attr_reader :host_content
+
+    def self.present(host_content)
+      new(host_content).present
+    end
+
+    def initialize(host_content)
+      @host_content = host_content
+    end
+
+    def present
+      {
+        title: host_content.title,
+        base_path: host_content.base_path,
+        document_type: host_content.document_type,
+        publishing_app: host_content.publishing_app,
+        last_edited_by_editor_id: host_content.last_edited_by_editor_id,
+        last_edited_at: host_content.last_edited_at,
+        unique_pageviews: host_content.unique_pageviews,
+        instances: host_content.instances,
+        host_content_id: host_content.host_content_id,
+        primary_publishing_organisation: {
+          content_id: host_content.primary_publishing_organisation_content_id,
+          title: host_content.primary_publishing_organisation_title,
+          base_path: host_content.primary_publishing_organisation_base_path,
+        },
+      }
+    end
+  end
+end

--- a/app/presenters/host_content_presenter.rb
+++ b/app/presenters/host_content_presenter.rb
@@ -26,22 +26,7 @@ module Presenters
       return [] unless host_content.any?
 
       host_content.map do |edition|
-        {
-          title: edition.title,
-          base_path: edition.base_path,
-          document_type: edition.document_type,
-          publishing_app: edition.publishing_app,
-          last_edited_by_editor_id: edition.last_edited_by_editor_id,
-          last_edited_at: edition.last_edited_at,
-          unique_pageviews: edition.unique_pageviews,
-          instances: edition.instances,
-          host_content_id: edition.host_content_id,
-          primary_publishing_organisation: {
-            content_id: edition.primary_publishing_organisation_content_id,
-            title: edition.primary_publishing_organisation_title,
-            base_path: edition.primary_publishing_organisation_base_path,
-          },
-        }
+        HostContentItemPresenter.present(edition)
       end
     end
 

--- a/app/services/get_host_content_item_service.rb
+++ b/app/services/get_host_content_item_service.rb
@@ -1,0 +1,32 @@
+class GetHostContentItemService
+  def initialize(target_content_id, host_content_id)
+    @target_content_id = target_content_id
+    @host_content_id = host_content_id
+  end
+
+  def call
+    if Document.find_by(content_id: target_content_id).nil?
+      message = "Could not find an edition to get host content for"
+      raise CommandError.new(code: 404, message:)
+    end
+
+    if results.count.zero?
+      message = "Could not find host_content_id #{host_content_id} in host content for #{target_content_id}"
+      raise CommandError.new(code: 404, message:)
+    end
+
+    Presenters::HostContentItemPresenter.present(results[0])
+  end
+
+private
+
+  attr_accessor :target_content_id, :order, :page, :per_page, :host_content_id
+
+  def query
+    @query ||= Queries::GetHostContent.new(target_content_id, host_content_id:)
+  end
+
+  def results
+    @results ||= query.call
+  end
+end

--- a/app/services/get_host_content_service.rb
+++ b/app/services/get_host_content_service.rb
@@ -26,7 +26,13 @@ private
   attr_accessor :target_content_id, :order, :page, :per_page
 
   def query
-    @query ||= Queries::GetHostContent.new(target_content_id, order_field:, order_direction:, page:, per_page:)
+    @query ||= Queries::GetHostContent.new(
+      target_content_id,
+      order_field:,
+      order_direction:,
+      page:,
+      per_page:,
+    )
   end
 
   def host_content

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,6 +23,7 @@ Rails.application.routes.draw do
         put "/content/:content_id", to: "content_items#put_content"
         get "/content/:content_id", to: "content_items#show"
         get "/content/:content_id/host-content", to: "content_items#host_content"
+        get "/content/:content_id/host-content/:host_content_id", to: "content_items#host_content_item"
         # Point legacy `embedded` endpoint to `host_content` endpoint
         get "/content/:content_id/embedded", to: "content_items#host_content"
         post "/content/:content_id/publish", to: "content_items#publish"

--- a/docs/api.md
+++ b/docs/api.md
@@ -17,6 +17,7 @@ message queue for other apps (e.g. `email-alert-service`) to consume.
 - [`GET /v2/content`](#get-v2content)
 - [`GET /v2/content/:content_id`](#get-v2contentcontent_id)
 - [`GET /v2/content/:content_id/host-content`](#get-v2contentcontent_idhost-content)
+- [`GET /v2/content/:content_id/host-content/:host_content_id`](#get-v2contentcontent_idhost-contenthost_content_id)
 - [`PATCH /v2/links/:content_id`](#patch-v2linkscontent_id)
 - [`GET /v2/links/:content_id`](#get-v2linkscontent_id)
 - [`GET /v2/expanded-links/:content_id`](#get-v2expanded-linkscontent_id)
@@ -449,6 +450,18 @@ it wants to defer to a reusable piece of content, such as an email address.
     "-title".
 - `page` *(optional, default: "1")*
   - The page number of results to return
+
+## `GET /v2/content/:content_id/host-content/:host_content_id`
+
+Returns metadata for a single item of content with ID `:host_content_id` that has an embedded reference to 
+the target `:content_id`.
+
+### Path parameters
+
+- [`content_id`](model.md#content_id)
+  - Identifies the target document for the reusable piece of content
+- [`host_content_id`](model.md#content_id)
+  - Identifies the document to return the metadata for
 
 ## `PATCH /v2/links/:content_id`
 

--- a/spec/presenters/host_content_item_presenter_spec.rb
+++ b/spec/presenters/host_content_item_presenter_spec.rb
@@ -1,0 +1,50 @@
+RSpec.describe Presenters::HostContentItemPresenter do
+  describe "#present" do
+    let(:organisation_edition_id) { SecureRandom.uuid }
+    let(:last_edited_by_editor_id) { SecureRandom.uuid }
+    let(:host_content_id) { SecureRandom.uuid }
+    let(:last_edited_at) { 2.days.ago }
+
+    let(:host_edition) do
+      double("Queries::GetHostContent::Result",
+             id: "1",
+             title: "foo",
+             base_path: "/foo",
+             document_type: "publication",
+             publishing_app: "publisher",
+             last_edited_by_editor_id:,
+             last_edited_at:,
+             unique_pageviews: 123,
+             host_content_id:,
+             primary_publishing_organisation_content_id: organisation_edition_id,
+             primary_publishing_organisation_title: "bar",
+             primary_publishing_organisation_base_path: "/bar",
+             instances: 1)
+    end
+
+    let(:result) { described_class.present(host_edition) }
+
+    let(:expected_output) do
+      {
+        title: "foo",
+        base_path: "/foo",
+        document_type: "publication",
+        publishing_app: "publisher",
+        last_edited_by_editor_id:,
+        last_edited_at:,
+        unique_pageviews: 123,
+        instances: 1,
+        host_content_id: host_content_id,
+        primary_publishing_organisation: {
+          content_id: organisation_edition_id,
+          title: "bar",
+          base_path: "/bar",
+        },
+      }
+    end
+
+    it "presents a single host content item" do
+      expect(result).to eq(expected_output)
+    end
+  end
+end

--- a/spec/presenters/host_content_presenter_spec.rb
+++ b/spec/presenters/host_content_presenter_spec.rb
@@ -47,22 +47,7 @@ RSpec.describe Presenters::HostContentPresenter do
           organisations: 2,
         },
         results: [
-          {
-            title: "foo",
-            base_path: "/foo",
-            document_type: "publication",
-            publishing_app: "publisher",
-            last_edited_by_editor_id:,
-            last_edited_at:,
-            unique_pageviews: 123,
-            instances: 1,
-            host_content_id: host_content_id,
-            primary_publishing_organisation: {
-              content_id: organisation_edition_id,
-              title: "bar",
-              base_path: "/bar",
-            },
-          },
+          Presenters::HostContentItemPresenter.present(host_editions[0]),
         ],
       }
     end

--- a/spec/services/get_host_content_item_service_spec.rb
+++ b/spec/services/get_host_content_item_service_spec.rb
@@ -1,0 +1,49 @@
+RSpec.describe GetHostContentItemService do
+  describe "#call" do
+    let(:target_content_id) { SecureRandom.uuid }
+    let(:host_content_id) { SecureRandom.uuid }
+
+    context "when the target_content_id doesn't match a Document" do
+      it "returns 404" do
+        expect { described_class.new(target_content_id, host_content_id).call }.to raise_error(CommandError) do |error|
+          expect(error.code).to eq(404)
+          expect(error.message).to eq("Could not find an edition to get host content for")
+        end
+      end
+    end
+
+    context "when the host_content_id doesn't match a Document" do
+      before do
+        allow(Document).to receive(:find_by).with(content_id: target_content_id).and_return(anything)
+      end
+
+      it "returns 404" do
+        expect { described_class.new(target_content_id, host_content_id).call }.to raise_error(CommandError) do |error|
+          expect(error.code).to eq(404)
+          expect(error.message).to eq("Could not find host_content_id #{host_content_id} in host content for #{target_content_id}")
+        end
+      end
+    end
+
+    context "when content for host_content_id exists" do
+      let(:result_stub) { double("Queries::GetHostContent::Result") }
+      let(:host_editions_stub) { [result_stub] }
+      let(:embedded_content_stub) { double(Queries::GetHostContent, call: [result_stub]) }
+      let(:result_stub) { double }
+
+      before do
+        allow(Document).to receive(:find_by).and_return(anything)
+        allow(Queries::GetHostContent).to receive(:new).and_return(embedded_content_stub)
+        allow(Presenters::HostContentItemPresenter).to receive(:present).and_return(result_stub)
+      end
+
+      it "returns a presented form of the response from the query" do
+        result = described_class.new(target_content_id, host_content_id).call
+
+        expect(result).to eq(result_stub)
+
+        expect(Presenters::HostContentItemPresenter).to have_received(:present).with(result_stub)
+      end
+    end
+  end
+end


### PR DESCRIPTION
When viewing the details of a particular piece of content that embeds a block, we need to return the relevant metadata. Rather than returning all the objects (which could be on multiple pages) and filtering through them, we add a `host_content_id` argument, which allows us to filter on the database side.

Trello card: https://trello.com/c/WZvzmuMI/763-bug-mainstream-preview-bug-within-guide-chapters