### PR TITLE
Add schema example for withdrawn travel advice

### DIFF
--- a/content_schemas/examples/travel_advice/frontend/withdrawn-full-country.json
+++ b/content_schemas/examples/travel_advice/frontend/withdrawn-full-country.json
@@ -1,0 +1,522 @@
+{
+  "analytics_identifier": null,
+  "base_path": "/foreign-travel-advice/albania",
+  "content_id": "2a3938e1-d588-45fc-8c8f-0f51814d5409",
+  "document_type": "travel_advice",
+  "first_published_at": "2016-02-29T09:24:10.000+00:00",
+  "locale": "en",
+  "phase": "live",
+  "public_updated_at": "2017-02-14T15:42:21.000+00:00",
+  "publishing_app": "travel-advice-publisher",
+  "rendering_app": "government-frontend",
+  "schema_name": "travel_advice",
+  "title": "Albania travel advice",
+  "updated_at": "2017-02-17T12:52:43.537Z",
+  "withdrawn_notice": {
+    "explanation": "<div class=\"govspeak\"><p>This information has been archived as it is now out of date.</p></div>",
+    "withdrawn_at": "2017-02-28T13:05:30Z"
+  },
+  "links": {
+    "ordered_related_items": [
+      {
+        "analytics_identifier": null,
+        "api_path": "/api/content/driving-abroad",
+        "base_path": "/driving-abroad",
+        "content_id": "e4d06cb9-9e2e-4e82-b802-0aad013ae16c",
+        "description": "You'll need a Great Britain or Northern Ireland licence to drive abroad and an International Driving Permit in some non-EU countries",
+        "document_type": "answer",
+        "locale": "en",
+        "public_updated_at": "2015-07-09T08:31:23Z",
+        "schema_name": "generic_with_external_related_links",
+        "title": "Driving abroad",
+        "withdrawn": false,
+        "links": {
+          "mainstream_browse_pages": [
+            {
+              "analytics_identifier": null,
+              "api_path": "/api/content/browse/abroad/living-abroad",
+              "base_path": "/browse/abroad/living-abroad",
+              "content_id": "bbb8985a-5451-4e9d-a601-8c55853a096c",
+              "description": "Includes tax, State Pension, benefits and UK government services abroad",
+              "document_type": "mainstream_browse_page",
+              "locale": "en",
+              "public_updated_at": "2015-06-24T13:56:51Z",
+              "schema_name": "mainstream_browse_page",
+              "title": "Living abroad",
+              "withdrawn": false,
+              "links": {
+                "parent": [
+                  {
+                    "analytics_identifier": null,
+                    "api_path": "/api/content/browse/abroad",
+                    "base_path": "/browse/abroad",
+                    "content_id": "86eb717a-fb40-42e7-83fa-d031a03880fb",
+                    "description": "Includes renewing passports and travel advice by country",
+                    "document_type": "mainstream_browse_page",
+                    "locale": "en",
+                    "public_updated_at": "2015-04-08T10:48:43Z",
+                    "schema_name": "mainstream_browse_page",
+                    "title": "Passports, travel and living abroad",
+                    "withdrawn": false,
+                    "links": {
+                    },
+                    "api_url": "https://www.gov.uk/api/content/browse/abroad",
+                    "web_url": "https://www.gov.uk/browse/abroad"
+                  }
+                ]
+              },
+              "api_url": "https://www.gov.uk/api/content/browse/abroad/living-abroad",
+              "web_url": "https://www.gov.uk/browse/abroad/living-abroad"
+            },
+            {
+              "analytics_identifier": null,
+              "api_path": "/api/content/browse/abroad/travel-abroad",
+              "base_path": "/browse/abroad/travel-abroad",
+              "content_id": "b9849cd6-61a7-42dc-8124-362d2c7d48b0",
+              "description": "Includes the latest travel advice by country, your rights at the airport and getting help abroad",
+              "document_type": "mainstream_browse_page",
+              "locale": "en",
+              "public_updated_at": "2015-06-24T13:56:51Z",
+              "schema_name": "mainstream_browse_page",
+              "title": "Travel abroad",
+              "withdrawn": false,
+              "links": {
+                "parent": [
+                  {
+                    "analytics_identifier": null,
+                    "api_path": "/api/content/browse/abroad",
+                    "base_path": "/browse/abroad",
+                    "content_id": "86eb717a-fb40-42e7-83fa-d031a03880fb",
+                    "description": "Includes renewing passports and travel advice by country",
+                    "document_type": "mainstream_browse_page",
+                    "locale": "en",
+                    "public_updated_at": "2015-04-08T10:48:43Z",
+                    "schema_name": "mainstream_browse_page",
+                    "title": "Passports, travel and living abroad",
+                    "withdrawn": false,
+                    "links": {
+                    },
+                    "api_url": "https://www.gov.uk/api/content/browse/abroad",
+                    "web_url": "https://www.gov.uk/browse/abroad"
+                  }
+                ]
+              },
+              "api_url": "https://www.gov.uk/api/content/browse/abroad/travel-abroad",
+              "web_url": "https://www.gov.uk/browse/abroad/travel-abroad"
+            },
+            {
+              "analytics_identifier": null,
+              "api_path": "/api/content/browse/driving/driving-uk-and-abroad",
+              "base_path": "/browse/driving/driving-uk-and-abroad",
+              "content_id": "231ad2c1-c1cd-4e00-8479-5277cfe05027",
+              "description": "",
+              "document_type": "mainstream_browse_page",
+              "locale": "en",
+              "public_updated_at": "2016-10-10T23:14:51Z",
+              "schema_name": "mainstream_browse_page",
+              "title": "Driving in the UK and abroad",
+              "withdrawn": false,
+              "links": {
+                "parent": [
+                  {
+                    "analytics_identifier": null,
+                    "api_path": "/api/content/browse/driving",
+                    "base_path": "/browse/driving",
+                    "content_id": "03531ffd-314b-4fed-9361-fa9816005c31",
+                    "description": "Apply for a driving licence, tax your vehicle, book your driving test, and find out the legal requirements for buying, owning, importing or scrapping a car or motorcycle, and read about your rights and responsibilities as a driver",
+                    "document_type": "mainstream_browse_page",
+                    "locale": "en",
+                    "public_updated_at": "2016-10-07T22:18:32Z",
+                    "schema_name": "mainstream_browse_page",
+                    "title": "Driving and transport",
+                    "withdrawn": false,
+                    "links": {
+                    },
+                    "api_url": "https://www.gov.uk/api/content/browse/driving",
+                    "web_url": "https://www.gov.uk/browse/driving"
+                  }
+                ]
+              },
+              "api_url": "https://www.gov.uk/api/content/browse/driving/driving-uk-and-abroad",
+              "web_url": "https://www.gov.uk/browse/driving/driving-uk-and-abroad"
+            }
+          ]
+        },
+        "api_url": "https://www.gov.uk/api/content/driving-abroad",
+        "web_url": "https://www.gov.uk/driving-abroad"
+      },
+      {
+        "analytics_identifier": null,
+        "api_path": "/api/content/hand-luggage-restrictions",
+        "base_path": "/hand-luggage-restrictions",
+        "content_id": "95f9c380-30bc-44c7-86b4-e9c9ef0fc272",
+        "description": "Hand luggage restrictions at UK airports - carry-on luggage, checked-in baggage, restricted items and liquids",
+        "document_type": "guide",
+        "locale": "en",
+        "public_updated_at": "2015-09-07T16:23:07Z",
+        "schema_name": "generic_with_external_related_links",
+        "title": "Hand luggage restrictions at UK airports",
+        "withdrawn": false,
+        "links": {
+          "mainstream_browse_pages": [
+            {
+              "analytics_identifier": null,
+              "api_path": "/api/content/browse/abroad/travel-abroad",
+              "base_path": "/browse/abroad/travel-abroad",
+              "content_id": "b9849cd6-61a7-42dc-8124-362d2c7d48b0",
+              "description": "Includes the latest travel advice by country, your rights at the airport and getting help abroad",
+              "document_type": "mainstream_browse_page",
+              "locale": "en",
+              "public_updated_at": "2015-06-24T13:56:51Z",
+              "schema_name": "mainstream_browse_page",
+              "title": "Travel abroad",
+              "withdrawn": false,
+              "links": {
+                "parent": [
+                  {
+                    "analytics_identifier": null,
+                    "api_path": "/api/content/browse/abroad",
+                    "base_path": "/browse/abroad",
+                    "content_id": "86eb717a-fb40-42e7-83fa-d031a03880fb",
+                    "description": "Includes renewing passports and travel advice by country",
+                    "document_type": "mainstream_browse_page",
+                    "locale": "en",
+                    "public_updated_at": "2015-04-08T10:48:43Z",
+                    "schema_name": "mainstream_browse_page",
+                    "title": "Passports, travel and living abroad",
+                    "withdrawn": false,
+                    "links": {
+                    },
+                    "api_url": "https://www.gov.uk/api/content/browse/abroad",
+                    "web_url": "https://www.gov.uk/browse/abroad"
+                  }
+                ]
+              },
+              "api_url": "https://www.gov.uk/api/content/browse/abroad/travel-abroad",
+              "web_url": "https://www.gov.uk/browse/abroad/travel-abroad"
+            }
+          ]
+        },
+        "api_url": "https://www.gov.uk/api/content/hand-luggage-restrictions",
+        "web_url": "https://www.gov.uk/hand-luggage-restrictions"
+      },
+      {
+        "analytics_identifier": null,
+        "api_path": "/api/content/renew-adult-passport",
+        "base_path": "/renew-adult-passport",
+        "content_id": "82248bb1-c4d6-41e0-9494-d98123475626",
+        "description": "How to apply, how long it takes, how much it costs, track your application, unexpired visas, replacing a damaged passport",
+        "document_type": "guide",
+        "locale": "en",
+        "public_updated_at": "2015-01-12T00:01:07Z",
+        "schema_name": "generic_with_external_related_links",
+        "title": "Renew or replace your adult passport",
+        "withdrawn": false,
+        "links": {
+          "mainstream_browse_pages": [
+            {
+              "analytics_identifier": null,
+              "api_path": "/api/content/browse/abroad/passports",
+              "base_path": "/browse/abroad/passports",
+              "content_id": "dd842862-e148-4fe3-b363-e57d6a2689aa",
+              "description": "Eligibility, fees, applying, renewing and updating",
+              "document_type": "mainstream_browse_page",
+              "locale": "en",
+              "public_updated_at": "2016-12-05T17:00:29Z",
+              "schema_name": "mainstream_browse_page",
+              "title": "Passports",
+              "withdrawn": false,
+              "links": {
+                "parent": [
+                  {
+                    "analytics_identifier": null,
+                    "api_path": "/api/content/browse/abroad",
+                    "base_path": "/browse/abroad",
+                    "content_id": "86eb717a-fb40-42e7-83fa-d031a03880fb",
+                    "description": "Includes renewing passports and travel advice by country",
+                    "document_type": "mainstream_browse_page",
+                    "locale": "en",
+                    "public_updated_at": "2015-04-08T10:48:43Z",
+                    "schema_name": "mainstream_browse_page",
+                    "title": "Passports, travel and living abroad",
+                    "withdrawn": false,
+                    "links": {
+                    },
+                    "api_url": "https://www.gov.uk/api/content/browse/abroad",
+                    "web_url": "https://www.gov.uk/browse/abroad"
+                  }
+                ]
+              },
+              "api_url": "https://www.gov.uk/api/content/browse/abroad/passports",
+              "web_url": "https://www.gov.uk/browse/abroad/passports"
+            }
+          ]
+        },
+        "api_url": "https://www.gov.uk/api/content/renew-adult-passport",
+        "web_url": "https://www.gov.uk/renew-adult-passport"
+      }
+    ],
+    "organisations": [
+      {
+        "analytics_identifier": "D13",
+        "api_path": "/api/content/government/organisations/foreign-commonwealth-office",
+        "base_path": "/government/organisations/foreign-commonwealth-office",
+        "content_id": "9adfc4ed-9f6c-4976-a6d8-18d34356367c",
+        "description": null,
+        "document_type": "organisation",
+        "locale": "en",
+        "public_updated_at": "2016-03-22T14:43:46Z",
+        "schema_name": "organisation",
+        "title": "Foreign & Commonwealth Office",
+        "withdrawn": false,
+        "details": {
+          "brand": "foreign-commonwealth-office",
+          "logo": {
+            "formatted_title": "Foreign &amp;<br/>Commonwealth <br/>Office",
+            "crest": "single-identity"
+          }
+        },
+        "links": {
+        },
+        "api_url": "https://www.gov.uk/api/content/government/organisations/foreign-commonwealth-office",
+        "web_url": "https://www.gov.uk/government/organisations/foreign-commonwealth-office"
+      }
+    ],
+    "parent": [
+      {
+        "analytics_identifier": null,
+        "api_path": "/api/content/foreign-travel-advice",
+        "base_path": "/foreign-travel-advice",
+        "content_id": "08d48cdd-6b50-43ff-a53b-beab47f4aab0",
+        "description": "Latest travel advice by country including safety and security, entry requirements, travel warnings and health",
+        "document_type": "travel_advice_index",
+        "locale": "en",
+        "public_updated_at": "2017-02-17T12:52:36Z",
+        "schema_name": "travel_advice_index",
+        "title": "Foreign travel advice",
+        "withdrawn": false,
+        "links": {
+          "parent": [
+            {
+              "analytics_identifier": null,
+              "api_path": "/api/content/browse/abroad/travel-abroad",
+              "base_path": "/browse/abroad/travel-abroad",
+              "content_id": "b9849cd6-61a7-42dc-8124-362d2c7d48b0",
+              "description": "Includes the latest travel advice by country, your rights at the airport and getting help abroad",
+              "document_type": "mainstream_browse_page",
+              "locale": "en",
+              "public_updated_at": "2015-06-24T13:56:51Z",
+              "schema_name": "mainstream_browse_page",
+              "title": "Travel abroad",
+              "withdrawn": false,
+              "links": {
+                "parent": [
+                  {
+                    "analytics_identifier": null,
+                    "api_path": "/api/content/browse/abroad",
+                    "base_path": "/browse/abroad",
+                    "content_id": "86eb717a-fb40-42e7-83fa-d031a03880fb",
+                    "description": "Includes renewing passports and travel advice by country",
+                    "document_type": "mainstream_browse_page",
+                    "locale": "en",
+                    "public_updated_at": "2015-04-08T10:48:43Z",
+                    "schema_name": "mainstream_browse_page",
+                    "title": "Passports, travel and living abroad",
+                    "withdrawn": false,
+                    "links": {
+                    },
+                    "api_url": "https://www.gov.uk/api/content/browse/abroad",
+                    "web_url": "https://www.gov.uk/browse/abroad"
+                  }
+                ]
+              },
+              "api_url": "https://www.gov.uk/api/content/browse/abroad/travel-abroad",
+              "web_url": "https://www.gov.uk/browse/abroad/travel-abroad"
+            }
+          ]
+        },
+        "api_url": "https://www.gov.uk/api/content/foreign-travel-advice",
+        "web_url": "https://www.gov.uk/foreign-travel-advice"
+      }
+    ],
+    "related": [
+      {
+        "analytics_identifier": null,
+        "api_path": "/api/content/renew-adult-passport",
+        "base_path": "/renew-adult-passport",
+        "content_id": "82248bb1-c4d6-41e0-9494-d98123475626",
+        "description": "How to apply, how long it takes, how much it costs, track your application, unexpired visas, replacing a damaged passport",
+        "document_type": "guide",
+        "locale": "en",
+        "public_updated_at": "2015-01-12T00:01:07Z",
+        "schema_name": "generic_with_external_related_links",
+        "title": "Renew or replace your adult passport",
+        "withdrawn": false,
+        "links": {
+        },
+        "api_url": "https://www.gov.uk/api/content/renew-adult-passport",
+        "web_url": "https://www.gov.uk/renew-adult-passport"
+      },
+      {
+        "analytics_identifier": null,
+        "api_path": "/api/content/browse/abroad/travel-abroad",
+        "base_path": "/browse/abroad/travel-abroad",
+        "content_id": "b9849cd6-61a7-42dc-8124-362d2c7d48b0",
+        "description": "Includes the latest travel advice by country, your rights at the airport and getting help abroad",
+        "document_type": "mainstream_browse_page",
+        "locale": "en",
+        "public_updated_at": "2015-06-24T13:56:51Z",
+        "schema_name": "mainstream_browse_page",
+        "title": "Travel abroad",
+        "withdrawn": false,
+        "links": {
+        },
+        "api_url": "https://www.gov.uk/api/content/browse/abroad/travel-abroad",
+        "web_url": "https://www.gov.uk/browse/abroad/travel-abroad"
+      },
+      {
+        "analytics_identifier": null,
+        "api_path": "/api/content/hand-luggage-restrictions",
+        "base_path": "/hand-luggage-restrictions",
+        "content_id": "95f9c380-30bc-44c7-86b4-e9c9ef0fc272",
+        "description": "Hand luggage restrictions at UK airports - carry-on luggage, checked-in baggage, restricted items and liquids",
+        "document_type": "guide",
+        "locale": "en",
+        "public_updated_at": "2015-09-07T16:23:07Z",
+        "schema_name": "generic_with_external_related_links",
+        "title": "Hand luggage restrictions at UK airports",
+        "withdrawn": false,
+        "links": {
+        },
+        "api_url": "https://www.gov.uk/api/content/hand-luggage-restrictions",
+        "web_url": "https://www.gov.uk/hand-luggage-restrictions"
+      },
+      {
+        "analytics_identifier": null,
+        "api_path": "/api/content/driving-abroad",
+        "base_path": "/driving-abroad",
+        "content_id": "e4d06cb9-9e2e-4e82-b802-0aad013ae16c",
+        "description": "You'll need a Great Britain or Northern Ireland licence to drive abroad and an International Driving Permit in some non-EU countries",
+        "document_type": "answer",
+        "locale": "en",
+        "public_updated_at": "2015-07-09T08:31:23Z",
+        "schema_name": "generic_with_external_related_links",
+        "title": "Driving abroad",
+        "withdrawn": false,
+        "links": {
+        },
+        "api_url": "https://www.gov.uk/api/content/driving-abroad",
+        "web_url": "https://www.gov.uk/driving-abroad"
+      },
+      {
+        "analytics_identifier": null,
+        "api_path": "/api/content/browse/abroad",
+        "base_path": "/browse/abroad",
+        "content_id": "86eb717a-fb40-42e7-83fa-d031a03880fb",
+        "description": "Includes renewing passports and travel advice by country",
+        "document_type": "mainstream_browse_page",
+        "locale": "en",
+        "public_updated_at": "2015-04-08T10:48:43Z",
+        "schema_name": "mainstream_browse_page",
+        "title": "Passports, travel and living abroad",
+        "withdrawn": false,
+        "links": {
+        },
+        "api_url": "https://www.gov.uk/api/content/browse/abroad",
+        "web_url": "https://www.gov.uk/browse/abroad"
+      }
+    ],
+    "available_translations": [
+      {
+        "analytics_identifier": null,
+        "base_path": "/foreign-travel-advice/albania",
+        "content_id": "2a3938e1-d588-45fc-8c8f-0f51814d5409",
+        "description": "Latest travel advice for Albania including safety and security, entry requirements, travel warnings and health",
+        "document_type": "travel_advice",
+        "locale": "en",
+        "public_updated_at": "2017-02-14T15:42:21Z",
+        "schema_name": "travel_advice",
+        "title": "Albania travel advice",
+        "api_path": "/api/content/foreign-travel-advice/albania",
+        "withdrawn": false,
+        "api_url": "https://www.gov.uk/api/content/foreign-travel-advice/albania",
+        "web_url": "https://www.gov.uk/foreign-travel-advice/albania",
+        "links": {
+        }
+      }
+    ]
+  },
+  "description": "Latest travel advice for Albania including safety and security, entry requirements, travel warnings and health",
+  "details": {
+    "country": {
+      "slug": "albania",
+      "name": "Albania"
+    },
+    "updated_at": "2017-02-16T10:02:00Z",
+    "reviewed_at": "2017-02-14T15:42:21Z",
+    "change_description": "Latest update: Summary – the main opposition party has called for mass protests against the government in Tirana on 18 February 2017; the political atmosphere is likely to become changeable as the country approaches national elections on 18 June 2017; monitor local and international media, take extra care and avoid political rallies and demonstrations; don’t attempt to cross any roadblocks set up by protesters as this might provoke a violent reaction ",
+    "email_signup_link": "/foreign-travel-advice/albania/email-signup",
+    "parts": [
+      {
+        "slug": "summary",
+        "title": "Summary",
+        "body": "<p>The main opposition party has called for mass protests against the government in Tirana on 18 February 2017. The political atmosphere is likely to become changeable as the country approaches national elections on 18 June 2017. Monitor local and international media, take extra care and avoid political rallies and demonstrations. Don’t attempt to cross any roadblocks set up by protesters as this might provoke a violent reaction. </p>\n\n<p>Over 80,000 British nationals visit Albania every year. Most visits are trouble-free.</p>\n\n<p>From December to February severe weather may cause flooding, particularly in northern Albania. Heavy snowfall in mountainous areas can lead to disruption to transport and services.  </p>\n\n<p>Public security is generally good, particularly in Tirana. Crime and violence does occur in some areas, but is not typically targeted at foreigners. Gun ownership is widespread. See <a href=\"/foreign-travel-advice/albania/safety-and-security\">Crime.</a></p>\n\n<p>When visiting hill towns on the northern border with Kosovo, you should exercise caution and heed warning signs about unexploded landmines and other unexploded ordnance. See <a href=\"/foreign-travel-advice/albania/safety-and-security\">Landmines.</a></p>\n\n<p>There is an underlying threat from terrorism. See <a href=\"/foreign-travel-advice/albania/terrorism\">Terrorism.</a></p>\n\n<p>If you’re abroad and you need emergency help from the UK government, contact the <a href=\"https://www.gov.uk/government/world/embassies\">nearest British embassy, consulate or high commission</a>. </p>\n\n<p>Take out comprehensive travel and medical <a href=\"https://www.gov.uk/foreign-travel-insurance\">insurance</a> before you travel.</p>\n"
+      },
+      {
+        "slug": "safety-and-security",
+        "title": "Safety and security",
+        "body": "<h3 id=\"crime\">Crime</h3>\n\n<p>Public security is generally good, particularly in Tirana, and Albanians are very hospitable to visitors. Crime and violence does occur in some areas, but reports of crime specifically targeting foreigners are rare. There have been occasional shootings and small explosions, but these appear to be related to internal disputes over criminal, business or political interests.  </p>\n\n<p>There have been reports of luggage stolen from hotel rooms and public transport, particularly in the coastal resorts of Vlore and Saranda. Be vigilant and keep valuables in a safe place.  </p>\n\n<h3 id=\"landmines\">Landmines</h3>\n\n<p>In December 2009 Albania officially declared it had met its  <a rel=\"external\" href=\"http://www.unog.ch/80256EE600585943/(httpPages)/CA826818C8330D2BC1257180004B1B2E?OpenDocument\">‘Ottawa Convention Article 5’</a> obligations and had reached mine-free status. However, when visiting hill towns on the northern border with Kosovo and Montenegro you should take care, particularly if hiking and follow the signs warning about unexploded landmines and other unexploded ordnance. Demining is ongoing on the Kosovo side.   </p>\n\n<h3 id=\"road-travel\">Road travel</h3>\n\n<p>Driving can be very hazardous. Roads are poor, especially in rural areas. Street lighting in urban areas is subject to power cuts. Elsewhere, even on the major inter-urban arterial routes, there is no street lighting. If you are travelling at night, watch out for unmarked road works, potholes and unlit vehicles. Four-wheel drive vehicles are often more practical on rural and minor roads.</p>\n\n<p>Albanian driving can often be aggressive and erratic. Deaths from road traffic accidents are amongst the highest in Europe.  Police have taken some measures to decrease the number of accidents. Minor traffic disputes can quickly escalate, especially as some motorists could be armed. Avoid reacting to provocative behaviour by other road users. If you are involved in a traffic accident, even a minor one, you are supposed to wait until the police arrive. This will usually happen quickly in built-up areas.</p>\n\n<p>If you are intending to import a vehicle into Albania, make sure you have all the necessary papers on arrival at the border. Consult the <a rel=\"external\" href=\"http://www.albanianembassy.co.uk\">Albanian Embassy</a> in London before you leave. The British Embassy will be unable to help anyone attempting to bring a vehicle into Albania without the correct paperwork. </p>\n\n<p>An International Driving Permit (IDP) is recommended.</p>\n\n<h3 id=\"air-travel\">Air travel</h3>\n\n<p>A list of incidents and accidents can be found on the website of the  <a rel=\"external\" href=\"http://aviation-safety.net/index.php\">Aviation Safety network</a>.  </p>\n\n<p>In 2009 the International Civil Aviation Organisation carried out an <a rel=\"external\" href=\"http://www.icao.int/safety/Pages/USOAP-Results.aspx\">audit</a> of the level of implementation of the critical elements of safely oversight in Albania.  </p>\n\n<p>We can’t offer advice on the safety of individual airlines. However, the International Air Transport Association publishes a <a rel=\"external\" href=\"http://www.iata.org/whatwedo/safety/audit/Pages/index.aspx\">list of registered airlines</a> that have been audited and found to meet a number of operational safety standards and recommended practices. This list is not exhaustive and the absence of an airline from this list does not necessarily mean that it is unsafe.  </p>\n\n<h3 id=\"sea-travel\">Sea travel</h3>\n\n<p>There are some local press reports that jet skis and boats being rented along the coasts may lack adequate safety precautions and equipment.</p>\n\n<h3 id=\"swimming\">Swimming</h3>\n\n<p>The Albanian National Environment Agency reported in 2016 that 83% of beaches in Albania are of a very good or good standard but the report raised concerns over a small number of beaches including beaches in Durres, Vlore and Saranda which are polluted as a result of inadequate sewage disposal and treatment. </p>\n\n<h3 id=\"political-situation\">Political situation</h3>\n\n<p>Tension between religious groups and expression of extremist views is very rare, and attitudes to western countries are overwhelmingly positive.</p>\n"
+      },
+      {
+        "slug": "terrorism",
+        "title": "Terrorism",
+        "body": "<p>There is an underlying threat from terrorism. Attacks, although unlikely, could be indiscriminate, including places frequented by expatriates and foreign travellers. </p>\n\n<p>There is considered to be a heightened threat of terrorist attack globally against UK interests and British nationals, from groups or individuals motivated by the conflict in Iraq and Syria. You should be vigilant at this time.</p>\n\n<p>Find out more about the <a href=\"https://www.gov.uk/guidance/reduce-your-risk-from-terrorism-while-abroad\">global threat from terrorism</a>, how to minimise your risk and what to do in the event of a terrorist attack.</p>\n"
+      },
+      {
+        "slug": "local-laws-and-customs",
+        "title": "Local laws and customs",
+        "body": "<p>English is not widely spoken but it is increasingly spoken by younger people.</p>\n\n<p>Homosexuality is decriminalised. Anti-discrimination and anti hate-crime legislation is in place. Tirana has several gay-friendly bars and a number of LGBT support groups.  </p>\n\n<p>Penalties for drug-related crimes are severe.  </p>\n\n<p>The Albanian authorities do not always inform the British Embassy when British nationals have been arrested. If you are detained, you may insist on your right to contact a British consular officer.</p>\n"
+      },
+      {
+        "slug": "entry-requirements",
+        "title": "Entry requirements",
+        "body": "<p>The information on this page covers the most common types of travel and reflects the UK government’s understanding of the rules currently in place. Unless otherwise stated, this information is for travellers using a full ‘British Citizen’ passport.</p>\n\n<p>The authorities in the country or territory you’re travelling to are responsible for setting and enforcing the rules for entry. If you’re unclear about any aspect of the entry requirements, or you need further reassurance, you’ll need to contact the <a href=\"https://www.gov.uk/government/publications/foreign-embassies-in-the-uk\">embassy, high commission or consulate</a> of the country or territory you’re travelling to. </p>\n\n<p>You should also consider checking with your transport provider or travel company to make sure your passport and other travel documents meet their requirements.</p>\n\n<h3 id=\"visas\">Visas</h3>\n\n<p>British citizens can enter and remain in Albania for a maximum of 90 days in every 6-month period without a visa. The Albanian authorities require anyone staying longer than 90 days to apply at a local police station for a residence permit.    </p>\n\n<h3 id=\"passport-validity\">Passport validity </h3>\n\n<p>Your passport should be valid for a minimum period of 3 months from the date of entry into Albania.  </p>\n\n<h3 id=\"yellow-fever-certificate-requirements\">Yellow fever certificate requirements</h3>\n<p>Check whether you need a yellow fever certificate by visiting the National Travel Health Network and Centre’s <a rel=\"external\" href=\"http://travelhealthpro.org.uk/country/2/albania#Vaccine_recommendations\">TravelHealthPro website</a>.</p>\n\n<h3 id=\"uk-emergency-travel-documents\">UK Emergency Travel Documents</h3>\n\n<p>UK Emergency Travel Documents are accepted for entry, airside transit and exit from Albania.</p>\n"
+      },
+      {
+        "slug": "health",
+        "title": "Health",
+        "body": "<p>Visit your health professional at least 4 to 6 weeks before your trip to check whether you need any vaccinations or other preventive measures. Country specific information and advice is published by the National Travel Health Network and Centre on the <a rel=\"external\" href=\"http://travelhealthpro.org.uk/country-information/\">TravelHealthPro website</a> and by NHS (Scotland) on the <a rel=\"external\" href=\"http://www.fitfortravel.nhs.uk/destinations.aspx\">fitfortravel website</a>. Useful information and advice about healthcare abroad is also available on the <a rel=\"external\" href=\"http://www.nhs.uk/NHSEngland/Healthcareabroad/Pages/Healthcareabroad.aspx\">NHS Choices website</a>.</p>\n\n<p>Medical and dental facilities (including those for accident and emergency use) are very poor, particularly outside Tirana. Make sure you have adequate travel health insurance and accessible funds to cover the cost of any medical treatment abroad, evacuation by air ambulance and repatriation.  </p>\n\n<p>The tap water in Albania may cause illness - you should drink only bottled water. If you drink milk, make sure it is UHT (pasteurised).  </p>\n\n<p>If you need emergency medical assistance during your trip, dial 127 or 04 2222 235 and ask for an ambulance. You should contact your insurance/medical assistance company promptly if you are referred to a medical facility for treatment. </p>\n"
+      },
+      {
+        "slug": "natural-disasters",
+        "title": "Natural disasters",
+        "body": "<p>Albania lies in a seismically-active zone, and tremors are common. Serious earthquakes are less frequent but do occur. To learn more about what to do before, during and after an earthquake, see this <a rel=\"external\" href=\"http://www.ready.gov/earthquakes\">advice</a> from the US Federal Emergency Management Agency.</p>\n"
+      },
+      {
+        "slug": "money",
+        "title": "Money",
+        "body": "<p>Major credit and debit cards are accepted in most banks, large supermarkets and international hotels. Smaller businesses and taxis often only accept cash. There are numerous ATMs in Tirana and the main towns, as well as bureaux de change where Sterling, US Dollars and Euros are widely accepted. Although street money-changers operate openly, they do so illegally. Only use banks or established bureaux de change. There have been some cases of credit card fraud.</p>\n"
+      },
+      {
+        "slug": "travel-advice-help-and-support",
+        "title": "Travel advice help and support",
+        "body": "\n<div role=\"note\" aria-label=\"Help\" class=\"application-notice help-notice\">\n<p>If you’re abroad and you need emergency help from the UK government, contact the <a href=\"https://www.gov.uk/government/world/embassies\">nearest British embassy, consulate or high commission</a>. If you need urgent help because something has happened to a friend or relative abroad, contact the Foreign and Commonwealth Office (FCO) in London on 020 7008 1500 (24 hours).</p>\n</div>\n\n<h3 id=\"foreign-travel-checklist\">Foreign travel checklist</h3>\n\n<p>Read our <a href=\"https://www.gov.uk/guidance/foreign-travel-checklist\">foreign travel checklist</a> to help you plan for your trip abroad and stay safe while you’re there. </p>\n\n<h3 id=\"travel-safety\">Travel safety</h3>\n\n<p>The FCO travel advice helps you make your own decisions about foreign travel. Your safety is our main concern, but we can’t provide tailored advice for individual trips. If you’re concerned about whether or not it’s safe for you to travel, you should read the travel advice for the country or territory you’re travelling to, together with information from other sources you’ve identified, before making your own decision on whether to travel. Only you can decide whether it’s safe for you to travel.  </p>\n\n<p>When we judge the level of risk to British nationals in a particular place has become unacceptably high, we’ll state on the travel advice page for that country or territory that we advise against all or all but essential travel. <a href=\"https://www.gov.uk/guidance/how-the-foreign-commonwealth-office-puts-together-travel-advice\">Read more about how the FCO assesses and categorises risk in foreign travel advice</a>.  </p>\n\n<p>Our <a href=\"https://www.gov.uk/guidance/how-to-deal-with-a-crisis-overseas\">crisis overseas page</a> suggests additional things you can do before and during foreign travel to help you stay safe.</p>\n\n<h3 id=\"refunds-and-cancellations\">Refunds and cancellations</h3>\n\n<p>If you wish to cancel or change a holiday that you’ve booked, you should contact your travel company.  The question of refunds and cancellations is a matter for you and your travel company. Travel companies make their own decisions about whether or not to offer customers a refund. Many of them use our travel advice to help them reach these decisions, but we do not instruct travel companies on when they can or can’t offer a refund to their customers.</p>\n\n<p>For more information about your rights if you wish to cancel a holiday, visit <a rel=\"external\" href=\"https://www.citizensadvice.org.uk/consumer/holiday-cancellations-and-compensation/cancelling-a-holiday/\">the Citizen’s Advice Bureau website</a>. For help resolving problems with a flight booking, visit the <a rel=\"external\" href=\"https://www.caa.co.uk/Passengers/Resolving-travel-problems/\">website of the Civil Aviation Authority</a>. For questions about travel insurance, contact your insurance provider and if you’re not happy with their response, you can complain to the <a rel=\"external\" href=\"http://www.financial-ombudsman.org.uk/consumer/complaints.htm\">Financial Ombudsman Service</a>. </p>\n\n<h3 id=\"registering-your-travel-details-with-us\">Registering your travel details with us</h3>\n\n<p>We’re no longer asking people to register with us before travel. Our <a href=\"https://www.gov.uk/guidance/foreign-travel-checklist\">foreign travel checklist</a> and <a href=\"https://www.gov.uk/guidance/how-to-deal-with-a-crisis-overseas\">crisis overseas page</a> suggest things you can do before and during foreign travel to plan your trip and stay safe.</p>\n\n<h3 id=\"previous-versions-of-fco-travel-advice\">Previous versions of FCO travel advice</h3>\n\n<p>If you’re looking for a previous version of the FCO travel advice, visit the <a rel=\"external\" href=\"http://webarchive.nationalarchives.gov.uk/*/http:/www.gov.uk/foreign-travel-advice\">National Archives website</a>. If you can’t find the page you’re looking for there, <a href=\"&#109;&#097;&#105;&#108;&#116;&#111;:&#116;&#114;&#097;&#118;&#101;&#108;&#097;&#100;&#118;&#105;&#099;&#101;&#112;&#117;&#098;&#108;&#105;&#099;&#101;&#110;&#113;&#117;&#105;&#114;&#105;&#101;&#115;&#064;&#102;&#099;&#111;&#046;&#103;&#111;&#118;&#046;&#117;&#107;\">send us a request</a>. </p>\n\n<h3 id=\"further-help\">Further help</h3>\n\n<p>If you’re a British national and you have a question about travelling abroad that isn’t covered in our foreign travel advice or elsewhere on GOV.UK, you can <a href=\"&#109;&#097;&#105;&#108;&#116;&#111;:&#116;&#114;&#097;&#118;&#101;&#108;&#097;&#100;&#118;&#105;&#099;&#101;&#112;&#117;&#098;&#108;&#105;&#099;&#101;&#110;&#113;&#117;&#105;&#114;&#105;&#101;&#115;&#064;&#102;&#099;&#111;&#046;&#103;&#111;&#118;&#046;&#117;&#107;\">submit an enquiry</a>.  We’re not able to provide tailored advice for specific trips.</p>\n"
+      }
+    ],
+    "alert_status": [
+
+    ],
+    "max_cache_time": 10,
+    "image": {
+      "url": "https://assets.publishing.service.gov.uk/media/513a0efbed915d425e000002/120613_Albania_Travel_Advice_WEB_Ed2_jpeg.jpg",
+      "content_type": "image/jpeg"
+    },
+    "document": {
+      "attachment_type": "file",
+      "id": "43be2ac0-ea23-4b34-a73c-e2ac268e7f6c",
+      "url": "https://assets.publishing.service.gov.uk/media/513a0efced915d4261000001/120613_Albania_Travel_Advice_Ed2_pdf.pdf",
+      "content_type": "application/pdf"
+    },
+    "publishing_request_id": "30559-1487239320.697-62.232.86.100-23977"
+  }
+}


### PR DESCRIPTION
This is the same as the full country example, but with a populated `withdrawn_notice`.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
