### PR TITLE
Remove main facet label and value

### DIFF
--- a/content_schemas/dist/formats/finder/frontend/schema.json
+++ b/content_schemas/dist/formats/finder/frontend/schema.json
@@ -860,14 +860,6 @@
           "description": "A human readable label",
           "type": "string"
         },
-        "main_facet_label": {
-          "description": "A label that refers to the main facet label of this facet if it is a sub facet. The label is used to generate sub facet labels on frontend apps.",
-          "type": "string"
-        },
-        "main_facet_value": {
-          "description": "A value that refers to the main facet value of this facet if it is a sub facet. The value is used to group sub facets into sub category groupings for navigational purposes.",
-          "type": "string"
-        },
         "sub_facets": {
           "description": "Possible values to show for non-dynamic select nested facets. All values are shown regardless of the search.",
           "type": "array",

--- a/content_schemas/dist/formats/finder/notification/schema.json
+++ b/content_schemas/dist/formats/finder/notification/schema.json
@@ -973,14 +973,6 @@
           "description": "A human readable label",
           "type": "string"
         },
-        "main_facet_label": {
-          "description": "A label that refers to the main facet label of this facet if it is a sub facet. The label is used to generate sub facet labels on frontend apps.",
-          "type": "string"
-        },
-        "main_facet_value": {
-          "description": "A value that refers to the main facet value of this facet if it is a sub facet. The value is used to group sub facets into sub category groupings for navigational purposes.",
-          "type": "string"
-        },
         "sub_facets": {
           "description": "Possible values to show for non-dynamic select nested facets. All values are shown regardless of the search.",
           "type": "array",

--- a/content_schemas/dist/formats/finder/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/finder/publisher_v2/schema.json
@@ -626,14 +626,6 @@
           "description": "A human readable label",
           "type": "string"
         },
-        "main_facet_label": {
-          "description": "A label that refers to the main facet label of this facet if it is a sub facet. The label is used to generate sub facet labels on frontend apps.",
-          "type": "string"
-        },
-        "main_facet_value": {
-          "description": "A value that refers to the main facet value of this facet if it is a sub facet. The value is used to group sub facets into sub category groupings for navigational purposes.",
-          "type": "string"
-        },
         "sub_facets": {
           "description": "Possible values to show for non-dynamic select nested facets. All values are shown regardless of the search.",
           "type": "array",

--- a/content_schemas/formats/shared/definitions/label_value_pair_with_subfacets.jsonnet
+++ b/content_schemas/formats/shared/definitions/label_value_pair_with_subfacets.jsonnet
@@ -16,14 +16,6 @@
         description: "A value to use for form controls",
         type: "string",
       },
-      main_facet_label: {
-        description: "A label that refers to the main facet label of this facet if it is a sub facet. The label is used to generate sub facet labels on frontend apps.",
-        type: "string",
-      },
-      main_facet_value: {
-        description: "A value that refers to the main facet value of this facet if it is a sub facet. The value is used to group sub facets into sub category groupings for navigational purposes.",
-        type: "string",
-      },
       sub_facets: {
         description: "Possible values to show for non-dynamic select nested facets. All values are shown regardless of the search.",
         type: "array",


### PR DESCRIPTION
This commit follows a series of changes that introduced `sub_facets` in the "top level" facet allowed values. Thus, the `main_facet_label` and `main_facet_value` can only exists within the `sub_facet`.

Previous commits expanded the schema so that `main_facet_label` and `main_facet_value` existed where available both in `label_value_pair.jsonnet` and `label_value_pair_with_subfacets.jsonnet`, so that Specialist Publisher changes can go through. Now we're contracting the schema to only allow those labels/values where we need them, as part of the nested `sub_facets` field.


See relevant ticket [here](https://trello.com/c/EeZOA3iW/3534-spike-replicating-taxons-approach-for-nested-facets).