### PR TITLE
content modelling/865 fields in embed codes

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -118,7 +118,7 @@ GEM
     climate_control (1.2.0)
     concurrent-ruby (1.3.5)
     connection_pool (2.5.0)
-    content_block_tools (0.3.1)
+    content_block_tools (0.4.0)
       actionview (>= 6)
     crack (1.0.0)
       bigdecimal

--- a/app/presenters/content_embed_presenter.rb
+++ b/app/presenters/content_embed_presenter.rb
@@ -57,19 +57,20 @@ module Presenters
         embedded_edition = embedded_editions[content_reference.content_id]
         content = content.gsub(
           embed_code,
-          get_content_for_edition(embedded_edition),
+          get_content_for_edition(embedded_edition, embed_code),
         )
       end
 
       content
     end
 
-    def get_content_for_edition(edition)
+    def get_content_for_edition(edition, embed_code)
       ContentBlockTools::ContentBlock.new(
         document_type: edition.document_type,
         content_id: edition.document.content_id,
         title: edition.title,
         details: edition.details,
+        embed_code: embed_code,
       ).render
     end
   end

--- a/lib/expansion_rules.rb
+++ b/lib/expansion_rules.rb
@@ -91,7 +91,8 @@ module_function
 
   DEFAULT_FIELDS_AND_DESCRIPTION = (DEFAULT_FIELDS + [:description]).freeze
 
-  CONTENT_BLOCK_FIELDS = (DEFAULT_FIELDS + details_fields(:email_address)).freeze
+  CONTENT_BLOCK_EMAIL_FIELDS = (DEFAULT_FIELDS + details_fields(:email_address)).freeze
+  CONTENT_BLOCK_POSTAL_FIELDS = (DEFAULT_FIELDS + details_fields(:line_1, :town_or_city, :postcode)).freeze
   CONTACT_FIELDS = (DEFAULT_FIELDS + details_fields(:description, :title, :contact_form_links, :post_addresses, :email_addresses, :phone_numbers)).freeze
   GOVERNMENT_FIELDS = (MANDATORY_FIELDS + %i[api_path base_path document_type] + details_fields(:started_on, :ended_on, :current)).freeze
   ORGANISATION_FIELDS = (DEFAULT_FIELDS - [:public_updated_at] + details_fields(:acronym, :logo, :brand, :default_news_image, :organisation_govuk_status)).freeze
@@ -164,7 +165,9 @@ module_function
       { document_type: :contact,
         fields: CONTACT_FIELDS },
       { document_type: :content_block_email_address,
-        fields: CONTENT_BLOCK_FIELDS },
+        fields: CONTENT_BLOCK_EMAIL_FIELDS },
+      { document_type: :content_block_postal_address,
+        fields: CONTENT_BLOCK_POSTAL_FIELDS },
       { document_type: :topical_event,
         fields: DEFAULT_FIELDS },
       { document_type: :organisation,

--- a/spec/lib/expansion_rules_spec.rb
+++ b/spec/lib/expansion_rules_spec.rb
@@ -40,7 +40,8 @@ RSpec.describe ExpansionRules do
   describe ".expansion_fields" do
     let(:default_fields) { rules::DEFAULT_FIELDS }
     let(:contact_fields) { default_fields + [%i[details description], %i[details title], %i[details contact_form_links], %i[details post_addresses], %i[details email_addresses], %i[details phone_numbers]] }
-    let(:content_block_fields) { default_fields + [%i[details email_address]] }
+    let(:content_block_email_fields) { default_fields + [%i[details email_address]] }
+    let(:content_block_postal_fields) { default_fields + [%i[details line_1], %i[details town_or_city], %i[details postcode]] }
     let(:organisation_fields) { default_fields - [:public_updated_at] + [%i[details acronym], %i[details logo], %i[details brand], %i[details default_news_image], %i[details organisation_govuk_status]] }
     let(:taxon_fields) { default_fields + %i[description details phase] }
     let(:default_fields_and_description) { default_fields + %i[description] }
@@ -68,7 +69,8 @@ RSpec.describe ExpansionRules do
     specify { expect(rules.expansion_fields(:parent)).to eq(default_fields) }
 
     specify { expect(rules.expansion_fields(:contact)).to eq(contact_fields) }
-    specify { expect(rules.expansion_fields(:content_block_email_address)).to eq(content_block_fields) }
+    specify { expect(rules.expansion_fields(:content_block_email_address)).to eq(content_block_email_fields) }
+    specify { expect(rules.expansion_fields(:content_block_postal_address)).to eq(content_block_postal_fields) }
     specify { expect(rules.expansion_fields(:historic_appointment)).to eq(historic_appointment_fields) }
     specify { expect(rules.expansion_fields(:fatality_notice)).to eq(fatality_notice_fields) }
     specify { expect(rules.expansion_fields(:mainstream_browse_page)).to eq(default_fields_and_description) }

--- a/spec/presenters/content_embed_presenter_spec.rb
+++ b/spec/presenters/content_embed_presenter_spec.rb
@@ -1,5 +1,6 @@
 RSpec.describe Presenters::ContentEmbedPresenter do
   let(:embedded_content_id) { SecureRandom.uuid }
+  let(:embed_code) { "{{embed:contact:#{embedded_content_id}}}" }
   let(:document) { create(:document) }
   let(:edition) do
     create(
@@ -38,6 +39,7 @@ RSpec.describe Presenters::ContentEmbedPresenter do
         content_id: embedded_edition.document.content_id,
         title: embedded_edition.title,
         details: embedded_edition.details,
+        embed_code: embed_code,
       ).at_least(:once).and_return(stub_block)
     end
 
@@ -162,6 +164,7 @@ RSpec.describe Presenters::ContentEmbedPresenter do
 
     context "when multiple documents are embedded in different parts of the document" do
       let(:other_embedded_content_id) { SecureRandom.uuid }
+      let(:other_embed_code) { "{{embed:contact:#{other_embedded_content_id}}}" }
 
       let!(:other_embedded_edition) do
         embedded_document = create(:document, content_id: other_embedded_content_id)
@@ -184,6 +187,7 @@ RSpec.describe Presenters::ContentEmbedPresenter do
           content_id: other_embedded_edition.document.content_id,
           title: other_embedded_edition.title,
           details: other_embedded_edition.details,
+          embed_code: other_embed_code,
         ).at_least(:once).and_return(other_stub_block)
       end
 

--- a/spec/presenters/details_presenter_spec.rb
+++ b/spec/presenters/details_presenter_spec.rb
@@ -197,7 +197,7 @@ RSpec.describe Presenters::DetailsPresenter do
           let(:edition_details) { edition.details }
           let(:expected_details) do
             {
-              field_name => presented_details_for(embeddable_content),
+              field_name => presented_details_for(embeddable_content, field_value),
             }.symbolize_keys
           end
 
@@ -219,8 +219,8 @@ RSpec.describe Presenters::DetailsPresenter do
           let(:expected_details) do
             {
               field_name => [
-                { content_type: "text/html", content: presented_details_for(embeddable_content) },
-                { content_type: "text/govspeak", content: presented_details_for(embeddable_content) },
+                { content_type: "text/html", content: presented_details_for(embeddable_content, field_value) },
+                { content_type: "text/govspeak", content: presented_details_for(embeddable_content, field_value) },
               ],
             }.symbolize_keys
           end

--- a/spec/presenters/queries/expanded_link_set_spec.rb
+++ b/spec/presenters/queries/expanded_link_set_spec.rb
@@ -82,6 +82,8 @@ RSpec.describe Presenters::Queries::ExpandedLinkSet do
         create(:edition, state: "published", content_store: "live", document_type: "contact", title: "Some contact")
       end
 
+      let(:embed_code) { "{{embed:contact:#{contact.document.content_id}}}" }
+
       before do
         create_edition(a, "/a", document_type: "person")
         create_edition(
@@ -92,7 +94,7 @@ RSpec.describe Presenters::Queries::ExpandedLinkSet do
             body: [
               {
                 content_type: "text/govspeak",
-                content: "{{embed:contact:#{contact.document.content_id}}}",
+                content: embed_code,
               },
             ],
           },
@@ -110,11 +112,11 @@ RSpec.describe Presenters::Queries::ExpandedLinkSet do
         expect(c[:details][:body]).to match([
           {
             content_type: "text/govspeak",
-            content: presented_details_for(contact),
+            content: presented_details_for(contact, embed_code),
           },
           {
             content_type: "text/html",
-            content: "<p>#{presented_details_for(contact)}</p>\n",
+            content: "<p>#{presented_details_for(contact, embed_code)}</p>\n",
           },
         ])
       end

--- a/spec/support/content_block_helpers.rb
+++ b/spec/support/content_block_helpers.rb
@@ -1,10 +1,11 @@
 module ContentBlockHelpers
-  def presented_details_for(edition)
+  def presented_details_for(edition, embed_code)
     ContentBlockTools::ContentBlock.new(
       document_type: edition.document_type,
       content_id: edition.document.content_id,
       title: edition.title,
       details: edition.details,
+      embed_code: embed_code,
     ).render
   end
 end


### PR DESCRIPTION
This fixes the breaking changes introduced in to the ContentBlockTools gem: https://github.com/alphagov/govuk_content_block_tools/pull/17 


--- 
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
