### PR TITLE
(766) Ensure duplicate links are retained in array/hash

### DIFF
--- a/app/services/embedded_content_finder_service.rb
+++ b/app/services/embedded_content_finder_service.rb
@@ -11,9 +11,9 @@ class EmbeddedContentFinderService
   def find_content_references(value)
     case value
     when Array
-      value.map { |item| find_content_references(item) }.flatten.uniq
+      value.map { |item| find_content_references(item) }.uniq.flatten
     when Hash
-      value.map { |_, v| find_content_references(v) }.flatten.uniq
+      value.map { |_, v| find_content_references(v) }.uniq.flatten
     when String
       ContentBlockTools::ContentBlockReference.find_all_in_document(value)
     else


### PR DESCRIPTION
Trello card: https://trello.com/c/ZapsO3t5/766-number-of-instances-not-being-picked-up

When a document is part of an array/hash (such as Mainstream documents), we were still calling `.uniq` after going through each item. This meant that documents such as Answers, Guides etc weren’t getting the correct metadata, as any duplicate links were getting thrown away.

To get around this, we call `.uniq` BEFORE calling `.flatten`. This ensures that we retain the number of instances without double counting for multipart content.