### PR TITLE
content-modelling/942- change cadence to frequency

### DIFF
--- a/content_schemas/dist/formats/content_block_pension/notification/schema.json
+++ b/content_schemas/dist/formats/content_block_pension/notification/schema.json
@@ -395,21 +395,24 @@
               "required": [
                 "name",
                 "amount",
-                "cadence"
+                "frequency"
               ],
               "additionalProperties": false,
               "order": [
                 "name",
                 "amount",
-                "cadence",
-                "description"
+                "description",
+                "frequency"
               ],
               "properties": {
                 "amount": {
                   "type": "string",
                   "pattern": "^£{1}[1-9]{1,3}(,\\d{3})*(\\.\\d{2})?"
                 },
-                "cadence": {
+                "description": {
+                  "type": "string"
+                },
+                "frequency": {
                   "type": "string",
                   "enum": [
                     "a day",
@@ -417,9 +420,6 @@
                     "a month",
                     "a year"
                   ]
-                },
-                "description": {
-                  "type": "string"
                 },
                 "name": {
                   "type": "string"

--- a/content_schemas/dist/formats/content_block_pension/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/content_block_pension/publisher_v2/schema.json
@@ -208,21 +208,24 @@
               "required": [
                 "name",
                 "amount",
-                "cadence"
+                "frequency"
               ],
               "additionalProperties": false,
               "order": [
                 "name",
                 "amount",
-                "cadence",
-                "description"
+                "description",
+                "frequency"
               ],
               "properties": {
                 "amount": {
                   "type": "string",
                   "pattern": "^£{1}[1-9]{1,3}(,\\d{3})*(\\.\\d{2})?"
                 },
-                "cadence": {
+                "description": {
+                  "type": "string"
+                },
+                "frequency": {
                   "type": "string",
                   "enum": [
                     "a day",
@@ -230,9 +233,6 @@
                     "a month",
                     "a year"
                   ]
-                },
-                "description": {
-                  "type": "string"
                 },
                 "name": {
                   "type": "string"

--- a/content_schemas/examples/content_block_pension/publisher_v2/example.json
+++ b/content_schemas/examples/content_block_pension/publisher_v2/example.json
@@ -11,19 +11,19 @@
       "rate-1": {
         "name": "Rate 1",
         "amount": "£221.20",
-        "cadence": "a week",
+        "frequency": "a week",
         "description": "Your weekly pension amount"
       },
       "rate-2": {
         "name": "Rate without decimal point",
         "amount": "£221",
-        "cadence": "a week",
+        "frequency": "a week",
         "description": "Your weekly pension amount"
       },
       "rate-3": {
         "name": "Rate with big value",
         "amount": "£1,223",
-        "cadence": "a week",
+        "frequency": "a week",
         "description": "Your weekly pension amount"
       }
     }

--- a/content_schemas/formats/content_block_pension.jsonnet
+++ b/content_schemas/formats/content_block_pension.jsonnet
@@ -16,7 +16,7 @@ local utils = import "shared/utils/content_block_utils.jsonnet";
               type: "string",
               pattern: "^£{1}[1-9]{1,3}(,\\d{3})*(\\.\\d{2})?",
             },
-            cadence: {
+            frequency: {
               type: "string",
               enum: ["a day", "a week", "a month", "a year"],
             },
@@ -24,7 +24,7 @@ local utils = import "shared/utils/content_block_utils.jsonnet";
               type: "string",
             },
           },
-          ["amount", "cadence"],
+          ["amount", "frequency"],
         ),
       },
     },


### PR DESCRIPTION
https://trello.com/c/kthgiJOk/942-change-cadence-to-frequency-on-rate

* change the `cadence` key to `frequency` in rates schema for `content_block_pensions`. 
This will introduce breaking changes to Content Block Manager on Whitehall which will be mitigated by a rake task in follow up PR (and that the tool is not yet in use in production) https://github.com/alphagov/whitehall/pull/9988 

---
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
