### PR TITLE
content-modelling/915 - count instances across multiple parts of document

### DIFF
--- a/app/services/embedded_content_finder_service.rb
+++ b/app/services/embedded_content_finder_service.rb
@@ -11,9 +11,9 @@ class EmbeddedContentFinderService
   def find_content_references(value)
     case value
     when Array
-      value.map { |item| find_content_references(item) }.uniq.flatten
+      value.map { |item| find_content_references(item) }.flatten
     when Hash
-      value.map { |_, v| find_content_references(v) }.uniq.flatten
+      value.map { |_, v| find_content_references(v) }.flatten
     when String
       ContentBlockTools::ContentBlockReference.find_all_in_document(value)
     else

--- a/spec/integration/put_content/content_with_embedded_content_spec.rb
+++ b/spec/integration/put_content/content_with_embedded_content_spec.rb
@@ -156,7 +156,7 @@ RSpec.describe "PUT /v2/content when embedded content is provided" do
     it "should create links" do
       expect {
         put "/v2/content/#{content_id}", params: payload.to_json
-      }.to change(Link, :count).by(2)
+      }.to change(Link, :count).by(4)
 
       expect(Link.find_by(target_content_id: first_contact.content_id)).not_to be_nil
       expect(Link.find_by(target_content_id: second_contact.content_id)).not_to be_nil

--- a/spec/services/embedded_content_finder_service_spec.rb
+++ b/spec/services/embedded_content_finder_service_spec.rb
@@ -91,7 +91,9 @@ RSpec.shared_examples "finds references" do |document_type|
         }
         links = EmbeddedContentFinderService.new.fetch_linked_content_ids(details, Edition::DEFAULT_LOCALE)
 
-        expect(links).to eq([editions[0].content_id, editions[1].content_id])
+        expect(links.length).to eq(4)
+        expect(links.count(editions[0].content_id)).to eq(2)
+        expect(links.count(editions[1].content_id)).to eq(2)
       end
 
       it "returns duplicates when there is more than one content reference in the field and #{field_name} is a multipart document" do
@@ -129,7 +131,36 @@ RSpec.shared_examples "finds references" do |document_type|
         }
         links = EmbeddedContentFinderService.new.fetch_linked_content_ids(details, Edition::DEFAULT_LOCALE)
 
-        expect(links).to eq([editions[0].content_id, editions[0].content_id, editions[1].content_id, editions[1].content_id])
+        expect(links.length).to eq(8)
+        expect(links.count(editions[0].content_id)).to eq(4)
+        expect(links.count(editions[1].content_id)).to eq(4)
+      end
+
+      it "returns duplicates when there is more than one content reference in the field and #{field_name} is a guide document" do
+        details = {
+          field_name => [
+            {
+              "title": "Key stage 3 and 4",
+              "slug": "key-stage-3-and-4",
+              "body": "some string with another reference: {{embed:#{document_type}:#{editions[0].content_id}}} and another {{embed:#{document_type}:#{editions[0].content_id}}}",
+            },
+            {
+              "title": "Other compulsory subjects",
+              "slug": "other-compulsory-subjects",
+              "body": "some string with another reference: {{embed:#{document_type}:#{editions[1].content_id}}} {{embed:#{document_type}:#{editions[1].content_id}}}",
+            },
+            {
+              "title": "Overview",
+              "slug": "overview",
+              "body": "some string with another reference: {{embed:#{document_type}:#{editions[1].content_id}}} {{embed:#{document_type}:#{editions[1].content_id}}}",
+            },
+          ],
+        }
+        links = EmbeddedContentFinderService.new.fetch_linked_content_ids(details, Edition::DEFAULT_LOCALE)
+
+        expect(links.length).to eq(6)
+        expect(links.count(editions[0].content_id)).to eq(2)
+        expect(links.count(editions[1].content_id)).to eq(4)
       end
 
       it "finds content references when the field is a hash" do


### PR DESCRIPTION
https://trello.com/c/Afrbz6Yp/915-the-number-of-instances-are-one-less-than-the-actual-number-of-instances-in-host-content

For the Content Block Manager, we want to count the number of times a content block is embedded in a Document.
This is done when a Put request is made and the `EmbeddedContentFinderService` generates the `embed-links` for a Document. 
We [previously configured this service](https://github.com/alphagov/publishing-api/commit/561288f623b48166d45ff7b81bfeba9539197f3d) to not count duplicates across different parts of a Document, because some content schemas return their content duplicated as both `text/govspeak` and `text/html`. However we've since figured out that we need to count instances across parts for Documents like Guide's in Mainstream. As far as I can tell from the content schemas, the schemas that duplicate their content in the `details` key are only the following:

* manual (specialist-publisher)
* research_for_development_output (specialist-publisher)
* specialist_document (specialist-publisher)
* travel_advice (travel-advice-publisher)

As the Content Block Manager is not yet supported by Specialist Publisher or Travel Advice, we're going ahead with this in order to make sure the counts are correct for Mainstream. 

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
