### PR TITLE
content-modelling/ refactor embedded editions

### DIFF
--- a/app/presenters/content_embed_presenter.rb
+++ b/app/presenters/content_embed_presenter.rb
@@ -43,8 +43,10 @@ module Presenters
         value.each do |nested_key, nested_value|
           value[nested_key] = convert_field(nested_value)
         end
-      else
+      when String
         render_embedded_editions(value)
+      else
+        value
       end
     end
 

--- a/app/queries/get_embedded_editions_from_host_edition.rb
+++ b/app/queries/get_embedded_editions_from_host_edition.rb
@@ -1,0 +1,18 @@
+module Queries
+  class GetEmbeddedEditionsFromHostEdition
+    def self.call(edition:)
+      Edition.with_document
+                              .where(
+                                documents: {
+                                  content_id: edition.links.where(link_type:).pluck(:target_content_id),
+                                },
+                              )
+                              .where(Edition.arel_table[:state].eq("published"))
+                              .index_by(&:content_id)
+    end
+
+    def self.link_type
+      "embed"
+    end
+  end
+end

--- a/spec/presenters/content_embed_presenter_spec.rb
+++ b/spec/presenters/content_embed_presenter_spec.rb
@@ -214,51 +214,6 @@ RSpec.describe Presenters::ContentEmbedPresenter do
         end
       end
 
-      context "when the embedded content is available in multiple locales" do
-        let(:details) { { body: "some string with a reference: {{embed:contact:#{embedded_content_id}}}" } }
-
-        let!(:welsh_edition) do
-          embedded_document = create(:document, content_id: embedded_content_id, locale: "cy")
-          create(
-            :edition,
-            document: embedded_document,
-            state: "published",
-            content_store: "live",
-            document_type: "contact",
-            title: "WELSH",
-          )
-        end
-
-        context "when the document is in the default language" do
-          it "returns embedded content references with values from the same language" do
-            expect(described_class.new(edition).render_embedded_content(details)).to eq({
-              body: "some string with a reference: #{expected_value}",
-            })
-          end
-        end
-
-        context "when the document is in an available locale" do
-          let(:document) { create(:document, locale: "cy") }
-          let(:embedded_edition) { welsh_edition }
-
-          it "returns embedded content references with values from the same language" do
-            expect(described_class.new(edition).render_embedded_content(details)).to eq({
-              body: "some string with a reference: #{expected_value}",
-            })
-          end
-        end
-
-        context "when the document is in an unavailable locale" do
-          let(:document) { create(:document, locale: "fr") }
-
-          it "returns embedded content references with values from the default language" do
-            expect(described_class.new(edition).render_embedded_content(details)).to eq({
-              body: "some string with a reference: #{expected_value}",
-            })
-          end
-        end
-      end
-
       context "when multiple documents are embedded in different parts of the document" do
         let(:other_embedded_content_id) { SecureRandom.uuid }
         let(:other_embed_code) { "{{embed:contact:#{other_embedded_content_id}}}" }

--- a/spec/queries/get_embedded_editions_from_host_edition_spec.rb
+++ b/spec/queries/get_embedded_editions_from_host_edition_spec.rb
@@ -1,0 +1,45 @@
+RSpec.describe Queries::GetEmbeddedEditionsFromHostEdition do
+  describe ".call" do
+    let(:embedded_content_id) { SecureRandom.uuid }
+    let(:host_edition) do
+      create(:live_edition,
+             details: {
+               body: "<p>{{embed:email_address:#{embedded_content_id}}}</p>\n",
+             },
+             links_hash: {
+               embed: [embedded_content_id],
+             })
+    end
+
+    let(:block_document) do
+      create(:document, content_id: embedded_content_id)
+    end
+
+    let!(:content_block) do
+      create(:live_edition,
+             document: block_document,
+             document_type: "content_block_email_address",
+             schema_name: "content_block_email_address",
+             details: {
+               "email_address" => "foo@example.com",
+             })
+    end
+
+    let!(:draft_content_block) do
+      create(:draft_edition,
+             document: block_document,
+             user_facing_version: 2,
+             document_type: "content_block_email_address",
+             schema_name: "content_block_email_address",
+             details: {
+               "email_address" => "another@example.com",
+             })
+    end
+
+    context "when there are live and draft embedded editions" do
+      it "returns embedded editions" do
+        expect(described_class.call(edition: host_edition)).to eq({ embedded_content_id => content_block })
+      end
+    end
+  end
+end


### PR DESCRIPTION
https://trello.com/c/UwDgEDMN/970-bug-tech-debt-inefficient-embed-searching

When looking at optimising our embedded editions process, I noticed that we are using quite a complicated set of
db queries to get the embedded editions from a host edition - as the GraphQL team are looking to reduce queries [1] I thought I would take a look. 

This new  query I think improves things:
1. If I've worked it out right, this makes one less call to db
2. It's much simpler and I've removed the logic around locale and state - for embedded editions we only have `en` and we only ever want `published`editions. This might change in the future, but seems like the simpler we can keep things for now the better.

This will only affect calls where embed codes have been found, so won't make much of a difference now, but should still be a bit of an improvement if we ever scale to 100's of embeds!

[1] https://trello.com/c/ilVC6hCV


---
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
