### PR TITLE
change content block pension rate cadence

### DIFF
--- a/content_schemas/dist/formats/content_block_pension/notification/schema.json
+++ b/content_schemas/dist/formats/content_block_pension/notification/schema.json
@@ -408,8 +408,10 @@
                 "cadence": {
                   "type": "string",
                   "enum": [
-                    "weekly",
-                    "monthly"
+                    "a day",
+                    "a week",
+                    "a month",
+                    "a year"
                   ]
                 },
                 "description": {

--- a/content_schemas/dist/formats/content_block_pension/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/content_block_pension/publisher_v2/schema.json
@@ -225,8 +225,10 @@
                 "cadence": {
                   "type": "string",
                   "enum": [
-                    "weekly",
-                    "monthly"
+                    "a day",
+                    "a week",
+                    "a month",
+                    "a year"
                   ]
                 },
                 "description": {

--- a/content_schemas/examples/content_block_pension/publisher_v2/example.json
+++ b/content_schemas/examples/content_block_pension/publisher_v2/example.json
@@ -11,7 +11,7 @@
       "rate-1": {
         "name": "Rate 1",
         "amount": "£221.20",
-        "cadence": "weekly",
+        "cadence": "a week",
         "description": "Your weekly pension amount"
       }
     }

--- a/content_schemas/formats/content_block_pension.jsonnet
+++ b/content_schemas/formats/content_block_pension.jsonnet
@@ -18,7 +18,7 @@ local utils = import "shared/utils/content_block_utils.jsonnet";
             },
             cadence: {
               type: "string",
-              enum: ["weekly", "monthly"],
+              enum: ["a day", "a week", "a month", "a year"],
             },
             description: {
               type: "string",


### PR DESCRIPTION
https://trello.com/c/z9afIAop/909-update-cadence-label-and-values

previously we had the enums as 'weekly', 'monthly'
etc, but we now want to use this field as if it
was the exact copy content designers would be
pasting into documents.

frontend changes here https://github.com/alphagov/whitehall/pull/9960

----

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
