### PR TITLE
Add strong_migrations gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,7 @@ gem "rails-pg-extras"
 gem "sentry-sidekiq"
 gem "sidekiq-scheduler"
 gem "sidekiq-unique-jobs", "< 8.0.10"
+gem "strong_migrations"
 gem "with_advisory_lock"
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -855,6 +855,8 @@ GEM
     string_pattern (2.3.0)
       regexp_parser (~> 2.5, >= 2.5.0)
     stringio (3.1.6)
+    strong_migrations (2.2.1)
+      activerecord (>= 7)
     sync (0.5.0)
     table_print (1.5.7)
     term-ansicolor (1.11.2)
@@ -948,6 +950,7 @@ DEPENDENCIES
   sidekiq-scheduler
   sidekiq-unique-jobs (< 8.0.10)
   simplecov
+  strong_migrations
   timecop
   web-console
   webmock

--- a/config/initializers/strong_migrations.rb
+++ b/config/initializers/strong_migrations.rb
@@ -1,0 +1,2 @@
+StrongMigrations.lock_timeout = 10.seconds
+StrongMigrations.statement_timeout = 1.hour


### PR DESCRIPTION
From the README:

>  Catch unsafe migrations in development
>
>    ✓  Detects potentially dangerous operations
>    ✓  Prevents them from running by default
>    ✓  Provides instructions on safer ways to do what you want

This should help prevent accidents like adding indexes non-concurrently,
which can lock tables and cause incidents.

Lots of information about what this tool does in the README:

https://github.com/ankane/strong_migrations/blob/master/README.md

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️
