### PR TITLE
StateForDocumentValidator performance improvement

### DIFF
--- a/app/validators/state_for_document_validator.rb
+++ b/app/validators/state_for_document_validator.rb
@@ -7,11 +7,11 @@ class StateForDocumentValidator < ActiveModel::Validator
       state: record.state == "draft" ? "draft" : %w[published unpublished],
     }
 
-    conflict = Edition.where(criteria).where.not(id: record.id).order(nil).first
+    conflict_id = Edition.where(criteria).where.not(id: record.id).pick(:id)
 
-    if conflict
+    if conflict_id
       error = "state=#{record.state} and document=#{record.document_id} "\
-        "conflicts with edition id=#{conflict[:id]}"
+        "conflicts with edition id=#{conflict_id}"
       record.errors.add(:base, error)
     end
   end

--- a/app/validators/version_for_document_validator.rb
+++ b/app/validators/version_for_document_validator.rb
@@ -7,12 +7,12 @@ class VersionForDocumentValidator < ActiveModel::Validator
       user_facing_version: record.user_facing_version,
     }
 
-    conflict = Edition.where(criteria).where.not(id: record.id).order(nil).first
+    conflict_id = Edition.where(criteria).where.not(id: record.id).pick(:id)
 
-    if conflict
+    if conflict_id
       error = "user_facing_version=#{record.user_facing_version} and "\
         "document=#{record.document_id} conflicts with edition "\
-        "id=#{conflict[:id]}"
+        "id=#{conflict_id}"
       record.errors.add(:base, error)
     end
   end


### PR DESCRIPTION
Update performance of validator to help with a current publishing incident


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
