### PR TITLE
Add custom type for nested facet and additional sub_facets field

### DIFF
--- a/content_schemas/dist/formats/finder/frontend/schema.json
+++ b/content_schemas/dist/formats/finder/frontend/schema.json
@@ -399,7 +399,7 @@
             "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
             "type": "array",
             "items": {
-              "$ref": "#/definitions/label_value_pair"
+              "$ref": "#/definitions/label_value_pair_with_sub_facets"
             }
           },
           "closed_value": {
@@ -836,6 +836,44 @@
         "main_facet_value": {
           "description": "A value that refers to the main facet value of this facet if it is a sub facet. The value is used to group sub facets into sub category groupings for navigational purposes.",
           "type": "string"
+        },
+        "value": {
+          "description": "A value to use for form controls",
+          "type": "string"
+        }
+      }
+    },
+    "label_value_pair_with_sub_facets": {
+      "description": "One of many possible values a user can select from",
+      "type": "object",
+      "required": [
+        "label",
+        "value"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "default": {
+          "description": "The default option for a radio facet",
+          "type": "boolean"
+        },
+        "label": {
+          "description": "A human readable label",
+          "type": "string"
+        },
+        "main_facet_label": {
+          "description": "A label that refers to the main facet label of this facet if it is a sub facet. The label is used to generate sub facet labels on frontend apps.",
+          "type": "string"
+        },
+        "main_facet_value": {
+          "description": "A value that refers to the main facet value of this facet if it is a sub facet. The value is used to group sub facets into sub category groupings for navigational purposes.",
+          "type": "string"
+        },
+        "sub_facets": {
+          "description": "Possible values to show for non-dynamic select nested facets. All values are shown regardless of the search.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/label_value_pair"
+          }
         },
         "value": {
           "description": "A value to use for form controls",

--- a/content_schemas/dist/formats/finder/frontend/schema.json
+++ b/content_schemas/dist/formats/finder/frontend/schema.json
@@ -511,6 +511,7 @@
               "date",
               "hidden",
               "hidden_clearable",
+              "nested",
               "radio",
               "research_and_statistics",
               "official_documents",

--- a/content_schemas/dist/formats/finder/notification/schema.json
+++ b/content_schemas/dist/formats/finder/notification/schema.json
@@ -499,7 +499,7 @@
             "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
             "type": "array",
             "items": {
-              "$ref": "#/definitions/label_value_pair"
+              "$ref": "#/definitions/label_value_pair_with_sub_facets"
             }
           },
           "closed_value": {
@@ -949,6 +949,44 @@
         "main_facet_value": {
           "description": "A value that refers to the main facet value of this facet if it is a sub facet. The value is used to group sub facets into sub category groupings for navigational purposes.",
           "type": "string"
+        },
+        "value": {
+          "description": "A value to use for form controls",
+          "type": "string"
+        }
+      }
+    },
+    "label_value_pair_with_sub_facets": {
+      "description": "One of many possible values a user can select from",
+      "type": "object",
+      "required": [
+        "label",
+        "value"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "default": {
+          "description": "The default option for a radio facet",
+          "type": "boolean"
+        },
+        "label": {
+          "description": "A human readable label",
+          "type": "string"
+        },
+        "main_facet_label": {
+          "description": "A label that refers to the main facet label of this facet if it is a sub facet. The label is used to generate sub facet labels on frontend apps.",
+          "type": "string"
+        },
+        "main_facet_value": {
+          "description": "A value that refers to the main facet value of this facet if it is a sub facet. The value is used to group sub facets into sub category groupings for navigational purposes.",
+          "type": "string"
+        },
+        "sub_facets": {
+          "description": "Possible values to show for non-dynamic select nested facets. All values are shown regardless of the search.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/label_value_pair"
+          }
         },
         "value": {
           "description": "A value to use for form controls",

--- a/content_schemas/dist/formats/finder/notification/schema.json
+++ b/content_schemas/dist/formats/finder/notification/schema.json
@@ -611,6 +611,7 @@
               "date",
               "hidden",
               "hidden_clearable",
+              "nested",
               "radio",
               "research_and_statistics",
               "official_documents",

--- a/content_schemas/dist/formats/finder/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/finder/publisher_v2/schema.json
@@ -403,6 +403,7 @@
               "date",
               "hidden",
               "hidden_clearable",
+              "nested",
               "radio",
               "research_and_statistics",
               "official_documents",

--- a/content_schemas/dist/formats/finder/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/finder/publisher_v2/schema.json
@@ -291,7 +291,7 @@
             "description": "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
             "type": "array",
             "items": {
-              "$ref": "#/definitions/label_value_pair"
+              "$ref": "#/definitions/label_value_pair_with_sub_facets"
             }
           },
           "closed_value": {
@@ -602,6 +602,44 @@
         "main_facet_value": {
           "description": "A value that refers to the main facet value of this facet if it is a sub facet. The value is used to group sub facets into sub category groupings for navigational purposes.",
           "type": "string"
+        },
+        "value": {
+          "description": "A value to use for form controls",
+          "type": "string"
+        }
+      }
+    },
+    "label_value_pair_with_sub_facets": {
+      "description": "One of many possible values a user can select from",
+      "type": "object",
+      "required": [
+        "label",
+        "value"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "default": {
+          "description": "The default option for a radio facet",
+          "type": "boolean"
+        },
+        "label": {
+          "description": "A human readable label",
+          "type": "string"
+        },
+        "main_facet_label": {
+          "description": "A label that refers to the main facet label of this facet if it is a sub facet. The label is used to generate sub facet labels on frontend apps.",
+          "type": "string"
+        },
+        "main_facet_value": {
+          "description": "A value that refers to the main facet value of this facet if it is a sub facet. The value is used to group sub facets into sub category groupings for navigational purposes.",
+          "type": "string"
+        },
+        "sub_facets": {
+          "description": "Possible values to show for non-dynamic select nested facets. All values are shown regardless of the search.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/label_value_pair"
+          }
         },
         "value": {
           "description": "A value to use for form controls",

--- a/content_schemas/formats/shared/definitions/finder.jsonnet
+++ b/content_schemas/formats/shared/definitions/finder.jsonnet
@@ -199,6 +199,7 @@
             "date",
             "hidden",
             "hidden_clearable",
+            "nested",
             "radio",
             "research_and_statistics",
             "official_documents",

--- a/content_schemas/formats/shared/definitions/finder.jsonnet
+++ b/content_schemas/formats/shared/definitions/finder.jsonnet
@@ -228,7 +228,7 @@
           description: "Possible values to show for non-dynamic select facets. All values are shown regardless of the search.",
           type: "array",
           items: {
-            "$ref": "#/definitions/label_value_pair",
+            "$ref": "#/definitions/label_value_pair_with_sub_facets",
           },
         },
         option_lookup: {

--- a/content_schemas/formats/shared/definitions/label_value_pair_with_subfacets.jsonnet
+++ b/content_schemas/formats/shared/definitions/label_value_pair_with_subfacets.jsonnet
@@ -1,0 +1,40 @@
+{
+  label_value_pair_with_sub_facets: {
+    description: "One of many possible values a user can select from",
+    type: "object",
+    additionalProperties: false,
+    required: [
+      "label",
+      "value",
+    ],
+    properties: {
+      label: {
+        description: "A human readable label",
+        type: "string",
+      },
+      value: {
+        description: "A value to use for form controls",
+        type: "string",
+      },
+      main_facet_label: {
+        description: "A label that refers to the main facet label of this facet if it is a sub facet. The label is used to generate sub facet labels on frontend apps.",
+        type: "string",
+      },
+      main_facet_value: {
+        description: "A value that refers to the main facet value of this facet if it is a sub facet. The value is used to group sub facets into sub category groupings for navigational purposes.",
+        type: "string",
+      },
+      sub_facets: {
+        description: "Possible values to show for non-dynamic select nested facets. All values are shown regardless of the search.",
+        type: "array",
+        items: {
+          "$ref": "#/definitions/label_value_pair",
+        },
+      },
+      default: {
+        description: "The default option for a radio facet",
+        type: "boolean"
+      }
+    },
+  },
+}


### PR DESCRIPTION
Changes:
- introduce new type "nested" for nested facets
- re-introduce the `sub_facets` field
- temporarily duplicate `main_facet_label` and `main_facet_value` at both main and sub levels.

[Trello](https://trello.com/c/EeZOA3iW/3534-spike-replicating-taxons-approach-for-nested-facets)