### PR TITLE
Add database indices for GraphQL optimisation

### DIFF
--- a/db/migrate/20250127105807_add_graphql_optimisation_index_to_editions.rb
+++ b/db/migrate/20250127105807_add_graphql_optimisation_index_to_editions.rb
@@ -1,0 +1,7 @@
+class AddGraphqlOptimisationIndexToEditions < ActiveRecord::Migration[8.0]
+  def change
+    add_index :editions, %i[document_id document_type], where: "(details ->> 'current') = 'true'", name: :index_editions_on_document_id_and_document_type_current
+    add_index :editions, %i[document_id document_type], where: "content_store = 'live'", name: :index_editions_on_document_id_and_document_type_live
+    add_index :links, %i[link_set_id link_type]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_01_06_115835) do
+ActiveRecord::Schema[8.0].define(version: 2025_01_27_105807) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -96,6 +96,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_01_06_115835) do
     t.uuid "last_edited_by_editor_id"
     t.index ["base_path", "content_store"], name: "index_editions_on_base_path_and_content_store", unique: true
     t.index ["document_id", "content_store"], name: "index_editions_on_document_id_and_content_store", unique: true
+    t.index ["document_id", "document_type"], name: "index_editions_on_document_id_and_document_type_current", where: "((details ->> 'current'::text) = 'true'::text)"
+    t.index ["document_id", "document_type"], name: "index_editions_on_document_id_and_document_type_live", where: "((content_store)::text = 'live'::text)"
     t.index ["document_id", "state"], name: "index_editions_on_document_id_and_state"
     t.index ["document_id", "user_facing_version"], name: "index_editions_on_document_id_and_user_facing_version", unique: true
     t.index ["document_id"], name: "index_editions_on_document_id"
@@ -158,6 +160,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_01_06_115835) do
     t.integer "position", default: 0, null: false
     t.integer "edition_id"
     t.index ["edition_id"], name: "index_links_on_edition_id"
+    t.index ["link_set_id", "link_type"], name: "index_links_on_link_set_id_and_link_type"
     t.index ["link_set_id", "target_content_id"], name: "index_links_on_link_set_id_and_target_content_id"
     t.index ["link_set_id"], name: "index_links_on_link_set_id"
     t.index ["link_type"], name: "index_links_on_link_type"


### PR DESCRIPTION
(Note: base branch is `add-graphql-optimisation-indices`)

This adds indices which improve the performance of request-time link expansion for GraphQL queries.

Results in a reduction in execution time for one of the ministers index page queries from ~418ms to ~3.8ms.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
