### PR TITLE
Remove `FIXME` as no longer required

### DIFF
--- a/config/initializers/gds_sso.rb
+++ b/config/initializers/gds_sso.rb
@@ -1,5 +1,0 @@
-GDS::SSO.config do |config|
-  # FIXME: This app should be switched to be Rails api_only. Once this is done
-  # this setting will be superfluous
-  config.api_only = true
-end


### PR DESCRIPTION
This configuration was added and a `FIXME` comment added in 0af91661d186b460dd62a08334b4b1e2e2feb731, however the `api_only` setting was enabled for this application in b7712f3ba7630aa87db2be9b1ac5f35e298131ed.

Therefore removing the duplicated configuration and `FIXME` comment, which has been unnecessary for the last six years.