### PR TITLE
Remove unused `details_for_govspeak_conversion` method

### DIFF
--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -133,29 +133,6 @@ class Edition < ApplicationRecord
     errors.add(:user_facing_version, message)
   end
 
-  # FIXME: This method is used to retrieve a version of .details that doesn't
-  # have text/html, thus this can be used to convert the item to HTML
-  # It is here for comparing our Govspeak output with that that was provided to
-  # us previously and can be removed once we have migrated most applications.
-  def details_for_govspeak_conversion
-    return details unless details.is_a?(Hash)
-
-    value_without_html = lambda do |value|
-      wrapped = Array.wrap(value)
-      html = wrapped.find { |item| item.is_a?(Hash) && item[:content_type] == "text/html" }
-      govspeak = wrapped.find { |item| item.is_a?(Hash) && item[:content_type] == "text/govspeak" }
-      if html.present? && govspeak.present?
-        wrapped - [html]
-      else
-        value
-      end
-    end
-
-    details.deep_dup.transform_values do |value|
-      value_without_html.call(value)
-    end
-  end
-
   def publish
     update!(state: "published", content_store: "live")
   end

--- a/spec/models/edition_spec.rb
+++ b/spec/models/edition_spec.rb
@@ -283,54 +283,6 @@ RSpec.describe Edition do
     end
   end
 
-  describe "#details_for_govspeak_conversion" do
-    subject do
-      build(:edition, details:)
-        .details_for_govspeak_conversion
-    end
-
-    let(:html_content) { { content_type: "text/html", content: "<b>Hello</b>" } }
-    let(:govspeak_content) { { content_type: "text/govspeak", content: "**Hello**" } }
-
-    context "details has no body" do
-      let(:details) { { field: "value" } }
-      it { is_expected.to match(details) }
-    end
-
-    context "details doesn't have a text/govspeak content type" do
-      let(:details) { { body: [html_content] } }
-      it { is_expected.to match(details) }
-    end
-
-    context "details doesn't have a text/html content type" do
-      let(:details) { { body: [govspeak_content] } }
-      it { is_expected.to match(details) }
-    end
-
-    context "details has text/html and text/govspeak content types" do
-      let(:details) { { body: [html_content, govspeak_content] } }
-      it { is_expected.to match(body: [govspeak_content]) }
-    end
-
-    context "details has govspeak in multiple keys" do
-      let(:details) do
-        {
-          key_1: [html_content, govspeak_content],
-          key_2: [govspeak_content, html_content],
-          key_3: html_content,
-        }
-      end
-      let(:expected_result) do
-        {
-          key_1: [govspeak_content],
-          key_2: [govspeak_content],
-          key_3: html_content,
-        }
-      end
-      it { is_expected.to match(expected_result) }
-    end
-  end
-
   it_behaves_like WellFormedContentTypesValidator
 
   context "#publish" do


### PR DESCRIPTION
This method is not being used anywhere, other than it's own test.

It was used in `DataHygiene::GovspeakCompare` that was removed in f4466c0f6347849c24308c6dabdf7e64e0b9105a.