### PR TITLE
(ADR-009 PR 1) Add link_set_content_id column to links

### DIFF
--- a/db/migrate/20250325162853_add_link_set_content_id_to_links.rb
+++ b/db/migrate/20250325162853_add_link_set_content_id_to_links.rb
@@ -1,0 +1,6 @@
+class AddLinkSetContentIdToLinks < ActiveRecord::Migration[8.0]
+  def change
+    add_column :links, :link_set_content_id, :uuid
+    add_foreign_key :links, :link_sets, column: :link_set_content_id, primary_key: :content_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_01_28_101515) do
+ActiveRecord::Schema[8.0].define(version: 2025_03_25_162853) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -159,6 +159,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_01_28_101515) do
     t.datetime "updated_at", precision: nil, null: false
     t.integer "position", default: 0, null: false
     t.integer "edition_id"
+    t.uuid "link_set_content_id"
     t.index ["edition_id", "link_type"], name: "index_links_on_edition_id_and_link_type"
     t.index ["edition_id"], name: "index_links_on_edition_id"
     t.index ["link_set_id", "link_type"], name: "index_links_on_link_set_id_and_link_type"
@@ -217,5 +218,6 @@ ActiveRecord::Schema[8.0].define(version: 2025_01_28_101515) do
   add_foreign_key "link_changes", "actions", on_delete: :cascade
   add_foreign_key "links", "editions", on_delete: :cascade
   add_foreign_key "links", "link_sets"
+  add_foreign_key "links", "link_sets", column: "link_set_content_id", primary_key: "content_id"
   add_foreign_key "unpublishings", "editions", on_delete: :cascade
 end


### PR DESCRIPTION
This is a foreign key to link_sets. Initially the column is empty (all null). It will be populated in future PRs.

https://github.com/alphagov/publishing-api/blob/adr-009/docs/arch/adr-009-change-linksets-primary-key-to-content-id.md

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️