### PR TITLE
Ignore locale when queuing dependencies

### DIFF
--- a/app/sidekiq/host_content_update_job.rb
+++ b/app/sidekiq/host_content_update_job.rb
@@ -40,4 +40,12 @@ private
   def source_edition
     @source_edition ||= Document.find_by(content_id:).live
   end
+
+  def dependencies
+    Queries::ContentDependencies.new(
+      content_id:,
+      locale: Edition::DEFAULT_LOCALE,
+      content_stores:,
+    ).call
+  end
 end

--- a/spec/sidekiq/host_content_update_job_spec.rb
+++ b/spec/sidekiq/host_content_update_job_spec.rb
@@ -63,4 +63,27 @@ RSpec.describe HostContentUpdateJob, :perform do
     expect(event.payload[:source_block][:updated_by_user_uid]).to eq(latest_publish_event.user_uid)
     expect(event.payload[:message]).to eq("Host content updated by content block update")
   end
+
+  describe "when the locale is a non-English locale" do
+    subject(:worker_perform) do
+      described_class.new.perform(
+        "content_id" => content_id,
+        "locale" => "cy",
+        "content_store" => "Adapters::ContentStore",
+        "orphaned_content_ids" => [],
+      )
+    end
+
+    let(:edition_dependee) { double(:edition_dependent, call: []) }
+
+    it "searches in the default locale" do
+      expect(Queries::ContentDependencies).to receive(:new).with(
+        content_id:,
+        locale: Edition::DEFAULT_LOCALE,
+        content_stores: %w[live],
+      ).and_return(edition_dependee)
+
+      worker_perform
+    end
+  end
 end


### PR DESCRIPTION
This follows on from https://github.com/alphagov/publishing-api/pull/3183 and allows us to ignore the locale when queueing dependent content, by overriding the `dependencies` method in the HostContentUpdateJob
