### PR TITLE
Switch off auto-camelization for GraphQL fields

### DIFF
--- a/app/graphql/types/base_argument.rb
+++ b/app/graphql/types/base_argument.rb
@@ -2,5 +2,8 @@
 
 module Types
   class BaseArgument < GraphQL::Schema::Argument
+    def initialize(*args, camelize: false, **kwargs, &block)
+      super
+    end
   end
 end

--- a/app/graphql/types/base_field.rb
+++ b/app/graphql/types/base_field.rb
@@ -3,5 +3,9 @@
 module Types
   class BaseField < GraphQL::Schema::Field
     argument_class Types::BaseArgument
+
+    def initialize(*args, camelize: false, **kwargs, &block)
+      super
+    end
   end
 end

--- a/spec/graphql/types/edition_type_spec.rb
+++ b/spec/graphql/types/edition_type_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "Types::EditionType" do
 
         expect(
           run_graphql_field(
-            "Edition.withdrawnNotice",
+            "Edition.withdrawn_notice",
             edition,
           ),
         ).to eq(expected)
@@ -23,7 +23,7 @@ RSpec.describe "Types::EditionType" do
       it "returns nil" do
         expect(
           run_graphql_field(
-            "Edition.withdrawnNotice",
+            "Edition.withdrawn_notice",
             create(:edition),
           ),
         ).to be_nil

--- a/spec/graphql/types/query_type_spec.rb
+++ b/spec/graphql/types/query_type_spec.rb
@@ -4,10 +4,10 @@ RSpec.describe Types::QueryType do
   describe "#edition" do
     let(:query) do
       <<~QUERY
-        query($basePath: String!, $contentStore: String!) {
-          edition(basePath: $basePath, contentStore: $contentStore) {
+        query($base_path: String!, $content_store: String!) {
+          edition(base_path: $base_path, content_store: $content_store) {
             ... on Edition {
-              basePath
+              base_path
               state
             }
           }
@@ -21,11 +21,11 @@ RSpec.describe Types::QueryType do
       context "requesting the draft edition" do
         it "returns the draft edition" do
           expected_data = {
-            "basePath" => draft_edition.base_path,
+            "base_path" => draft_edition.base_path,
             "state" => "draft",
           }
 
-          result = PublishingApiSchema.execute(query, variables: { basePath: draft_edition.base_path, contentStore: "draft" })
+          result = PublishingApiSchema.execute(query, variables: { base_path: draft_edition.base_path, content_store: "draft" })
           edition_data = result.dig("data", "edition")
           expect(edition_data).to eq(expected_data)
         end
@@ -33,7 +33,7 @@ RSpec.describe Types::QueryType do
 
       context "requesting the live edition" do
         it "returns no edition" do
-          result = PublishingApiSchema.execute(query, variables: { basePath: draft_edition.base_path, contentStore: "live" })
+          result = PublishingApiSchema.execute(query, variables: { base_path: draft_edition.base_path, content_store: "live" })
           edition_data = result.dig("data", "edition")
           expect(edition_data).to be_nil
         end
@@ -45,7 +45,7 @@ RSpec.describe Types::QueryType do
 
       context "requesting the draft edition" do
         it "returns no edition" do
-          result = PublishingApiSchema.execute(query, variables: { basePath: live_edition.base_path, contentStore: "draft" })
+          result = PublishingApiSchema.execute(query, variables: { base_path: live_edition.base_path, content_store: "draft" })
           edition_data = result.dig("data", "edition")
           expect(edition_data).to be_nil
         end
@@ -54,11 +54,11 @@ RSpec.describe Types::QueryType do
       context "requesting the live edition" do
         it "returns the live edition" do
           expected_data = {
-            "basePath" => live_edition.base_path,
+            "base_path" => live_edition.base_path,
             "state" => "published",
           }
 
-          result = PublishingApiSchema.execute(query, variables: { basePath: live_edition.base_path, contentStore: "live" })
+          result = PublishingApiSchema.execute(query, variables: { base_path: live_edition.base_path, content_store: "live" })
           edition_data = result.dig("data", "edition")
           expect(edition_data).to eq(expected_data)
         end
@@ -74,11 +74,11 @@ RSpec.describe Types::QueryType do
       context "requesting the draft edition" do
         it "returns the draft edition" do
           expected_data = {
-            "basePath" => draft_edition.base_path,
+            "base_path" => draft_edition.base_path,
             "state" => "draft",
           }
 
-          result = PublishingApiSchema.execute(query, variables: { basePath: draft_edition.base_path, contentStore: "draft" })
+          result = PublishingApiSchema.execute(query, variables: { base_path: draft_edition.base_path, content_store: "draft" })
           edition_data = result.dig("data", "edition")
           expect(edition_data).to eq(expected_data)
         end
@@ -87,11 +87,11 @@ RSpec.describe Types::QueryType do
       context "requesting the live edition" do
         it "returns the live edition" do
           expected_data = {
-            "basePath" => live_edition.base_path,
+            "base_path" => live_edition.base_path,
             "state" => "published",
           }
 
-          result = PublishingApiSchema.execute(query, variables: { basePath: live_edition.base_path, contentStore: "live" })
+          result = PublishingApiSchema.execute(query, variables: { base_path: live_edition.base_path, content_store: "live" })
           edition_data = result.dig("data", "edition")
           expect(edition_data).to eq(expected_data)
         end

--- a/spec/integration/graphql/generic_edition_spec.rb
+++ b/spec/integration/graphql/generic_edition_spec.rb
@@ -9,29 +9,29 @@ RSpec.describe "GraphQL" do
       post "/graphql", params: {
         query:
           "{
-            edition(basePath: \"/my/generic/edition\") {
+            edition(base_path: \"/my/generic/edition\") {
               ... on Edition {
                 title
-                analyticsIdentifier
-                basePath
-                contentId
+                analytics_identifier
+                base_path
+                content_id
                 description
                 details
-                documentType
-                firstPublishedAt
+                document_type
+                first_published_at
                 locale
                 phase
-                publicUpdatedAt
-                publishingApp
-                publishingRequestId
-                publishingScheduledAt
-                renderingApp
-                scheduledPublishingDelaySeconds
-                schemaName
-                updatedAt
-                withdrawnNotice {
+                public_updated_at
+                publishing_app
+                publishing_request_id
+                publishing_scheduled_at
+                rendering_app
+                scheduled_publishing_delay_seconds
+                schema_name
+                updated_at
+                withdrawn_notice {
                   explanation
-                  withdrawnAt
+                  withdrawn_at
                 }
               }
             }
@@ -41,25 +41,25 @@ RSpec.describe "GraphQL" do
       expected = {
         "data": {
           "edition": {
-            "analyticsIdentifier": @edition.analytics_identifier,
-            "basePath": @edition.base_path,
-            "contentId": @edition.content_id,
+            "analytics_identifier": @edition.analytics_identifier,
+            "base_path": @edition.base_path,
+            "content_id": @edition.content_id,
             "description": @edition.description,
             "details": @edition.details,
-            "documentType": @edition.document_type,
-            "firstPublishedAt": @edition.first_published_at.iso8601,
+            "document_type": @edition.document_type,
+            "first_published_at": @edition.first_published_at.iso8601,
             "locale": @edition.locale,
             "phase": @edition.phase,
-            "publicUpdatedAt": @edition.public_updated_at.iso8601,
-            "publishingApp": @edition.publishing_app,
-            "publishingRequestId": @edition.publishing_request_id,
-            "publishingScheduledAt": nil,
-            "renderingApp": @edition.rendering_app,
-            "scheduledPublishingDelaySeconds": nil,
-            "schemaName": @edition.schema_name,
+            "public_updated_at": @edition.public_updated_at.iso8601,
+            "publishing_app": @edition.publishing_app,
+            "publishing_request_id": @edition.publishing_request_id,
+            "publishing_scheduled_at": nil,
+            "rendering_app": @edition.rendering_app,
+            "scheduled_publishing_delay_seconds": nil,
+            "schema_name": @edition.schema_name,
             "title": @edition.title,
-            "updatedAt": @edition.updated_at.iso8601,
-            "withdrawnNotice": nil,
+            "updated_at": @edition.updated_at.iso8601,
+            "withdrawn_notice": nil,
           },
         },
       }
@@ -84,11 +84,11 @@ RSpec.describe "GraphQL" do
         post "/graphql", params: {
           query:
             "{
-              edition(basePath: \"/my/withdrawn/edition\") {
+              edition(base_path: \"/my/withdrawn/edition\") {
                 ... on Edition {
-                  withdrawnNotice {
+                  withdrawn_notice {
                     explanation
-                    withdrawnAt
+                    withdrawn_at
                   }
                 }
               }
@@ -98,9 +98,9 @@ RSpec.describe "GraphQL" do
         expected = {
           "data": {
             "edition": {
-              "withdrawnNotice": {
+              "withdrawn_notice": {
                 "explanation": "for integration testing",
-                "withdrawnAt": "2024-10-27T17:00:00Z",
+                "withdrawn_at": "2024-10-27T17:00:00Z",
               },
             },
           },
@@ -116,9 +116,9 @@ RSpec.describe "GraphQL" do
       post "/graphql", params: {
         query:
           "{
-            edition(basePath: \"/my/generic/edition\") {
+            edition(base_path: \"/my/generic/edition\") {
               ... on Edition {
-                worldLocations {
+                world_locations {
                   active
                 }
               }
@@ -132,7 +132,7 @@ RSpec.describe "GraphQL" do
         {
           errors: [
             hash_including(
-              message: "Field 'worldLocations' doesn't exist on type 'Edition'",
+              message: "Field 'world_locations' doesn't exist on type 'Edition'",
             ),
           ],
         },

--- a/spec/integration/graphql/ministers_index_spec.rb
+++ b/spec/integration/graphql/ministers_index_spec.rb
@@ -27,59 +27,59 @@ RSpec.describe "GraphQL" do
       post "/graphql", params: {
         query:
         "{
-          edition(basePath: \"/government/ministers\") {
+          edition(base_path: \"/government/ministers\") {
             ... on MinistersIndex {
-              basePath
+              base_path
 
               links {
-                orderedCabinetMinisters {
+                ordered_cabinet_ministers {
                   ...basePersonInfo
                 }
 
-                orderedAlsoAttendsCabinet {
+                ordered_also_attends_cabinet {
                   ...basePersonInfo
                 }
 
-                orderedAssistantWhips {
+                ordered_assistant_whips {
                   ...basePersonInfo
                 }
 
-                orderedBaronessesAndLordsInWaitingWhips {
+                ordered_baronesses_and_lords_in_waiting_whips {
                   ...basePersonInfo
                 }
 
-                orderedHouseLordsWhips {
+                ordered_house_lords_whips {
                   ...basePersonInfo
                 }
 
-                orderedHouseOfCommonsWhips {
+                ordered_house_of_commons_whips {
                   ...basePersonInfo
                 }
 
-                orderedJuniorLordsOfTheTreasuryWhips {
+                ordered_junior_lords_of_the_treasury_whips {
                   ...basePersonInfo
                 }
 
-                orderedMinisterialDepartments {
+                ordered_ministerial_departments {
                   title
-                  webUrl
+                  web_url
 
                   details {
                     brand
 
                     logo {
                       crest
-                      formattedTitle
+                      formatted_title
                     }
                   }
 
                   links {
-                    orderedMinisters {
+                    ordered_ministers {
                       ...basePersonInfo
                     }
 
-                    orderedRoles {
-                      contentId
+                    ordered_roles {
+                      content_id
                     }
                   }
                 }
@@ -90,36 +90,36 @@ RSpec.describe "GraphQL" do
 
         fragment basePersonInfo on MinistersIndexPerson {
           title
-          basePath
-          webUrl
+          base_path
+          web_url
 
           details {
-            privyCounsellor
+            privy_counsellor
 
             image {
               url
-              altText
+              alt_text
             }
           }
 
           links {
-            roleAppointments {
+            role_appointments {
               details {
                 current
               }
 
               links {
                 role {
-                  contentId
+                  content_id
                   title
-                  webUrl
+                  web_url
 
                   details {
-                    rolePaymentType
+                    role_payment_type
                     seniority
-                    whipOrganisation {
+                    whip_organisation {
                       label
-                      sortOrder
+                      sort_order
                     }
                   }
                 }
@@ -146,25 +146,25 @@ RSpec.describe "GraphQL" do
       expect(parsed_response).to match({
         data: {
           edition: {
-            basePath: "/government/ministers",
+            base_path: "/government/ministers",
             links: be_kind_of(Hash),
           },
         },
       })
 
       expect(parsed_links.keys).to match(%i[
-        orderedCabinetMinisters
-        orderedAlsoAttendsCabinet
-        orderedAssistantWhips
-        orderedBaronessesAndLordsInWaitingWhips
-        orderedHouseLordsWhips
-        orderedHouseOfCommonsWhips
-        orderedJuniorLordsOfTheTreasuryWhips
-        orderedMinisterialDepartments
+        ordered_cabinet_ministers
+        ordered_also_attends_cabinet
+        ordered_assistant_whips
+        ordered_baronesses_and_lords_in_waiting_whips
+        ordered_house_lords_whips
+        ordered_house_of_commons_whips
+        ordered_junior_lords_of_the_treasury_whips
+        ordered_ministerial_departments
       ])
     end
 
-    describe "orderedCabinetMinisters links" do
+    describe "ordered_cabinet_ministers links" do
       before do
         person1 = create_person_with_role_appointment("Keir Starmer 1", "1st Minister")
         extra_role = create_role("First Lord of The Treasury")
@@ -181,31 +181,31 @@ RSpec.describe "GraphQL" do
       it "exposes the links' fields" do
         make_request
 
-        expect(parsed_links.fetch(:orderedCabinetMinisters)).to match([
+        expect(parsed_links.fetch(:ordered_cabinet_ministers)).to match([
           {
-            basePath: "/government/people/keir-starmer-1",
+            base_path: "/government/people/keir-starmer-1",
             details: {
               image: {
                 url: "http://assets.dev.gov.uk/media/keir-starmer-1.jpg",
-                altText: "Keir Starmer 1",
+                alt_text: "Keir Starmer 1",
               },
-              privyCounsellor: nil,
+              privy_counsellor: nil,
             },
             links: {
-              roleAppointments: [
+              role_appointments: [
                 {
                   details: { current: true },
                   links: {
                     role: [
                       {
-                        contentId: uuid_matcher,
+                        content_id: uuid_matcher,
                         details: {
-                          rolePaymentType: nil,
+                          role_payment_type: nil,
                           seniority: 100,
-                          whipOrganisation: nil,
+                          whip_organisation: nil,
                         },
                         title: "1st Minister",
-                        webUrl: "http://www.dev.gov.uk/government/ministers/1st-minister",
+                        web_url: "http://www.dev.gov.uk/government/ministers/1st-minister",
                       },
                     ],
                   },
@@ -215,14 +215,14 @@ RSpec.describe "GraphQL" do
                   links: {
                     role: [
                       {
-                        contentId: uuid_matcher,
+                        content_id: uuid_matcher,
                         details: {
-                          rolePaymentType: nil,
+                          role_payment_type: nil,
                           seniority: 100,
-                          whipOrganisation: nil,
+                          whip_organisation: nil,
                         },
                         title: "First Lord of The Treasury",
-                        webUrl: "http://www.dev.gov.uk/government/ministers/first-lord-of-the-treasury",
+                        web_url: "http://www.dev.gov.uk/government/ministers/first-lord-of-the-treasury",
                       },
                     ],
                   },
@@ -230,32 +230,32 @@ RSpec.describe "GraphQL" do
               ],
             },
             title: "Keir Starmer 1",
-            webUrl: "http://www.dev.gov.uk/government/people/keir-starmer-1",
+            web_url: "http://www.dev.gov.uk/government/people/keir-starmer-1",
           },
           {
-            basePath: "/government/people/keir-starmer-2",
+            base_path: "/government/people/keir-starmer-2",
             details: {
               image: {
                 url: "http://assets.dev.gov.uk/media/keir-starmer-2.jpg",
-                altText: "Keir Starmer 2",
+                alt_text: "Keir Starmer 2",
               },
-              privyCounsellor: nil,
+              privy_counsellor: nil,
             },
             links: {
-              roleAppointments: [
+              role_appointments: [
                 {
                   details: { current: true },
                   links: {
                     role: [
                       {
-                        contentId: uuid_matcher,
+                        content_id: uuid_matcher,
                         details: {
-                          rolePaymentType: nil,
+                          role_payment_type: nil,
                           seniority: 100,
-                          whipOrganisation: nil,
+                          whip_organisation: nil,
                         },
                         title: "2nd Minister",
-                        webUrl: "http://www.dev.gov.uk/government/ministers/2nd-minister",
+                        web_url: "http://www.dev.gov.uk/government/ministers/2nd-minister",
                       },
                     ],
                   },
@@ -263,32 +263,32 @@ RSpec.describe "GraphQL" do
               ],
             },
             title: "Keir Starmer 2",
-            webUrl: "http://www.dev.gov.uk/government/people/keir-starmer-2",
+            web_url: "http://www.dev.gov.uk/government/people/keir-starmer-2",
           },
           {
-            basePath: "/government/people/keir-starmer-3",
+            base_path: "/government/people/keir-starmer-3",
             details: {
               image: {
                 url: "http://assets.dev.gov.uk/media/keir-starmer-3.jpg",
-                altText: "Keir Starmer 3",
+                alt_text: "Keir Starmer 3",
               },
-              privyCounsellor: nil,
+              privy_counsellor: nil,
             },
             links: {
-              roleAppointments: [
+              role_appointments: [
                 {
                   details: { current: true },
                   links: {
                     role: [
                       {
-                        contentId: uuid_matcher,
+                        content_id: uuid_matcher,
                         details: {
-                          rolePaymentType: nil,
+                          role_payment_type: nil,
                           seniority: 100,
-                          whipOrganisation: nil,
+                          whip_organisation: nil,
                         },
                         title: "3rd Minister",
-                        webUrl: "http://www.dev.gov.uk/government/ministers/3rd-minister",
+                        web_url: "http://www.dev.gov.uk/government/ministers/3rd-minister",
                       },
                     ],
                   },
@@ -296,7 +296,7 @@ RSpec.describe "GraphQL" do
               ],
             },
             title: "Keir Starmer 3",
-            webUrl: "http://www.dev.gov.uk/government/people/keir-starmer-3",
+            web_url: "http://www.dev.gov.uk/government/people/keir-starmer-3",
           },
         ])
       end
@@ -314,31 +314,31 @@ RSpec.describe "GraphQL" do
       it "exposes the links' fields" do
         make_request
 
-        expect(parsed_links.fetch(:orderedAlsoAttendsCabinet)).to match([
+        expect(parsed_links.fetch(:ordered_also_attends_cabinet)).to match([
           {
-            basePath: "/government/people/alan-campbell",
+            base_path: "/government/people/alan-campbell",
             details: {
               image: {
                 url: "http://assets.dev.gov.uk/media/alan-campbell.jpg",
-                altText: "Alan Campbell",
+                alt_text: "Alan Campbell",
               },
-              privyCounsellor: nil,
+              privy_counsellor: nil,
             },
             links: {
-              roleAppointments: [
+              role_appointments: [
                 {
                   details: { current: true },
                   links: {
                     role: [
                       {
-                        contentId: uuid_matcher,
+                        content_id: uuid_matcher,
                         details: {
-                          rolePaymentType: nil,
+                          role_payment_type: nil,
                           seniority: 100,
-                          whipOrganisation: nil,
+                          whip_organisation: nil,
                         },
                         title: "Parliamentary Secretary to the Treasury (Chief Whip)",
-                        webUrl: "http://www.dev.gov.uk/government/ministers/parliamentary-secretary-to-the-treasury-chief-whip",
+                        web_url: "http://www.dev.gov.uk/government/ministers/parliamentary-secretary-to-the-treasury-chief-whip",
                       },
                     ],
                   },
@@ -346,7 +346,7 @@ RSpec.describe "GraphQL" do
               ],
             },
             title: "Alan Campbell",
-            webUrl: "http://www.dev.gov.uk/government/people/alan-campbell",
+            web_url: "http://www.dev.gov.uk/government/people/alan-campbell",
           },
         ])
       end
@@ -369,34 +369,34 @@ RSpec.describe "GraphQL" do
       it "exposes the links' fields" do
         make_request
 
-        expect(parsed_links.fetch(:orderedAssistantWhips)).to match([
+        expect(parsed_links.fetch(:ordered_assistant_whips)).to match([
           {
-            basePath: "/government/people/christian-wakeford-mp",
+            base_path: "/government/people/christian-wakeford-mp",
             details: {
               image: {
-                altText: "Christian Wakeford MP",
+                alt_text: "Christian Wakeford MP",
                 url: "http://assets.dev.gov.uk/media/christian-wakeford-mp.jpg",
               },
-              privyCounsellor: nil,
+              privy_counsellor: nil,
             },
             links: {
-              roleAppointments: [
+              role_appointments: [
                 {
                   details: { current: true },
                   links: {
                     role: [
                       {
-                        contentId: uuid_matcher,
+                        content_id: uuid_matcher,
                         details: {
-                          rolePaymentType: nil,
+                          role_payment_type: nil,
                           seniority: 100,
-                          whipOrganisation: {
+                          whip_organisation: {
                             label: "Assistant Whips",
-                            sortOrder: 3,
+                            sort_order: 3,
                           },
                         },
                         title: "Assistant Whip, House of Commons",
-                        webUrl: "http://www.dev.gov.uk/government/ministers/assistant-whip-house-of-commons",
+                        web_url: "http://www.dev.gov.uk/government/ministers/assistant-whip-house-of-commons",
                       },
                     ],
                   },
@@ -404,7 +404,7 @@ RSpec.describe "GraphQL" do
               ],
             },
             title: "Christian Wakeford MP",
-            webUrl: "http://www.dev.gov.uk/government/people/christian-wakeford-mp",
+            web_url: "http://www.dev.gov.uk/government/people/christian-wakeford-mp",
           },
         ])
       end
@@ -421,31 +421,31 @@ RSpec.describe "GraphQL" do
       it "exposes the links' fields" do
         make_request
 
-        expect(parsed_links.fetch(:orderedBaronessesAndLordsInWaitingWhips)).to match([
+        expect(parsed_links.fetch(:ordered_baronesses_and_lords_in_waiting_whips)).to match([
           {
-            basePath: "/government/people/lord-cryer",
+            base_path: "/government/people/lord-cryer",
             details: {
               image: {
-                altText: "Lord Cryer",
+                alt_text: "Lord Cryer",
                 url: "http://assets.dev.gov.uk/media/lord-cryer.jpg",
               },
-              privyCounsellor: nil,
+              privy_counsellor: nil,
             },
             links: {
-              roleAppointments: [
+              role_appointments: [
                 {
                   details: { current: true },
                   links: {
                     role: [
                       {
-                        contentId: uuid_matcher,
+                        content_id: uuid_matcher,
                         details: {
-                          rolePaymentType: "Unpaid",
+                          role_payment_type: "Unpaid",
                           seniority: 100,
-                          whipOrganisation: nil,
+                          whip_organisation: nil,
                         },
                         title: "Lord in Waiting",
-                        webUrl: "http://www.dev.gov.uk/government/ministers/lord-in-waiting",
+                        web_url: "http://www.dev.gov.uk/government/ministers/lord-in-waiting",
                       },
                     ],
                   },
@@ -453,7 +453,7 @@ RSpec.describe "GraphQL" do
               ],
             },
             title: "Lord Cryer",
-            webUrl: "http://www.dev.gov.uk/government/people/lord-cryer",
+            web_url: "http://www.dev.gov.uk/government/people/lord-cryer",
           },
         ])
       end
@@ -471,31 +471,31 @@ RSpec.describe "GraphQL" do
       it "exposes the links' fields" do
         make_request
 
-        expect(parsed_links.fetch(:orderedHouseLordsWhips)).to match([
+        expect(parsed_links.fetch(:ordered_house_lords_whips)).to match([
           {
-            basePath: "/government/people/baroness-wheeler-mbe",
+            base_path: "/government/people/baroness-wheeler-mbe",
             details: {
               image: {
-                altText: "Baroness Wheeler MBE",
+                alt_text: "Baroness Wheeler MBE",
                 url: "http://assets.dev.gov.uk/media/baroness-wheeler-mbe.jpg",
               },
-              privyCounsellor: nil,
+              privy_counsellor: nil,
             },
             links: {
-              roleAppointments: [
+              role_appointments: [
                 {
                   details: { current: true },
                   links: {
                     role: [
                       {
-                        contentId: uuid_matcher,
+                        content_id: uuid_matcher,
                         details: {
-                          rolePaymentType: nil,
+                          role_payment_type: nil,
                           seniority: 100,
-                          whipOrganisation: nil,
+                          whip_organisation: nil,
                         },
                         title: "Captain of The King’s Bodyguard of the Yeoman of the Guard",
-                        webUrl: "http://www.dev.gov.uk/government/ministers/captain-of-the-king-s-bodyguard-of-the-yeoman-of-the-guard",
+                        web_url: "http://www.dev.gov.uk/government/ministers/captain-of-the-king-s-bodyguard-of-the-yeoman-of-the-guard",
                       },
                     ],
                   },
@@ -503,7 +503,7 @@ RSpec.describe "GraphQL" do
               ],
             },
             title: "Baroness Wheeler MBE",
-            webUrl: "http://www.dev.gov.uk/government/people/baroness-wheeler-mbe",
+            web_url: "http://www.dev.gov.uk/government/people/baroness-wheeler-mbe",
           },
         ])
       end
@@ -521,31 +521,31 @@ RSpec.describe "GraphQL" do
       it "exposes the links' fields" do
         make_request
 
-        expect(parsed_links.fetch(:orderedHouseOfCommonsWhips)).to match([
+        expect(parsed_links.fetch(:ordered_house_of_commons_whips)).to match([
           {
-            basePath: "/government/people/samantha-dixon-mp",
+            base_path: "/government/people/samantha-dixon-mp",
             details: {
               image: {
-                altText: "Samantha Dixon MP",
+                alt_text: "Samantha Dixon MP",
                 url: "http://assets.dev.gov.uk/media/samantha-dixon-mp.jpg",
               },
-              privyCounsellor: nil,
+              privy_counsellor: nil,
             },
             links: {
-              roleAppointments: [
+              role_appointments: [
                 {
                   details: { current: true },
                   links: {
                     role: [
                       {
-                        contentId: uuid_matcher,
+                        content_id: uuid_matcher,
                         details: {
-                          rolePaymentType: nil,
+                          role_payment_type: nil,
                           seniority: 100,
-                          whipOrganisation: nil,
+                          whip_organisation: nil,
                         },
                         title: "Vice Chamberlain of HM Household",
-                        webUrl: "http://www.dev.gov.uk/government/ministers/vice-chamberlain-of-hm-household",
+                        web_url: "http://www.dev.gov.uk/government/ministers/vice-chamberlain-of-hm-household",
                       },
                     ],
                   },
@@ -553,7 +553,7 @@ RSpec.describe "GraphQL" do
               ],
             },
             title: "Samantha Dixon MP",
-            webUrl: "http://www.dev.gov.uk/government/people/samantha-dixon-mp",
+            web_url: "http://www.dev.gov.uk/government/people/samantha-dixon-mp",
           },
         ])
       end
@@ -571,31 +571,31 @@ RSpec.describe "GraphQL" do
       it "exposes the links' fields" do
         make_request
 
-        expect(parsed_links.fetch(:orderedJuniorLordsOfTheTreasuryWhips)).to match([
+        expect(parsed_links.fetch(:ordered_junior_lords_of_the_treasury_whips)).to match([
           {
-            basePath: "/government/people/vicky-foxcroft-mp",
+            base_path: "/government/people/vicky-foxcroft-mp",
             details: {
               image: {
-                altText: "Vicky Foxcroft MP",
+                alt_text: "Vicky Foxcroft MP",
                 url: "http://assets.dev.gov.uk/media/vicky-foxcroft-mp.jpg",
               },
-              privyCounsellor: nil,
+              privy_counsellor: nil,
             },
             links: {
-              roleAppointments: [
+              role_appointments: [
                 {
                   details: { current: true },
                   links: {
                     role: [
                       {
-                        contentId: uuid_matcher,
+                        content_id: uuid_matcher,
                         details: {
-                          rolePaymentType: nil,
+                          role_payment_type: nil,
                           seniority: 100,
-                          whipOrganisation: nil,
+                          whip_organisation: nil,
                         },
                         title: "Junior Lord of the Treasury (Government Whip)",
-                        webUrl: "http://www.dev.gov.uk/government/ministers/junior-lord-of-the-treasury-government-whip",
+                        web_url: "http://www.dev.gov.uk/government/ministers/junior-lord-of-the-treasury-government-whip",
                       },
                     ],
                   },
@@ -603,7 +603,7 @@ RSpec.describe "GraphQL" do
               ],
             },
             title: "Vicky Foxcroft MP",
-            webUrl: "http://www.dev.gov.uk/government/people/vicky-foxcroft-mp",
+            web_url: "http://www.dev.gov.uk/government/people/vicky-foxcroft-mp",
           },
         ])
       end
@@ -629,38 +629,38 @@ RSpec.describe "GraphQL" do
       it "exposes the links' fields" do
         make_request
 
-        expect(parsed_links.fetch(:orderedMinisterialDepartments)).to match([
+        expect(parsed_links.fetch(:ordered_ministerial_departments)).to match([
           {
             details: {
               brand: nil,
               logo: nil,
             },
             links: {
-              orderedMinisters: [
+              ordered_ministers: [
                 {
-                  basePath: "/government/people/keir-starmer",
+                  base_path: "/government/people/keir-starmer",
                   details: {
                     image: {
-                      altText: "Keir Starmer",
+                      alt_text: "Keir Starmer",
                       url: "http://assets.dev.gov.uk/media/keir-starmer.jpg",
                     },
-                    privyCounsellor: nil,
+                    privy_counsellor: nil,
                   },
                   links: {
-                    roleAppointments: [
+                    role_appointments: [
                       {
                         details: { current: true },
                         links: {
                           role: [
                             {
-                              contentId: uuid_matcher,
+                              content_id: uuid_matcher,
                               details: {
-                                rolePaymentType: nil,
+                                role_payment_type: nil,
                                 seniority: 100,
-                                whipOrganisation: nil,
+                                whip_organisation: nil,
                               },
                               title: "Prime Minister",
-                              webUrl: "http://www.dev.gov.uk/government/ministers/prime-minister",
+                              web_url: "http://www.dev.gov.uk/government/ministers/prime-minister",
                             },
                           ],
                         },
@@ -670,14 +670,14 @@ RSpec.describe "GraphQL" do
                         links: {
                           role: [
                             {
-                              contentId: uuid_matcher,
+                              content_id: uuid_matcher,
                               details: {
-                                rolePaymentType: nil,
+                                role_payment_type: nil,
                                 seniority: 100,
-                                whipOrganisation: nil,
+                                whip_organisation: nil,
                               },
                               title: "First Lord of The Treasury",
-                              webUrl: "http://www.dev.gov.uk/government/ministers/first-lord-of-the-treasury",
+                              web_url: "http://www.dev.gov.uk/government/ministers/first-lord-of-the-treasury",
                             },
                           ],
                         },
@@ -685,17 +685,17 @@ RSpec.describe "GraphQL" do
                     ],
                   },
                   title: "Keir Starmer",
-                  webUrl: "http://www.dev.gov.uk/government/people/keir-starmer",
+                  web_url: "http://www.dev.gov.uk/government/people/keir-starmer",
                 },
               ],
-              orderedRoles: [
+              ordered_roles: [
                 {
-                  contentId: uuid_matcher,
+                  content_id: uuid_matcher,
                 },
               ],
             },
             title: "Cabinet Office",
-            webUrl: "http://www.dev.gov.uk/government/organisations/cabinet-office",
+            web_url: "http://www.dev.gov.uk/government/organisations/cabinet-office",
           },
         ])
       end

--- a/spec/integration/graphql/news_article_spec.rb
+++ b/spec/integration/graphql/news_article_spec.rb
@@ -83,16 +83,16 @@ RSpec.describe "GraphQL" do
         query: <<~QUERY,
           {
               edition(
-                basePath: "/government/news/announcement",
-                contentStore: "live",
+                base_path: "/government/news/announcement",
+                content_store: "live",
               ) {
                 ... on NewsArticle {
-                  basePath
+                  base_path
                   title
                   details
                   links {
-                    availableTranslations {
-                      basePath
+                    available_translations {
+                      base_path
                       locale
                     }
                     government {
@@ -102,31 +102,31 @@ RSpec.describe "GraphQL" do
                       title
                     }
                     organisations {
-                      basePath
+                      base_path
                       title
                     }
                     people {
-                      basePath
+                      base_path
                       title
                     }
                     taxons {
-                      basePath
-                      contentId
+                      base_path
+                      content_id
                       title
                       links {
-                        parentTaxons {
-                          basePath
-                          contentId
+                        parent_taxons {
+                          base_path
+                          content_id
                           title
                         }
                       }
                     }
-                    topicalEvents {
-                      basePath
+                    topical_events {
+                      base_path
                       title
                     }
-                    worldLocations {
-                      basePath
+                    world_locations {
+                      base_path
                       title
                     }
                   }
@@ -139,14 +139,14 @@ RSpec.describe "GraphQL" do
       expected = {
         data: {
           edition: {
-            basePath: @edition.base_path,
+            base_path: @edition.base_path,
             details: {
               body: @edition.details[:body],
             },
             links: {
-              availableTranslations: [
+              available_translations: [
                 {
-                  basePath: @edition.base_path,
+                  base_path: @edition.base_path,
                   locale: @edition.locale,
                 },
               ],
@@ -160,41 +160,41 @@ RSpec.describe "GraphQL" do
               ],
               organisations: [
                 {
-                  basePath: @organisation.base_path,
+                  base_path: @organisation.base_path,
                   title: @organisation.title,
                 },
               ],
               people: [
                 {
-                  basePath: @person.base_path,
+                  base_path: @person.base_path,
                   title: @person.title,
                 },
               ],
               taxons: [
                 {
-                  basePath: @child_taxon.base_path,
-                  contentId: @child_taxon.content_id,
+                  base_path: @child_taxon.base_path,
+                  content_id: @child_taxon.content_id,
                   title: @child_taxon.title,
                   links: {
-                    parentTaxons: [
+                    parent_taxons: [
                       {
-                        basePath: @parent_taxon.base_path,
-                        contentId: @parent_taxon.content_id,
+                        base_path: @parent_taxon.base_path,
+                        content_id: @parent_taxon.content_id,
                         title: @parent_taxon.title,
                       },
                     ],
                   },
                 },
               ],
-              topicalEvents: [
+              topical_events: [
                 {
-                  basePath: @topical_event.base_path,
+                  base_path: @topical_event.base_path,
                   title: @topical_event.title,
                 },
               ],
-              worldLocations: [
+              world_locations: [
                 {
-                  basePath: @world_location.base_path,
+                  base_path: @world_location.base_path,
                   title: @world_location.title,
                 },
               ],

--- a/spec/integration/graphql/roles_spec.rb
+++ b/spec/integration/graphql/roles_spec.rb
@@ -113,33 +113,33 @@ RSpec.describe "GraphQL" do
       post "/graphql", params: {
         query:
           "{
-            edition(basePath: \"/government/ministers/prime-minister\") {
+            edition(base_path: \"/government/ministers/prime-minister\") {
               ... on Role {
-                basePath
+                base_path
                 locale
                 title
 
                 details {
                   body
-                  supportsHistoricalAccounts
+                  supports_historical_accounts
                 }
 
                 links {
-                  availableTranslations {
-                    basePath
+                  available_translations {
+                    base_path
                     locale
                   }
 
-                  roleAppointments {
+                  role_appointments {
                     details {
                       current
-                      endedOn
-                      startedOn
+                      ended_on
+                      started_on
                     }
 
                     links {
                       person {
-                        basePath
+                        base_path
                         title
 
                         details {
@@ -149,8 +149,8 @@ RSpec.describe "GraphQL" do
                     }
                   }
 
-                  orderedParentOrganisations {
-                    basePath
+                  ordered_parent_organisations {
+                    base_path
                     title
                   }
                 }
@@ -162,34 +162,34 @@ RSpec.describe "GraphQL" do
       expected = {
         data: {
           edition: {
-            basePath: "/government/ministers/prime-minister",
+            base_path: "/government/ministers/prime-minister",
             locale: "en",
             title: "Prime Minister",
             details: {
               body: "<h1 id=\"prime-minister\">Prime Minister</h1>\n<p>The Prime Minister is the leader of His Majesty’s Government</p>\n",
-              supportsHistoricalAccounts: true,
+              supports_historical_accounts: true,
             },
             links: {
-              availableTranslations: [
+              available_translations: [
                 {
-                  basePath: "/government/ministers/prime-minister",
+                  base_path: "/government/ministers/prime-minister",
                   locale: "en",
                 },
                 {
-                  basePath: "/government/ministers/prime-minister.es",
+                  base_path: "/government/ministers/prime-minister.es",
                   locale: "es",
                 },
               ],
-              roleAppointments: [
+              role_appointments: [
                 {
                   details: {
                     current: true,
-                    endedOn: nil,
-                    startedOn: "2024-07-05T00:00:00Z",
+                    ended_on: nil,
+                    started_on: "2024-07-05T00:00:00Z",
                   },
                   links: {
                     person: [
-                      basePath: "/government/people/keir-starmer",
+                      base_path: "/government/people/keir-starmer",
                       title: "The Rt Hon Sir Keir Starmer KCB KC MP",
                       details: {
                         body: "<p>Sir Keir Starmer became Prime Minister on 5 July 2024.</p>\n",
@@ -200,12 +200,12 @@ RSpec.describe "GraphQL" do
                 {
                   details: {
                     current: false,
-                    endedOn: "2024-07-05T00:00:00Z",
-                    startedOn: "2022-10-25T00:00:00Z",
+                    ended_on: "2024-07-05T00:00:00Z",
+                    started_on: "2022-10-25T00:00:00Z",
                   },
                   links: {
                     person: [
-                      basePath: "/government/people/rishi-sunak",
+                      base_path: "/government/people/rishi-sunak",
                       details: {
                         body: "<p>Rishi Sunak was Prime Minister between 25 October 2022 and 5 July 2024.</p>\n",
                       },
@@ -214,13 +214,13 @@ RSpec.describe "GraphQL" do
                   },
                 },
               ],
-              orderedParentOrganisations: [
+              ordered_parent_organisations: [
                 {
-                  basePath: "/government/organisations/cabinet-office",
+                  base_path: "/government/organisations/cabinet-office",
                   title: "Cabinet Office",
                 },
                 {
-                  basePath: "/government/organisations/prime-ministers-office-10-downing-street",
+                  base_path: "/government/organisations/prime-ministers-office-10-downing-street",
                   title: "Prime Minister's Office, 10 Downing Street",
                 },
               ],

--- a/spec/integration/graphql/world_index_spec.rb
+++ b/spec/integration/graphql/world_index_spec.rb
@@ -39,24 +39,24 @@ RSpec.describe "GraphQL" do
         query:
           "fragment worldLocationInfo on WorldLocation {
             active
-            analyticsIdentifier
-            contentId
+            analytics_identifier
+            content_id
             name
             slug
-            updatedAt
+            updated_at
           }
 
           {
-            edition(basePath: \"/world\") {
+            edition(base_path: \"/world\") {
               ... on WorldIndex {
                 title
 
                 details {
-                  worldLocations {
+                  world_locations {
                     ...worldLocationInfo
                   }
 
-                  internationalDelegations {
+                  international_delegations {
                     ...worldLocationInfo
                   }
                 }
@@ -70,24 +70,24 @@ RSpec.describe "GraphQL" do
           edition: {
             title: "Help and services around the world",
             details: {
-              worldLocations: [
+              world_locations: [
                 {
                   active: true,
-                  analyticsIdentifier: "WL1",
-                  contentId: "d3b7ba48-5027-4a98-a594-1108d205dc66",
+                  analytics_identifier: "WL1",
+                  content_id: "d3b7ba48-5027-4a98-a594-1108d205dc66",
                   name: "Test World Location",
                   slug: "test-world-location",
-                  updatedAt: "2024-10-18T14:22:38+01:00",
+                  updated_at: "2024-10-18T14:22:38+01:00",
                 },
               ],
-              internationalDelegations: [
+              international_delegations: [
                 {
                   active: false,
-                  analyticsIdentifier: "WL2",
-                  contentId: "f0313f16-e25c-4bfe-a0fc-e561833f705f",
+                  analytics_identifier: "WL2",
+                  content_id: "f0313f16-e25c-4bfe-a0fc-e561833f705f",
                   name: "Test International Delegation",
                   slug: "test-international-delegation",
-                  updatedAt: "2024-10-19T15:07:44+01:00",
+                  updated_at: "2024-10-19T15:07:44+01:00",
                 },
               ],
             },


### PR DESCRIPTION
GraphQL Ruby automatically [camelises field names](https://graphql-ruby.org/fields/introduction.html#field-names). We would like to switch this off and always use snake casing to match the field names currently present in content items.

Therefore applying this as a default to all our fields.

[Trello card](https://trello.com/c/RMkMvY8b)