### PR TITLE
Support multiple content types in details fields

### DIFF
--- a/app/presenters/content_type_resolver.rb
+++ b/app/presenters/content_type_resolver.rb
@@ -1,0 +1,43 @@
+class Presenters::ContentTypeResolver
+  def initialize(content_type)
+    self.content_type = content_type
+  end
+
+  def resolve(object)
+    case object
+    when Hash
+      resolve_hash(object)
+    when Array
+      resolve_array(object)
+    else
+      object
+    end
+  end
+
+private
+
+  def resolve_hash(hash)
+    hash.inject({}) do |memo, (key, value)|
+      memo.merge(key => resolve(value))
+    end
+  end
+
+  def resolve_array(array)
+    if array.all? { |v| v.is_a?(Hash) }
+      array = array.map(&:symbolize_keys)
+      content_for_type = extract_content(array)
+    end
+
+    if content_for_type
+      content_for_type[:content]
+    else
+      array.map { |e| resolve(e) }
+    end
+  end
+
+  def extract_content(array)
+    array.detect { |h| h[:content_type] == content_type && h[:content] }
+  end
+
+  attr_accessor :content_type
+end

--- a/spec/graphql/types/edition_type_spec.rb
+++ b/spec/graphql/types/edition_type_spec.rb
@@ -30,4 +30,54 @@ RSpec.describe "Types::EditionType" do
       end
     end
   end
+
+  context "content types in the details" do
+    context "when the body is a string" do
+      it "returns the string" do
+        edition = create(:edition, details: { body: "some text" })
+
+        expect(
+          run_graphql_field(
+            "Edition.details",
+            edition,
+          )[:body],
+        ).to eq("some text")
+      end
+    end
+
+    context "when there are multiple content types and one is html" do
+      it "returns the html" do
+        edition = create(:edition, details: {
+          body: [
+            { content_type: "text/govspeak", content: "some text" },
+            { content_type: "text/html", content: "<p>some other text</p>" },
+          ],
+        })
+
+        expect(
+          run_graphql_field(
+            "Edition.details",
+            edition,
+          )[:body],
+        ).to eq("<p>some other text</p>")
+      end
+    end
+
+    context "when there are multiple content types and none are html" do
+      it "converts the govspeak to html" do
+        edition = create(:edition, details: {
+          body: [
+            { content_type: "text/govspeak", content: "some text" },
+          ],
+        })
+
+        expect(
+          run_graphql_field(
+            "Edition.details",
+            edition,
+          )[:body],
+        ).to eq("<p>some text</p>\n")
+      end
+    end
+  end
 end

--- a/spec/presenters/content_type_resolver_spec.rb
+++ b/spec/presenters/content_type_resolver_spec.rb
@@ -1,0 +1,130 @@
+RSpec.describe Presenters::ContentTypeResolver do
+  subject { described_class.new("html") }
+
+  it "inlines content of the specified content type" do
+    result = subject.resolve(
+      body: [
+        { content_type: "html", content: "<p>body</p>" },
+        { content_type: "text", content: "body" },
+      ],
+    )
+
+    expect(result).to eq(
+      body: "<p>body</p>",
+    )
+  end
+
+  it "works for string keys as well as symbols" do
+    result = subject.resolve(
+      "body" => [
+        { "content_type" => "html", "content" => "<p>body</p>" },
+        { "content_type" => "text", "content" => "body" },
+      ],
+    )
+
+    expect(result).to eq(
+      "body" => "<p>body</p>",
+    )
+  end
+
+  it "does not affect other fields" do
+    result = subject.resolve(
+      string: "string",
+      array: [],
+      number: 123,
+    )
+
+    expect(result).to eq(
+      string: "string",
+      array: [],
+      number: 123,
+    )
+  end
+
+  it "handles hashes with content types but no content field" do
+    result = subject.resolve([
+      content_type: "application/pdf",
+      path: "some/document.pdf",
+    ])
+
+    expect(result).to eq([
+      content_type: "application/pdf",
+      path: "some/document.pdf",
+    ])
+  end
+
+  it "recurses on nested hashes" do
+    result = subject.resolve(
+      details: {
+        foo: {
+          bar: {
+            content: [
+              { content_type: "html", content: "<p>body</p>" },
+            ],
+          },
+        },
+      },
+    )
+
+    expect(result).to eq(
+      details: {
+        foo: {
+          bar: {
+            content: "<p>body</p>",
+          },
+        },
+      },
+    )
+  end
+
+  it "recurses on nested arrays" do
+    result = subject.resolve(
+      paragraphs: [
+        [
+          [
+            {
+              body: [
+                { content_type: "html", content: "<p>body</p>" },
+              ],
+            },
+          ],
+        ],
+      ],
+    )
+
+    expect(result).to eq(
+      paragraphs: [
+        [
+          [
+            {
+              body: "<p>body</p>",
+            },
+          ],
+        ],
+      ],
+    )
+  end
+
+  it "doesn't resolve incomplete multi-type content" do
+    result = subject.resolve(
+      details: {
+        body: {
+          content: [
+            { content: "<p>body</p>" },
+            { content_type: "html" },
+          ],
+        },
+      },
+    )
+    expect(result).to eq(
+      details: {
+        body: {
+          content: [
+            { content: "<p>body</p>" },
+            { content_type: "html" },
+          ],
+        },
+      },
+    )
+  end
+end


### PR DESCRIPTION
According to [ADR-004](https://github.com/alphagov/publishing-api/blob/main/docs/arch/adr-004-govspeak-and-embedded-content.md), it is possible to represent content in an array format containing multiple types. This can include already parsed govspeak in HTML format or only govspeak. In the latter case, Publishing API parses this and converts to HTML before sending the content to Content Store.

This replicates that behaviour for GraphQL responses, expanding this to all fields within `details`, not just the body.

As we are now using the `DetailsPresenter`, it also has the side effect of supporting embedded content and full change history in GraphQL responses.

[Trello card](https://trello.com/c/Rp5p0NTL)