### PR TITLE
Return locale when fetching host content

### DIFF
--- a/app/controllers/v2/content_items_controller.rb
+++ b/app/controllers/v2/content_items_controller.rb
@@ -45,6 +45,7 @@ module V2
       results = GetHostContentItemService.new(
         path_params[:content_id],
         path_params[:host_content_id],
+        query_params[:locale],
       ).call
 
       render json: results

--- a/app/presenters/host_content_item_presenter.rb
+++ b/app/presenters/host_content_item_presenter.rb
@@ -21,6 +21,7 @@ module Presenters
         unique_pageviews: host_content.unique_pageviews,
         instances: host_content.instances,
         host_content_id: host_content.host_content_id,
+        host_locale: host_content.host_locale,
         primary_publishing_organisation: {
           content_id: host_content.primary_publishing_organisation_content_id,
           title: host_content.primary_publishing_organisation_title,

--- a/app/queries/get_host_content.rb
+++ b/app/queries/get_host_content.rb
@@ -64,9 +64,9 @@ module Queries
 
     ORDER_DIRECTIONS = %i[asc desc].freeze
 
-    attr_reader :target_content_id, :state, :order_field, :order_direction, :page, :per_page, :host_content_id
+    attr_reader :target_content_id, :state, :order_field, :order_direction, :page, :per_page, :host_content_id, :locale
 
-    def initialize(target_content_id, order_field: nil, order_direction: nil, page: nil, per_page: nil, host_content_id: nil)
+    def initialize(target_content_id, order_field: nil, order_direction: nil, page: nil, per_page: nil, host_content_id: nil, locale: nil)
       @target_content_id = target_content_id
       @state = "published"
       @order_direction = ORDER_DIRECTIONS.include?(order_direction || :asc) ? order_direction : raise(KeyError, "Unknown order direction: #{order_direction}")
@@ -74,6 +74,7 @@ module Queries
       @page = page || 0
       @per_page = per_page || DEFAULT_PER_PAGE
       @host_content_id = host_content_id
+      @locale = locale
     end
 
     def call
@@ -111,9 +112,9 @@ module Queries
       clauses = TABLES[:editions][:state].eq(state)
                                          .and(TABLES[:links][:link_type].eq(embedded_link_type))
                                          .and(TABLES[:links][:target_content_id].eq(target_content_id))
-      if host_content_id
-        clauses = clauses.and(TABLES[:documents][:content_id]).eq(host_content_id)
-      end
+
+      clauses = clauses.and(TABLES[:documents][:content_id]).eq(host_content_id) if host_content_id
+      clauses = clauses.and(TABLES[:documents][:locale]).eq(locale) if locale
 
       clauses
     end

--- a/app/queries/get_host_content.rb
+++ b/app/queries/get_host_content.rb
@@ -9,6 +9,7 @@ module Queries
       :last_edited_by_editor_id,
       :last_edited_at,
       :host_content_id,
+      :host_locale,
       :primary_publishing_organisation_content_id,
       :primary_publishing_organisation_title,
       :primary_publishing_organisation_base_path,
@@ -48,6 +49,7 @@ module Queries
       { field: TABLES[:org_editions][:base_path], alias: "primary_publishing_organisation_base_path", included_in_group?: true },
       { field: TABLES[:statistics_caches][:unique_pageviews], alias: "unique_pageviews", included_in_group?: true },
       { field: TABLES[:documents][:content_id], alias: "host_content_id", included_in_group?: true },
+      { field: TABLES[:documents][:locale], alias: "host_locale", included_in_group?: true },
       { field: TABLES[:editions][:id].count, alias: "instances", included_in_group?: false },
     ].freeze
 

--- a/app/services/get_host_content_item_service.rb
+++ b/app/services/get_host_content_item_service.rb
@@ -1,7 +1,8 @@
 class GetHostContentItemService
-  def initialize(target_content_id, host_content_id)
+  def initialize(target_content_id, host_content_id, locale = Edition::DEFAULT_LOCALE)
     @target_content_id = target_content_id
     @host_content_id = host_content_id
+    @locale = locale
   end
 
   def call
@@ -20,10 +21,10 @@ class GetHostContentItemService
 
 private
 
-  attr_accessor :target_content_id, :order, :page, :per_page, :host_content_id
+  attr_accessor :target_content_id, :order, :page, :per_page, :host_content_id, :locale
 
   def query
-    @query ||= Queries::GetHostContent.new(target_content_id, host_content_id:)
+    @query ||= Queries::GetHostContent.new(target_content_id, host_content_id:, locale:)
   end
 
   def results

--- a/docs/api.md
+++ b/docs/api.md
@@ -483,6 +483,11 @@ the target `:content_id`.
 - [`host_content_id`](model.md#content_id)
   - Identifies the document to return the metadata for
 
+### Query parameters
+
+- `locale` *(optional, default: "en")*
+  - An optional locale to filter by
+
 ## `PATCH /v2/links/:content_id`
 
 [Request/Response detail][patch-link-set-pact]

--- a/spec/integration/host_content_spec.rb
+++ b/spec/integration/host_content_spec.rb
@@ -94,6 +94,18 @@ RSpec.describe "Host content" do
 
       expect(response_body).to eq(host_edition_response)
     end
+
+    it "allows filtering by locale" do
+      get "/v2/content/#{content_block.content_id}/host-content/#{host_edition.content_id}?locale=en"
+      response_body = parsed_response
+
+      expect(response_body).to eq(host_edition_response)
+    end
+
+    it "returns 404 when not found in a given locale" do
+      get "/v2/content/#{content_block.content_id}/host-content/#{host_edition.content_id}?locale=cy"
+      expect(response.status).to eq(404)
+    end
   end
 
   context "when host content appears more than once in a field" do

--- a/spec/integration/host_content_spec.rb
+++ b/spec/integration/host_content_spec.rb
@@ -67,6 +67,7 @@ RSpec.describe "Host content" do
         "unique_pageviews" => statistics_cache.unique_pageviews,
         "instances" => 1,
         "host_content_id" => host_edition.content_id,
+        "host_locale" => host_edition.document.locale,
         "primary_publishing_organisation" => {
           "content_id" => publishing_organisation.content_id,
           "title" => publishing_organisation.title,

--- a/spec/presenters/host_content_item_presenter_spec.rb
+++ b/spec/presenters/host_content_item_presenter_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe Presenters::HostContentItemPresenter do
              last_edited_at:,
              unique_pageviews: 123,
              host_content_id:,
+             host_locale: "en",
              primary_publishing_organisation_content_id: organisation_edition_id,
              primary_publishing_organisation_title: "bar",
              primary_publishing_organisation_base_path: "/bar",
@@ -35,6 +36,7 @@ RSpec.describe Presenters::HostContentItemPresenter do
         unique_pageviews: 123,
         instances: 1,
         host_content_id: host_content_id,
+        host_locale: "en",
         primary_publishing_organisation: {
           content_id: organisation_edition_id,
           title: "bar",

--- a/spec/presenters/host_content_presenter_spec.rb
+++ b/spec/presenters/host_content_presenter_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe Presenters::HostContentPresenter do
               last_edited_at:,
               unique_pageviews: 123,
               host_content_id:,
+              host_locale: "en",
               primary_publishing_organisation_content_id: organisation_edition_id,
               primary_publishing_organisation_title: "bar",
               primary_publishing_organisation_base_path: "/bar",

--- a/spec/queries/get_host_content_spec.rb
+++ b/spec/queries/get_host_content_spec.rb
@@ -113,6 +113,18 @@ RSpec.describe Queries::GetHostContent do
         expect(results[0].primary_publishing_organisation_base_path).to eq(organisation.base_path)
         expect(results[0].instances).to eq(1)
       end
+
+      it "allows filtering by locale" do
+        host_edition = published_host_editions[1]
+
+        welsh_results = described_class.new(target_content_id, host_content_id: host_edition.content_id, locale: "cy").call
+
+        expect(welsh_results.count).to eq(0)
+
+        english_results = described_class.new(target_content_id, host_content_id: host_edition.content_id, locale: "en").call
+
+        expect(english_results.count).to eq(1)
+      end
     end
 
     context "when the content is embedded more than once" do

--- a/spec/queries/get_host_content_spec.rb
+++ b/spec/queries/get_host_content_spec.rb
@@ -87,6 +87,7 @@ RSpec.describe Queries::GetHostContent do
           expect(results[i].document_type).to eq(host_edition.document_type)
           expect(results[i].publishing_app).to eq(host_edition.publishing_app)
           expect(results[i].host_content_id).to eq(host_edition.content_id)
+          expect(results[i].host_locale).to eq(host_edition.document.locale)
           expect(results[i].primary_publishing_organisation_content_id).to eq(organisation.content_id)
           expect(results[i].primary_publishing_organisation_title).to eq(organisation.title)
           expect(results[i].primary_publishing_organisation_base_path).to eq(organisation.base_path)
@@ -114,7 +115,7 @@ RSpec.describe Queries::GetHostContent do
       end
     end
 
-    context "when the content id embedded more than once" do
+    context "when the content is embedded more than once" do
       before do
         create(:live_edition,
                details: {
@@ -131,6 +132,27 @@ RSpec.describe Queries::GetHostContent do
         results = described_class.new(target_content_id).call
 
         expect(results[0].instances).to eq(2)
+      end
+    end
+
+    context "when the edition is in a locale other than English" do
+      before do
+        create(:live_edition,
+               document: create(:document, locale: "cy"),
+               details: {
+                 body: "<p>{{embed:email_address:#{target_content_id}}}</p>\n",
+               },
+               links_hash: {
+                 primary_publishing_organisation: [organisation.content_id],
+                 embed: [target_content_id, target_content_id],
+               },
+               publishing_app: "example-app")
+      end
+
+      it "returns the locale" do
+        results = described_class.new(target_content_id).call
+
+        expect(results[0].host_locale).to eq("cy")
       end
     end
 

--- a/spec/services/get_host_content_item_service_spec.rb
+++ b/spec/services/get_host_content_item_service_spec.rb
@@ -44,6 +44,22 @@ RSpec.describe GetHostContentItemService do
 
         expect(Presenters::HostContentItemPresenter).to have_received(:present).with(result_stub)
       end
+
+      context "when a locale is specified" do
+        let(:locale) { "cy" }
+
+        before do
+          allow(Queries::GetHostContent).to receive(:new).with(target_content_id, host_content_id:, locale:).and_return(embedded_content_stub)
+        end
+
+        it "returns a presented form of the response from the query" do
+          result = described_class.new(target_content_id, host_content_id, locale).call
+
+          expect(result).to eq(result_stub)
+
+          expect(Presenters::HostContentItemPresenter).to have_received(:present).with(result_stub)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Trello card: https://trello.com/c/8SRwSAUh/968-bug-defer-payment-welsh-guide-preview-in-edit-journey-leads-to-server-error-published-state

When fetching host content, we will sometimes need to specify the locale (for example, when content is in Welsh). At the moment, if a document is only in Welsh, then we can’t generate a local preview in Content Block Manager.

We also need to update the `host-content` endpoint to optionally filter by locales, which will cover when a piece of content has multiple translations.