### PR TITLE
Use content_id to associate actions with link sets instead of link_set_id

### DIFF
--- a/app/models/action.rb
+++ b/app/models/action.rb
@@ -1,9 +1,8 @@
 class Action < ApplicationRecord
   belongs_to :edition, optional: true
-  belongs_to :link_set, optional: true
+  belongs_to :link_set, optional: true, foreign_key: :content_id, primary_key: :content_id
   belongs_to :event
 
-  validate :one_of_edition_link_set
   validates :action, presence: true
 
   def self.create_put_content_action(updated_draft, locale, event)
@@ -44,19 +43,10 @@ class Action < ApplicationRecord
       locale: nil,
       action: "PatchLinkSet",
       user_uid: event.user_uid,
-      link_set:,
       event:,
     )
 
     after_links = link_set.links.to_a
     LinkChangeService.new(action, before_links, after_links).record
-  end
-
-private
-
-  def one_of_edition_link_set
-    if edition_id && link_set_id || edition && link_set
-      errors.add(:base, "can not be associated with both an edition and link set")
-    end
   end
 end

--- a/spec/models/action_spec.rb
+++ b/spec/models/action_spec.rb
@@ -17,11 +17,5 @@ RSpec.describe Action do
       let(:link_set) { create(:link_set) }
       it { is_expected.to be_valid }
     end
-
-    context "edition and link set" do
-      let(:edition) { create(:edition) }
-      let(:link_set) { create(:link_set) }
-      it { is_expected.not_to be_valid }
-    end
   end
 end


### PR DESCRIPTION
Now that we have populated link_set_content_id and indexed it in all environments, we can start using it instead of link_set_id.

The actions table is the smallest and least risky of the changes we need to make. Previously actions related to link sets stored the content_id and the link_set_id, which is kind of redundant as they're both equivalent ways of referring to a link set. Now that we're removing the link_set_id in favour of content_id, we can only refer to the latter.

Unfortunately this means we have to give up the validation that an actions can't be for both an edition and a link_set. I don't think this is a huge concession though. It does mean if you look at an action that's not got anything to do with a link set, you'll be able to call `.link_set` on it, and get the link_set for the content_id of the edition. That feels okay to me though.

This will mean we can later remove the link_set_id column from actions, and eventually the id column from link_sets

