### PR TITLE
Add a special route for /chat

### DIFF
--- a/lib/data/special_routes.yaml
+++ b/lib/data/special_routes.yaml
@@ -277,3 +277,15 @@
   :title: 'Apply for a licence'
   :rendering_app: 'licensify'
   :override_existing: true
+
+- :base_path: "/chat"
+  :content_id: "62256aa9-f0e8-463a-8483-2f03be24287d"
+  :document_type: "gone"
+  # title and description are required to be null for a gone schema
+  :title: ~
+  :description: ~
+  :additional_routes:
+    - :base_path: "/chat/about"
+    - :base_path: "/chat/support"
+    - :base_path: "/chat/privacy"
+    - :base_path: "/chat/accessibility"

--- a/lib/special_route_publisher.rb
+++ b/lib/special_route_publisher.rb
@@ -42,7 +42,7 @@ class SpecialRoutePublisher
   def publish_route(route)
     routes = get_routes(route)
 
-    routes.each { |r| Rails.logger.info("Publishing #{r[:type]} route #{r[:path]}, routing to #{route.fetch(:rendering_app)}...") }
+    routes.each { |r| Rails.logger.info("Publishing #{r[:type]} route #{r[:path]}, routing to #{route[:rendering_app]}...") }
 
     content_id = route.fetch(:content_id)
 
@@ -68,7 +68,7 @@ class SpecialRoutePublisher
       details: {},
       routes:,
       publishing_app: "publishing-api",
-      rendering_app: route.fetch(:rendering_app),
+      rendering_app: route[:rendering_app],
       public_updated_at: Time.zone.now.iso8601,
       update_type: route.fetch(:update_type, "major"),
     })


### PR DESCRIPTION
Trello: https://trello.com/c/evNZhxxc/2285-set-up-410-page-for-govuk-chat-to-be-served-by-govuk

This PR configures a route for /chat (and a few content sub pages) so they can return a gone response.

The motivation for this is that we are going to remove the chat application from GOV.UK routing and want to leave behind the appropriate 410 responses.

The first commit here makes a modification to SpecialRoutePublisher in order to enable publishing special routes of the gone /redirect schema. The second commit applies the change.

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
