### PR TITLE
(ADR-009 PR 3) Populate link_set_content_id with rake task

### DIFF
--- a/lib/tasks/add_link_set_content_id_to_links.rake
+++ b/lib/tasks/add_link_set_content_id_to_links.rake
@@ -1,0 +1,19 @@
+desc "Add link_set_content_id to links"
+task :add_link_set_content_id_to_links, [:link_id] => [:environment] do |t, args|
+  link_id = args.fetch(:link_id, 0).to_i
+  link_set_links = Link.joins(:link_set).includes(:link_set).where(id: link_id..)
+  count = 0
+  total = link_set_links.count
+
+  link_set_links.find_in_batches do |links|
+    puts "Processing link ids from #{links.first.id} to #{links.last.id}"
+    Link.transaction do
+      links.each do |link|
+        link.update!(link_set_content_id: link.link_set.content_id)
+      end
+    end
+    count += links.size
+    puts "Processed #{(100 * count.to_f / total).round(1)}% (#{count} / #{total})"
+    sleep(0.1)
+  end
+end

--- a/lib/tasks/add_link_set_content_id_to_links.rake
+++ b/lib/tasks/add_link_set_content_id_to_links.rake
@@ -1,19 +1,36 @@
 desc "Add link_set_content_id to links"
-task :add_link_set_content_id_to_links, [:link_id] => [:environment] do |t, args|
+task :add_link_set_content_id_to_links, [:link_id] => [:environment] do |_t, args|
+  batch_size = 1000
   link_id = args.fetch(:link_id, 0).to_i
-  link_set_links = Link.joins(:link_set).includes(:link_set).where(id: link_id..)
-  count = 0
-  total = link_set_links.count
+  total_updated = 0
+  link_set_links = Link.where.not(link_set_id: nil)
+  total_count = link_set_links.where(id: link_id...).count
 
-  link_set_links.find_in_batches do |links|
-    puts "Processing link ids from #{links.first.id} to #{links.last.id}"
-    Link.transaction do
-      links.each do |link|
-        link.update!(link_set_content_id: link.link_set.content_id)
-      end
-    end
-    count += links.size
-    puts "Processed #{(100 * count.to_f / total).round(1)}% (#{count} / #{total})"
+  loop do
+    max_link_id = link_set_links.where(id: link_id...)
+                                .order(id: :asc).limit(batch_size)
+                                .pluck(:id).last
+    break if max_link_id.nil?
+
+    puts "Processing link ids from #{link_id} to #{max_link_id}"
+
+    sql = <<-SQL
+      UPDATE links
+      SET link_set_content_id = link_sets.content_id
+      FROM link_sets
+      WHERE links.link_set_id IS NOT NULL AND links.link_set_id = link_sets.id
+      AND links.id BETWEEN ? AND ?
+    SQL
+
+    ActiveRecord::Base.connection.execute(
+      ActiveRecord::Base.sanitize_sql_array([sql, link_id, max_link_id]),
+    )
+
+    link_id = max_link_id + 1
+    total_updated += batch_size
+    puts "Processed #{total_updated} of #{total_count} links so far (#{(total_updated.to_f / total_count * 100).round(1)}%)"
     sleep(0.1)
   end
+
+  puts "Finished processing links. Total updated: #{total_updated}"
 end


### PR DESCRIPTION
I considered two ways of doing this (see the individual commits). The way I settled on is much faster, but requires some SQL strings because ActiveRecord doesn't support `UPDATE / FROM` in postgres yet.

I've tested the rake task against my local database, and it chomps through at a reasonable rate - should take less than an hour I think.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️