### PR TITLE
Remove unused `format_name` property

### DIFF
--- a/content_schemas/dist/formats/finder/frontend/schema.json
+++ b/content_schemas/dist/formats/finder/frontend/schema.json
@@ -328,9 +328,6 @@
         "filter": {
           "$ref": "#/definitions/finder_filter"
         },
-        "format_name": {
-          "type": "string"
-        },
         "generic_description": {
           "type": "boolean"
         },

--- a/content_schemas/dist/formats/finder/notification/schema.json
+++ b/content_schemas/dist/formats/finder/notification/schema.json
@@ -428,9 +428,6 @@
         "filter": {
           "$ref": "#/definitions/finder_filter"
         },
-        "format_name": {
-          "type": "string"
-        },
         "generic_description": {
           "type": "boolean"
         },

--- a/content_schemas/dist/formats/finder/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/finder/publisher_v2/schema.json
@@ -220,9 +220,6 @@
         "filter": {
           "$ref": "#/definitions/finder_filter"
         },
-        "format_name": {
-          "type": "string"
-        },
         "generic_description": {
           "type": "boolean"
         },

--- a/content_schemas/formats/finder.jsonnet
+++ b/content_schemas/formats/finder.jsonnet
@@ -58,9 +58,6 @@
         facets: {
           "$ref": "#/definitions/finder_facets",
         },
-        format_name: {
-          type: "string",
-        },
         label_text: {
           type: "string",
         },


### PR DESCRIPTION
Dependent on:

- https://github.com/alphagov/contacts-admin/pull/1592
- https://github.com/alphagov/specialist-publisher/pull/2998
- https://github.com/alphagov/search-api/pull/3139
- https://github.com/alphagov/whitehall/pull/9881

Trello: https://trello.com/c/ZiFU2o6B

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
