### PR TITLE
Remove unused 'important_board_members' column from schema

### DIFF
--- a/content_schemas/dist/formats/organisation/frontend/schema.json
+++ b/content_schemas/dist/formats/organisation/frontend/schema.json
@@ -394,10 +394,6 @@
           "description": "Whether the organisation is exempt from Freedom of Information requests.",
           "type": "boolean"
         },
-        "important_board_members": {
-          "description": "The number of board members that will have photos displayed for them.",
-          "type": "integer"
-        },
         "logo": {
           "description": "The organisation's logo, including the logo image and formatted name.",
           "type": "object",

--- a/content_schemas/dist/formats/organisation/notification/schema.json
+++ b/content_schemas/dist/formats/organisation/notification/schema.json
@@ -541,10 +541,6 @@
           "description": "Whether the organisation is exempt from Freedom of Information requests.",
           "type": "boolean"
         },
-        "important_board_members": {
-          "description": "The number of board members that will have photos displayed for them.",
-          "type": "integer"
-        },
         "logo": {
           "description": "The organisation's logo, including the logo image and formatted name.",
           "type": "object",

--- a/content_schemas/dist/formats/organisation/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/organisation/publisher_v2/schema.json
@@ -235,10 +235,6 @@
           "description": "Whether the organisation is exempt from Freedom of Information requests.",
           "type": "boolean"
         },
-        "important_board_members": {
-          "description": "The number of board members that will have photos displayed for them.",
-          "type": "integer"
-        },
         "logo": {
           "description": "The organisation's logo, including the logo image and formatted name.",
           "type": "object",

--- a/content_schemas/examples/guide/frontend/guide-with-hide-navigation.json
+++ b/content_schemas/examples/guide/frontend/guide-with-hide-navigation.json
@@ -465,7 +465,6 @@
           "ordered_special_representatives": [
 
           ],
-          "important_board_members": 1,
           "organisation_featuring_priority": "news",
           "organisation_govuk_status": {
             "status": "live",

--- a/content_schemas/examples/guide/frontend/guide-with-step-navs-and-hide-navigation.json
+++ b/content_schemas/examples/guide/frontend/guide-with-step-navs-and-hide-navigation.json
@@ -651,7 +651,6 @@
           "ordered_special_representatives": [
 
           ],
-          "important_board_members": 1,
           "organisation_featuring_priority": "news",
           "organisation_govuk_status": {
             "status": "replaced",

--- a/content_schemas/examples/guide/frontend/single-page-guide-with-step-navs-and-hide-navigation.json
+++ b/content_schemas/examples/guide/frontend/single-page-guide-with-step-navs-and-hide-navigation.json
@@ -1153,7 +1153,6 @@
           "ordered_special_representatives": [
 
           ],
-          "important_board_members": 1,
           "organisation_featuring_priority": "service",
           "organisation_govuk_status": {
             "status": "live",

--- a/content_schemas/examples/organisation/frontend/attorney_general.json
+++ b/content_schemas/examples/organisation/frontend/attorney_general.json
@@ -964,7 +964,6 @@
     "ordered_promotional_features": [
 
     ],
-    "important_board_members": 1,
     "organisation_featuring_priority": "news",
     "organisation_govuk_status": {
       "status": "live",

--- a/content_schemas/examples/organisation/frontend/charity_commission.json
+++ b/content_schemas/examples/organisation/frontend/charity_commission.json
@@ -1713,7 +1713,6 @@
     "ordered_promotional_features": [
 
     ],
-    "important_board_members": 2,
     "organisation_featuring_priority": "service",
     "organisation_govuk_status": {
       "status": "live",

--- a/content_schemas/examples/organisation/frontend/court.json
+++ b/content_schemas/examples/organisation/frontend/court.json
@@ -290,7 +290,6 @@
     "ordered_promotional_features": [
 
     ],
-    "important_board_members": 1,
     "organisation_featuring_priority": "service",
     "organisation_govuk_status": {
       "status": "live",

--- a/content_schemas/examples/organisation/frontend/number_10.json
+++ b/content_schemas/examples/organisation/frontend/number_10.json
@@ -1583,7 +1583,6 @@
         ]
       }
     ],
-    "important_board_members": 1,
     "organisation_featuring_priority": "news",
     "organisation_govuk_status": {
       "status": "live",

--- a/content_schemas/examples/organisation/frontend/organisation.json
+++ b/content_schemas/examples/organisation/frontend/organisation.json
@@ -2339,7 +2339,6 @@
     "ordered_promotional_features": [
 
     ],
-    "important_board_members": 1,
     "organisation_featuring_priority": "news",
     "organisation_govuk_status": {
       "status": "no_longer_exists",

--- a/content_schemas/examples/organisation/frontend/tribunal.json
+++ b/content_schemas/examples/organisation/frontend/tribunal.json
@@ -201,7 +201,6 @@
     "ordered_promotional_features": [
 
     ],
-    "important_board_members": 1,
     "organisation_featuring_priority": "service",
     "organisation_govuk_status": {
       "status": "live",

--- a/content_schemas/examples/organisation/frontend/wales_office.json
+++ b/content_schemas/examples/organisation/frontend/wales_office.json
@@ -1205,7 +1205,6 @@
     "ordered_promotional_features": [
 
     ],
-    "important_board_members": 4,
     "organisation_featuring_priority": "news",
     "organisation_govuk_status": {
       "status": "live",

--- a/content_schemas/examples/specialist_document/frontend/eu-withdrawal-act-2018-statutory-instruments.json
+++ b/content_schemas/examples/specialist_document/frontend/eu-withdrawal-act-2018-statutory-instruments.json
@@ -363,7 +363,6 @@
           "ordered_special_representatives": [
 
           ],
-          "important_board_members": 1,
           "organisation_featuring_priority": "news",
           "organisation_govuk_status": {
             "status": "live",
@@ -448,7 +447,6 @@
           "ordered_special_representatives": [
 
           ],
-          "important_board_members": 1,
           "organisation_featuring_priority": "news",
           "organisation_govuk_status": {
             "status": "live",
@@ -537,7 +535,6 @@
           "ordered_special_representatives": [
 
           ],
-          "important_board_members": 1,
           "organisation_featuring_priority": "service",
           "organisation_govuk_status": {
             "status": "live",

--- a/content_schemas/formats/organisation.jsonnet
+++ b/content_schemas/formats/organisation.jsonnet
@@ -96,10 +96,6 @@
           },
           description: "A set of promotional features to display for the organisation. Turn into proper links once organisations are fully migrated.",
         },
-        important_board_members: {
-          type: "integer",
-          description: "The number of board members that will have photos displayed for them.",
-        },
         organisation_featuring_priority: {
           type: "string",
           enum: [


### PR DESCRIPTION
Removed in https://github.com/alphagov/whitehall/pull/9765

Trello: https://trello.com/c/mz0WLkIR/3282-remove-display-management-team-images-feature

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
