### PR TITLE
Add document type labels to publication schema

### DIFF
--- a/content_schemas/dist/formats/publication/frontend/schema.json
+++ b/content_schemas/dist/formats/publication/frontend/schema.json
@@ -382,6 +382,10 @@
         "change_history": {
           "$ref": "#/definitions/change_history"
         },
+        "document_type_label": {
+          "description": "a human readable version of the document type",
+          "type": "string"
+        },
         "documents": {
           "$ref": "#/definitions/attachments_with_thumbnails"
         },

--- a/content_schemas/dist/formats/publication/notification/schema.json
+++ b/content_schemas/dist/formats/publication/notification/schema.json
@@ -495,6 +495,10 @@
         "change_history": {
           "$ref": "#/definitions/change_history"
         },
+        "document_type_label": {
+          "description": "a human readable version of the document type",
+          "type": "string"
+        },
         "documents": {
           "$ref": "#/definitions/attachments_with_thumbnails"
         },

--- a/content_schemas/dist/formats/publication/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/publication/publisher_v2/schema.json
@@ -317,6 +317,10 @@
         "change_history": {
           "$ref": "#/definitions/change_history"
         },
+        "document_type_label": {
+          "description": "a human readable version of the document type",
+          "type": "string"
+        },
         "documents": {
           "$ref": "#/definitions/attachments_with_thumbnails"
         },

--- a/content_schemas/formats/publication.jsonnet
+++ b/content_schemas/formats/publication.jsonnet
@@ -46,6 +46,10 @@
             type: "string",
           },
         },
+        document_type_label: {
+          description: "a human readable version of the document type",
+          type: "string",
+        },
         body: {
           "$ref": "#/definitions/body",
         },


### PR DESCRIPTION
The [official documents](https://www.gov.uk/official-documents) and [research and statistics](https://www.gov.uk/search/research-and-statistics) finders render a human friendly version of the document type in the search result metadata.

Now that we are seeking to index all Whitehall documents via Publishing API, we need to make sure that we send these labels as part of the edition payload.

Link to Whitehall PR: https://github.com/alphagov/whitehall/pull/10001 

Trello: https://trello.com/c/upZnqIOL
