### PR TITLE
Revert "Do not loop through details unless embed links exist"

### DIFF
--- a/app/presenters/content_embed_presenter.rb
+++ b/app/presenters/content_embed_presenter.rb
@@ -5,8 +5,6 @@ module Presenters
     end
 
     def render_embedded_content(details)
-      return details unless target_content_ids
-
       details.each_pair do |field, value|
         next if value.blank?
 
@@ -18,15 +16,13 @@ module Presenters
 
   private
 
-    def target_content_ids
-      @target_content_ids ||= @edition
-                                .links
-                                .where(link_type: "embed")
-                                .pluck(:target_content_id)
-    end
-
     def embedded_editions
       @embedded_editions ||= begin
+        target_content_ids = @edition
+         .links
+         .where(link_type: "embed")
+         .pluck(:target_content_id)
+
         embedded_edition_ids = ::Queries::GetEditionIdsWithFallbacks.call(
           target_content_ids,
           locale_fallback_order: [@edition.locale, Edition::DEFAULT_LOCALE].uniq,


### PR DESCRIPTION
This reverts commit 0c78953ead3478ff19aaba3d7e1e6e32f094f8d0.

We previously introduced an optimisation to reduce the amount of text parsing needed for embedded content links, however this resulted in a database query instead of the text parsing.

For some pages (e.g. the Prime Minister page), this resulted in GraphQL reequests making 176 queries to render the page (instead of 15), which was slower than parsing the text.

Reverting the change, to restore the previous behaviour.

[Trello card](https://trello.com/c/ilVC6hCV)