### PR TITLE
content-modelling/Handle incorrect content IDs found in embeds

### DIFF
--- a/app/presenters/content_embed_presenter.rb
+++ b/app/presenters/content_embed_presenter.rb
@@ -59,10 +59,17 @@ module Presenters
       embedded_content_references.uniq.each do |content_reference|
         embed_code = content_reference.embed_code
         embedded_edition = embedded_editions[content_reference.content_id]
-        content = content.gsub(
-          embed_code,
-          get_content_for_edition(embedded_edition, embed_code),
-        )
+        if embedded_edition.present?
+          content = content.gsub(
+            embed_code,
+            get_content_for_edition(embedded_edition, embed_code),
+          )
+        else
+          Sentry.capture_exception(CommandError.new(
+                                     code: 422,
+                                     message: "Could not find a live edition for embedded content ID: #{content_reference.content_id}",
+                                   ))
+        end
       end
 
       content

--- a/spec/integration/put_content/content_with_embedded_content_spec.rb
+++ b/spec/integration/put_content/content_with_embedded_content_spec.rb
@@ -312,11 +312,11 @@ RSpec.describe "PUT /v2/content when embedded content is provided" do
       payload.merge!(document_type: "press_release", schema_name: "news_article", details: { body: "{{embed:contact:#{fake_content_id}}}" })
     end
 
-    it "should return a 422 error" do
+    it "should not create a new Link" do
       put "/v2/content/#{content_id}", params: payload.to_json
 
-      expect(response).to be_unprocessable
-      expect(response.body).to match(/Could not find any live editions in locale en for: #{fake_content_id}/)
+      expect(response).to be_ok
+      expect(Link.find_by(target_content_id: fake_content_id)).to be_nil
     end
   end
 
@@ -330,11 +330,13 @@ RSpec.describe "PUT /v2/content when embedded content is provided" do
       payload.merge!(document_type: "press_release", schema_name: "news_article", details: { body: "{{embed:contact:#{contact.document.content_id}}} {{embed:contact:#{first_fake_content_id}}} {{embed:contact:#{second_fake_content_id}}}" })
     end
 
-    it "should return a 422 error" do
+    it "should return a 200 with only the existing links" do
       put "/v2/content/#{content_id}", params: payload.to_json
 
-      expect(response).to be_unprocessable
-      expect(response.body).to match(/Could not find any live editions in locale en for: #{first_fake_content_id}, #{second_fake_content_id}/)
+      expect(response).to be_ok
+      expect(Link.find_by(target_content_id: first_fake_content_id)).to be_nil
+      expect(Link.find_by(target_content_id: second_fake_content_id)).to be_nil
+      expect(Link.find_by(target_content_id: contact.document.content_id)).not_to be_nil
     end
   end
 

--- a/spec/presenters/content_embed_presenter_spec.rb
+++ b/spec/presenters/content_embed_presenter_spec.rb
@@ -29,250 +29,284 @@ RSpec.describe Presenters::ContentEmbedPresenter do
     )
   end
 
+  let(:fake_content_id) { SecureRandom.uuid }
+
   describe "#render_embedded_content" do
-    let(:expected_value) do
-      "<span class=\"content-embed content-embed__contact\"
+    context "when the content reference does not have a corresponding live Edition" do
+      context "when there is one edition that hasn't been found" do
+        let(:details) { { body: "some string with a reference: {{embed:contact:#{fake_content_id}}}" } }
+
+        it "alerts Sentry and returns the content as is" do
+          expect(Sentry).to receive(:capture_exception).with(CommandError.new(
+                                                               code: 422,
+                                                               message: "Could not find a live edition for embedded content ID: #{fake_content_id}",
+                                                             ))
+          expect(described_class.new(edition).render_embedded_content(details)).to eq({
+            body: "some string with a reference: {{embed:contact:#{fake_content_id}}}",
+          })
+        end
+      end
+    end
+
+    context "when there are live editions for the embedded content" do
+      let(:expected_value) do
+        "<span class=\"content-embed content-embed__contact\"
           data-content-block=\"\"
           data-document-type=\"contact\"
           data-content-id=\"#{embedded_content_id}\"
           data-embed-code=\"#{embed_code}\">VALUE</span>".squish
-    end
-    let(:stub_block) { double(ContentBlockTools::ContentBlock, render: expected_value) }
+      end
+      let(:stub_block) { double(ContentBlockTools::ContentBlock, render: expected_value) }
 
-    before do
-      expect(ContentBlockTools::ContentBlock).to receive(:new).with(
-        document_type: embedded_edition.document_type,
-        content_id: embedded_edition.document.content_id,
-        title: embedded_edition.title,
-        details: embedded_edition.details,
-        embed_code: embed_code,
-      ).at_least(:once).and_return(stub_block)
-    end
-
-    context "when body is a string" do
-      context "when there is only one embed" do
-        let(:details) { { body: "some string with a reference: {{embed:contact:#{embedded_content_id}}}" } }
-        it "returns embedded content references with values from their editions" do
-          expect(described_class.new(edition).render_embedded_content(details)).to eq({
-            body: "some string with a reference: #{expected_value}",
-          })
-        end
+      before do
+        expect(ContentBlockTools::ContentBlock).to receive(:new).with(
+          document_type: embedded_edition.document_type,
+          content_id: embedded_edition.document.content_id,
+          title: embedded_edition.title,
+          details: embedded_edition.details,
+          embed_code: embed_code,
+        ).at_least(:once).and_return(stub_block)
       end
 
-      context "when there are multiple embeds" do
-        context "when there are multiple embeds to the same block" do
-          let(:details) { { body: "some string with a reference: #{embed_code} and another: #{embed_code}" } }
-          it "returns embedded content" do
+      context "when body is a string" do
+        context "when there is a mix of existing and not existing live editions" do
+          let(:details) { { body: "some string with a reference: {{embed:contact:#{embedded_content_id}}} {{embed:contact:#{fake_content_id}}}" } }
+
+          it "alerts Sentry and returns the expected content" do
+            expect(Sentry).to receive(:capture_exception).with(CommandError.new(
+                                                                 code: 422,
+                                                                 message: "Could not find a live edition for embedded content ID: #{fake_content_id}",
+                                                               ))
             expect(described_class.new(edition).render_embedded_content(details)).to eq({
-              body: "some string with a reference: #{expected_value} and another: #{expected_value}",
+              body: "some string with a reference: #{expected_value} {{embed:contact:#{fake_content_id}}}",
             })
           end
         end
 
-        context "when there are multiple embeds for different blocks" do
-          let(:embedded_content_id_2) { SecureRandom.uuid }
-          let!(:embedded_edition_2) do
-            embedded_document = create(:document, content_id: embedded_content_id_2)
-            create(
-              :edition,
-              document: embedded_document,
-              state: "published",
-              content_store: "live",
-              document_type: "content_block_pension",
-              title: "VALUE2",
-            )
+        context "when there is only one embed" do
+          let(:details) { { body: "some string with a reference: {{embed:contact:#{embedded_content_id}}}" } }
+          it "returns embedded content references with values from their editions" do
+            expect(described_class.new(edition).render_embedded_content(details)).to eq({
+              body: "some string with a reference: #{expected_value}",
+            })
           end
-          let(:embed_code_2) { "{{embed:content_block_pension:#{embedded_content_id_2}}}" }
-          let(:links_hash) do
-            {
-              embed: [embedded_content_id, embedded_content_id_2],
-            }
+        end
+
+        context "when there are multiple embeds" do
+          context "when there are multiple embeds to the same block" do
+            let(:details) { { body: "some string with a reference: #{embed_code} and another: #{embed_code}" } }
+            it "returns embedded content" do
+              expect(described_class.new(edition).render_embedded_content(details)).to eq({
+                body: "some string with a reference: #{expected_value} and another: #{expected_value}",
+              })
+            end
           end
-          let(:expected_value_2) do
-            "<span class=\"content-embed content-embed__contact\"
+
+          context "when there are multiple embeds for different blocks" do
+            let(:embedded_content_id_2) { SecureRandom.uuid }
+            let!(:embedded_edition_2) do
+              embedded_document = create(:document, content_id: embedded_content_id_2)
+              create(
+                :edition,
+                document: embedded_document,
+                state: "published",
+                content_store: "live",
+                document_type: "content_block_pension",
+                title: "VALUE2",
+              )
+            end
+            let(:embed_code_2) { "{{embed:content_block_pension:#{embedded_content_id_2}}}" }
+            let(:links_hash) do
+              {
+                embed: [embedded_content_id, embedded_content_id_2],
+              }
+            end
+            let(:expected_value_2) do
+              "<span class=\"content-embed content-embed__contact\"
           data-content-block=\"\"
           data-document-type=\"contact\"
           data-content-id=\"#{embedded_content_id_2}\"
           data-embed-code=\"#{embed_code_2}\">VALUE2</span>".squish
-          end
-          let(:stub_block_2) { double(ContentBlockTools::ContentBlock, render: expected_value_2) }
+            end
+            let(:stub_block_2) { double(ContentBlockTools::ContentBlock, render: expected_value_2) }
 
-          before do
-            expect(ContentBlockTools::ContentBlock).to receive(:new).with(
-              document_type: embedded_edition_2.document_type,
-              content_id: embedded_edition_2.document.content_id,
-              title: embedded_edition_2.title,
-              details: embedded_edition_2.details,
-              embed_code: embed_code_2,
-            ).and_return(stub_block_2)
-          end
-          let(:details) { { body: "some string with a reference: #{embed_code} and another: #{embed_code_2}" } }
+            before do
+              expect(ContentBlockTools::ContentBlock).to receive(:new).with(
+                document_type: embedded_edition_2.document_type,
+                content_id: embedded_edition_2.document.content_id,
+                title: embedded_edition_2.title,
+                details: embedded_edition_2.details,
+                embed_code: embed_code_2,
+              ).and_return(stub_block_2)
+            end
+            let(:details) { { body: "some string with a reference: #{embed_code} and another: #{embed_code_2}" } }
 
-          it "returns embedded content" do
-            expect(described_class.new(edition).render_embedded_content(details)).to eq({
-              body: "some string with a reference: #{expected_value} and another: #{expected_value_2}",
-            })
+            it "returns embedded content" do
+              expect(described_class.new(edition).render_embedded_content(details)).to eq({
+                body: "some string with a reference: #{expected_value} and another: #{expected_value_2}",
+              })
+            end
           end
         end
       end
-    end
 
-    context "when body is an array" do
-      let(:details) do
-        { body: [
-          { content_type: "text/govspeak", content: "some string with a reference: {{embed:contact:#{embedded_content_id}}}" },
-          { content_type: "text/html", content: "some string with a reference: {{embed:contact:#{embedded_content_id}}}" },
-        ] }
-      end
+      context "when body is an array" do
+        let(:details) do
+          { body: [
+            { content_type: "text/govspeak", content: "some string with a reference: {{embed:contact:#{embedded_content_id}}}" },
+            { content_type: "text/html", content: "some string with a reference: {{embed:contact:#{embedded_content_id}}}" },
+          ] }
+        end
 
-      it "returns embedded content references with values from their editions" do
-        expect(described_class.new(edition).render_embedded_content(details)).to eq({
-          body: [
-            { content_type: "text/govspeak", content: "some string with a reference: #{expected_value}" },
-            { content_type: "text/html", content: "some string with a reference: #{expected_value}" },
-          ],
-        })
-      end
-    end
-
-    context "when body is a hash" do
-      let(:details) do
-        { body: { title: "some string with a reference: {{embed:contact:#{embedded_content_id}}}" } }
-      end
-
-      it "returns embedded content references with values from their editions" do
-        expect(described_class.new(edition).render_embedded_content(details)).to eq({
-          body: { title: "some string with a reference: #{expected_value}" },
-        })
-      end
-    end
-
-    context "when body is a multipart document" do
-      let(:details) do
-        {
-          parts: [
+        it "returns embedded content references with values from their editions" do
+          expect(described_class.new(edition).render_embedded_content(details)).to eq({
             body: [
-              {
-                content: "some string with a reference: {{embed:contact:#{embedded_content_id}}}",
-                content_type: "text/govspeak",
-              },
+              { content_type: "text/govspeak", content: "some string with a reference: #{expected_value}" },
+              { content_type: "text/html", content: "some string with a reference: #{expected_value}" },
             ],
-            slug: "some-slug",
-            title: "Some title",
-          ],
-        }
+          })
+        end
       end
 
-      it "returns embedded content references with values from their editions" do
-        expect(described_class.new(edition).render_embedded_content(details)).to eq(
+      context "when body is a hash" do
+        let(:details) do
+          { body: { title: "some string with a reference: {{embed:contact:#{embedded_content_id}}}" } }
+        end
+
+        it "returns embedded content references with values from their editions" do
+          expect(described_class.new(edition).render_embedded_content(details)).to eq({
+            body: { title: "some string with a reference: #{expected_value}" },
+          })
+        end
+      end
+
+      context "when body is a multipart document" do
+        let(:details) do
           {
             parts: [
               body: [
                 {
-                  content: "some string with a reference: #{expected_value}",
+                  content: "some string with a reference: {{embed:contact:#{embedded_content_id}}}",
                   content_type: "text/govspeak",
                 },
               ],
               slug: "some-slug",
               title: "Some title",
             ],
-          },
-        )
-      end
-    end
+          }
+        end
 
-    context "when the embedded content is available in multiple locales" do
-      let(:details) { { body: "some string with a reference: {{embed:contact:#{embedded_content_id}}}" } }
-
-      let!(:welsh_edition) do
-        embedded_document = create(:document, content_id: embedded_content_id, locale: "cy")
-        create(
-          :edition,
-          document: embedded_document,
-          state: "published",
-          content_store: "live",
-          document_type: "contact",
-          title: "WELSH",
-        )
-      end
-
-      context "when the document is in the default language" do
-        it "returns embedded content references with values from the same language" do
-          expect(described_class.new(edition).render_embedded_content(details)).to eq({
-            body: "some string with a reference: #{expected_value}",
-          })
+        it "returns embedded content references with values from their editions" do
+          expect(described_class.new(edition).render_embedded_content(details)).to eq(
+            {
+              parts: [
+                body: [
+                  {
+                    content: "some string with a reference: #{expected_value}",
+                    content_type: "text/govspeak",
+                  },
+                ],
+                slug: "some-slug",
+                title: "Some title",
+              ],
+            },
+          )
         end
       end
 
-      context "when the document is in an available locale" do
-        let(:document) { create(:document, locale: "cy") }
-        let(:embedded_edition) { welsh_edition }
+      context "when the embedded content is available in multiple locales" do
+        let(:details) { { body: "some string with a reference: {{embed:contact:#{embedded_content_id}}}" } }
 
-        it "returns embedded content references with values from the same language" do
-          expect(described_class.new(edition).render_embedded_content(details)).to eq({
-            body: "some string with a reference: #{expected_value}",
-          })
+        let!(:welsh_edition) do
+          embedded_document = create(:document, content_id: embedded_content_id, locale: "cy")
+          create(
+            :edition,
+            document: embedded_document,
+            state: "published",
+            content_store: "live",
+            document_type: "contact",
+            title: "WELSH",
+          )
+        end
+
+        context "when the document is in the default language" do
+          it "returns embedded content references with values from the same language" do
+            expect(described_class.new(edition).render_embedded_content(details)).to eq({
+              body: "some string with a reference: #{expected_value}",
+            })
+          end
+        end
+
+        context "when the document is in an available locale" do
+          let(:document) { create(:document, locale: "cy") }
+          let(:embedded_edition) { welsh_edition }
+
+          it "returns embedded content references with values from the same language" do
+            expect(described_class.new(edition).render_embedded_content(details)).to eq({
+              body: "some string with a reference: #{expected_value}",
+            })
+          end
+        end
+
+        context "when the document is in an unavailable locale" do
+          let(:document) { create(:document, locale: "fr") }
+
+          it "returns embedded content references with values from the default language" do
+            expect(described_class.new(edition).render_embedded_content(details)).to eq({
+              body: "some string with a reference: #{expected_value}",
+            })
+          end
         end
       end
 
-      context "when the document is in an unavailable locale" do
-        let(:document) { create(:document, locale: "fr") }
+      context "when multiple documents are embedded in different parts of the document" do
+        let(:other_embedded_content_id) { SecureRandom.uuid }
+        let(:other_embed_code) { "{{embed:contact:#{other_embedded_content_id}}}" }
 
-        it "returns embedded content references with values from the default language" do
+        let!(:other_embedded_edition) do
+          embedded_document = create(:document, content_id: other_embedded_content_id)
+          create(
+            :edition,
+            document: embedded_document,
+            state: "published",
+            content_store: "live",
+            document_type: "contact",
+            title: "VALUE2",
+          )
+        end
+
+        let(:other_expected_value) { "VALUE2" }
+        let(:other_stub_block) { double(ContentBlockTools::ContentBlock, render: other_expected_value) }
+
+        before do
+          expect(ContentBlockTools::ContentBlock).to receive(:new).with(
+            document_type: other_embedded_edition.document_type,
+            content_id: other_embedded_edition.document.content_id,
+            title: other_embedded_edition.title,
+            details: other_embedded_edition.details,
+            embed_code: other_embed_code,
+          ).at_least(:once).and_return(other_stub_block)
+        end
+
+        let(:links_hash) do
+          {
+            embed: [embedded_content_id, other_embedded_content_id],
+          }
+        end
+
+        let(:details) do
+          {
+            title: "title string with reference: {{embed:contact:#{other_embedded_content_id}}}",
+            body: "some string with a reference: {{embed:contact:#{embedded_content_id}}}",
+          }
+        end
+
+        it "returns embedded content references with values from their editions" do
           expect(described_class.new(edition).render_embedded_content(details)).to eq({
+            title: "title string with reference: #{other_expected_value}",
             body: "some string with a reference: #{expected_value}",
           })
         end
-      end
-    end
-
-    context "when multiple documents are embedded in different parts of the document" do
-      let(:other_embedded_content_id) { SecureRandom.uuid }
-      let(:other_embed_code) { "{{embed:contact:#{other_embedded_content_id}}}" }
-
-      let!(:other_embedded_edition) do
-        embedded_document = create(:document, content_id: other_embedded_content_id)
-        create(
-          :edition,
-          document: embedded_document,
-          state: "published",
-          content_store: "live",
-          document_type: "contact",
-          title: "VALUE2",
-        )
-      end
-
-      let(:other_expected_value) { "VALUE2" }
-      let(:other_stub_block) { double(ContentBlockTools::ContentBlock, render: other_expected_value) }
-
-      before do
-        expect(ContentBlockTools::ContentBlock).to receive(:new).with(
-          document_type: other_embedded_edition.document_type,
-          content_id: other_embedded_edition.document.content_id,
-          title: other_embedded_edition.title,
-          details: other_embedded_edition.details,
-          embed_code: other_embed_code,
-        ).at_least(:once).and_return(other_stub_block)
-      end
-
-      let(:links_hash) do
-        {
-          embed: [embedded_content_id, other_embedded_content_id],
-        }
-      end
-
-      let(:details) do
-        {
-          title: "title string with reference: {{embed:contact:#{other_embedded_content_id}}}",
-          body: "some string with a reference: {{embed:contact:#{embedded_content_id}}}",
-        }
-      end
-
-      it "returns embedded content references with values from their editions" do
-        expect(described_class.new(edition).render_embedded_content(details)).to eq({
-          title: "title string with reference: #{other_expected_value}",
-          body: "some string with a reference: #{expected_value}",
-        })
       end
     end
   end


### PR DESCRIPTION
https://trello.com/c/S4xH4K03/878-debug-logging-and-error-handling-for-embed-codes

Previously, if an editor published an Edition with an embed code with an incorrect or missing content ID, then it would fail silently (on Mainstream) or show generic error page (on Whitehall). It seemed like the error for Mainstream wasn't propagating (possibly because it was being called in a Worker, so the Sidekiq job was just failing and retrying in background?).

This is a first pass at handling when we might have an incorrect Content ID, allowing the Edition to be published and the incorrect embed code rendered in plain text in the process, but also alerting Sentry so it will be easier to catch if this issue occurs.

The error handling was introduced [last year here](https://github.com/alphagov/publishing-api/pull/2813), before we started embedded Content Blocks in earnest and I think only Contacts were the embedded content being used? 

Is it better to allow the Editor to publish an incorrect block, when they can see that it's not being rendered and correct it, instead of either failing in the background or throwing an error preventing publication?  I'm not sure without touching more of the Mainstream architecture how we would throw a more helpful error....

Still TODO:

* Add the new errors to the Sentry rules to send them to our #content-modelling-dev channel


---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
