### PR TITLE
Make migrations concurrent

### DIFF
--- a/db/migrate/20250127105807_add_graphql_optimisation_index_to_editions.rb
+++ b/db/migrate/20250127105807_add_graphql_optimisation_index_to_editions.rb
@@ -1,7 +1,9 @@
 class AddGraphqlOptimisationIndexToEditions < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
   def change
-    add_index :editions, %i[document_id document_type], where: "(details ->> 'current') = 'true'", name: :index_editions_on_document_id_and_document_type_current
-    add_index :editions, %i[document_id document_type], where: "content_store = 'live'", name: :index_editions_on_document_id_and_document_type_live
-    add_index :links, %i[link_set_id link_type]
+    add_index :editions, %i[document_id document_type], where: "(details ->> 'current') = 'true'", name: :index_editions_on_document_id_and_document_type_current, algorithm: :concurrently
+    add_index :editions, %i[document_id document_type], where: "content_store = 'live'", name: :index_editions_on_document_id_and_document_type_live, algorithm: :concurrently
+    add_index :links, %i[link_set_id link_type], algorithm: :concurrently
   end
 end

--- a/db/migrate/20250128101515_add_edition_link_index.rb
+++ b/db/migrate/20250128101515_add_edition_link_index.rb
@@ -1,5 +1,7 @@
 class AddEditionLinkIndex < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
   def change
-    add_index :links, %i[edition_id link_type]
+    add_index :links, %i[edition_id link_type], algorithm: :concurrently
   end
 end


### PR DESCRIPTION
The migrations to add new indexes were previously locking all writes to the editions table at the time of running.

As one of the migrations is slow (several minutes), this caused degraded performance of the application.

Making them concurrent to remove the need for the tables to be locked.

[Trello card](https://trello.com/c/74p1aw8n)