### PR TITLE
Add main facet key to finder schema

### DIFF
--- a/content_schemas/dist/formats/finder/frontend/schema.json
+++ b/content_schemas/dist/formats/finder/frontend/schema.json
@@ -454,6 +454,10 @@
             "description": "When set to true, the height of the option select facet will be larger",
             "type": "boolean"
           },
+          "main_facet_key": {
+            "description": "If this facet is a subfacet, a reference point back to the main facet.",
+            "type": "string"
+          },
           "name": {
             "description": "Label for the facet.",
             "type": "string"

--- a/content_schemas/dist/formats/finder/notification/schema.json
+++ b/content_schemas/dist/formats/finder/notification/schema.json
@@ -554,6 +554,10 @@
             "description": "When set to true, the height of the option select facet will be larger",
             "type": "boolean"
           },
+          "main_facet_key": {
+            "description": "If this facet is a subfacet, a reference point back to the main facet.",
+            "type": "string"
+          },
           "name": {
             "description": "Label for the facet.",
             "type": "string"

--- a/content_schemas/dist/formats/finder/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/finder/publisher_v2/schema.json
@@ -342,6 +342,10 @@
             "description": "When set to true, the height of the option select facet will be larger",
             "type": "boolean"
           },
+          "main_facet_key": {
+            "description": "If this facet is a subfacet, a reference point back to the main facet.",
+            "type": "string"
+          },
           "name": {
             "description": "Label for the facet.",
             "type": "string"

--- a/content_schemas/formats/shared/definitions/finder.jsonnet
+++ b/content_schemas/formats/shared/definitions/finder.jsonnet
@@ -207,6 +207,10 @@
             "topical"
           ],
         },
+        main_facet_key: {
+          description: "If this facet is a subfacet, a reference point back to the main facet.",
+          type: "string",
+        },
         sub_facet_key: {
           description: "The key field name used for the subcategory of this facet.",
           type: "string",


### PR DESCRIPTION
If the facet is a sub facet, add main facet key so frontend is able to render sub-facet views without having to do a look up of the related main facet.

https://trello.com/c/y9Wj7iHe/3501-nested-facets-changes-to-frontend-because-of-rendering-app-migration

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
