### PR TITLE
Swap Ministers Index GraphQL #joins for #includes

### DIFF
--- a/app/graphql/types/base_object.rb
+++ b/app/graphql/types/base_object.rb
@@ -12,7 +12,7 @@ module Types
       define_method(field_name_and_link_type.to_sym) do
         Edition
           .live
-          .joins(document: { reverse_links: :link_set })
+          .includes(document: { reverse_links: :link_set })
           .where(
             document: { locale: "en" },
             link_set: { content_id: object.content_id },

--- a/app/graphql/types/ministers_index_type.rb
+++ b/app/graphql/types/ministers_index_type.rb
@@ -61,7 +61,7 @@ module Types
         def role_appointments
           Edition
             .live
-            .joins(
+            .includes(
               document: {
                 reverse_links: { # role -> role_appointment
                   link_set: {


### PR DESCRIPTION
Swap Ministers Index GraphQL #joins for #includes -- because #includes eagerloads the specified associations, whereas #joins does not do that.

With my local data, this reduced the number of database queries made in order to serve the Ministers Index page from 1144 down to 280.

https://trello.com/c/dhngeJLd/1493-measure-and-improve-performance-of-ministers-index-graphql