### PR TITLE
Remove `EVENT_LOG_AWS_BUCKETNAME` environment variable

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -113,11 +113,6 @@ module PublishingAPI
       zh-tw
     ]
 
-    config.s3_export = OpenStruct.new(
-      bucket: ENV["EVENT_LOG_AWS_BUCKETNAME"],
-      events_key_prefix: "events/",
-    )
-
     # This also configures session_options for use below
     config.session_store :cookie_store, key: "_interslice_session"
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -40,7 +40,6 @@ Rails.application.configure do
   # Raises error for missing translations.
   # config.i18n.raise_on_missing_translations = true
 
-  config.s3_export.bucket = "test-publishing-api"
   # Annotate rendered view with file names.
   # config.action_view.annotate_rendered_view_with_filenames = true
 


### PR DESCRIPTION
The code that uses this environment variable was removed in https://github.com/alphagov/publishing-api/pull/3204, therefore the environment variable itself can now be deleted.