### PR TITLE
Make the metadata block on specialist documents optional

### DIFF
--- a/content_schemas/dist/formats/finder/frontend/schema.json
+++ b/content_schemas/dist/formats/finder/frontend/schema.json
@@ -346,6 +346,9 @@
         "reject": {
           "$ref": "#/definitions/finder_reject_filter"
         },
+        "show_metadata_block": {
+          "$ref": "#/definitions/finder_show_metadata_block"
+        },
         "show_summaries": {
           "$ref": "#/definitions/finder_show_summaries"
         },
@@ -617,6 +620,9 @@
           }
         }
       }
+    },
+    "finder_show_metadata_block": {
+      "type": "boolean"
     },
     "finder_show_summaries": {
       "type": "boolean"

--- a/content_schemas/dist/formats/finder/notification/schema.json
+++ b/content_schemas/dist/formats/finder/notification/schema.json
@@ -446,6 +446,9 @@
         "reject": {
           "$ref": "#/definitions/finder_reject_filter"
         },
+        "show_metadata_block": {
+          "$ref": "#/definitions/finder_show_metadata_block"
+        },
         "show_summaries": {
           "$ref": "#/definitions/finder_show_summaries"
         },
@@ -717,6 +720,9 @@
           }
         }
       }
+    },
+    "finder_show_metadata_block": {
+      "type": "boolean"
     },
     "finder_show_summaries": {
       "type": "boolean"

--- a/content_schemas/dist/formats/finder/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/finder/publisher_v2/schema.json
@@ -238,6 +238,9 @@
         "reject": {
           "$ref": "#/definitions/finder_reject_filter"
         },
+        "show_metadata_block": {
+          "$ref": "#/definitions/finder_show_metadata_block"
+        },
         "show_summaries": {
           "$ref": "#/definitions/finder_show_summaries"
         },
@@ -509,6 +512,9 @@
           }
         }
       }
+    },
+    "finder_show_metadata_block": {
+      "type": "boolean"
     },
     "finder_show_summaries": {
       "type": "boolean"

--- a/content_schemas/examples/specialist_document/frontend/countryside-stewardship-grants.json
+++ b/content_schemas/examples/specialist_document/frontend/countryside-stewardship-grants.json
@@ -315,7 +315,8 @@
                 }
               ]
             }
-          ]
+          ],
+          "show_metadata_block": true
         },
         "links": {
         },

--- a/content_schemas/examples/specialist_document/frontend/drug-device-alerts.json
+++ b/content_schemas/examples/specialist_document/frontend/drug-device-alerts.json
@@ -315,7 +315,8 @@
               "display_as_result_metadata": true,
               "filterable": true
             }
-          ]
+          ],
+          "show_metadata_block": true
         },
         "links": {
         },

--- a/content_schemas/formats/finder.jsonnet
+++ b/content_schemas/formats/finder.jsonnet
@@ -64,6 +64,9 @@
         show_summaries: {
           "$ref": "#/definitions/finder_show_summaries",
         },
+        show_metadata_block: {
+          "$ref": "#/definitions/finder_show_metadata_block",
+        },
         signup_link: {
           "$ref": "#/definitions/finder_signup_link",
         },

--- a/content_schemas/formats/shared/definitions/finder.jsonnet
+++ b/content_schemas/formats/shared/definitions/finder.jsonnet
@@ -275,6 +275,9 @@
   finder_show_summaries: {
     type: "boolean",
   },
+  finder_show_metadata_block: {
+    type: "boolean",
+  },
   finder_signup_link: {
     anyOf: [
       {

--- a/lib/expansion_rules.rb
+++ b/lib/expansion_rules.rb
@@ -99,7 +99,7 @@ module_function
   ORGANISATION_FIELDS = (DEFAULT_FIELDS - [:public_updated_at] + details_fields(:acronym, :logo, :brand, :default_news_image, :organisation_govuk_status)).freeze
   TAXON_FIELDS = (DEFAULT_FIELDS + %i[description details phase]).freeze
   NEED_FIELDS = (DEFAULT_FIELDS + details_fields(:role, :goal, :benefit, :met_when, :justifications)).freeze
-  FINDER_FIELDS = (DEFAULT_FIELDS + details_fields(:facets)).freeze
+  FINDER_FIELDS = (DEFAULT_FIELDS + details_fields(:facets, :show_metadata_block)).freeze
   FATALITY_NOTICE_FIELDS = (DEFAULT_FIELDS + details_fields(:roll_call_introduction, :casualties))
   HISTORIC_APPOINTMENT_FIELDS = (DEFAULT_FIELDS + details_fields(:political_party, :dates_in_office))
   MINISTERIAL_ROLE_FIELDS = (DEFAULT_FIELDS + details_fields(:body, :role_payment_type, :seniority, :whip_organisation)).freeze

--- a/spec/lib/expansion_rules_spec.rb
+++ b/spec/lib/expansion_rules_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe ExpansionRules do
     let(:default_fields_and_description) { default_fields + %i[description] }
     let(:need_fields) { default_fields + [%i[details role], %i[details goal], %i[details benefit], %i[details met_when], %i[details justifications]] }
     let(:fatality_notice_fields) { default_fields + [%i[details roll_call_introduction], %i[details casualties]] }
-    let(:finder_fields) { default_fields + [%i[details facets]] }
+    let(:finder_fields) { default_fields + [%i[details facets], %i[details show_metadata_block]] }
     let(:historic_appointment_fields) { default_fields + [%i[details political_party], %i[details dates_in_office]] }
     let(:ministerial_role_fields) { role_fields + [%i[details seniority], %i[details whip_organisation]] }
     let(:person_fields) { default_fields + [%i[details body], %i[details image]] }


### PR DESCRIPTION
These change is necessary to make the rendering the blue metadata box at the top of specialist documents dependent on a value defined in the schema of each finder.

**Associated PRs**

1. [Government-Frontend](https://github.com/alphagov/government-frontend/pull/3639)
2. [Specialist-Publisher](https://github.com/alphagov/specialist-publisher/pull/3076)

[Trello](https://trello.com/c/spUCgJtQ/3539-make-it-possible-to-hide-the-blue-box-on-specialist-documents)


