### PR TITLE
Do not authenticate GraphQL requests

### DIFF
--- a/app/controllers/graphql_controller.rb
+++ b/app/controllers/graphql_controller.rb
@@ -6,6 +6,8 @@ class GraphqlController < ApplicationController
   # but you'll have to authenticate your user separately
   # protect_from_forgery with: :null_session
 
+  skip_before_action :authenticate_user!, only: [:execute]
+
   def execute
     variables = prepare_variables(params[:variables])
     query = params[:query]


### PR DESCRIPTION
Publishing API is only available internally within our infrastructure and can only return  data we make available through that endpoint.

Therefore removing the authentication of read requests for GraphQL only. This matches [the same behaviour](https://github.com/alphagov/content-store/blob/2a77ee211152ff44b38613d6f61194ce93b01062/app/controllers/content_items_controller.rb#L2) we have in Content Store for returning content items.

With regards to the performance of the read replica, authenticating every request will result in data being read/written to the primary (non-replica) database for each request (e.g. user permissions).

[Trello card](https://trello.com/c/8QZKAla1)