### PR TITLE
Add World Locations to list of formats with no rendering app

### DIFF
--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -37,7 +37,7 @@ class Edition < ApplicationRecord
   ].freeze
 
   NON_RENDERABLE_FORMATS = %w[redirect gone].freeze
-  NO_RENDERING_APP_FORMATS = %w[contact external_content role_appointment].freeze
+  NO_RENDERING_APP_FORMATS = %w[contact external_content role_appointment world_location].freeze
   CONTENT_BLOCK_PREFIX = "content_block".freeze
 
   belongs_to :document


### PR DESCRIPTION
World Locations are not rendered on GOV.UK, so can be added to the list of formats that do not require a rendering app.

[Trello card](https://trello.com/c/6jD9m6Sl)