### PR TITLE
Add JSON route for find-local-council

### DIFF
--- a/lib/data/special_routes.yaml
+++ b/lib/data/special_routes.yaml
@@ -26,6 +26,13 @@
   :type: "prefix"
   :rendering_app: "content-store"
 
+- :base_path: "/api/local-authority"
+  :content_id: "941aa7c4-1acb-4a5c-95f4-d39eb64a902b"
+  :title: "Local Authority API"
+  :description: "API version of /find-local-council for app use"
+  :type: "prefix"
+  :rendering_app: "frontend"
+
 - :base_path: "/api/personalisation/check-email-subscription"
   :content_id: "f8f91a56-2298-4365-9590-d7e80fe8c066"
   :title: "Account API - Check email Subscription"


### PR DESCRIPTION
Adds the /api/local-authority path on frontend as a special route.

https://trello.com/c/YX1VcZj0/335-create-json-endpoint-version-of-find-local-council-for-app

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
