### PR TITLE
Add job to delete old `Event` data

### DIFF
--- a/app/sidekiq/remove_old_events_job.rb
+++ b/app/sidekiq/remove_old_events_job.rb
@@ -1,0 +1,7 @@
+class RemoveOldEventsJob
+  include Sidekiq::Job
+
+  def perform
+    Event.where("created_at < ?", 30.days.ago).destroy_all
+  end
+end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -15,3 +15,5 @@
   :schedule:
     UpdateStatisticsCachesJob:
       cron: '30 2 * * *' # Runs at 2:30 a.m every day
+    RemoveOldEventsJob:
+      cron: '30 3 * * *' # Runs at 3:30 a.m every day

--- a/spec/sidekiq/remove_old_events_job_spec.rb
+++ b/spec/sidekiq/remove_old_events_job_spec.rb
@@ -1,0 +1,13 @@
+RSpec.describe RemoveOldEventsJob, :perform do
+  before do
+    @event_1 = create(:event, created_at: 31.days.ago)
+    @event_2 = create(:event, created_at: 29.days.ago)
+  end
+
+  it "deletes only records older than 30 days" do
+    described_class.new.perform
+
+    expect { @event_1.reload }.to raise_error(ActiveRecord::RecordNotFound)
+    expect(@event_2.reload).to be_present
+  end
+end


### PR DESCRIPTION
According to the [documentation](https://github.com/alphagov/publishing-api/blob/bdf8c1ddda898df1fb2f2e68102f63c2a4e2ac47/docs/model.md?plain=1#L238-L240), the `Event` model contains data solely for debugging by developers.

The table has been growing in size recently since the task to export data to S3 broke and was subsequently switched off in https://github.com/alphagov/govuk-helm-charts/pull/2448.

Therefore adding a new lightweight task to delete `Event` records that are older than 30 days.

[Trello card](https://trello.com/c/Kfr9IjDX)