### PR TITLE
(932) Improve validation for rate amounts

### DIFF
--- a/content_schemas/dist/formats/content_block_pension/notification/schema.json
+++ b/content_schemas/dist/formats/content_block_pension/notification/schema.json
@@ -403,7 +403,7 @@
               "properties": {
                 "amount": {
                   "type": "string",
-                  "pattern": "£[0-9]+\\.[0-9]+"
+                  "pattern": "^£{1}[1-9]{1,3}(,\\d{3})*(\\.\\d{2})?"
                 },
                 "cadence": {
                   "type": "string",

--- a/content_schemas/dist/formats/content_block_pension/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/content_block_pension/publisher_v2/schema.json
@@ -220,7 +220,7 @@
               "properties": {
                 "amount": {
                   "type": "string",
-                  "pattern": "£[0-9]+\\.[0-9]+"
+                  "pattern": "^£{1}[1-9]{1,3}(,\\d{3})*(\\.\\d{2})?"
                 },
                 "cadence": {
                   "type": "string",

--- a/content_schemas/examples/content_block_pension/publisher_v2/example.json
+++ b/content_schemas/examples/content_block_pension/publisher_v2/example.json
@@ -13,6 +13,18 @@
         "amount": "£221.20",
         "cadence": "a week",
         "description": "Your weekly pension amount"
+      },
+      "rate-2": {
+        "name": "Rate without decimal point",
+        "amount": "£221",
+        "cadence": "a week",
+        "description": "Your weekly pension amount"
+      },
+      "rate-3": {
+        "name": "Rate with big value",
+        "amount": "£1,223",
+        "cadence": "a week",
+        "description": "Your weekly pension amount"
       }
     }
   },

--- a/content_schemas/formats/content_block_pension.jsonnet
+++ b/content_schemas/formats/content_block_pension.jsonnet
@@ -14,7 +14,7 @@ local utils = import "shared/utils/content_block_utils.jsonnet";
           {
             amount: {
               type: "string",
-              pattern: "£[0-9]+\\.[0-9]+",
+              pattern: "^£{1}[1-9]{1,3}(,\\d{3})*(\\.\\d{2})?",
             },
             cadence: {
               type: "string",


### PR DESCRIPTION
Trello card: https://trello.com/c/VWe7vgjf/932-improve-validation-for-rate-amounts

This improves the rate validation to:

- Ensure only 1 currency symbol is present
- Make decimal points optional
- Ensure bigger numbers have commas (as per the numbers guidance https://www.gov.uk/guidance/style-guide/a-to-z#numbers)

I’ve also added a couple of extra rates to ensure the validation works as expected.