### PR TITLE
Update fatality_notice_with_minister example to have no change history

### DIFF
--- a/content_schemas/examples/fatality_notice/frontend/fatality_notice_with_minister.json
+++ b/content_schemas/examples/fatality_notice/frontend/fatality_notice_with_minister.json
@@ -2,7 +2,7 @@
   "content_id": "03ee93e2-21ab-4bd8-a5cd-89b2adbcbf4f",
   "base_path": "/government/fatalities/sir-george-pomeroy-colley-killed-in-boer-war-ministerial-announcement",
   "description": "It is with great sadness that the Ministry of Defence must confirm that Sir George Pomeroy Colley, died in battle in Zululand on 27 February 1881.",
-  "public_updated_at": "2016-09-14T18:19:27+01:00",
+  "public_updated_at": "1881-02-27T15:45:44.000+00:00",
   "title": "Sir George Pomeroy Colley killed in Boer War",
   "updated_at": "2016-09-14T10:37:00Z",
   "schema_name": "fatality_notice",
@@ -12,10 +12,6 @@
     "body": "<div class=\"govspeak\"><h2 id=\"sir-george-pomeroy-colley\">Sir George Pomeroy Colley</h2><figure class=\"image embedded\">  <div class=\"img\"></div>  <figcaption>Sir George Pomeroy Colley (All rights reserved.)</figcaption></figure><p>Colley served nearly all of his military and administrative career in British South Africa, but he played a significant part in the Second Anglo-Afghan War as military secretary and then private secretary to the governor-general of India, Lord Lytton. The war began in November 1878 and ended in May 1879 with the Treaty of Gandamak.</p><p>After the war Colley returned to South Africa, became high commissioner for South Eastern Africa in 1880… and died a year later at the Battle of Majuba Hill during the First Boer War.</p><p>A british officer had the following to say</p><blockquote>  <p class=\"last-child\">Major General Colley was an exceptional talent, and it is with great sadness that we have learned about this loss. His contribution to Britain through his efforts in the Boer War will not be forgotten.</p></blockquote></div>",
     "first_public_at": "1881-02-27T15:45:44.000+00:00",
     "change_history": [
-      {
-        "public_timestamp": "2016-09-14T18:19:27+01:00",
-        "note": "Updated information."
-      },
       {
         "public_timestamp": "1881-02-27T15:45:44.000+00:00",
         "note": "First published."


### PR DESCRIPTION
- allows this example to do double-duty in frontend test suite.

Needed for: https://github.com/alphagov/frontend/pull/4640

https://trello.com/c/2QCsgFab/492-move-fatality-notices-from-government-frontend-to-frontend

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
