### PR TITLE
Batch GraphQL reverse link expansion queries

### DIFF
--- a/app/graphql/sources/reverse_linked_to_editions_source.rb
+++ b/app/graphql/sources/reverse_linked_to_editions_source.rb
@@ -1,26 +1,25 @@
 module Sources
   class ReverseLinkedToEditionsSource < GraphQL::Dataloader::Source
     # rubocop:disable Lint/MissingSuper
-    def initialize(parent_object:)
-      @object = parent_object
-      @content_store = parent_object.content_store.to_sym
+    def initialize(content_store:)
+      @content_store = content_store.to_sym
     end
     # rubocop:enable Lint/MissingSuper
 
-    def fetch(link_types)
-      all_links = @object
-        .document
-        .reverse_links
-        .includes(source_documents: @content_store)
-        .where(link_type: link_types)
+    def fetch(editions_and_link_types)
+      content_id_tuples = editions_and_link_types.map { |edition, link_type| "('#{edition.content_id}','#{link_type}')" }.join(",")
 
-      link_types_map = link_types.index_with { [] }
+      all_links = Link
+        .where('("links"."target_content_id", "links"."link_type") IN (?)', Arel.sql(content_id_tuples))
+        .includes(source_documents: @content_store)
+
+      link_types_map = editions_and_link_types.map { [_1.content_id, _2] }.index_with { [] }
 
       all_links.each_with_object(link_types_map) { |link, hash|
         if link.link_set
-          hash[link.link_type].concat(editions_for_link_set_link(link))
+          hash[[link.target_content_id, link.link_type]].concat(editions_for_link_set_link(link))
         elsif link.edition
-          hash[link.link_type] << link.edition
+          hash[[link.target_content_id, link.link_type]] << link.edition
         end
       }.values
     end

--- a/app/graphql/types/base_object.rb
+++ b/app/graphql/types/base_object.rb
@@ -19,8 +19,8 @@ module Types
       field(field_name_and_link_type.to_sym, graphql_field_type)
 
       define_method(field_name_and_link_type.to_sym) do
-        dataloader.with(Sources::ReverseLinkedToEditionsSource, parent_object: object)
-          .load(belongs_to.to_s)
+        dataloader.with(Sources::ReverseLinkedToEditionsSource, content_store: object.content_store)
+          .load([object, belongs_to.to_s])
       end
     end
   end

--- a/app/graphql/types/edition_type.rb
+++ b/app/graphql/types/edition_type.rb
@@ -103,11 +103,11 @@ module Types
 
       def role_appointments
         if %w[role ministerial_role].include?(object.document_type)
-          dataloader.with(Sources::ReverseLinkedToEditionsSource, parent_object: object)
-            .load("role")
+          dataloader.with(Sources::ReverseLinkedToEditionsSource, content_store: object.content_store)
+            .load([object, "role"])
         else
-          dataloader.with(Sources::ReverseLinkedToEditionsSource, parent_object: object)
-            .load("person")
+          dataloader.with(Sources::ReverseLinkedToEditionsSource, content_store: object.content_store)
+            .load([object, "person"])
         end
       end
 

--- a/spec/graphql/sources/reverse_linked_to_editions_source_spec.rb
+++ b/spec/graphql/sources/reverse_linked_to_editions_source_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Sources::ReverseLinkedToEditionsSource do
     create(:link, link_set: link_set_3, target_content_id: target_edition.content_id, link_type: "test_link")
 
     GraphQL::Dataloader.with_dataloading do |dataloader|
-      request = dataloader.with(described_class, parent_object: target_edition).request("test_link")
+      request = dataloader.with(described_class, content_store: target_edition.content_store).request([target_edition, "test_link"])
 
       expect(request.load).to eq([source_edition_1, source_edition_3])
     end
@@ -37,7 +37,7 @@ RSpec.describe Sources::ReverseLinkedToEditionsSource do
            })
 
     GraphQL::Dataloader.with_dataloading do |dataloader|
-      request = dataloader.with(described_class, parent_object: target_edition).request("test_link")
+      request = dataloader.with(described_class, content_store: target_edition.content_store).request([target_edition, "test_link"])
 
       expect(request.load).to eq([source_edition_1, source_edition_2])
     end


### PR DESCRIPTION
Previously `ReverseLinkedToEditionsSource` would make one query per edition (getting linked editions, given a list of link types).

This change makes one query per target edition, by getting the dataloader to batch queries across multiple editions and link types.

This mirrors the change we made for direct links in cff1b0cd414b0e886dee9c584d8396754b13513b.

[Trello card](https://trello.com/c/mHg4qQ6E)