### PR TITLE
Return success from publish command when document already has a published edition and no draft exists

### DIFF
--- a/app/commands/v2/publish.rb
+++ b/app/commands/v2/publish.rb
@@ -2,9 +2,11 @@ module Commands
   module V2
     class Publish < BaseCommand
       def call
-        validate
-        publish_edition
-        after_transaction_commit { send_downstream }
+        unless already_published? && edition.nil?
+          validate
+          publish_edition
+          after_transaction_commit { send_downstream }
+        end
 
         Success.new({ content_id: })
       end
@@ -82,13 +84,8 @@ module Commands
       end
 
       def no_draft_item_exists
-        if already_published?
-          message = "Cannot publish an already published edition"
-          raise_command_error(409, message, { fields: {} })
-        else
-          message = "Item with content_id #{content_id} and locale #{locale} does not exist"
-          raise_command_error(404, message, { fields: {} })
-        end
+        message = "Item with content_id #{content_id} and locale #{locale} does not exist"
+        raise_command_error(404, message, { fields: {} })
       end
 
       def validate_update_type

--- a/docs/api.md
+++ b/docs/api.md
@@ -187,6 +187,8 @@ Transitions an edition from a draft state to a published state. The edition
 will be presented in the live content store. Uses
 [optimistic-locking](#optimistic-locking-previous_version).
 
+This endpoint is idempotent. If the document already has a published edition and does not have a draft edition, the endpoint will return a 200 OK response.
+
 ### Path parameters
 
 - [`content_id`](model.md#content_id)

--- a/spec/commands/v2/publish_spec.rb
+++ b/spec/commands/v2/publish_spec.rb
@@ -727,10 +727,11 @@ RSpec.describe Commands::V2::Publish do
           )
         end
 
-        it "raises an error to indicate it has already been published" do
+        it "performs a no-op" do
+          expect(DownstreamLiveJob).not_to receive(:perform_async_in_queue)
           expect {
             described_class.call(payload)
-          }.to raise_error(CommandError, /already published edition/)
+          }.not_to raise_error
         end
       end
     end


### PR DESCRIPTION
Previously the publish command raised a conflict error in this case.

However, this error was rarely useful to the Publishing apps, as in almost all cases it is caused by publishing apps having to do their own dependency resolution due to shortcomings in Publishing API's dependency resolution, or by Sidekiq's "at least once" job running guarantees.

We therefore return a success response from the publish command and perform a no-op in this situation, rather than return an HTTP 409 error response for the publishing app to handle.

## Why

This causes occasional errors in Whitehall which trigger Sentry alerts. Whilst we could ignore 409 responses in Whitehall, it seems sensible to make a change on the Publishing API side. From a RESTful API perspective the request has been successful in that the document is in the published state.

For further discussion see this Trello card: https://trello.com/c/h7xkpcUj and [Slack thread](https://gds.slack.com/archives/C03D792LYJG/p1734448614763359) 

This will require an accompanying PR to update the Pact tests for Publishing API: https://github.com/alphagov/gds-api-adapters/pull/1319
