### PR TITLE
Add configuration for read replica

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,6 +7,13 @@ inherit_mode:
   merge:
     - Exclude
 
+Rails/UnknownEnv:
+  Environments:
+    - development
+    - test
+    - production
+    - production_replica
+
 # **************************************************************
 # TRY NOT TO ADD OVERRIDES IN THIS FILE
 #

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,3 +1,10 @@
 class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
+
+  if Rails.env.production_replica?
+    connects_to database: {
+      writing: :primary,
+      reading: :primary_replica,
+    }
+  end
 end

--- a/config/database.yml
+++ b/config/database.yml
@@ -16,4 +16,11 @@ test:
 
 production:
   <<: *default
-  # Rails reads values from DATABASE_URL env var.
+
+production_replica:
+  primary:
+    <<: *default
+  primary_replica:
+    <<: *default
+    url: <%= ENV["REPLICA_DATABASE_URL"] %>
+    replica: true

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -29,3 +29,6 @@ test:
 # and move the `production:` environment over there.
 production:
   secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
+
+production_replica:
+  secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>


### PR DESCRIPTION
The read replica is a separate deployment of this application, which connects to both the primary database (e.g. for writing user records after authentication) and the replica database (for all reads).

Toggling of the application is done by changing the `RAILS_ENV` environment variable from `production` to `production_replica`.

This was developed based on the guide "[Multiple Databases with Active Record](https://guides.rubyonrails.org/active_record_multiple_databases.html)".

Whilst authentication was removed from GraphQL requests in https://github.com/alphagov/publishing-api/pull/3220, I am leaving the connection to the primary database in the replica, since we may wish to authenticate other requests in the future.

Depends on https://github.com/alphagov/govuk-helm-charts/pull/3077.

[Trello card](https://trello.com/c/8QZKAla1)