### PR TITLE
bump Content Block Tools to 0.4.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -118,7 +118,7 @@ GEM
     climate_control (1.2.0)
     concurrent-ruby (1.3.5)
     connection_pool (2.5.0)
-    content_block_tools (0.4.1)
+    content_block_tools (0.4.2)
       actionview (>= 6)
     crack (1.0.0)
       bigdecimal

--- a/spec/integration/put_content/content_with_embedded_content_spec.rb
+++ b/spec/integration/put_content/content_with_embedded_content_spec.rb
@@ -204,7 +204,7 @@ RSpec.describe "PUT /v2/content when embedded content is provided" do
     let(:first_contact) { create(:edition, state: "published", content_store: "live", document_type: "contact") }
     let(:second_contact) { create(:edition, state: "published", content_store: "live", document_type: "contact") }
     let(:first_embed_code) { "{{embed:contact:#{first_contact.document.content_id}}}" }
-    let(:second_embed_code) { "{{embed:contact:#{first_contact.document.content_id}}}" }
+    let(:second_embed_code) { "{{embed:contact:#{second_contact.document.content_id}}}" }
     let(:document) { create(:document, content_id:) }
 
     before do


### PR DESCRIPTION
https://trello.com/c/Pomls5FJ/881-enable-preview-for-pension-blocks-in-whitehall

This is needed to make previewing frontend changes work, in addition to this Whitehall PR https://github.com/alphagov/whitehall/pull/9910

---
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
