### PR TITLE
Add missing schema_name to corporate_information_page examples

### DIFF
--- a/content_schemas/examples/corporate_information_page/frontend/corporate_information_page.json
+++ b/content_schemas/examples/corporate_information_page/frontend/corporate_information_page.json
@@ -134,6 +134,7 @@
         "web_url": "https://www.gov.uk/government/organisations/department-of-health",
         "locale": "en",
         "analytics_identifier": "D12",
+        "schema_name": "organisation",
         "details": {
           "brand": "department-of-health",
           "logo": {

--- a/content_schemas/examples/corporate_information_page/frontend/corporate_information_page_complaints.json
+++ b/content_schemas/examples/corporate_information_page/frontend/corporate_information_page_complaints.json
@@ -29,6 +29,7 @@
         "web_url": "https://www.gov.uk/government/organisations/department-of-health",
         "locale": "en",
         "analytics_identifier": "D12",
+        "schema_name": "organisation",
         "details": {
           "brand": "department-of-health",
           "logo": {

--- a/content_schemas/examples/corporate_information_page/frontend/corporate_information_page_media.json
+++ b/content_schemas/examples/corporate_information_page/frontend/corporate_information_page_media.json
@@ -29,6 +29,7 @@
         "web_url": "https://www.gov.uk/government/organisations/department-of-health",
         "locale": "en",
         "analytics_identifier": "D12",
+        "schema_name": "organisation",
         "details": {
           "brand": "department-of-health",
           "logo": {

--- a/content_schemas/examples/corporate_information_page/frontend/corporate_information_page_translated_custom_logo.json
+++ b/content_schemas/examples/corporate_information_page/frontend/corporate_information_page_translated_custom_logo.json
@@ -29,6 +29,7 @@
         "web_url": "https://www.gov.uk/government/organisations/land-registry",
         "locale": "en",
         "analytics_identifier": "D69",
+        "schema_name": "organisation",
         "details": {
           "brand": "department-for-business-innovation-skills",
           "logo": {

--- a/content_schemas/examples/corporate_information_page/frontend/corporate_information_page_without_description.json
+++ b/content_schemas/examples/corporate_information_page/frontend/corporate_information_page_without_description.json
@@ -29,6 +29,7 @@
         "web_url": "https://www.gov.uk/government/organisations/department-of-health",
         "locale": "en",
         "analytics_identifier": "D12",
+        "schema_name": "organisation",
         "details": {
           "brand": "department-of-health",
           "logo": {


### PR DESCRIPTION
This was missing from the examples and is needed as part of https://github.com/alphagov/frontend/pull/4608

Trello card: https://trello.com/c/EKDXTDsm/398-move-document-type-corporateinformationpage-from-government-frontend-to-frontend

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
