### PR TITLE
Add govspeak support for finder summary

### DIFF
--- a/content_schemas/dist/formats/finder/frontend/schema.json
+++ b/content_schemas/dist/formats/finder/frontend/schema.json
@@ -663,6 +663,9 @@
         },
         {
           "type": "null"
+        },
+        {
+          "type": "string"
         }
       ]
     },

--- a/content_schemas/dist/formats/finder/notification/schema.json
+++ b/content_schemas/dist/formats/finder/notification/schema.json
@@ -763,6 +763,9 @@
         },
         {
           "type": "null"
+        },
+        {
+          "$ref": "#/definitions/multiple_content_types"
         }
       ]
     },
@@ -1022,6 +1025,25 @@
         "zh-hk",
         "zh-tw"
       ]
+    },
+    "multiple_content_types": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_type",
+          "content"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content": {
+            "type": "string"
+          },
+          "content_type": {
+            "type": "string"
+          }
+        }
+      }
     },
     "payload_version": {
       "description": "Counter to indicate when the payload was generated",

--- a/content_schemas/dist/formats/finder/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/finder/publisher_v2/schema.json
@@ -551,6 +551,9 @@
         },
         {
           "type": "null"
+        },
+        {
+          "$ref": "#/definitions/multiple_content_types"
         }
       ]
     },
@@ -671,6 +674,25 @@
         "zh-hk",
         "zh-tw"
       ]
+    },
+    "multiple_content_types": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "content_type",
+          "content"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "content": {
+            "type": "string"
+          },
+          "content_type": {
+            "type": "string"
+          }
+        }
+      }
     },
     "public_updated_at": {
       "description": "When the content was last significantly changed (a major update). Shown to users.  Automatically determined by the publishing-api, unless overridden by the publishing application.",

--- a/content_schemas/formats/shared/definitions/finder.jsonnet
+++ b/content_schemas/formats/shared/definitions/finder.jsonnet
@@ -288,6 +288,9 @@
       {
         type: "null",
       },
+      {
+        "$ref": "#/definitions/multiple_content_types",
+      },
     ],
   },
   finder_beta: {


### PR DESCRIPTION
## What

The schemas in Specialist Publisher have a summary property which [can (and often does) contain HTML](https://github.com/alphagov/specialist-publisher/blob/60ed75ec42c1c32d481f7edb9f4ce4fc3a1b643a/lib/documents/schemas/tax_tribunal_decisions.json#L86). This is exposed to the publisher on the “edit metadata” form ([example](https://specialist-publisher.publishing.service.gov.uk/admin/metadata/tax-tribunal-decisions)).

The property should be stored in the schema as GovSpeak, and rendered in the publisher <textarea> as GovSpeak, but presented downstream as HTML.

## Why

Publishers shouldn’t be expected to have to write HTML. And if they do use GovSpeak, the developer has to manually convert this to HTML before it can be processed.

https://trello.com/c/FHjlxPUv/3410-add-govspeak-support-for-summary-property-in-specialist-publisher-schemas

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
