### PR TITLE
content-modelling/ 880 - fix replacing embed codes in host documents

### DIFF
--- a/app/presenters/content_embed_presenter.rb
+++ b/app/presenters/content_embed_presenter.rb
@@ -52,7 +52,7 @@ module Presenters
       embedded_content_references = EmbeddedContentFinderService.new.find_content_references(content)
       return content if embedded_content_references.empty?
 
-      embedded_content_references.each do |content_reference|
+      embedded_content_references.uniq.each do |content_reference|
         embed_code = content_reference.embed_code
         embedded_edition = embedded_editions[content_reference.content_id]
         content = content.gsub(


### PR DESCRIPTION
https://trello.com/c/fP2L929o/901-bug-email-preview-in-mainstream-publisher-not-displaying-correctly

The helper method in Content Block Tools that finds
 content block embeds was recently set to
return mutliple references to one block [1] - this
then caused a knock-on effect for rendering blocks in
a document, because it would try to replace the
embed code multiple times, causing issues now that
the embed code is returned in the data attributes of
a span. We should only need to run `gsub` once to replace
all the embed codes for a reference, so I'm calling `uniq`
in the code that uses the Tool.

[1] https://github.com/alphagov/govuk_content_block_tools/pull/6

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
