### PR TITLE
(801) Add document type to HostContentUpdateJob events

### DIFF
--- a/app/sidekiq/host_content_update_job.rb
+++ b/app/sidekiq/host_content_update_job.rb
@@ -11,6 +11,7 @@ private
       source_block: {
         title: source_edition.title,
         content_id: source_edition.content_id,
+        document_type: source_edition.document_type,
         updated_by_user_uid: source_edition_publication_event&.user_uid,
       },
     }

--- a/lib/tasks/add_document_type_to_host_content_update_events.rake
+++ b/lib/tasks/add_document_type_to_host_content_update_events.rake
@@ -1,0 +1,16 @@
+desc "Add a document type to the payload of HostContentUpdateJob events"
+task add_document_type_to_host_content_update_events: :environment do
+  events = Event.where(action: "HostContentUpdateJob")
+  content_ids = events.map { |e| e.payload.dig(:source_block, :content_id) }
+  editions = Edition.with_document.where(state: "published", documents: { content_id: content_ids })
+  document_types = editions.map { |e| [e.document.content_id, e.document_type] }.to_h
+
+  events.each do |event|
+    content_id = event.payload.dig(:source_block, :content_id)
+    document_type = document_types[content_id]
+    next unless content_id && document_type
+
+    event.payload = event.payload.deep_merge({ source_block: { document_type: } })
+    event.save!
+  end
+end

--- a/spec/lib/tasks/add_document_type_to_host_content_update_events_spec.rb
+++ b/spec/lib/tasks/add_document_type_to_host_content_update_events_spec.rb
@@ -1,0 +1,35 @@
+RSpec.describe "Add document type to events Rake task" do
+  let(:task) { Rake::Task["add_document_type_to_host_content_update_events"] }
+  before { task.reenable }
+
+  it "adds the document types to the events payload" do
+    editions = [
+      create(:edition, state: "published", document_type: "content_type_1"),
+      create(:edition, state: "published", document_type: "content_type_2"),
+      create(:edition, state: "published", document_type: "content_type_3"),
+    ]
+
+    events = [
+      create(:event, action: "HostContentUpdateJob", payload: { source_block: { content_id: editions[0].document.content_id } }),
+      create(:event, action: "HostContentUpdateJob", payload: { source_block: { content_id: editions[1].document.content_id } }),
+      create(:event, action: "HostContentUpdateJob", payload: { source_block: { content_id: editions[2].document.content_id } }),
+    ]
+
+    event_without_content_id = create(:event, action: "HostContentUpdateJob", payload: { something: "else" })
+    other_event = create(:event, action: "SomeOtherAction", payload: { source_block: { content_id: editions[2].document.content_id } })
+
+    task.invoke
+
+    events.each_with_index do |e, i|
+      expect(e.reload.payload).to eq({
+        source_block: {
+          content_id: editions[i].document.content_id,
+          document_type: editions[i].document_type,
+        },
+      })
+    end
+
+    expect(event_without_content_id.reload.payload).to eq({ something: "else" })
+    expect(other_event.reload.payload).to eq({ source_block: { content_id: editions[2].document.content_id } })
+  end
+end

--- a/spec/sidekiq/host_content_update_job_spec.rb
+++ b/spec/sidekiq/host_content_update_job_spec.rb
@@ -1,6 +1,7 @@
 RSpec.describe HostContentUpdateJob, :perform do
   let(:content_id) { SecureRandom.uuid }
-  let(:edition) { build(:live_edition) }
+  let(:document_type) { "content_block_email_address" }
+  let(:edition) { build(:live_edition, document_type:) }
   let(:document) { build(:document, live: edition, content_id:) }
 
   subject(:worker_perform) do
@@ -58,6 +59,7 @@ RSpec.describe HostContentUpdateJob, :perform do
     expect(event.content_id).to eq(dependent_content_id)
     expect(event.payload[:source_block][:title]).to eq(edition.title)
     expect(event.payload[:source_block][:content_id]).to eq(content_id)
+    expect(event.payload[:source_block][:document_type]).to eq(document_type)
     expect(event.payload[:source_block][:updated_by_user_uid]).to eq(latest_publish_event.user_uid)
     expect(event.payload[:message]).to eq("Host content updated by content block update")
   end


### PR DESCRIPTION
Trello card: https://trello.com/c/iYVwlbzT/801-link-to-content-block-from-whitehall-history

This adds an additional `document_type` to the `HostContentUpdateJob` events introduced in https://github.com/alphagov/publishing-api/pull/2993. This will allow us to identify the type of block that has been updated when viewing a dependent document's history.