### PR TITLE
Support multiple refs to the same content block

### DIFF
--- a/app/services/embedded_content_finder_service.rb
+++ b/app/services/embedded_content_finder_service.rb
@@ -25,8 +25,9 @@ private
 
   def check_all_references_exist(content_references, locale)
     found_editions = live_editions(content_references, locale)
-    if found_editions.count != content_references.count
-      not_found_content_ids = content_references.map(&:content_id) - found_editions.map(&:content_id)
+    not_found_content_ids = content_references.map(&:content_id) - found_editions.map(&:content_id)
+
+    if not_found_content_ids.any?
       raise CommandError.new(
         code: 422,
         message: "Could not find any live editions in locale #{locale} for: #{not_found_content_ids.join(', ')}, ",

--- a/spec/services/embedded_content_finder_service_spec.rb
+++ b/spec/services/embedded_content_finder_service_spec.rb
@@ -6,7 +6,7 @@ RSpec.shared_examples "finds references" do |document_type|
                state: "published",
                document_type:,
                content_store: "live",
-               details: { title: "Some Title" }),
+               details: { title: "Some Title", another: "thing" }),
         create(:edition,
                state: "published",
                document_type:,
@@ -38,6 +38,14 @@ RSpec.shared_examples "finds references" do |document_type|
         links = EmbeddedContentFinderService.new.fetch_linked_content_ids(details, Edition::DEFAULT_LOCALE)
 
         expect(links).to eq([editions[0].content_id, editions[0].content_id, editions[1].content_id])
+      end
+
+      it "returns duplicates when there are field references in the field" do
+        details = { field_name => "{{embed:#{document_type}:#{editions[0].content_id}/title}} {{embed:#{document_type}:#{editions[0].content_id}/another}}" }
+
+        links = EmbeddedContentFinderService.new.fetch_linked_content_ids(details, Edition::DEFAULT_LOCALE)
+
+        expect(links).to eq([editions[0].content_id, editions[0].content_id])
       end
 
       it "finds content references when #{field_name} is an array of hashes" do


### PR DESCRIPTION
Before if there were mutliple references to the same content in a document, the content finder would throw an error. I’ve tweaked the logic, so we allow for duplicates when checking references exist