### PR TITLE
`subscription_list_title_prefix` is now always a string

### DIFF
--- a/content_schemas/dist/formats/finder_email_signup/frontend/schema.json
+++ b/content_schemas/dist/formats/finder_email_signup/frontend/schema.json
@@ -747,25 +747,7 @@
       "type": "integer"
     },
     "subscription_list_title_prefix": {
-      "oneOf": [
-        {
-          "type": "object",
-          "properties": {
-            "many": {
-              "type": "string"
-            },
-            "plural": {
-              "type": "string"
-            },
-            "singular": {
-              "type": "string"
-            }
-          }
-        },
-        {
-          "type": "string"
-        }
-      ]
+      "type": "string"
     },
     "title": {
       "type": "string"

--- a/content_schemas/dist/formats/finder_email_signup/notification/schema.json
+++ b/content_schemas/dist/formats/finder_email_signup/notification/schema.json
@@ -874,25 +874,7 @@
       "minItems": 1
     },
     "subscription_list_title_prefix": {
-      "oneOf": [
-        {
-          "type": "object",
-          "properties": {
-            "many": {
-              "type": "string"
-            },
-            "plural": {
-              "type": "string"
-            },
-            "singular": {
-              "type": "string"
-            }
-          }
-        },
-        {
-          "type": "string"
-        }
-      ]
+      "type": "string"
     },
     "title": {
       "type": "string"

--- a/content_schemas/dist/formats/finder_email_signup/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/finder_email_signup/publisher_v2/schema.json
@@ -522,25 +522,7 @@
       "minItems": 1
     },
     "subscription_list_title_prefix": {
-      "oneOf": [
-        {
-          "type": "object",
-          "properties": {
-            "many": {
-              "type": "string"
-            },
-            "plural": {
-              "type": "string"
-            },
-            "singular": {
-              "type": "string"
-            }
-          }
-        },
-        {
-          "type": "string"
-        }
-      ]
+      "type": "string"
     },
     "title": {
       "type": "string"

--- a/content_schemas/examples/finder_email_signup/frontend/cma-cases-email-signup.json
+++ b/content_schemas/examples/finder_email_signup/frontend/cma-cases-email-signup.json
@@ -132,10 +132,6 @@
       }
     ],
     "email_filter_by": "case_type",
-    "subscription_list_title_prefix": {
-      "singular": "Competition and Markets Authority (CMA) cases with the following case type: ",
-      "plural": "Competition and Markets Authority (CMA) cases with the following case types: ",
-      "many": "Competition and Markets Authority (CMA) cases: "
-    }
+    "subscription_list_title_prefix": "Competition and Markets Authority (CMA) cases"
   }
 }

--- a/content_schemas/examples/finder_email_signup/frontend/raib-report-email-signup.json
+++ b/content_schemas/examples/finder_email_signup/frontend/raib-report-email-signup.json
@@ -98,10 +98,6 @@
       }
     ],
     "email_filter_by": "railway_type",
-    "subscription_list_title_prefix": {
-      "singular": "Rail Accident Investigation Branch (RAIB) reports with the following railway type: ",
-      "plural": "Rail Accident Investigation Branch (RAIB) reports with the following railway types: ",
-      "many": "Rail Accident Investigation Branch (RAIB) reports: "
-    }
+    "subscription_list_title_prefix": "Rail Accident Investigation Branch (RAIB) reports"
   }
 }

--- a/content_schemas/examples/finder_email_signup/publisher_v2/finder_email_signup.json
+++ b/content_schemas/examples/finder_email_signup/publisher_v2/finder_email_signup.json
@@ -18,11 +18,7 @@
   "details": {
     "beta": false,
     "email_filter_by": "case_type",
-    "subscription_list_title_prefix": {
-      "singular": "Competition and Markets Authority (CMA) cases with the following case type: ",
-      "plural": "Competition and Markets Authority (CMA) cases with the following case types: ",
-      "many": "Competition and Markets Authority (CMA) cases: "
-    },
+    "subscription_list_title_prefix": "Competition and Markets Authority (CMA) cases",
     "email_filter_facets": [
       {
         "facet_id": "case_type",

--- a/content_schemas/examples/finder_email_signup/publisher_v2/finder_email_signup_multi_facet.json
+++ b/content_schemas/examples/finder_email_signup/publisher_v2/finder_email_signup_multi_facet.json
@@ -72,10 +72,6 @@
         }
       }
     ],
-    "subscription_list_title_prefix": {
-      "singular": "Competition and Markets Authority (CMA) cases with the following case type: ",
-      "plural": "Competition and Markets Authority (CMA) cases with the following case types: ",
-      "many": "Competition and Markets Authority (CMA) cases: "
-    }
+    "subscription_list_title_prefix": "Competition and Markets Authority (CMA) cases"
   }
 }

--- a/content_schemas/formats/finder_email_signup.jsonnet
+++ b/content_schemas/formats/finder_email_signup.jsonnet
@@ -2,25 +2,7 @@
   document_type: "finder_email_signup",
   definitions: {
     subscription_list_title_prefix: {
-      oneOf: [
-        {
-          type: "object",
-          properties: {
-            plural: {
-              type: "string",
-            },
-            singular: {
-              type: "string",
-            },
-            many: {
-              type: "string",
-            },
-          },
-        },
-        {
-          type: "string",
-        },
-      ],
+      type: "string",
     },
     facet_name: {
       oneOf: [


### PR DESCRIPTION
subscription_list_title_prefix is now always a string - see commits for details.

NB, I did also check for `signup_copy` and `email_filter_facets.body` (removed in https://github.com/alphagov/specialist-publisher/pull/2943) but there was nothing to remove here.

Trello: https://trello.com/c/l9XfLavV/3212-email-alerts-on-edit-finder-form

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
