### PR TITLE
content-modelling/ fix error handling for content embeds

### DIFF
--- a/app/presenters/content_embed_presenter.rb
+++ b/app/presenters/content_embed_presenter.rb
@@ -65,10 +65,10 @@ module Presenters
             get_content_for_edition(embedded_edition, embed_code),
           )
         else
-          Sentry.capture_exception(CommandError.new(
-                                     code: 422,
-                                     message: "Could not find a live edition for embedded content ID: #{content_reference.content_id}",
-                                   ))
+          GovukError.notify(CommandError.new(
+                              code: 422,
+                              message: "Could not find a live edition for embedded content ID: #{content_reference.content_id}",
+                            ))
         end
       end
 

--- a/app/services/embedded_content_finder_service.rb
+++ b/app/services/embedded_content_finder_service.rb
@@ -27,10 +27,10 @@ private
     not_found_content_ids = content_references.map(&:content_id) - found_editions.map(&:content_id)
 
     if not_found_content_ids.any?
-      Sentry.capture_exception(CommandError.new(
-                                 code: 422,
-                                 message: "Could not find any live editions for embedded content IDs: #{not_found_content_ids.join(', ')}",
-                               ))
+      GovukError.notify(CommandError.new(
+                          code: 422,
+                          message: "Could not find any live editions for embedded content IDs: #{not_found_content_ids.join(', ')}",
+                        ))
     end
     content_references.map(&:content_id) - not_found_content_ids
   end

--- a/spec/presenters/content_embed_presenter_spec.rb
+++ b/spec/presenters/content_embed_presenter_spec.rb
@@ -37,10 +37,10 @@ RSpec.describe Presenters::ContentEmbedPresenter do
         let(:details) { { body: "some string with a reference: {{embed:contact:#{fake_content_id}}}" } }
 
         it "alerts Sentry and returns the content as is" do
-          expect(Sentry).to receive(:capture_exception).with(CommandError.new(
-                                                               code: 422,
-                                                               message: "Could not find a live edition for embedded content ID: #{fake_content_id}",
-                                                             ))
+          expect(GovukError).to receive(:notify).with(CommandError.new(
+                                                        code: 422,
+                                                        message: "Could not find a live edition for embedded content ID: #{fake_content_id}",
+                                                      ))
           expect(described_class.new(edition).render_embedded_content(details)).to eq({
             body: "some string with a reference: {{embed:contact:#{fake_content_id}}}",
           })
@@ -73,10 +73,10 @@ RSpec.describe Presenters::ContentEmbedPresenter do
           let(:details) { { body: "some string with a reference: {{embed:contact:#{embedded_content_id}}} {{embed:contact:#{fake_content_id}}}" } }
 
           it "alerts Sentry and returns the expected content" do
-            expect(Sentry).to receive(:capture_exception).with(CommandError.new(
-                                                                 code: 422,
-                                                                 message: "Could not find a live edition for embedded content ID: #{fake_content_id}",
-                                                               ))
+            expect(GovukError).to receive(:notify).with(CommandError.new(
+                                                          code: 422,
+                                                          message: "Could not find a live edition for embedded content ID: #{fake_content_id}",
+                                                        ))
             expect(described_class.new(edition).render_embedded_content(details)).to eq({
               body: "some string with a reference: #{expected_value} {{embed:contact:#{fake_content_id}}}",
             })

--- a/spec/services/embedded_content_finder_service_spec.rb
+++ b/spec/services/embedded_content_finder_service_spec.rb
@@ -214,10 +214,10 @@ RSpec.describe EmbeddedContentFinderService do
 
     it "alerts Sentry when there is are embeds without live editions" do
       details = { body: "{{embed:contact:00000000-0000-0000-0000-000000000000}}" }
-      expect(Sentry).to receive(:capture_exception).with(CommandError.new(
-                                                           code: 422,
-                                                           message: "Could not find any live editions for embedded content IDs: 00000000-0000-0000-0000-000000000000",
-                                                         ))
+      expect(GovukError).to receive(:notify).with(CommandError.new(
+                                                    code: 422,
+                                                    message: "Could not find any live editions for embedded content IDs: 00000000-0000-0000-0000-000000000000",
+                                                  ))
 
       links = EmbeddedContentFinderService.new.fetch_linked_content_ids(details, "foo")
 


### PR DESCRIPTION
https://trello.com/c/S4xH4K03/878-debug-logging-and-error-handling-for-embed-codes 

This follows the correct method for manually reporting errors: https://github.com/alphagov/govuk_app_config/blob/073c9b2312a4893b040c9225b713ac880c69f5b8/README.md#manual-error-reporting

---
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
