### PR TITLE
Support empty change history in GraphQL

### DIFF
--- a/app/presenters/change_history_presenter.rb
+++ b/app/presenters/change_history_presenter.rb
@@ -28,7 +28,7 @@ module Presenters
     def change_notes
       ChangeNote
         .joins(:edition)
-        .where(editions: { document: })
+        .where(editions: { document: edition.document_id })
         .where("user_facing_version <= ?", version_number)
         .where.not(public_timestamp: nil)
         .order(:public_timestamp)
@@ -36,10 +36,6 @@ module Presenters
 
     def version_number
       edition.user_facing_version
-    end
-
-    def document
-      edition.document
     end
   end
 end

--- a/app/presenters/change_history_presenter.rb
+++ b/app/presenters/change_history_presenter.rb
@@ -29,13 +29,9 @@ module Presenters
       ChangeNote
         .joins(:edition)
         .where(editions: { document: edition.document_id })
-        .where("user_facing_version <= ?", version_number)
+        .where("user_facing_version <= ?", edition.user_facing_version)
         .where.not(public_timestamp: nil)
         .order(:public_timestamp)
-    end
-
-    def version_number
-      edition.user_facing_version
     end
   end
 end

--- a/lib/graphql_selections.rb
+++ b/lib/graphql_selections.rb
@@ -63,6 +63,8 @@ class GraphqlSelections
       database_selections.insert(table, columns)
     end
 
+    database_selections.insert(:editions, %i[document_id user_facing_version])
+
     database_selections
   end
 

--- a/spec/lib/graphql_selections_spec.rb
+++ b/spec/lib/graphql_selections_spec.rb
@@ -1,11 +1,17 @@
 RSpec.describe GraphqlSelections do
   describe ".with_edition_fields" do
+    it "always includes selections necessary for fetching change notes from the database" do
+      selections = GraphqlSelections.with_edition_fields([])
+
+      expect(selections.to_h).to eq({ editions: %i[document_id user_facing_version] })
+    end
+
     it "nests the editions selections under `editions`" do
       selections = GraphqlSelections.with_edition_fields(
         %i[id base_path],
       )
 
-      expect(selections.to_h).to eq({ editions: %i[base_path id] })
+      expect(selections.to_h).to eq({ editions: %i[base_path id document_id user_facing_version] })
     end
 
     it "resolves field names that aren't database columns" do
@@ -14,7 +20,7 @@ RSpec.describe GraphqlSelections do
       )
 
       expect(selections.to_h).to eq({
-        editions: %i[base_path],
+        editions: %i[base_path document_id user_facing_version],
         documents: %i[content_id],
       })
     end
@@ -25,7 +31,7 @@ RSpec.describe GraphqlSelections do
       )
 
       expect(selections.to_h).to eq({
-        editions: %i[id content_store],
+        editions: %i[id content_store document_id user_facing_version],
       })
     end
 
@@ -34,7 +40,7 @@ RSpec.describe GraphqlSelections do
         %i[id withdrawn_notice],
       )
 
-      expect(selections.to_h).to eq({ editions: %i[id] })
+      expect(selections.to_h).to eq({ editions: %i[id document_id user_facing_version] })
     end
   end
 
@@ -45,7 +51,7 @@ RSpec.describe GraphqlSelections do
       )
 
       expect(selections.to_h).to eq({
-        editions: %i[id document_type],
+        editions: %i[id document_id user_facing_version document_type],
         documents: %i[content_id],
       })
     end
@@ -56,7 +62,7 @@ RSpec.describe GraphqlSelections do
       )
 
       expect(selections.to_h).to eq({
-        editions: %i[base_path document_type],
+        editions: %i[base_path document_id user_facing_version document_type],
         unpublishings: [
           "created_at AS unpublishing_created_at",
           "explanation AS unpublishing_explanation",
@@ -72,7 +78,7 @@ RSpec.describe GraphqlSelections do
       )
 
       expect(selections.to_h).to eq({
-        editions: %i[id content_store document_type],
+        editions: %i[id content_store document_id user_facing_version document_type],
         documents: %i[content_id locale],
       })
     end


### PR DESCRIPTION
[Trello](https://trello.com/c/UcUg1Wdb/1635-re-support-change-histories-for-editions-with-no-change-notes)

When requesting the change history from an edition's details field for an edition with no change notes using GraphQL, a 500 error occurs. This is due to our work to eager load associations and reduce selected database columns. Here we select a couple of new columns to support an additional database query in `ChangeHistoryPresenter`, thereby fixing the problem

This issue didn't affect any existing frontend GraphQL queries, but it was a reduction in support from before the database selections work