### PR TITLE
Remove temporary rake task

### DIFF
--- a/lib/tasks/data_hygiene.rake
+++ b/lib/tasks/data_hygiene.rake
@@ -19,32 +19,6 @@ namespace :data_hygiene do
     end
   end
 
-  desc "Unpublish remaining whitehall-frontend rendered editions"
-  task unpublish_whitehall_frontend: :environment do
-    whitehall_frontend_documents = Edition
-                                    .where(state: "published", rendering_app: "whitehall-frontend")
-                                    .map(&:document)
-
-    whitehall_frontend_documents.each do |document|
-      if document.draft.present?
-        Commands::V2::DiscardDraft.call(
-          {
-            content_id: document.content_id,
-            locale: document.locale,
-          },
-        )
-      end
-
-      Commands::V2::Unpublish.call(
-        {
-          content_id: document.content_id,
-          locale: document.locale,
-          type: "gone",
-        },
-      )
-    end
-  end
-
   desc "Check the status of a document whether it's in Content Store"
   task :document_status_check, %i[content_id locale] => :environment do |_, args|
     document = Document.find_by!(args.to_hash)


### PR DESCRIPTION
This rake task was added to unpublish some orphaned editions that were previously rendered by Whitehall Frontend.

The task has been run in production, so the code can now be removed.

[Trello card](https://trello.com/c/1viCnlBt)