### PR TITLE
(ADR-009 PR 2) Write links(link_set_content_id) in patch link set

### DIFF
--- a/app/commands/v2/patch_link_set.rb
+++ b/app/commands/v2/patch_link_set.rb
@@ -18,7 +18,12 @@ module Commands
           link_set.links.where(link_type: group).delete_all
 
           payload_content_ids.uniq.each_with_index do |content_id, i|
-            link_set.links.create!(target_content_id: content_id, link_type: group, position: i)
+            link_set.links.create!(
+              link_set_content_id: link_set.content_id,
+              target_content_id: content_id,
+              link_type: group,
+              position: i,
+            )
           end
         end
 


### PR DESCRIPTION
This is ADR-009 step 2 - Update the code to write to both columns.

PATCH /v2/links/:content_id is the only endpoint that creates or updates link set links, so I'm pretty confident this is the only place we need to dual-write to the old (link_set_id) and new (link_set_content_id) columns.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️