### PR TITLE
Bump content_block_tools from 0.4.5 to 0.4.6

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -119,7 +119,7 @@ GEM
     climate_control (1.2.0)
     concurrent-ruby (1.3.5)
     connection_pool (2.5.0)
-    content_block_tools (0.4.5)
+    content_block_tools (0.4.6)
       actionview (>= 6)
     crack (1.0.0)
       bigdecimal


### PR DESCRIPTION
Bumps content_block_tools from 0.4.5 to 0.4.6 (remove noisy logs) https://github.com/alphagov/govuk_content_block_tools/pull/25 

---
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
