### PR TITLE
Update examples to remove rendering app from moved formats

### DIFF
--- a/content_schemas/examples/get_involved/frontend/get_involved.json
+++ b/content_schemas/examples/get_involved/frontend/get_involved.json
@@ -9,7 +9,6 @@
   "public_updated_at": "2021-10-29T12:29:28.000+00:00",
   "publishing_app": "whitehall",
   "publishing_scheduled_at": null,
-  "rendering_app": "government-frontend",
   "scheduled_publishing_delay_seconds": null,
   "schema_name": "get_involved",
   "title": "Get involved",

--- a/content_schemas/examples/help_page/frontend/about-govuk.json
+++ b/content_schemas/examples/help_page/frontend/about-govuk.json
@@ -187,7 +187,6 @@
   "publishing_app": "publisher",
   "publishing_request_id": "21-1695825958.174-10.13.21.25-10471",
   "publishing_scheduled_at": null,
-  "rendering_app": "government-frontend",
   "scheduled_publishing_delay_seconds": null,
   "schema_name": "help_page",
   "title": "About GOV.UK",

--- a/content_schemas/examples/help_page/frontend/cookie-details.json
+++ b/content_schemas/examples/help_page/frontend/cookie-details.json
@@ -160,7 +160,6 @@
   "publishing_app": "publisher",
   "publishing_request_id": "21-1726665231.794-10.13.22.107-15684",
   "publishing_scheduled_at": null,
-  "rendering_app": "government-frontend",
   "scheduled_publishing_delay_seconds": null,
   "schema_name": "help_page",
   "title": "Details about cookies on GOV.UK",

--- a/content_schemas/examples/help_page/frontend/help_page.json
+++ b/content_schemas/examples/help_page/frontend/help_page.json
@@ -8,7 +8,6 @@
   "phase": "live",
   "public_updated_at": "2014-12-16T12:49:50.000+00:00",
   "publishing_app": "publisher",
-  "rendering_app": "frontend",
   "schema_name": "help_page",
   "title": "Cookies",
   "updated_at": "2017-01-30T12:30:33.483Z",

--- a/content_schemas/examples/speech/frontend/best-practice-oral-statement.json
+++ b/content_schemas/examples/speech/frontend/best-practice-oral-statement.json
@@ -8,7 +8,6 @@
   "phase": "live",
   "public_updated_at": "2014-04-30T11:59:35.000+00:00",
   "publishing_app": "whitehall",
-  "rendering_app": "government-frontend",
   "schema_name": "speech",
   "title": "Reform of police stop and search powers",
   "updated_at": "2018-01-10T12:50:20.248Z",

--- a/content_schemas/examples/speech/frontend/best-practice-speaking-notes.json
+++ b/content_schemas/examples/speech/frontend/best-practice-speaking-notes.json
@@ -8,7 +8,6 @@
   "phase": "live",
   "public_updated_at": "2012-05-22T00:00:00.000+00:00",
   "publishing_app": "whitehall",
-  "rendering_app": "government-frontend",
   "schema_name": "speech",
   "title": "Lord McNally’s speaking note for Westminster Legal Policy Forum event",
   "updated_at": "2018-01-10T12:36:48.656Z",

--- a/content_schemas/examples/speech/frontend/best-practice-written-statement.json
+++ b/content_schemas/examples/speech/frontend/best-practice-written-statement.json
@@ -8,7 +8,6 @@
   "phase": "live",
   "public_updated_at": "2014-04-01T08:55:00.000+00:00",
   "publishing_app": "whitehall",
-  "rendering_app": "government-frontend",
   "schema_name": "speech",
   "title": "Glasgow 2014 Commonwealth Games airspace restrictions",
   "updated_at": "2018-01-10T14:07:43.544Z",

--- a/content_schemas/examples/travel_advice/frontend/alt-country.json
+++ b/content_schemas/examples/travel_advice/frontend/alt-country.json
@@ -8,7 +8,6 @@
   "phase": "live",
   "public_updated_at": "2017-02-14T15:33:43.000+00:00",
   "publishing_app": "travel-advice-publisher",
-  "rendering_app": "government-frontend",
   "schema_name": "travel_advice",
   "title": "Turkey travel advice",
   "updated_at": "2017-02-17T12:52:44.142Z",

--- a/content_schemas/examples/travel_advice/frontend/full-country-without-summary.json
+++ b/content_schemas/examples/travel_advice/frontend/full-country-without-summary.json
@@ -8,7 +8,6 @@
   "phase": "live",
   "public_updated_at": "2017-02-14T15:42:21.000+00:00",
   "publishing_app": "travel-advice-publisher",
-  "rendering_app": "government-frontend",
   "schema_name": "travel_advice",
   "title": "Albania travel advice",
   "updated_at": "2017-02-17T12:52:43.537Z",

--- a/content_schemas/examples/travel_advice/frontend/full-country.json
+++ b/content_schemas/examples/travel_advice/frontend/full-country.json
@@ -8,7 +8,6 @@
   "phase": "live",
   "public_updated_at": "2017-02-14T15:42:21.000+00:00",
   "publishing_app": "travel-advice-publisher",
-  "rendering_app": "government-frontend",
   "schema_name": "travel_advice",
   "title": "Albania travel advice",
   "updated_at": "2017-02-17T12:52:43.537Z",

--- a/content_schemas/examples/travel_advice/frontend/withdrawn-full-country.json
+++ b/content_schemas/examples/travel_advice/frontend/withdrawn-full-country.json
@@ -8,7 +8,6 @@
   "phase": "live",
   "public_updated_at": "2017-02-14T15:42:21.000+00:00",
   "publishing_app": "travel-advice-publisher",
-  "rendering_app": "government-frontend",
   "schema_name": "travel_advice",
   "title": "Albania travel advice",
   "updated_at": "2017-02-17T12:52:43.537Z",


### PR DESCRIPTION
- In general, the frontend examples (which are used in test suites) don't actually need to include rendering app. Some examples have it, some don't. So we can remove it from those examples where the rendering app has recently changed - we could alternatively have updated them, but since the info isn't actually necessary, it seems simpler to just remove it entirely.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
