### PR TITLE
Optimise render-time link expansion for GraphQL (ministers index page)

### DIFF
--- a/db/migrate/20250127105807_add_graphql_optimisation_index_to_editions.rb
+++ b/db/migrate/20250127105807_add_graphql_optimisation_index_to_editions.rb
@@ -1,0 +1,7 @@
+class AddGraphqlOptimisationIndexToEditions < ActiveRecord::Migration[8.0]
+  def change
+    add_index :editions, %i[document_id document_type], where: "(details ->> 'current') = 'true'", name: :index_editions_on_document_id_and_document_type_current
+    add_index :editions, %i[document_id document_type], where: "content_store = 'live'", name: :index_editions_on_document_id_and_document_type_live
+    add_index :links, %i[link_set_id link_type]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_01_06_115835) do
+ActiveRecord::Schema[8.0].define(version: 2025_01_27_105807) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -96,6 +96,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_01_06_115835) do
     t.uuid "last_edited_by_editor_id"
     t.index ["base_path", "content_store"], name: "index_editions_on_base_path_and_content_store", unique: true
     t.index ["document_id", "content_store"], name: "index_editions_on_document_id_and_content_store", unique: true
+    t.index ["document_id", "document_type"], name: "index_editions_on_document_id_and_document_type_current", where: "((details ->> 'current'::text) = 'true'::text)"
+    t.index ["document_id", "document_type"], name: "index_editions_on_document_id_and_document_type_live", where: "((content_store)::text = 'live'::text)"
     t.index ["document_id", "state"], name: "index_editions_on_document_id_and_state"
     t.index ["document_id", "user_facing_version"], name: "index_editions_on_document_id_and_user_facing_version", unique: true
     t.index ["document_id"], name: "index_editions_on_document_id"
@@ -158,6 +160,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_01_06_115835) do
     t.integer "position", default: 0, null: false
     t.integer "edition_id"
     t.index ["edition_id"], name: "index_links_on_edition_id"
+    t.index ["link_set_id", "link_type"], name: "index_links_on_link_set_id_and_link_type"
     t.index ["link_set_id", "target_content_id"], name: "index_links_on_link_set_id_and_target_content_id"
     t.index ["link_set_id"], name: "index_links_on_link_set_id"
     t.index ["link_type"], name: "index_links_on_link_type"


### PR DESCRIPTION
This adds indices which improve the performance of request-time link expansion for GraphQL queries.

Results in a reduction in execution time for the slowest of the ministers index page database queries from ~418ms to ~3.8ms (in the integration environment).

The entire response time for the ministers index page reduces from ~1,500ms to ~800ms, when queries are made against Publishing API in the integration environment.

This is done by:
- removing two bitmap heap scans which utilised a `BitmapAnd` (one on the `editions` table between the `document_id` and `document_type` fields, and the other on the `links` table between the `link_set_id` and  `link_type` fields) replacing them with faster index scans.
- reducing the amount of unnecessary records being searched by queries, by providing partial indices that include only the live document and the current records.

Example query (as generated by ActiveRecord):
```sql
SELECT "editions"."id" AS t0_r0, "editions"."title" AS t0_r1, "editions"."public_updated_at" AS t0_r2, "editions"."publishing_app" AS t0_r3, "editions"."rendering_app" AS t0_r4, "editions"."update_type" AS t0_r5, "editions"."phase" AS t0_r6, "editions"."analytics_identifier" AS t0_r7, "editions"."created_at" AS t0_r8, "editions"."updated_at" AS t0_r9, "editions"."document_type" AS t0_r10, "editions"."schema_name" AS t0_r11, "editions"."first_published_at" AS t0_r12, "editions"."last_edited_at" AS t0_r13, "editions"."state" AS t0_r14, "editions"."user_facing_version" AS t0_r15, "editions"."base_path" AS t0_r16, "editions"."content_store" AS t0_r17, "editions"."document_id" AS t0_r18, "editions"."description" AS t0_r19, "editions"."publishing_request_id" AS t0_r20, "editions"."major_published_at" AS t0_r21, "editions"."published_at" AS t0_r22, "editions"."publishing_api_first_published_at" AS t0_r23, "editions"."publishing_api_last_edited_at" AS t0_r24, "editions"."auth_bypass_ids" AS t0_r25, "editions"."details" AS t0_r26, "editions"."routes" AS t0_r27, "editions"."redirects" AS t0_r28, "editions"."last_edited_by_editor_id" AS t0_r29, "document"."id" AS t1_r0, "document"."content_id" AS t1_r1, "document"."locale" AS t1_r2, "document"."stale_lock_version" AS t1_r3, "document"."created_at" AS t1_r4, "document"."updated_at" AS t1_r5, "document"."owning_document_id" AS t1_r6, "reverse_links"."id" AS t2_r0, "reverse_links"."link_set_id" AS t2_r1, "reverse_links"."target_content_id" AS t2_r2, "reverse_links"."link_type" AS t2_r3, "reverse_links"."created_at" AS t2_r4, "reverse_links"."updated_at" AS t2_r5, "reverse_links"."position" AS t2_r6, "reverse_links"."edition_id" AS t2_r7, "link_sets"."id" AS t3_r0, "link_sets"."content_id" AS t3_r1, "link_sets"."created_at" AS t3_r2, "link_sets"."updated_at" AS t3_r3, "link_sets"."stale_lock_version" AS t3_r4, "documents"."id" AS t4_r0, "documents"."content_id" AS t4_r1, "documents"."locale" AS t4_r2, "documents"."stale_lock_version" AS t4_r3, "documents"."created_at" AS t4_r4, "documents"."updated_at" AS t4_r5, "documents"."owning_document_id" AS t4_r6, "editions_documents"."id" AS t5_r0, "editions_documents"."title" AS t5_r1, "editions_documents"."public_updated_at" AS t5_r2, "editions_documents"."publishing_app" AS t5_r3, "editions_documents"."rendering_app" AS t5_r4, "editions_documents"."update_type" AS t5_r5, "editions_documents"."phase" AS t5_r6, "editions_documents"."analytics_identifier" AS t5_r7, "editions_documents"."created_at" AS t5_r8, "editions_documents"."updated_at" AS t5_r9, "editions_documents"."document_type" AS t5_r10, "editions_documents"."schema_name" AS t5_r11, "editions_documents"."first_published_at" AS t5_r12, "editions_documents"."last_edited_at" AS t5_r13, "editions_documents"."state" AS t5_r14, "editions_documents"."user_facing_version" AS t5_r15, "editions_documents"."base_path" AS t5_r16, "editions_documents"."content_store" AS t5_r17, "editions_documents"."document_id" AS t5_r18, "editions_documents"."description" AS t5_r19, "editions_documents"."publishing_request_id" AS t5_r20, "editions_documents"."major_published_at" AS t5_r21, "editions_documents"."published_at" AS t5_r22, "editions_documents"."publishing_api_first_published_at" AS t5_r23, "editions_documents"."publishing_api_last_edited_at" AS t5_r24, "editions_documents"."auth_bypass_ids" AS t5_r25, "editions_documents"."details" AS t5_r26, "editions_documents"."routes" AS t5_r27, "editions_documents"."redirects" AS t5_r28, "editions_documents"."last_edited_by_editor_id" AS t5_r29, "link_set_links"."id" AS t6_r0, "link_set_links"."link_set_id" AS t6_r1, "link_set_links"."target_content_id" AS t6_r2, "link_set_links"."link_type" AS t6_r3, "link_set_links"."created_at" AS t6_r4, "link_set_links"."updated_at" AS t6_r5, "link_set_links"."position" AS t6_r6, "link_set_links"."edition_id" AS t6_r7 FROM "editions" LEFT OUTER JOIN "documents" "document" ON "document"."id" = "editions"."document_id" LEFT OUTER JOIN "links" "reverse_links" ON "reverse_links"."target_content_id" = "document"."content_id" LEFT OUTER JOIN "link_sets" ON "link_sets"."id" = "reverse_links"."link_set_id" LEFT OUTER JOIN "documents" ON "documents"."content_id" = "link_sets"."content_id" LEFT OUTER JOIN "editions" "editions_documents" ON "editions_documents"."document_id" = "documents"."id" LEFT OUTER JOIN "link_sets" "link_sets_documents_join" ON "link_sets_documents_join"."content_id" = "documents"."content_id" LEFT OUTER JOIN "links" "link_set_links" ON "link_set_links"."link_set_id" = "link_sets_documents_join"."id" WHERE "editions"."content_store" = 'live' AND "editions"."document_type" = 'ministerial_role' AND "document"."locale" = 'en' AND "reverse_links"."link_type" = 'role' AND "documents"."locale" = 'en' AND "editions_documents"."document_type" = 'role_appointment' AND "link_set_links"."target_content_id" IN ('f1c761dd-762f-469a-93b6-28a244cd2e4d', '8a5e71e0-9918-471a-af46-bf024ef1231c', 'd01cd743-767b-4057-8eba-3949fb11ff6a', '1f3c5ffd-5f02-42e5-83eb-8e4821e233c8', 'af4d57d2-480b-4341-a45a-12afe04ade11', 'ac0e5e69-9c5d-4b52-8ef5-5f6dec83d8df', '2f327edc-b73f-4471-b404-558171a13920', 'b2e4f332-b4f0-4ef2-9ebe-09ee356a1752', 'de5739d8-c9a2-4f5b-a246-1c8cb3e40984', '956b4454-bc77-4145-8c00-760140501574', '652661d8-8309-400c-9ed0-63055aa1248a', '98b0d71f-d312-410e-b508-0860410db0c3', '71d4e873-9d40-4ed5-97ea-75158ac630a1', '72b7af32-c0a5-4038-a8e8-e582463dc05a', '4c88d84b-0787-4bb5-a458-014e9c4ba7e2', '0924ea7a-fc2d-4362-bff2-074d9c3395a4', '37748e31-106f-4d5d-a796-3a7c7a0f6c6c', '48706710-a406-46dc-a3ab-977948a10397', '2acfec24-4aa3-4ab1-a44f-e3dd97df3da9', 'db71c46b-4430-4241-a54d-43f7d5f64ee4', '4166dc0b-f488-48f8-bacc-d5e9ff3d562b', '0e11b976-f017-4c29-b0f2-94468466af99', '85567506-c566-4a74-9f4d-412d540102f5', 'e04ec36e-4c73-4f03-a265-aa9eaf251601', '7ed59a39-adef-4a91-901b-6b7cb35d0864', '2f7b87d3-f096-4cfe-9c56-b6038b048241', '8f439fe5-f799-4fb6-a249-86fd399bb3cb', '3d33b0a9-1d1b-4b2d-b01e-0c444beca77d', 'b7143a21-df40-4b5d-82b2-d823272c6f6a', 'f6147149-a5e7-40e5-8e49-727f563e3e41', 'ced012a1-eb92-4374-bebb-d71c2dffe50b', 'dfa187f8-6653-4ef4-ac9a-107ac48c709a', '83085566-745b-4667-9e0e-0a563f94dc09', '933eb411-91df-4e80-b51b-f753390d0d44', '71ac6ca4-6ed5-4bc0-9586-cbc135bf3959', '8d7c6906-f1dd-4a7d-ba70-ecd1a08aefe6', '1351658c-f7d8-47c3-80b9-34f3573d1727', 'e2fd328b-5e60-47dc-99dc-091933cf1c4e', 'c90f90da-c329-40cf-8d41-e12bbfb29966', 'fafa4cba-a440-4d98-a5b1-d8f89473dbb7', '4a73d6f8-fbab-48e1-b67b-cdf2dcb2292f', 'dfffc4f6-a0f9-4261-a43b-bfa4518bcfad', '610e11f0-bb3d-4eac-9e49-ba078065a498', '70a5dbf1-9dbe-497b-affa-30bceb3f441d', '5a866e1a-9762-462c-8a85-e716c04ae0e4', '1543d0a0-852c-409e-a102-ef0e362eb9c9', '55bd1ea3-64ab-4bcd-ade5-1c12bd8e6d9d', '5b4427ff-d318-49cc-b2f5-bb7ebd6d91b6', '3450d42b-0ef1-4511-b18e-da5f75d0f0af', '7ed77f87-d16d-412b-8e84-eee728529699', '93f2d702-c240-4895-bbdd-bde1d2fbc16d', '478bf17c-7a51-4fed-88ac-1c8e3f9ee038', '5fc1461f-7d9f-4cb9-b14e-4bf63afb9d92', '701ce38d-c098-4090-bcef-23fe4000bdaf', '6c5726f8-95b1-4f61-9ba8-449cdceac98c', 'c8b3865a-9090-41e0-aba5-5ee25a80fd94', '8387f99d-c9cf-4af8-abe5-a12df14d3f8f', '2423a3f9-0f4a-4719-8d71-8874d1b4a462', '5c0970eb-de3d-4545-963e-de0b4a054ad3', 'a24384d8-8796-48d6-be1f-2e5f3f0dae77', 'd0d49672-5b29-4b82-9e2e-2b50ecd3d232', 'a04ce77a-9a9a-4250-95d7-ce2962ebd31c', '7fb363c6-4cc0-4438-a17e-e27c782f7272', '611cafa0-1b96-45fa-8a8a-7d254cba6ffb', '0f67909f-d12d-464e-a3b1-f8e43af6499b', '2d7e7e3b-3133-40b4-99b7-7b7cac0d489b', 'e90404ec-0219-4220-a8f9-5a19afcf8d0b', '03e706f4-2d29-483f-a6bc-728f526920c3') AND "link_set_links"."link_type" = 'person' AND (editions_documents.details ->> 'current' = 'true') ORDER BY "reverse_links"."position" ASC
```

Query explanation before optimisation:
```
Sort  (cost=1967.99..1967.99 rows=1 width=1832) (actual time=417.945..417.966 rows=97 loops=1)
  Sort Key: reverse_links.\"position\"
  Sort Method: quicksort  Memory: 282kB
  ->  Nested Loop  (cost=415.72..1967.98 rows=1 width=1832) (actual time=5.162..417.408 rows=97 loops=1)
        ->  Nested Loop  (cost=77.99..1626.22 rows=1 width=1050) (actual time=0.649..65.562 rows=97 loops=1)
              ->  Nested Loop  (cost=77.43..1592.31 rows=1 width=268) (actual time=0.635..64.502 rows=100 loops=1)
                    ->  Nested Loop  (cost=77.00..1584.75 rows=1 width=221) (actual time=0.623..63.555 rows=100 loops=1)
                          ->  Nested Loop  (cost=1.84..713.71 rows=11 width=154) (actual time=0.056..3.388 rows=100 loops=1)
                                ->  Nested Loop  (cost=1.42..609.54 rows=14 width=130) (actual time=0.049..2.684 rows=100 loops=1)
                                      ->  Nested Loop  (cost=0.99..497.83 rows=15 width=83) (actual time=0.040..1.779 rows=100 loops=1)
                                            ->  Index Scan using index_links_on_target_content_id_and_link_type on links link_set_links  (cost=0.56..371.20 rows=15 width=67) (actual time=0.028..0.873 rows=100 loops=1)
                                                  Index Cond: ((target_content_id = ANY ('{f1c761dd-762f-469a-93b6-28a244cd2e4d,8a5e71e0-9918-471a-af46-bf024ef1231c,d01cd743-767b-4057-8eba-3949fb11ff6a,1f3c5ffd-5f02-42e5-83eb-8e4821e233c8,af4d57d2-480b-4341-a45a-12afe04ade11,ac0e5e69-9c5d-4b52-8ef5-5f6dec83d8df,2f327edc-b73f-4471-b404-558171a13920,b2e4f332-b4f0-4ef2-9ebe-09ee356a1752,de5739d8-c9a2-4f5b-a246-1c8cb3e40984,956b4454-bc77-4145-8c00-760140501574,652661d8-8309-400c-9ed0-63055aa1248a,98b0d71f-d312-410e-b508-0860410db0c3,71d4e873-9d40-4ed5-97ea-75158ac630a1,72b7af32-c0a5-4038-a8e8-e582463dc05a,4c88d84b-0787-4bb5-a458-014e9c4ba7e2,0924ea7a-fc2d-4362-bff2-074d9c3395a4,37748e31-106f-4d5d-a796-3a7c7a0f6c6c,48706710-a406-46dc-a3ab-977948a10397,2acfec24-4aa3-4ab1-a44f-e3dd97df3da9,db71c46b-4430-4241-a54d-43f7d5f64ee4,4166dc0b-f488-48f8-bacc-d5e9ff3d562b,0e11b976-f017-4c29-b0f2-94468466af99,85567506-c566-4a74-9f4d-412d540102f5,e04ec36e-4c73-4f03-a265-aa9eaf251601,7ed59a39-adef-4a91-901b-6b7cb35d0864,2f7b87d3-f096-4cfe-9c56-b6038b048241,8f439fe5-f799-4fb6-a249-86fd399bb3cb,3d33b0a9-1d1b-4b2d-b01e-0c444beca77d,b7143a21-df40-4b5d-82b2-d823272c6f6a,f6147149-a5e7-40e5-8e49-727f563e3e41,ced012a1-eb92-4374-bebb-d71c2dffe50b,dfa187f8-6653-4ef4-ac9a-107ac48c709a,83085566-745b-4667-9e0e-0a563f94dc09,933eb411-91df-4e80-b51b-f753390d0d44,71ac6ca4-6ed5-4bc0-9586-cbc135bf3959,8d7c6906-f1dd-4a7d-ba70-ecd1a08aefe6,1351658c-f7d8-47c3-80b9-34f3573d1727,e2fd328b-5e60-47dc-99dc-091933cf1c4e,c90f90da-c329-40cf-8d41-e12bbfb29966,fafa4cba-a440-4d98-a5b1-d8f89473dbb7,4a73d6f8-fbab-48e1-b67b-cdf2dcb2292f,dfffc4f6-a0f9-4261-a43b-bfa4518bcfad,610e11f0-bb3d-4eac-9e49-ba078065a498,70a5dbf1-9dbe-497b-affa-30bceb3f441d,5a866e1a-9762-462c-8a85-e716c04ae0e4,1543d0a0-852c-409e-a102-ef0e362eb9c9,55bd1ea3-64ab-4bcd-ade5-1c12bd8e6d9d,5b4427ff-d318-49cc-b2f5-bb7ebd6d91b6,3450d42b-0ef1-4511-b18e-da5f75d0f0af,7ed77f87-d16d-412b-8e84-eee728529699,93f2d702-c240-4895-bbdd-bde1d2fbc16d,478bf17c-7a51-4fed-88ac-1c8e3f9ee038,5fc1461f-7d9f-4cb9-b14e-4bf63afb9d92,701ce38d-c098-4090-bcef-23fe4000bdaf,6c5726f8-95b1-4f61-9ba8-449cdceac98c,c8b3865a-9090-41e0-aba5-5ee25a80fd94,8387f99d-c9cf-4af8-abe5-a12df14d3f8f,2423a3f9-0f4a-4719-8d71-8874d1b4a462,5c0970eb-de3d-4545-963e-de0b4a054ad3,a24384d8-8796-48d6-be1f-2e5f3f0dae77,d0d49672-5b29-4b82-9e2e-2b50ecd3d232,a04ce77a-9a9a-4250-95d7-ce2962ebd31c,7fb363c6-4cc0-4438-a17e-e27c782f7272,611cafa0-1b96-45fa-8a8a-7d254cba6ffb,0f67909f-d12d-464e-a3b1-f8e43af6499b,2d7e7e3b-3133-40b4-99b7-7b7cac0d489b,e90404ec-0219-4220-a8f9-5a19afcf8d0b,03e706f4-2d29-483f-a6bc-728f526920c3}'::uuid[])) AND ((link_type)::text = 'person'::text))
                                            ->  Index Scan using link_sets_pkey on link_sets link_sets_documents_join  (cost=0.42..8.44 rows=1 width=20) (actual time=0.007..0.007 rows=1 loops=100)
                                                  Index Cond: (id = link_set_links.link_set_id)
                                      ->  Index Scan using index_documents_on_content_id_and_locale on documents  (cost=0.43..7.45 rows=1 width=47) (actual time=0.007..0.007 rows=1 loops=100)
                                            Index Cond: ((content_id = link_sets_documents_join.content_id) AND ((locale)::text = 'en'::text))
                                ->  Index Scan using index_link_sets_on_content_id on link_sets  (cost=0.42..7.44 rows=1 width=40) (actual time=0.005..0.005 rows=1 loops=100)
                                      Index Cond: (content_id = documents.content_id)
                          ->  Bitmap Heap Scan on links reverse_links  (cost=75.16..79.18 rows=1 width=67) (actual time=0.596..0.596 rows=1 loops=100)
                                Recheck Cond: ((link_set_id = link_sets.id) AND ((link_type)::text = 'role'::text))
                                Heap Blocks: exact=100
                                ->  BitmapAnd  (cost=75.16..75.16 rows=1 width=0) (actual time=0.593..0.593 rows=0 loops=100)
                                      ->  Bitmap Index Scan on index_links_on_link_set_id  (cost=0.00..4.36 rows=56 width=0) (actual time=0.005..0.005 rows=2 loops=100)
                                            Index Cond: (link_set_id = link_sets.id)
                                      ->  Bitmap Index Scan on index_links_on_link_type  (cost=0.00..69.06 rows=5933 width=0) (actual time=0.587..0.587 rows=9010 loops=100)
                                            Index Cond: ((link_type)::text = 'role'::text)
                    ->  Index Scan using index_documents_on_content_id_and_locale on documents document  (cost=0.43..7.56 rows=1 width=47) (actual time=0.007..0.007 rows=1 loops=100)
                          Index Cond: ((content_id = reverse_links.target_content_id) AND ((locale)::text = 'en'::text))
              ->  Index Scan using index_editions_on_document_id_and_content_store on editions  (cost=0.56..33.83 rows=1 width=782) (actual time=0.008..0.008 rows=1 loops=100)
                    Index Cond: ((document_id = document.id) AND ((content_store)::text = 'live'::text))
                    Filter: ((document_type)::text = 'ministerial_role'::text)
                    Rows Removed by Filter: 0
        ->  Bitmap Heap Scan on editions editions_documents  (cost=337.73..341.75 rows=1 width=782) (actual time=3.622..3.623 rows=1 loops=97)
              Recheck Cond: ((document_id = documents.id) AND ((document_type)::text = 'role_appointment'::text))
              Filter: ((details ->> 'current'::text) = 'true'::text)
              Rows Removed by Filter: 0
              Heap Blocks: exact=101
              ->  BitmapAnd  (cost=337.73..337.73 rows=1 width=0) (actual time=3.616..3.616 rows=0 loops=97)
                    ->  Bitmap Index Scan on index_editions_on_document_id  (cost=0.00..4.92 rows=131 width=0) (actual time=0.005..0.005 rows=1 loops=97)
                          Index Cond: (document_id = documents.id)
                    ->  Bitmap Index Scan on index_editions_on_document_type_and_state  (cost=0.00..332.52 rows=29878 width=0) (actual time=3.586..3.586 rows=32616 loops=97)
                          Index Cond: ((document_type)::text = 'role_appointment'::text)
Planning Time: 4.748 ms
Execution Time: 418.098 ms
```

Query explanation after optimisation:
```
Sort  (cost=740.83..740.84 rows=1 width=1832) (actual time=3.721..3.733 rows=97 loops=1)
  Sort Key: reverse_links.\"position\"
  Sort Method: quicksort  Memory: 282kB
  ->  Nested Loop  (cost=3.54..740.82 rows=1 width=1832) (actual time=0.092..3.466 rows=97 loops=1)
        ->  Nested Loop  (cost=3.12..733.33 rows=1 width=1050) (actual time=0.082..3.030 rows=100 loops=1)
              ->  Nested Loop  (cost=2.69..725.77 rows=1 width=1003) (actual time=0.073..2.520 rows=100 loops=1)
                    ->  Nested Loop  (cost=2.12..718.14 rows=1 width=936) (actual time=0.065..2.122 rows=100 loops=1)
                          ->  Nested Loop  (cost=1.70..710.70 rows=1 width=912) (actual time=0.057..1.673 rows=100 loops=1)
                                ->  Nested Loop  (cost=1.42..609.54 rows=14 width=130) (actual time=0.050..1.320 rows=100 loops=1)
                                      ->  Nested Loop  (cost=0.99..497.83 rows=15 width=83) (actual time=0.041..0.795 rows=100 loops=1)
                                            ->  Index Scan using index_links_on_target_content_id_and_link_type on links link_set_links  (cost=0.56..371.20 rows=15 width=67) (actual time=0.029..0.476 rows=100 loops=1)
                                                  Index Cond: ((target_content_id = ANY ('{f1c761dd-762f-469a-93b6-28a244cd2e4d,8a5e71e0-9918-471a-af46-bf024ef1231c,d01cd743-767b-4057-8eba-3949fb11ff6a,1f3c5ffd-5f02-42e5-83eb-8e4821e233c8,af4d57d2-480b-4341-a45a-12afe04ade11,ac0e5e69-9c5d-4b52-8ef5-5f6dec83d8df,2f327edc-b73f-4471-b404-558171a13920,b2e4f332-b4f0-4ef2-9ebe-09ee356a1752,de5739d8-c9a2-4f5b-a246-1c8cb3e40984,956b4454-bc77-4145-8c00-760140501574,652661d8-8309-400c-9ed0-63055aa1248a,98b0d71f-d312-410e-b508-0860410db0c3,71d4e873-9d40-4ed5-97ea-75158ac630a1,72b7af32-c0a5-4038-a8e8-e582463dc05a,4c88d84b-0787-4bb5-a458-014e9c4ba7e2,0924ea7a-fc2d-4362-bff2-074d9c3395a4,37748e31-106f-4d5d-a796-3a7c7a0f6c6c,48706710-a406-46dc-a3ab-977948a10397,2acfec24-4aa3-4ab1-a44f-e3dd97df3da9,db71c46b-4430-4241-a54d-43f7d5f64ee4,4166dc0b-f488-48f8-bacc-d5e9ff3d562b,0e11b976-f017-4c29-b0f2-94468466af99,85567506-c566-4a74-9f4d-412d540102f5,e04ec36e-4c73-4f03-a265-aa9eaf251601,7ed59a39-adef-4a91-901b-6b7cb35d0864,2f7b87d3-f096-4cfe-9c56-b6038b048241,8f439fe5-f799-4fb6-a249-86fd399bb3cb,3d33b0a9-1d1b-4b2d-b01e-0c444beca77d,b7143a21-df40-4b5d-82b2-d823272c6f6a,f6147149-a5e7-40e5-8e49-727f563e3e41,ced012a1-eb92-4374-bebb-d71c2dffe50b,dfa187f8-6653-4ef4-ac9a-107ac48c709a,83085566-745b-4667-9e0e-0a563f94dc09,933eb411-91df-4e80-b51b-f753390d0d44,71ac6ca4-6ed5-4bc0-9586-cbc135bf3959,8d7c6906-f1dd-4a7d-ba70-ecd1a08aefe6,1351658c-f7d8-47c3-80b9-34f3573d1727,e2fd328b-5e60-47dc-99dc-091933cf1c4e,c90f90da-c329-40cf-8d41-e12bbfb29966,fafa4cba-a440-4d98-a5b1-d8f89473dbb7,4a73d6f8-fbab-48e1-b67b-cdf2dcb2292f,dfffc4f6-a0f9-4261-a43b-bfa4518bcfad,610e11f0-bb3d-4eac-9e49-ba078065a498,70a5dbf1-9dbe-497b-affa-30bceb3f441d,5a866e1a-9762-462c-8a85-e716c04ae0e4,1543d0a0-852c-409e-a102-ef0e362eb9c9,55bd1ea3-64ab-4bcd-ade5-1c12bd8e6d9d,5b4427ff-d318-49cc-b2f5-bb7ebd6d91b6,3450d42b-0ef1-4511-b18e-da5f75d0f0af,7ed77f87-d16d-412b-8e84-eee728529699,93f2d702-c240-4895-bbdd-bde1d2fbc16d,478bf17c-7a51-4fed-88ac-1c8e3f9ee038,5fc1461f-7d9f-4cb9-b14e-4bf63afb9d92,701ce38d-c098-4090-bcef-23fe4000bdaf,6c5726f8-95b1-4f61-9ba8-449cdceac98c,c8b3865a-9090-41e0-aba5-5ee25a80fd94,8387f99d-c9cf-4af8-abe5-a12df14d3f8f,2423a3f9-0f4a-4719-8d71-8874d1b4a462,5c0970eb-de3d-4545-963e-de0b4a054ad3,a24384d8-8796-48d6-be1f-2e5f3f0dae77,d0d49672-5b29-4b82-9e2e-2b50ecd3d232,a04ce77a-9a9a-4250-95d7-ce2962ebd31c,7fb363c6-4cc0-4438-a17e-e27c782f7272,611cafa0-1b96-45fa-8a8a-7d254cba6ffb,0f67909f-d12d-464e-a3b1-f8e43af6499b,2d7e7e3b-3133-40b4-99b7-7b7cac0d489b,e90404ec-0219-4220-a8f9-5a19afcf8d0b,03e706f4-2d29-483f-a6bc-728f526920c3}'::uuid[])) AND ((link_type)::text = 'person'::text))
                                            ->  Index Scan using link_sets_pkey on link_sets link_sets_documents_join  (cost=0.42..8.44 rows=1 width=20) (actual time=0.003..0.003 rows=1 loops=100)
                                                  Index Cond: (id = link_set_links.link_set_id)
                                      ->  Index Scan using index_documents_on_content_id_and_locale on documents  (cost=0.43..7.45 rows=1 width=47) (actual time=0.005..0.005 rows=1 loops=100)
                                            Index Cond: ((content_id = link_sets_documents_join.content_id) AND ((locale)::text = 'en'::text))
                                ->  Index Scan using index_editions_on_document_id_and_document_type_current on editions editions_documents  (cost=0.28..7.22 rows=1 width=782) (actual time=0.002..0.002 rows=1 loops=100)
                                      Index Cond: ((document_id = documents.id) AND ((document_type)::text = 'role_appointment'::text))
                          ->  Index Scan using index_link_sets_on_content_id on link_sets  (cost=0.42..7.44 rows=1 width=40) (actual time=0.004..0.004 rows=1 loops=100)
                                Index Cond: (content_id = documents.content_id)
                    ->  Index Scan using index_links_on_link_set_id_and_link_type on links reverse_links  (cost=0.56..7.62 rows=1 width=67) (actual time=0.003..0.003 rows=1 loops=100)
                          Index Cond: ((link_set_id = link_sets.id) AND ((link_type)::text = 'role'::text))
              ->  Index Scan using index_documents_on_content_id_and_locale on documents document  (cost=0.43..7.56 rows=1 width=47) (actual time=0.004..0.004 rows=1 loops=100)
                    Index Cond: ((content_id = reverse_links.target_content_id) AND ((locale)::text = 'en'::text))
        ->  Index Scan using index_editions_on_document_id_and_document_type_live on editions  (cost=0.42..7.48 rows=1 width=782) (actual time=0.003..0.003 rows=1 loops=100)
              Index Cond: ((document_id = document.id) AND ((document_type)::text = 'ministerial_role'::text))
Planning Time: 4.817 ms
Execution Time: 3.848 ms
```

[Trello card](https://trello.com/c/74p1aw8n)