### PR TITLE
Add "editionable_topical_events" to the topical events content type

### DIFF
--- a/content_schemas/allowed_document_types.yml
+++ b/content_schemas/allowed_document_types.yml
@@ -39,6 +39,7 @@
 - document_collection
 - drcf_digital_markets_research
 - drug_safety_update
+- editionable_topical_event
 - email_alert_signup
 - embassies_index
 - employment_appeal_tribunal_decision

--- a/content_schemas/dist/formats/generic/frontend/schema.json
+++ b/content_schemas/dist/formats/generic/frontend/schema.json
@@ -75,6 +75,7 @@
         "document_collection",
         "drcf_digital_markets_research",
         "drug_safety_update",
+        "editionable_topical_event",
         "email_alert_signup",
         "embassies_index",
         "employment_appeal_tribunal_decision",

--- a/content_schemas/dist/formats/generic/notification/schema.json
+++ b/content_schemas/dist/formats/generic/notification/schema.json
@@ -99,6 +99,7 @@
         "document_collection",
         "drcf_digital_markets_research",
         "drug_safety_update",
+        "editionable_topical_event",
         "email_alert_signup",
         "embassies_index",
         "employment_appeal_tribunal_decision",

--- a/content_schemas/dist/formats/generic/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/generic/publisher_v2/schema.json
@@ -88,6 +88,7 @@
         "document_collection",
         "drcf_digital_markets_research",
         "drug_safety_update",
+        "editionable_topical_event",
         "email_alert_signup",
         "embassies_index",
         "employment_appeal_tribunal_decision",

--- a/content_schemas/dist/formats/generic_with_external_related_links/frontend/schema.json
+++ b/content_schemas/dist/formats/generic_with_external_related_links/frontend/schema.json
@@ -75,6 +75,7 @@
         "document_collection",
         "drcf_digital_markets_research",
         "drug_safety_update",
+        "editionable_topical_event",
         "email_alert_signup",
         "embassies_index",
         "employment_appeal_tribunal_decision",

--- a/content_schemas/dist/formats/generic_with_external_related_links/notification/schema.json
+++ b/content_schemas/dist/formats/generic_with_external_related_links/notification/schema.json
@@ -99,6 +99,7 @@
         "document_collection",
         "drcf_digital_markets_research",
         "drug_safety_update",
+        "editionable_topical_event",
         "email_alert_signup",
         "embassies_index",
         "employment_appeal_tribunal_decision",

--- a/content_schemas/dist/formats/generic_with_external_related_links/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/generic_with_external_related_links/publisher_v2/schema.json
@@ -88,6 +88,7 @@
         "document_collection",
         "drcf_digital_markets_research",
         "drug_safety_update",
+        "editionable_topical_event",
         "email_alert_signup",
         "embassies_index",
         "employment_appeal_tribunal_decision",

--- a/content_schemas/dist/formats/specialist_document/frontend/schema.json
+++ b/content_schemas/dist/formats/specialist_document/frontend/schema.json
@@ -75,6 +75,7 @@
         "document_collection",
         "drcf_digital_markets_research",
         "drug_safety_update",
+        "editionable_topical_event",
         "email_alert_signup",
         "embassies_index",
         "employment_appeal_tribunal_decision",

--- a/content_schemas/dist/formats/specialist_document/notification/schema.json
+++ b/content_schemas/dist/formats/specialist_document/notification/schema.json
@@ -99,6 +99,7 @@
         "document_collection",
         "drcf_digital_markets_research",
         "drug_safety_update",
+        "editionable_topical_event",
         "email_alert_signup",
         "embassies_index",
         "employment_appeal_tribunal_decision",

--- a/content_schemas/dist/formats/specialist_document/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/specialist_document/publisher_v2/schema.json
@@ -88,6 +88,7 @@
         "document_collection",
         "drcf_digital_markets_research",
         "drug_safety_update",
+        "editionable_topical_event",
         "email_alert_signup",
         "embassies_index",
         "employment_appeal_tribunal_decision",

--- a/content_schemas/dist/formats/topical_event/frontend/schema.json
+++ b/content_schemas/dist/formats/topical_event/frontend/schema.json
@@ -34,7 +34,8 @@
     "document_type": {
       "type": "string",
       "enum": [
-        "topical_event"
+        "topical_event",
+        "editionable_topical_event"
       ]
     },
     "first_published_at": {

--- a/content_schemas/dist/formats/topical_event/notification/schema.json
+++ b/content_schemas/dist/formats/topical_event/notification/schema.json
@@ -58,7 +58,8 @@
     "document_type": {
       "type": "string",
       "enum": [
-        "topical_event"
+        "topical_event",
+        "editionable_topical_event"
       ]
     },
     "email_document_supertype": {

--- a/content_schemas/dist/formats/topical_event/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/topical_event/publisher_v2/schema.json
@@ -47,7 +47,8 @@
     "document_type": {
       "type": "string",
       "enum": [
-        "topical_event"
+        "topical_event",
+        "editionable_topical_event"
       ]
     },
     "first_published_at": {

--- a/content_schemas/formats/topical_event.jsonnet
+++ b/content_schemas/formats/topical_event.jsonnet
@@ -1,5 +1,5 @@
 (import "shared/default_format.jsonnet") + {
-  document_type: "topical_event",
+  document_type: ["topical_event", "editionable_topical_event"],
   definitions: (import "shared/definitions/_whitehall.jsonnet") + {
     details: {
       type: "object",


### PR DESCRIPTION
This means that we can start adding editionable topical events to whitehall using the existing schema

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
