### PR TITLE
Optimise `details` handling for GraphQL

### DIFF
--- a/app/presenters/content_embed_presenter.rb
+++ b/app/presenters/content_embed_presenter.rb
@@ -5,6 +5,8 @@ module Presenters
     end
 
     def render_embedded_content(details)
+      return details unless target_content_ids
+
       details.each_pair do |field, value|
         next if value.blank?
 
@@ -16,13 +18,15 @@ module Presenters
 
   private
 
+    def target_content_ids
+      @target_content_ids ||= @edition
+                                .links
+                                .where(link_type: "embed")
+                                .pluck(:target_content_id)
+    end
+
     def embedded_editions
       @embedded_editions ||= begin
-        target_content_ids = @edition
-         .links
-         .where(link_type: "embed")
-         .pluck(:target_content_id)
-
         embedded_edition_ids = ::Queries::GetEditionIdsWithFallbacks.call(
           target_content_ids,
           locale_fallback_order: [@edition.locale, Edition::DEFAULT_LOCALE].uniq,

--- a/app/presenters/details_presenter.rb
+++ b/app/presenters/details_presenter.rb
@@ -22,29 +22,25 @@ module Presenters
 
   private
 
-    def govspeak_content?(value)
-      wrapped = Array.wrap(value)
-      wrapped.all? { |hsh| hsh.is_a?(Hash) } &&
-        wrapped.one? { |hsh| hsh[:content_type] == "text/govspeak" } &&
-        wrapped.none? { |hsh| hsh[:content_type] == "text/html" }
-    end
-
-    def html_content?(value)
-      wrapped = Array.wrap(value)
-      wrapped.all? { |hsh| hsh.is_a?(Hash) } &&
-        wrapped.one? { |hsh| hsh[:content_type] == "text/html" }
+    def parsed_content(array_of_hashes)
+      if array_of_hashes.one? { |hash| hash[:content_type] == "text/html" }
+        array_of_hashes
+      elsif array_of_hashes.one? { |hash| hash[:content_type] == "text/govspeak" }
+        render_govspeak(array_of_hashes)
+      end
     end
 
     def recursively_transform_govspeak(obj)
-      return obj if !obj.respond_to?(:map) || html_content?(obj)
-      return render_govspeak(obj) if govspeak_content?(obj)
-
-      if obj.is_a?(Hash)
+      if obj.is_a?(Array) && obj.all?(Hash) && (parsed_obj = parsed_content(obj))
+        parsed_obj
+      elsif obj.is_a?(Array)
+        obj.map { |o| recursively_transform_govspeak(o) }
+      elsif obj.is_a?(Hash)
         obj.transform_values do |value|
           recursively_transform_govspeak(value)
         end
       else
-        obj.map { |o| recursively_transform_govspeak(o) }
+        obj
       end
     end
 

--- a/app/presenters/details_presenter.rb
+++ b/app/presenters/details_presenter.rb
@@ -11,13 +11,10 @@ module Presenters
     end
 
     def details
-      @details ||=
-        begin
-          updated = content_embed(content_item_details).presence || content_item_details
-          updated = recursively_transform_govspeak(updated)
-          updated[:change_history] = change_history if change_history.present?
-          updated
-        end
+      updated = content_embed(content_item_details).presence || content_item_details
+      updated = recursively_transform_govspeak(updated)
+      updated[:change_history] = change_history if change_history.present?
+      updated
     end
 
   private

--- a/app/validators/well_formed_content_types_validator.rb
+++ b/app/validators/well_formed_content_types_validator.rb
@@ -23,7 +23,11 @@ private
   end
 
   def validate_hash!(hash)
-    validate_array!(hash.values)
+    if hash.keys == %i[content_type content]
+      @error_messages << "fields with content types should be presented in an array"
+    else
+      validate_array!(hash.values)
+    end
   end
 
   def validate_array!(array)

--- a/spec/graphql/types/edition_type_spec.rb
+++ b/spec/graphql/types/edition_type_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe "Types::EditionType" do
-  include GraphQL::Testing::Helpers.for(PublishingApiSchema)
+  include GraphQL::Testing::Helpers
 
   describe "#withdrawn_notice" do
     context "when the edition is withdrawn" do
@@ -12,6 +12,7 @@ RSpec.describe "Types::EditionType" do
 
         expect(
           run_graphql_field(
+            PublishingApiSchema,
             "Edition.withdrawn_notice",
             edition,
           ),
@@ -23,6 +24,7 @@ RSpec.describe "Types::EditionType" do
       it "returns nil" do
         expect(
           run_graphql_field(
+            PublishingApiSchema,
             "Edition.withdrawn_notice",
             create(:edition),
           ),
@@ -38,8 +40,10 @@ RSpec.describe "Types::EditionType" do
 
         expect(
           run_graphql_field(
+            PublishingApiSchema,
             "Edition.details",
             edition,
+            lookahead: OpenStruct.new(selections: [OpenStruct.new(name: :body)]),
           )[:body],
         ).to eq("some text")
       end
@@ -56,8 +60,10 @@ RSpec.describe "Types::EditionType" do
 
         expect(
           run_graphql_field(
+            PublishingApiSchema,
             "Edition.details",
             edition,
+            lookahead: OpenStruct.new(selections: [OpenStruct.new(name: :body)]),
           )[:body],
         ).to eq("<p>some other text</p>")
       end
@@ -73,8 +79,10 @@ RSpec.describe "Types::EditionType" do
 
         expect(
           run_graphql_field(
+            PublishingApiSchema,
             "Edition.details",
             edition,
+            lookahead: OpenStruct.new(selections: [OpenStruct.new(name: :body)]),
           )[:body],
         ).to eq("<p>some text</p>\n")
       end

--- a/spec/presenters/details_presenter_spec.rb
+++ b/spec/presenters/details_presenter_spec.rb
@@ -108,25 +108,6 @@ RSpec.describe Presenters::DetailsPresenter do
       it { is_expected.to match(expected_result) }
     end
 
-    context "when we're passed hashes rather than arrays" do
-      let(:edition_details) do
-        {
-          body: { content_type: "text/govspeak", content: "**hello**" },
-        }
-      end
-
-      let(:expected_result) do
-        {
-          body: [
-            { content_type: "text/govspeak", content: "**hello**" },
-            { content_type: "text/html", content: "<p><strong>hello</strong></p>\n" },
-          ],
-        }
-      end
-
-      it { is_expected.to match(expected_result) }
-    end
-
     context "when we're passed an image hash" do
       let(:edition_details) do
         { image: { content_type: "image/png", content: "some content" } }

--- a/spec/validators/well_formed_content_types_validator_spec.rb
+++ b/spec/validators/well_formed_content_types_validator_spec.rb
@@ -49,6 +49,13 @@ RSpec.describe WellFormedContentTypesValidator do
     expect(record.errors).to be_empty
   end
 
+  it "rejects hashes containing content types that are not wrapped in an array" do
+    value = { content_type: "text/html", content: "<p>content</p>" }
+    subject.validate_each(record, attribute, value)
+    expect(record.errors).to be_present
+    expect(record.errors.messages_for(:some_attribute)).to eq(["fields with content types should be presented in an array"])
+  end
+
   it "rejects values where the content key is missing" do
     value = [{ content_type: "text/html" }]
     subject.validate_each(record, attribute, value)


### PR DESCRIPTION
This makes a number of performance improvements to processing of `details` for GraphQL queries.  When we did profiling, we found `DetailsPresenter` is home to some of the most invoked and slowest methods within our own code when serving GraphQL responses.

The change in response time is only marginal for the document types we have already migrated to GraphQL, but has potential for larger improvements when we migrate documents containing a large amount of data in `details`, particularly those with extensive nesting.

## Change 1: Only parse details that are requested

At the moment, we are putting the entire contents of the `details` field through the `DetailsPresenter`, which is sub-optimal as we are parsing values that clients are not requesting.

By using lookaheads, we can determine which fields from `details` have been requested and only parse those.

In [a previous prototype](https://github.com/alphagov/publishing-api/blob/8e7da92c0fe1a76097e6533904d90776369d6456/app/graphql/types/generic_details_type.rb#L29-L47), we had only transformed the govspeak in the `body` field. However some schemas permit mixed govspeak/HTML content in other details fields, or even nested within other fields. We therefore need to recursively parse all items within `details`, as is already done using the `DetailsPresenter`, to ensure no raw govspeak to presented to the client.

Note: the code here could've been simpler (i.e. not duplicate the object, just slice the details hash) but the `ContentEmbedPresenter` requires a full `Edition` object.

## Change 2: Do not loop through details unless embed links exist

At the moment, we are looping through each item in `details` to look for any embedded content references. This is sub-optimal as we are searching through content for a tag that we know won't be there, if there is nothing to embed in the document.

We should skip doing this if there is nothing that could possibly be embedded, which we know by looking in the document's links.

## Change 3: Reduce lines of code executed in `DetailsPresenter`

This presenter currently performs some of the same code in different methods that determine the type of content in the field, and looks for content types even when we know there won't be any present.

Therefore refactoring this presenter to perform as little code execution as possible to order to determine the correct outcome for the content type given.

## Change 4: Remove useless memoization

Everywhere the `details` method is being called is not re-computing the response, therefore the memoization is pointless.

Removing it here, to avoid the unnecessary compute needed to check whether the instance variable has already been set.

[Trello card](https://trello.com/c/12Z8TvTb)