### PR TITLE
Reduce dataloader queries

### DIFF
--- a/app/graphql/sources/linked_to_editions_source.rb
+++ b/app/graphql/sources/linked_to_editions_source.rb
@@ -7,6 +7,10 @@ module Sources
     # rubocop:enable Lint/MissingSuper
 
     def fetch(editions_and_link_types)
+      all_selections = {
+        links: %i[link_type position],
+        documents: %i[content_id],
+      }
       edition_id_tuples = []
       content_id_tuples = []
       link_types_map = {}
@@ -17,37 +21,65 @@ module Sources
         link_types_map[[edition.content_id, link_type]] = []
       end
 
-      edition_links = Link
-        .joins(:edition, { target_documents: @content_store })
-        .includes(:edition, { target_documents: @content_store })
-        .where(
-          '("editions"."id", "links"."link_type") IN (?)',
-          Arel.sql(edition_id_tuples.join(",")),
-        )
-        .where(target_documents: { locale: "en" })
-        .order(link_type: :asc, position: :asc)
-
-      link_set_links = Link
-        .joins(:link_set, { target_documents: @content_store })
-        .includes(:link_set, { target_documents: @content_store })
+      link_set_links_target_editions = Edition
+        .joins(document: { reverse_links: :link_set })
         .where(
           '("link_sets"."content_id", "links"."link_type") IN (?)',
           Arel.sql(content_id_tuples.join(",")),
         )
-        .where(target_documents: { locale: "en" })
+        .where(
+          editions: { content_store: @content_store },
+          documents: { locale: "en" },
+        )
+        .select(
+          "editions.*",
+          all_selections,
+          { link_sets: { content_id: :source_content_id } },
+        )
+
+      edition_links_target_editions = Edition
+        .joins(document: :reverse_links)
+        .joins(
+          <<~SQL,
+            INNER JOIN editions source_editions
+            ON source_editions.id = links.edition_id
+          SQL
+        )
+        .joins(
+          <<~SQL,
+            INNER JOIN documents source_documents
+            ON source_documents.id = source_editions.document_id
+          SQL
+        )
+        .where(
+          '("source_editions"."id", "links"."link_type") IN (?)',
+          Arel.sql(edition_id_tuples.join(",")),
+        )
+        .where(
+          editions: { content_store: @content_store },
+          documents: { locale: "en" },
+        )
+        .select(
+          "editions.*",
+          all_selections,
+          { source_documents: { content_id: :source_content_id } },
+        )
+
+      all_editions = Edition
+        .from(
+          <<~SQL,
+            (
+              #{link_set_links_target_editions.to_sql}
+              UNION
+              #{edition_links_target_editions.to_sql}
+            ) AS editions
+          SQL
+        )
         .order(link_type: :asc, position: :asc)
 
-      all_links = edition_links + link_set_links
-
-      all_links.each_with_object(link_types_map) { |link, hash|
-        hash[[(link.link_set || link.edition).content_id, link.link_type]].concat(editions_for_link(link))
+      all_editions.each_with_object(link_types_map) { |edition, hash|
+        hash[[edition.source_content_id, edition.link_type]] << edition
       }.values
-    end
-
-  private
-
-    def editions_for_link(link)
-      link.target_documents.map { |document| document.send(@content_store) }
     end
   end
 end

--- a/app/graphql/sources/linked_to_editions_source.rb
+++ b/app/graphql/sources/linked_to_editions_source.rb
@@ -7,26 +7,37 @@ module Sources
     # rubocop:enable Lint/MissingSuper
 
     def fetch(editions_and_link_types)
-      content_id_tuples = editions_and_link_types.map { |edition, link_type| "('#{edition.content_id}','#{link_type}')" }.join(",")
-      edition_id_tuples = editions_and_link_types.map { |edition, link_type| "(#{edition.id},'#{link_type}')" }.join(",")
+      edition_id_tuples = []
+      content_id_tuples = []
+      link_types_map = {}
+
+      editions_and_link_types.each do |edition, link_type|
+        edition_id_tuples.push("(#{edition.id},'#{link_type}')")
+        content_id_tuples.push("('#{edition.content_id}','#{link_type}')")
+        link_types_map[[edition.content_id, link_type]] = []
+      end
 
       edition_links = Link
         .joins(:edition, { target_documents: @content_store })
         .includes(:edition, { target_documents: @content_store })
-        .where('("editions"."id", "links"."link_type") IN (?)', Arel.sql(edition_id_tuples))
+        .where(
+          '("editions"."id", "links"."link_type") IN (?)',
+          Arel.sql(edition_id_tuples.join(",")),
+        )
         .where(target_documents: { locale: "en" })
         .order(link_type: :asc, position: :asc)
 
       link_set_links = Link
         .joins(:link_set, { target_documents: @content_store })
         .includes(:link_set, { target_documents: @content_store })
-        .where('("link_sets"."content_id", "links"."link_type") IN (?)', Arel.sql(content_id_tuples))
+        .where(
+          '("link_sets"."content_id", "links"."link_type") IN (?)',
+          Arel.sql(content_id_tuples.join(",")),
+        )
         .where(target_documents: { locale: "en" })
         .order(link_type: :asc, position: :asc)
 
       all_links = edition_links + link_set_links
-
-      link_types_map = editions_and_link_types.map { [_1.content_id, _2] }.index_with { [] }
 
       all_links.each_with_object(link_types_map) { |link, hash|
         hash[[(link.link_set || link.edition).content_id, link.link_type]].concat(editions_for_link(link))

--- a/app/graphql/sources/reverse_linked_to_editions_source.rb
+++ b/app/graphql/sources/reverse_linked_to_editions_source.rb
@@ -7,13 +7,20 @@ module Sources
     # rubocop:enable Lint/MissingSuper
 
     def fetch(editions_and_link_types)
-      content_id_tuples = editions_and_link_types.map { |edition, link_type| "('#{edition.content_id}','#{link_type}')" }.join(",")
+      content_id_tuples = []
+      link_types_map = {}
+
+      editions_and_link_types.each do |edition, link_type|
+        content_id_tuples.push("('#{edition.content_id}','#{link_type}')")
+        link_types_map[[edition.content_id, link_type]] = []
+      end
 
       all_links = Link
-        .where('("links"."target_content_id", "links"."link_type") IN (?)', Arel.sql(content_id_tuples))
+        .where(
+          '("links"."target_content_id", "links"."link_type") IN (?)',
+          Arel.sql(content_id_tuples.join(",")),
+        )
         .includes(source_documents: @content_store)
-
-      link_types_map = editions_and_link_types.map { [_1.content_id, _2] }.index_with { [] }
 
       all_links.each_with_object(link_types_map) { |link, hash|
         if link.link_set

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -75,7 +75,15 @@ class Edition < ApplicationRecord
   validates_with StateForDocumentValidator
   validates_with RoutesAndRedirectsValidator
 
-  delegate :content_id, :locale, to: :document
+  def self.attribute_or_delegate(*names, to:)
+    names.each do |name|
+      define_method(name) do
+        attribute(name.to_s) || method(to).call.method(name).call
+      end
+    end
+  end
+
+  attribute_or_delegate :content_id, :locale, to: :document
 
   def auth_bypass_ids_are_uuids
     unless auth_bypass_ids.all? { |id| UuidValidator.valid?(id) }

--- a/spec/factories/link.rb
+++ b/spec/factories/link.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :link do
-    link_set
+    link_set          { create(:link_set) unless edition }
     target_content_id { SecureRandom.uuid }
     link_type         { "organisations" }
   end

--- a/spec/graphql/sources/linked_to_editions_source_spec.rb
+++ b/spec/graphql/sources/linked_to_editions_source_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Sources::LinkedToEditionsSource do
     GraphQL::Dataloader.with_dataloading do |dataloader|
       request = dataloader.with(described_class, content_store: source_edition.content_store).request([source_edition, "test_link"])
 
-      expect(request.load).to eq([target_edition_1, target_edition_3])
+      expect(request.load).to match_array([target_edition_1, target_edition_3])
     end
   end
 
@@ -30,7 +30,7 @@ RSpec.describe Sources::LinkedToEditionsSource do
     GraphQL::Dataloader.with_dataloading do |dataloader|
       request = dataloader.with(described_class, content_store: source_edition.content_store).request([source_edition, "test_link"])
 
-      expect(request.load).to eq([target_edition_1, target_edition_3])
+      expect(request.load).to match_array([target_edition_1, target_edition_3])
     end
   end
 
@@ -51,7 +51,7 @@ RSpec.describe Sources::LinkedToEditionsSource do
     GraphQL::Dataloader.with_dataloading do |dataloader|
       request = dataloader.with(described_class, content_store: source_edition.content_store).request([source_edition, "test_link"])
 
-      expect(request.load).to eq([target_edition_1, target_edition_3])
+      expect(request.load).to match_array([target_edition_1, target_edition_3])
     end
   end
 
@@ -74,7 +74,7 @@ RSpec.describe Sources::LinkedToEditionsSource do
     GraphQL::Dataloader.with_dataloading do |dataloader|
       request = dataloader.with(described_class, content_store: source_edition.content_store).request([source_edition, "test_link"])
 
-      expect(request.load).to eq([target_edition_3, target_edition_4])
+      expect(request.load).to match_array([target_edition_3, target_edition_4])
     end
   end
 end


### PR DESCRIPTION
[Trello](https://trello.com/c/zMclxWKo/1589-use-lookahead-to-enable-selecting-subsets-of-columns-in-graphql)

This optimises(?) the database queries in `LinkedToEditionsSource` and `ReverseLinkedToEditionsSource`, reducing them down to one query each (in practice, one query per level of depth in the GraphQL query). This is a change en route to selecting a subset of columns - we'll open a separate pull request for that change

We're looking into the actual performance of this change at the minute but thought it was worth opening the pull request since the core bones are in place

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
