### PR TITLE
Ignore locale when finding content

### DIFF
--- a/app/commands/v2/put_content.rb
+++ b/app/commands/v2/put_content.rb
@@ -115,7 +115,7 @@ module Commands
       def fetch_embedded_content(edition)
         return [] if edition[:details].nil?
 
-        EmbeddedContentFinderService.new.fetch_linked_content_ids(edition[:details], edition.locale)
+        EmbeddedContentFinderService.new.fetch_linked_content_ids(edition[:details])
       end
 
       def create_redirect

--- a/app/services/embedded_content_finder_service.rb
+++ b/app/services/embedded_content_finder_service.rb
@@ -1,10 +1,10 @@
 class EmbeddedContentFinderService
-  def fetch_linked_content_ids(details, locale)
+  def fetch_linked_content_ids(details)
     content_references = details.values.map { |value|
       find_content_references(value)
     }.flatten.compact
 
-    live_content_ids(content_references, locale)
+    live_content_ids(content_references)
   end
 
   def find_content_references(value)
@@ -22,8 +22,8 @@ class EmbeddedContentFinderService
 
 private
 
-  def live_content_ids(content_references, locale)
-    found_editions = live_editions(content_references.uniq, locale)
+  def live_content_ids(content_references)
+    found_editions = live_editions(content_references.uniq)
     not_found_content_ids = content_references.map(&:content_id) - found_editions.map(&:content_id)
 
     if not_found_content_ids.any?
@@ -35,12 +35,12 @@ private
     content_references.map(&:content_id) - not_found_content_ids
   end
 
-  def live_editions(content_references, locale)
+  def live_editions(content_references)
     Edition.with_document.where(
       state: "published",
       content_store: "live",
       document_type: content_references.map(&:document_type),
-      documents: { content_id: content_references.map(&:content_id), locale: },
+      documents: { content_id: content_references.map(&:content_id) },
     )
   end
 end

--- a/spec/services/embedded_content_finder_service_spec.rb
+++ b/spec/services/embedded_content_finder_service_spec.rb
@@ -27,7 +27,7 @@ RSpec.shared_examples "finds references" do |document_type|
       it "finds content references" do
         details = { field_name => "{{embed:#{document_type}:#{editions[0].content_id}}} {{embed:#{document_type}:#{editions[1].content_id}}}" }
 
-        links = EmbeddedContentFinderService.new.fetch_linked_content_ids(details, Edition::DEFAULT_LOCALE)
+        links = EmbeddedContentFinderService.new.fetch_linked_content_ids(details)
 
         expect(links).to eq([editions[0].content_id, editions[1].content_id])
       end
@@ -35,7 +35,7 @@ RSpec.shared_examples "finds references" do |document_type|
       it "returns duplicates when there is more than one content reference in the field" do
         details = { field_name => "{{embed:#{document_type}:#{editions[0].content_id}}} {{embed:#{document_type}:#{editions[0].content_id}}} {{embed:#{document_type}:#{editions[1].content_id}}}" }
 
-        links = EmbeddedContentFinderService.new.fetch_linked_content_ids(details, Edition::DEFAULT_LOCALE)
+        links = EmbeddedContentFinderService.new.fetch_linked_content_ids(details)
 
         expect(links).to eq([editions[0].content_id, editions[0].content_id, editions[1].content_id])
       end
@@ -43,7 +43,7 @@ RSpec.shared_examples "finds references" do |document_type|
       it "returns duplicates when there are field references in the field" do
         details = { field_name => "{{embed:#{document_type}:#{editions[0].content_id}/title}} {{embed:#{document_type}:#{editions[0].content_id}/another}}" }
 
-        links = EmbeddedContentFinderService.new.fetch_linked_content_ids(details, Edition::DEFAULT_LOCALE)
+        links = EmbeddedContentFinderService.new.fetch_linked_content_ids(details)
 
         expect(links).to eq([editions[0].content_id, editions[0].content_id])
       end
@@ -51,7 +51,7 @@ RSpec.shared_examples "finds references" do |document_type|
       it "finds content references when #{field_name} is an array of hashes" do
         details = { field_name => [{ "content" => "{{embed:#{document_type}:#{editions[0].content_id}}} {{embed:#{document_type}:#{editions[1].content_id}}}" }] }
 
-        links = EmbeddedContentFinderService.new.fetch_linked_content_ids(details, Edition::DEFAULT_LOCALE)
+        links = EmbeddedContentFinderService.new.fetch_linked_content_ids(details)
 
         expect(links).to eq([editions[0].content_id, editions[1].content_id])
       end
@@ -89,7 +89,7 @@ RSpec.shared_examples "finds references" do |document_type|
             },
           ],
         }
-        links = EmbeddedContentFinderService.new.fetch_linked_content_ids(details, Edition::DEFAULT_LOCALE)
+        links = EmbeddedContentFinderService.new.fetch_linked_content_ids(details)
 
         expect(links.length).to eq(4)
         expect(links.count(editions[0].content_id)).to eq(2)
@@ -129,7 +129,7 @@ RSpec.shared_examples "finds references" do |document_type|
             },
           ],
         }
-        links = EmbeddedContentFinderService.new.fetch_linked_content_ids(details, Edition::DEFAULT_LOCALE)
+        links = EmbeddedContentFinderService.new.fetch_linked_content_ids(details)
 
         expect(links.length).to eq(8)
         expect(links.count(editions[0].content_id)).to eq(4)
@@ -156,7 +156,7 @@ RSpec.shared_examples "finds references" do |document_type|
             },
           ],
         }
-        links = EmbeddedContentFinderService.new.fetch_linked_content_ids(details, Edition::DEFAULT_LOCALE)
+        links = EmbeddedContentFinderService.new.fetch_linked_content_ids(details)
 
         expect(links.length).to eq(6)
         expect(links.count(editions[0].content_id)).to eq(2)
@@ -166,7 +166,7 @@ RSpec.shared_examples "finds references" do |document_type|
       it "finds content references when the field is a hash" do
         details = { field_name => { title: "{{embed:#{document_type}:#{editions[0].content_id}}}", slug: "{{embed:#{document_type}:#{editions[1].content_id}}}", current: true } }
 
-        links = EmbeddedContentFinderService.new.fetch_linked_content_ids(details, Edition::DEFAULT_LOCALE)
+        links = EmbeddedContentFinderService.new.fetch_linked_content_ids(details)
 
         expect(links).to eq([editions[0].content_id, editions[1].content_id])
       end
@@ -174,7 +174,7 @@ RSpec.shared_examples "finds references" do |document_type|
       it "returns duplicates when there is more than one content reference in the field and the field is a hash" do
         details = { field_name => { title: "{{embed:#{document_type}:#{editions[0].content_id}}} {{embed:#{document_type}:#{editions[0].content_id}}}", slug: "{{embed:#{document_type}:#{editions[1].content_id}}}", current: true } }
 
-        links = EmbeddedContentFinderService.new.fetch_linked_content_ids(details, Edition::DEFAULT_LOCALE)
+        links = EmbeddedContentFinderService.new.fetch_linked_content_ids(details)
 
         expect(links).to eq([editions[0].content_id, editions[0].content_id, editions[1].content_id])
       end
@@ -182,15 +182,7 @@ RSpec.shared_examples "finds references" do |document_type|
       it "does not return a content ID that is still draft" do
         details = { field_name => "{{embed:#{document_type}:#{draft_edition.content_id}}}" }
 
-        links = EmbeddedContentFinderService.new.fetch_linked_content_ids(details, "foo")
-
-        expect(links).to eq([])
-      end
-
-      it "does not return a live content ID that is not available in the current locale" do
-        details = { field_name => "{{embed:#{document_type}:#{editions[0].content_id}}}" }
-
-        links = EmbeddedContentFinderService.new.fetch_linked_content_ids(details, "foo")
+        links = EmbeddedContentFinderService.new.fetch_linked_content_ids(details)
 
         expect(links).to eq([])
       end
@@ -207,7 +199,7 @@ RSpec.describe EmbeddedContentFinderService do
     it "returns an empty hash where there are no embeds" do
       details = { body: "Hello world!" }
 
-      links = EmbeddedContentFinderService.new.fetch_linked_content_ids(details, Edition::DEFAULT_LOCALE)
+      links = EmbeddedContentFinderService.new.fetch_linked_content_ids(details)
 
       expect(links).to eq([])
     end
@@ -219,7 +211,7 @@ RSpec.describe EmbeddedContentFinderService do
                                                     message: "Could not find any live editions for embedded content IDs: 00000000-0000-0000-0000-000000000000",
                                                   ))
 
-      links = EmbeddedContentFinderService.new.fetch_linked_content_ids(details, "foo")
+      links = EmbeddedContentFinderService.new.fetch_linked_content_ids(details)
 
       expect(links).to eq([])
     end
@@ -227,7 +219,7 @@ RSpec.describe EmbeddedContentFinderService do
     context "when the field value is an array" do
       it "returns an empty array" do
         details = { body: [] }
-        result = EmbeddedContentFinderService.new.fetch_linked_content_ids(details, Edition::DEFAULT_LOCALE)
+        result = EmbeddedContentFinderService.new.fetch_linked_content_ids(details)
         expect(result).to eq([])
       end
     end
@@ -235,7 +227,7 @@ RSpec.describe EmbeddedContentFinderService do
     context "when the field value is a hash" do
       it "returns an empty array" do
         details = { body: {} }
-        result = EmbeddedContentFinderService.new.fetch_linked_content_ids(details, Edition::DEFAULT_LOCALE)
+        result = EmbeddedContentFinderService.new.fetch_linked_content_ids(details)
         expect(result).to eq([])
       end
     end
@@ -243,7 +235,7 @@ RSpec.describe EmbeddedContentFinderService do
     context "when the field value is a nested hash" do
       it "returns an empty array" do
         details = { body: { foo: {} } }
-        result = EmbeddedContentFinderService.new.fetch_linked_content_ids(details, Edition::DEFAULT_LOCALE)
+        result = EmbeddedContentFinderService.new.fetch_linked_content_ids(details)
         expect(result).to eq([])
       end
     end
@@ -251,7 +243,7 @@ RSpec.describe EmbeddedContentFinderService do
     context "when the field value is nil" do
       it "returns an empty array" do
         details = { body: nil }
-        result = EmbeddedContentFinderService.new.fetch_linked_content_ids(details, Edition::DEFAULT_LOCALE)
+        result = EmbeddedContentFinderService.new.fetch_linked_content_ids(details)
         expect(result).to eq([])
       end
     end
@@ -259,7 +251,7 @@ RSpec.describe EmbeddedContentFinderService do
     context "when the field value is a boolean" do
       it "returns an empty array" do
         details = { foo: true }
-        result = EmbeddedContentFinderService.new.fetch_linked_content_ids(details, Edition::DEFAULT_LOCALE)
+        result = EmbeddedContentFinderService.new.fetch_linked_content_ids(details)
         expect(result).to eq([])
       end
     end


### PR DESCRIPTION
At the moment, embeds are published in the English locale, and we filter by the content's locale too. As a result, documents in Welsh don't work. In future we _might_ have translations for content blocks, but as we don't at the moment, let's be less sensitive about locale and just serve the English one.