### PR TITLE
Don’t specify locale when queuing host content

### DIFF
--- a/app/sidekiq/host_content_update_job.rb
+++ b/app/sidekiq/host_content_update_job.rb
@@ -44,7 +44,7 @@ private
   def dependencies
     Queries::ContentDependencies.new(
       content_id:,
-      locale: Edition::DEFAULT_LOCALE,
+      locale: nil,
       content_stores:,
     ).call
   end

--- a/spec/sidekiq/host_content_update_job_spec.rb
+++ b/spec/sidekiq/host_content_update_job_spec.rb
@@ -76,10 +76,10 @@ RSpec.describe HostContentUpdateJob, :perform do
 
     let(:edition_dependee) { double(:edition_dependent, call: []) }
 
-    it "searches in the default locale" do
+    it "does not specify a locale" do
       expect(Queries::ContentDependencies).to receive(:new).with(
         content_id:,
-        locale: Edition::DEFAULT_LOCALE,
+        locale: nil,
         content_stores: %w[live],
       ).and_return(edition_dependee)
 


### PR DESCRIPTION
We mistakenly changed this to query for the default locale, when actually, we should be locale-agnostic, so not specify the locale at all.