### PR TITLE
Revert "Add owning_organisations to ministers index links"

### DIFF
--- a/content_schemas/dist/formats/answer/frontend/schema.json
+++ b/content_schemas/dist/formats/answer/frontend/schema.json
@@ -111,10 +111,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/content_schemas/dist/formats/answer/notification/schema.json
+++ b/content_schemas/dist/formats/answer/notification/schema.json
@@ -129,10 +129,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/content_schemas/dist/formats/calendar/frontend/schema.json
+++ b/content_schemas/dist/formats/calendar/frontend/schema.json
@@ -111,10 +111,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/content_schemas/dist/formats/calendar/notification/schema.json
+++ b/content_schemas/dist/formats/calendar/notification/schema.json
@@ -129,10 +129,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/content_schemas/dist/formats/call_for_evidence/frontend/schema.json
+++ b/content_schemas/dist/formats/call_for_evidence/frontend/schema.json
@@ -118,10 +118,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "$ref": "#/definitions/frontend_links_with_base_path"
         },

--- a/content_schemas/dist/formats/call_for_evidence/notification/schema.json
+++ b/content_schemas/dist/formats/call_for_evidence/notification/schema.json
@@ -136,10 +136,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "$ref": "#/definitions/frontend_links_with_base_path"
         },

--- a/content_schemas/dist/formats/case_study/frontend/schema.json
+++ b/content_schemas/dist/formats/case_study/frontend/schema.json
@@ -116,10 +116,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/content_schemas/dist/formats/case_study/notification/schema.json
+++ b/content_schemas/dist/formats/case_study/notification/schema.json
@@ -134,10 +134,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/content_schemas/dist/formats/completed_transaction/frontend/schema.json
+++ b/content_schemas/dist/formats/completed_transaction/frontend/schema.json
@@ -111,10 +111,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/content_schemas/dist/formats/completed_transaction/notification/schema.json
+++ b/content_schemas/dist/formats/completed_transaction/notification/schema.json
@@ -129,10 +129,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/content_schemas/dist/formats/consultation/frontend/schema.json
+++ b/content_schemas/dist/formats/consultation/frontend/schema.json
@@ -118,10 +118,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "$ref": "#/definitions/frontend_links_with_base_path"
         },

--- a/content_schemas/dist/formats/consultation/notification/schema.json
+++ b/content_schemas/dist/formats/consultation/notification/schema.json
@@ -136,10 +136,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "$ref": "#/definitions/frontend_links_with_base_path"
         },

--- a/content_schemas/dist/formats/contact/frontend/schema.json
+++ b/content_schemas/dist/formats/contact/frontend/schema.json
@@ -111,10 +111,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/content_schemas/dist/formats/contact/notification/schema.json
+++ b/content_schemas/dist/formats/contact/notification/schema.json
@@ -129,10 +129,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/content_schemas/dist/formats/content_block_email_address/notification/schema.json
+++ b/content_schemas/dist/formats/content_block_email_address/notification/schema.json
@@ -129,10 +129,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/content_schemas/dist/formats/content_block_pension/notification/schema.json
+++ b/content_schemas/dist/formats/content_block_pension/notification/schema.json
@@ -129,10 +129,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/content_schemas/dist/formats/content_block_postal_address/notification/schema.json
+++ b/content_schemas/dist/formats/content_block_postal_address/notification/schema.json
@@ -129,10 +129,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/content_schemas/dist/formats/coronavirus_landing_page/frontend/schema.json
+++ b/content_schemas/dist/formats/coronavirus_landing_page/frontend/schema.json
@@ -111,10 +111,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/content_schemas/dist/formats/coronavirus_landing_page/notification/schema.json
+++ b/content_schemas/dist/formats/coronavirus_landing_page/notification/schema.json
@@ -129,10 +129,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/content_schemas/dist/formats/corporate_information_page/frontend/schema.json
+++ b/content_schemas/dist/formats/corporate_information_page/frontend/schema.json
@@ -136,10 +136,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/content_schemas/dist/formats/corporate_information_page/notification/schema.json
+++ b/content_schemas/dist/formats/corporate_information_page/notification/schema.json
@@ -154,10 +154,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/content_schemas/dist/formats/detailed_guide/frontend/schema.json
+++ b/content_schemas/dist/formats/detailed_guide/frontend/schema.json
@@ -115,10 +115,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "$ref": "#/definitions/frontend_links_with_base_path"
         },

--- a/content_schemas/dist/formats/detailed_guide/notification/schema.json
+++ b/content_schemas/dist/formats/detailed_guide/notification/schema.json
@@ -133,10 +133,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "$ref": "#/definitions/frontend_links_with_base_path"
         },

--- a/content_schemas/dist/formats/document_collection/frontend/schema.json
+++ b/content_schemas/dist/formats/document_collection/frontend/schema.json
@@ -118,10 +118,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "$ref": "#/definitions/frontend_links_with_base_path"
         },

--- a/content_schemas/dist/formats/document_collection/notification/schema.json
+++ b/content_schemas/dist/formats/document_collection/notification/schema.json
@@ -136,10 +136,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "$ref": "#/definitions/frontend_links_with_base_path"
         },

--- a/content_schemas/dist/formats/email_alert_signup/frontend/schema.json
+++ b/content_schemas/dist/formats/email_alert_signup/frontend/schema.json
@@ -111,10 +111,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/content_schemas/dist/formats/email_alert_signup/notification/schema.json
+++ b/content_schemas/dist/formats/email_alert_signup/notification/schema.json
@@ -129,10 +129,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/content_schemas/dist/formats/embassies_index/frontend/schema.json
+++ b/content_schemas/dist/formats/embassies_index/frontend/schema.json
@@ -111,10 +111,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/content_schemas/dist/formats/embassies_index/notification/schema.json
+++ b/content_schemas/dist/formats/embassies_index/notification/schema.json
@@ -129,10 +129,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/content_schemas/dist/formats/external_content/notification/schema.json
+++ b/content_schemas/dist/formats/external_content/notification/schema.json
@@ -93,10 +93,6 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "part_of_step_navs": {
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/content_schemas/dist/formats/facet/frontend/schema.json
+++ b/content_schemas/dist/formats/facet/frontend/schema.json
@@ -111,10 +111,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/content_schemas/dist/formats/facet/notification/schema.json
+++ b/content_schemas/dist/formats/facet/notification/schema.json
@@ -129,10 +129,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/content_schemas/dist/formats/fatality_notice/frontend/schema.json
+++ b/content_schemas/dist/formats/fatality_notice/frontend/schema.json
@@ -115,10 +115,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/content_schemas/dist/formats/fatality_notice/notification/schema.json
+++ b/content_schemas/dist/formats/fatality_notice/notification/schema.json
@@ -133,10 +133,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/content_schemas/dist/formats/field_of_operation/frontend/schema.json
+++ b/content_schemas/dist/formats/field_of_operation/frontend/schema.json
@@ -115,10 +115,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/content_schemas/dist/formats/field_of_operation/notification/schema.json
+++ b/content_schemas/dist/formats/field_of_operation/notification/schema.json
@@ -133,10 +133,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/content_schemas/dist/formats/fields_of_operation/frontend/schema.json
+++ b/content_schemas/dist/formats/fields_of_operation/frontend/schema.json
@@ -115,10 +115,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/content_schemas/dist/formats/fields_of_operation/notification/schema.json
+++ b/content_schemas/dist/formats/fields_of_operation/notification/schema.json
@@ -133,10 +133,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/content_schemas/dist/formats/finder/frontend/schema.json
+++ b/content_schemas/dist/formats/finder/frontend/schema.json
@@ -114,10 +114,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/content_schemas/dist/formats/finder/notification/schema.json
+++ b/content_schemas/dist/formats/finder/notification/schema.json
@@ -132,10 +132,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/content_schemas/dist/formats/finder_email_signup/frontend/schema.json
+++ b/content_schemas/dist/formats/finder_email_signup/frontend/schema.json
@@ -110,10 +110,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/content_schemas/dist/formats/finder_email_signup/notification/schema.json
+++ b/content_schemas/dist/formats/finder_email_signup/notification/schema.json
@@ -128,10 +128,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/content_schemas/dist/formats/generic/frontend/schema.json
+++ b/content_schemas/dist/formats/generic/frontend/schema.json
@@ -299,10 +299,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/content_schemas/dist/formats/generic/notification/schema.json
+++ b/content_schemas/dist/formats/generic/notification/schema.json
@@ -317,10 +317,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/content_schemas/dist/formats/generic_with_external_related_links/frontend/schema.json
+++ b/content_schemas/dist/formats/generic_with_external_related_links/frontend/schema.json
@@ -299,10 +299,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/content_schemas/dist/formats/generic_with_external_related_links/notification/schema.json
+++ b/content_schemas/dist/formats/generic_with_external_related_links/notification/schema.json
@@ -317,10 +317,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/content_schemas/dist/formats/get_involved/frontend/schema.json
+++ b/content_schemas/dist/formats/get_involved/frontend/schema.json
@@ -111,10 +111,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/content_schemas/dist/formats/get_involved/notification/schema.json
+++ b/content_schemas/dist/formats/get_involved/notification/schema.json
@@ -129,10 +129,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/content_schemas/dist/formats/gone/frontend/schema.json
+++ b/content_schemas/dist/formats/gone/frontend/schema.json
@@ -75,10 +75,6 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "part_of_step_navs": {
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/content_schemas/dist/formats/gone/notification/schema.json
+++ b/content_schemas/dist/formats/gone/notification/schema.json
@@ -77,10 +77,6 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "part_of_step_navs": {
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/content_schemas/dist/formats/government/frontend/schema.json
+++ b/content_schemas/dist/formats/government/frontend/schema.json
@@ -111,10 +111,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/content_schemas/dist/formats/government/notification/schema.json
+++ b/content_schemas/dist/formats/government/notification/schema.json
@@ -129,10 +129,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/content_schemas/dist/formats/guide/frontend/schema.json
+++ b/content_schemas/dist/formats/guide/frontend/schema.json
@@ -111,10 +111,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/content_schemas/dist/formats/guide/notification/schema.json
+++ b/content_schemas/dist/formats/guide/notification/schema.json
@@ -129,10 +129,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/content_schemas/dist/formats/help_page/frontend/schema.json
+++ b/content_schemas/dist/formats/help_page/frontend/schema.json
@@ -111,10 +111,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/content_schemas/dist/formats/help_page/notification/schema.json
+++ b/content_schemas/dist/formats/help_page/notification/schema.json
@@ -129,10 +129,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/content_schemas/dist/formats/historic_appointment/frontend/schema.json
+++ b/content_schemas/dist/formats/historic_appointment/frontend/schema.json
@@ -111,10 +111,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/content_schemas/dist/formats/historic_appointment/notification/schema.json
+++ b/content_schemas/dist/formats/historic_appointment/notification/schema.json
@@ -129,10 +129,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/content_schemas/dist/formats/historic_appointments/frontend/schema.json
+++ b/content_schemas/dist/formats/historic_appointments/frontend/schema.json
@@ -115,10 +115,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/content_schemas/dist/formats/historic_appointments/notification/schema.json
+++ b/content_schemas/dist/formats/historic_appointments/notification/schema.json
@@ -133,10 +133,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/content_schemas/dist/formats/history/frontend/schema.json
+++ b/content_schemas/dist/formats/history/frontend/schema.json
@@ -111,10 +111,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/content_schemas/dist/formats/history/notification/schema.json
+++ b/content_schemas/dist/formats/history/notification/schema.json
@@ -129,10 +129,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/content_schemas/dist/formats/hmrc_manual/frontend/schema.json
+++ b/content_schemas/dist/formats/hmrc_manual/frontend/schema.json
@@ -111,10 +111,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/content_schemas/dist/formats/hmrc_manual/notification/schema.json
+++ b/content_schemas/dist/formats/hmrc_manual/notification/schema.json
@@ -129,10 +129,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/content_schemas/dist/formats/hmrc_manual_section/frontend/schema.json
+++ b/content_schemas/dist/formats/hmrc_manual_section/frontend/schema.json
@@ -111,10 +111,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/content_schemas/dist/formats/hmrc_manual_section/notification/schema.json
+++ b/content_schemas/dist/formats/hmrc_manual_section/notification/schema.json
@@ -129,10 +129,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/content_schemas/dist/formats/homepage/frontend/schema.json
+++ b/content_schemas/dist/formats/homepage/frontend/schema.json
@@ -80,10 +80,6 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "part_of_step_navs": {
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/content_schemas/dist/formats/homepage/notification/schema.json
+++ b/content_schemas/dist/formats/homepage/notification/schema.json
@@ -98,10 +98,6 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "part_of_step_navs": {
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/content_schemas/dist/formats/how_government_works/frontend/schema.json
+++ b/content_schemas/dist/formats/how_government_works/frontend/schema.json
@@ -115,10 +115,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/content_schemas/dist/formats/how_government_works/notification/schema.json
+++ b/content_schemas/dist/formats/how_government_works/notification/schema.json
@@ -133,10 +133,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/content_schemas/dist/formats/html_publication/frontend/schema.json
+++ b/content_schemas/dist/formats/html_publication/frontend/schema.json
@@ -115,10 +115,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "$ref": "#/definitions/frontend_links_with_base_path"
         },

--- a/content_schemas/dist/formats/html_publication/notification/schema.json
+++ b/content_schemas/dist/formats/html_publication/notification/schema.json
@@ -133,10 +133,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "$ref": "#/definitions/frontend_links_with_base_path"
         },

--- a/content_schemas/dist/formats/landing_page/frontend/schema.json
+++ b/content_schemas/dist/formats/landing_page/frontend/schema.json
@@ -119,10 +119,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "$ref": "#/definitions/frontend_links_with_base_path"
         },

--- a/content_schemas/dist/formats/landing_page/notification/schema.json
+++ b/content_schemas/dist/formats/landing_page/notification/schema.json
@@ -137,10 +137,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "$ref": "#/definitions/frontend_links_with_base_path"
         },

--- a/content_schemas/dist/formats/licence/frontend/schema.json
+++ b/content_schemas/dist/formats/licence/frontend/schema.json
@@ -111,10 +111,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/content_schemas/dist/formats/licence/notification/schema.json
+++ b/content_schemas/dist/formats/licence/notification/schema.json
@@ -129,10 +129,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/content_schemas/dist/formats/link_collection/frontend/schema.json
+++ b/content_schemas/dist/formats/link_collection/frontend/schema.json
@@ -111,10 +111,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/content_schemas/dist/formats/link_collection/notification/schema.json
+++ b/content_schemas/dist/formats/link_collection/notification/schema.json
@@ -129,10 +129,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/content_schemas/dist/formats/local_transaction/frontend/schema.json
+++ b/content_schemas/dist/formats/local_transaction/frontend/schema.json
@@ -111,10 +111,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/content_schemas/dist/formats/local_transaction/notification/schema.json
+++ b/content_schemas/dist/formats/local_transaction/notification/schema.json
@@ -129,10 +129,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/content_schemas/dist/formats/mainstream_browse_page/frontend/schema.json
+++ b/content_schemas/dist/formats/mainstream_browse_page/frontend/schema.json
@@ -116,10 +116,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/content_schemas/dist/formats/mainstream_browse_page/notification/schema.json
+++ b/content_schemas/dist/formats/mainstream_browse_page/notification/schema.json
@@ -134,10 +134,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/content_schemas/dist/formats/manual/frontend/schema.json
+++ b/content_schemas/dist/formats/manual/frontend/schema.json
@@ -109,10 +109,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/content_schemas/dist/formats/manual/notification/schema.json
+++ b/content_schemas/dist/formats/manual/notification/schema.json
@@ -127,10 +127,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/content_schemas/dist/formats/manual_section/frontend/schema.json
+++ b/content_schemas/dist/formats/manual_section/frontend/schema.json
@@ -112,10 +112,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/content_schemas/dist/formats/manual_section/notification/schema.json
+++ b/content_schemas/dist/formats/manual_section/notification/schema.json
@@ -130,10 +130,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/content_schemas/dist/formats/ministers_index/frontend/schema.json
+++ b/content_schemas/dist/formats/ministers_index/frontend/schema.json
@@ -143,10 +143,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/content_schemas/dist/formats/ministers_index/notification/schema.json
+++ b/content_schemas/dist/formats/ministers_index/notification/schema.json
@@ -161,10 +161,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/content_schemas/dist/formats/need/frontend/schema.json
+++ b/content_schemas/dist/formats/need/frontend/schema.json
@@ -111,10 +111,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/content_schemas/dist/formats/need/notification/schema.json
+++ b/content_schemas/dist/formats/need/notification/schema.json
@@ -129,10 +129,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/content_schemas/dist/formats/news_article/frontend/schema.json
+++ b/content_schemas/dist/formats/news_article/frontend/schema.json
@@ -119,10 +119,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/content_schemas/dist/formats/news_article/notification/schema.json
+++ b/content_schemas/dist/formats/news_article/notification/schema.json
@@ -137,10 +137,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/content_schemas/dist/formats/organisation/frontend/schema.json
+++ b/content_schemas/dist/formats/organisation/frontend/schema.json
@@ -167,10 +167,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/content_schemas/dist/formats/organisation/notification/schema.json
+++ b/content_schemas/dist/formats/organisation/notification/schema.json
@@ -185,10 +185,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/content_schemas/dist/formats/organisations_homepage/frontend/schema.json
+++ b/content_schemas/dist/formats/organisations_homepage/frontend/schema.json
@@ -111,10 +111,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/content_schemas/dist/formats/organisations_homepage/notification/schema.json
+++ b/content_schemas/dist/formats/organisations_homepage/notification/schema.json
@@ -129,10 +129,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/content_schemas/dist/formats/person/frontend/schema.json
+++ b/content_schemas/dist/formats/person/frontend/schema.json
@@ -111,10 +111,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/content_schemas/dist/formats/person/notification/schema.json
+++ b/content_schemas/dist/formats/person/notification/schema.json
@@ -129,10 +129,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/content_schemas/dist/formats/place/frontend/schema.json
+++ b/content_schemas/dist/formats/place/frontend/schema.json
@@ -111,10 +111,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/content_schemas/dist/formats/place/notification/schema.json
+++ b/content_schemas/dist/formats/place/notification/schema.json
@@ -129,10 +129,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/content_schemas/dist/formats/publication/frontend/schema.json
+++ b/content_schemas/dist/formats/publication/frontend/schema.json
@@ -134,10 +134,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "$ref": "#/definitions/frontend_links_with_base_path"
         },

--- a/content_schemas/dist/formats/publication/notification/schema.json
+++ b/content_schemas/dist/formats/publication/notification/schema.json
@@ -152,10 +152,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "$ref": "#/definitions/frontend_links_with_base_path"
         },

--- a/content_schemas/dist/formats/redirect/frontend/schema.json
+++ b/content_schemas/dist/formats/redirect/frontend/schema.json
@@ -77,10 +77,6 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "part_of_step_navs": {
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/content_schemas/dist/formats/redirect/notification/schema.json
+++ b/content_schemas/dist/formats/redirect/notification/schema.json
@@ -79,10 +79,6 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "part_of_step_navs": {
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/content_schemas/dist/formats/role/frontend/schema.json
+++ b/content_schemas/dist/formats/role/frontend/schema.json
@@ -132,10 +132,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/content_schemas/dist/formats/role/notification/schema.json
+++ b/content_schemas/dist/formats/role/notification/schema.json
@@ -150,10 +150,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/content_schemas/dist/formats/role_appointment/frontend/schema.json
+++ b/content_schemas/dist/formats/role_appointment/frontend/schema.json
@@ -111,10 +111,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/content_schemas/dist/formats/role_appointment/notification/schema.json
+++ b/content_schemas/dist/formats/role_appointment/notification/schema.json
@@ -129,10 +129,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/content_schemas/dist/formats/service_manual_guide/frontend/schema.json
+++ b/content_schemas/dist/formats/service_manual_guide/frontend/schema.json
@@ -115,10 +115,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/content_schemas/dist/formats/service_manual_guide/notification/schema.json
+++ b/content_schemas/dist/formats/service_manual_guide/notification/schema.json
@@ -133,10 +133,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/content_schemas/dist/formats/service_manual_homepage/frontend/schema.json
+++ b/content_schemas/dist/formats/service_manual_homepage/frontend/schema.json
@@ -111,10 +111,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/content_schemas/dist/formats/service_manual_homepage/notification/schema.json
+++ b/content_schemas/dist/formats/service_manual_homepage/notification/schema.json
@@ -129,10 +129,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/content_schemas/dist/formats/service_manual_service_standard/frontend/schema.json
+++ b/content_schemas/dist/formats/service_manual_service_standard/frontend/schema.json
@@ -115,10 +115,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/content_schemas/dist/formats/service_manual_service_standard/notification/schema.json
+++ b/content_schemas/dist/formats/service_manual_service_standard/notification/schema.json
@@ -133,10 +133,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/content_schemas/dist/formats/service_manual_service_toolkit/frontend/schema.json
+++ b/content_schemas/dist/formats/service_manual_service_toolkit/frontend/schema.json
@@ -111,10 +111,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/content_schemas/dist/formats/service_manual_service_toolkit/notification/schema.json
+++ b/content_schemas/dist/formats/service_manual_service_toolkit/notification/schema.json
@@ -129,10 +129,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/content_schemas/dist/formats/service_manual_topic/frontend/schema.json
+++ b/content_schemas/dist/formats/service_manual_topic/frontend/schema.json
@@ -123,10 +123,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/content_schemas/dist/formats/service_manual_topic/notification/schema.json
+++ b/content_schemas/dist/formats/service_manual_topic/notification/schema.json
@@ -141,10 +141,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/content_schemas/dist/formats/service_sign_in/frontend/schema.json
+++ b/content_schemas/dist/formats/service_sign_in/frontend/schema.json
@@ -111,10 +111,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/content_schemas/dist/formats/service_sign_in/notification/schema.json
+++ b/content_schemas/dist/formats/service_sign_in/notification/schema.json
@@ -129,10 +129,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/content_schemas/dist/formats/simple_smart_answer/frontend/schema.json
+++ b/content_schemas/dist/formats/simple_smart_answer/frontend/schema.json
@@ -111,10 +111,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/content_schemas/dist/formats/simple_smart_answer/notification/schema.json
+++ b/content_schemas/dist/formats/simple_smart_answer/notification/schema.json
@@ -129,10 +129,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/content_schemas/dist/formats/smart_answer/frontend/schema.json
+++ b/content_schemas/dist/formats/smart_answer/frontend/schema.json
@@ -111,10 +111,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/content_schemas/dist/formats/smart_answer/notification/schema.json
+++ b/content_schemas/dist/formats/smart_answer/notification/schema.json
@@ -129,10 +129,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/content_schemas/dist/formats/special_route/frontend/schema.json
+++ b/content_schemas/dist/formats/special_route/frontend/schema.json
@@ -114,10 +114,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/content_schemas/dist/formats/special_route/notification/schema.json
+++ b/content_schemas/dist/formats/special_route/notification/schema.json
@@ -132,10 +132,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/content_schemas/dist/formats/specialist_document/frontend/schema.json
+++ b/content_schemas/dist/formats/specialist_document/frontend/schema.json
@@ -296,10 +296,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/content_schemas/dist/formats/specialist_document/notification/schema.json
+++ b/content_schemas/dist/formats/specialist_document/notification/schema.json
@@ -314,10 +314,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/content_schemas/dist/formats/speech/frontend/schema.json
+++ b/content_schemas/dist/formats/speech/frontend/schema.json
@@ -119,10 +119,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/content_schemas/dist/formats/speech/notification/schema.json
+++ b/content_schemas/dist/formats/speech/notification/schema.json
@@ -137,10 +137,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/content_schemas/dist/formats/statistical_data_set/frontend/schema.json
+++ b/content_schemas/dist/formats/statistical_data_set/frontend/schema.json
@@ -115,10 +115,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/content_schemas/dist/formats/statistical_data_set/notification/schema.json
+++ b/content_schemas/dist/formats/statistical_data_set/notification/schema.json
@@ -133,10 +133,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/content_schemas/dist/formats/statistics_announcement/frontend/schema.json
+++ b/content_schemas/dist/formats/statistics_announcement/frontend/schema.json
@@ -114,10 +114,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/content_schemas/dist/formats/statistics_announcement/notification/schema.json
+++ b/content_schemas/dist/formats/statistics_announcement/notification/schema.json
@@ -132,10 +132,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/content_schemas/dist/formats/step_by_step_nav/frontend/schema.json
+++ b/content_schemas/dist/formats/step_by_step_nav/frontend/schema.json
@@ -79,10 +79,6 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "pages_part_of_step_nav": {
           "description": "A list of content that should be navigable via this step by step journey",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/content_schemas/dist/formats/step_by_step_nav/notification/schema.json
+++ b/content_schemas/dist/formats/step_by_step_nav/notification/schema.json
@@ -97,10 +97,6 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "pages_part_of_step_nav": {
           "description": "A list of content that should be navigable via this step by step journey",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/content_schemas/dist/formats/substitute/notification/schema.json
+++ b/content_schemas/dist/formats/substitute/notification/schema.json
@@ -79,10 +79,6 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "part_of_step_navs": {
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/content_schemas/dist/formats/take_part/frontend/schema.json
+++ b/content_schemas/dist/formats/take_part/frontend/schema.json
@@ -111,10 +111,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/content_schemas/dist/formats/take_part/notification/schema.json
+++ b/content_schemas/dist/formats/take_part/notification/schema.json
@@ -129,10 +129,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/content_schemas/dist/formats/taxon/frontend/schema.json
+++ b/content_schemas/dist/formats/taxon/frontend/schema.json
@@ -115,10 +115,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/content_schemas/dist/formats/taxon/notification/schema.json
+++ b/content_schemas/dist/formats/taxon/notification/schema.json
@@ -133,10 +133,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/content_schemas/dist/formats/topical_event/frontend/schema.json
+++ b/content_schemas/dist/formats/topical_event/frontend/schema.json
@@ -111,10 +111,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/content_schemas/dist/formats/topical_event/notification/schema.json
+++ b/content_schemas/dist/formats/topical_event/notification/schema.json
@@ -129,10 +129,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/content_schemas/dist/formats/topical_event_about_page/frontend/schema.json
+++ b/content_schemas/dist/formats/topical_event_about_page/frontend/schema.json
@@ -111,10 +111,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/content_schemas/dist/formats/topical_event_about_page/notification/schema.json
+++ b/content_schemas/dist/formats/topical_event_about_page/notification/schema.json
@@ -129,10 +129,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/content_schemas/dist/formats/transaction/frontend/schema.json
+++ b/content_schemas/dist/formats/transaction/frontend/schema.json
@@ -111,10 +111,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/content_schemas/dist/formats/transaction/notification/schema.json
+++ b/content_schemas/dist/formats/transaction/notification/schema.json
@@ -129,10 +129,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/content_schemas/dist/formats/travel_advice/frontend/schema.json
+++ b/content_schemas/dist/formats/travel_advice/frontend/schema.json
@@ -111,10 +111,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/content_schemas/dist/formats/travel_advice/notification/schema.json
+++ b/content_schemas/dist/formats/travel_advice/notification/schema.json
@@ -129,10 +129,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/content_schemas/dist/formats/travel_advice_index/frontend/schema.json
+++ b/content_schemas/dist/formats/travel_advice_index/frontend/schema.json
@@ -111,10 +111,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/content_schemas/dist/formats/travel_advice_index/notification/schema.json
+++ b/content_schemas/dist/formats/travel_advice_index/notification/schema.json
@@ -129,10 +129,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/content_schemas/dist/formats/vanish/notification/schema.json
+++ b/content_schemas/dist/formats/vanish/notification/schema.json
@@ -79,10 +79,6 @@
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "part_of_step_navs": {
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"

--- a/content_schemas/dist/formats/working_group/frontend/schema.json
+++ b/content_schemas/dist/formats/working_group/frontend/schema.json
@@ -111,10 +111,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/content_schemas/dist/formats/working_group/notification/schema.json
+++ b/content_schemas/dist/formats/working_group/notification/schema.json
@@ -129,10 +129,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/content_schemas/dist/formats/world_index/frontend/schema.json
+++ b/content_schemas/dist/formats/world_index/frontend/schema.json
@@ -111,10 +111,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/content_schemas/dist/formats/world_index/notification/schema.json
+++ b/content_schemas/dist/formats/world_index/notification/schema.json
@@ -129,10 +129,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/content_schemas/dist/formats/world_location/frontend/schema.json
+++ b/content_schemas/dist/formats/world_location/frontend/schema.json
@@ -115,10 +115,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/content_schemas/dist/formats/world_location/notification/schema.json
+++ b/content_schemas/dist/formats/world_location/notification/schema.json
@@ -133,10 +133,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/content_schemas/dist/formats/world_location_news/frontend/schema.json
+++ b/content_schemas/dist/formats/world_location_news/frontend/schema.json
@@ -115,10 +115,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/content_schemas/dist/formats/world_location_news/notification/schema.json
+++ b/content_schemas/dist/formats/world_location_news/notification/schema.json
@@ -133,10 +133,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/content_schemas/dist/formats/worldwide_corporate_information_page/frontend/schema.json
+++ b/content_schemas/dist/formats/worldwide_corporate_information_page/frontend/schema.json
@@ -132,10 +132,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/content_schemas/dist/formats/worldwide_corporate_information_page/notification/schema.json
+++ b/content_schemas/dist/formats/worldwide_corporate_information_page/notification/schema.json
@@ -150,10 +150,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/content_schemas/dist/formats/worldwide_office/frontend/schema.json
+++ b/content_schemas/dist/formats/worldwide_office/frontend/schema.json
@@ -115,10 +115,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/content_schemas/dist/formats/worldwide_office/notification/schema.json
+++ b/content_schemas/dist/formats/worldwide_office/notification/schema.json
@@ -133,10 +133,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/content_schemas/dist/formats/worldwide_organisation/frontend/schema.json
+++ b/content_schemas/dist/formats/worldwide_organisation/frontend/schema.json
@@ -131,10 +131,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/content_schemas/dist/formats/worldwide_organisation/notification/schema.json
+++ b/content_schemas/dist/formats/worldwide_organisation/notification/schema.json
@@ -149,10 +149,6 @@
           "description": "The organisation that published the original version of the page. Corresponds to the first of the 'Lead organisations' in Whitehall for the first edition, and is empty for all other publishing applications.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
-        "owning_organisations": {
-          "description": "Link type automatically added by Publishing API",
-          "$ref": "#/definitions/frontend_links_with_base_path"
-        },
         "parent": {
           "description": "The parent content item.",
           "$ref": "#/definitions/frontend_links_with_base_path",

--- a/lib/expansion_rules.rb
+++ b/lib/expansion_rules.rb
@@ -41,8 +41,7 @@ module_function
     %i[ordered_house_of_commons_whips role_appointments role],
     %i[ordered_junior_lords_of_the_treasury_whips role_appointments role],
     %i[ordered_military_personnel role_appointments role],
-    %i[ordered_ministerial_departments ordered_ministers role_appointments role owning_organisations],
-    # TODO: Remove the ordered_roles expansion once we're using the owning_organisations link above:
+    %i[ordered_ministerial_departments ordered_ministers role_appointments role],
     %i[ordered_ministerial_departments ordered_roles],
     %i[ordered_ministers role_appointments role],
     %i[office_staff role_appointments role],
@@ -69,7 +68,6 @@ module_function
     person: :role_appointments,
     role: :role_appointments,
     ministerial: :ministers,
-    ordered_roles: :owning_organisations,
   }.freeze
 
   # These fields are required by the frontend_links definition

--- a/lib/schema_generator/expanded_links.rb
+++ b/lib/schema_generator/expanded_links.rb
@@ -47,10 +47,6 @@ module SchemaGenerator
       # `Role` content items that are ministerial roles will automatically
       # have a `ministers` link type from the main `ministers` index page.
       "ministers" => "frontend_links",
-
-      # `Role` content items will automatically have an `owning_organisations` link
-      # which refers back to the organisations that the role belongs to.
-      "owning_organisations" => "frontend_links_with_base_path",
     }.freeze
 
     def initialize(format)


### PR DESCRIPTION
This approach doesn't work with current content store implementation so I'm reverting to avoid unnecessary link expansion

Reverts alphagov/publishing-api#3162