### PR TITLE
Only retrieve change history from database if needed

### DIFF
--- a/app/graphql/types/edition_type.rb
+++ b/app/graphql/types/edition_type.rb
@@ -135,7 +135,7 @@ module Types
 
       field :body, String
       field :brand, String
-      field :change_history, GraphQL::Types::JSON
+      field :change_history, GraphQL::Types::JSON, extras: [:parent]
       field :current, Boolean
       field :default_news_image, Image
       field :display_date, GraphQL::Types::ISO8601DateTime
@@ -158,6 +158,7 @@ module Types
     field :active, Boolean, null: false
     field :analytics_identifier, String
     field :base_path, String
+    field :change_history, GraphQL::Types::JSON
     field :content_id, ID
     field :current, Boolean
     field :description, String
@@ -186,11 +187,15 @@ module Types
     field :web_url, String
     field :withdrawn_notice, WithdrawnNotice
 
+    def change_history
+      Presenters::ChangeHistoryPresenter.new(object).change_history
+    end
+
     def details
       Presenters::ContentTypeResolver.new("text/html").resolve(
         Presenters::DetailsPresenter.new(
           object.details,
-          Presenters::ChangeHistoryPresenter.new(object),
+          nil,
           Presenters::ContentEmbedPresenter.new(object),
         ).details,
       )

--- a/spec/integration/graphql/news_article_spec.rb
+++ b/spec/integration/graphql/news_article_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe "GraphQL" do
         document_type: "news_story",
         details: {
           body: "Some text",
+          change_history: [{ note: "Info", public_timestamp: "2025-01-01 00:01:00" }],
         },
       )
 
@@ -94,6 +95,7 @@ RSpec.describe "GraphQL" do
                   title
                   details {
                     body
+                    change_history
                   }
                   links {
                     available_translations {
@@ -147,6 +149,7 @@ RSpec.describe "GraphQL" do
             base_path: @edition.base_path,
             details: {
               body: @edition.details[:body],
+              change_history: [{ note: "Info", public_timestamp: "2025-01-01 00:01:00" }],
             },
             links: {
               available_translations: [


### PR DESCRIPTION
At the moment, we are retrieving the full change history for all documents from the datbase, whether it is needed or not.

This makes a change so the change history is only retrieved from the database if it has actually been requested by the client.

For the prime minister page, the number of database queries is reduced from 254 to 93.

[Trello card](https://trello.com/c/LorsXOIU)