### PR TITLE
Use content_id as primary key in link_set associations

### DIFF
--- a/app/commands/v2/patch_link_set.rb
+++ b/app/commands/v2/patch_link_set.rb
@@ -19,6 +19,12 @@ module Commands
 
           payload_content_ids.uniq.each_with_index do |content_id, i|
             link_set.links.create!(
+              # link_set_id needs to be set explicitly, as active record is now
+              # using the link_set_content_id as the foreign key of the association.
+              # We can't use link_set.id, as that will return content_id since it is
+              # set as the primary key column.
+              # TODO: ADR-009 - remove when we remove link_set_id
+              link_set_id: link_set.attributes["id"],
               link_set_content_id: link_set.content_id,
               target_content_id: content_id,
               link_type: group,

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -4,7 +4,11 @@ class Document < ApplicationRecord
   belongs_to :owning_document, class_name: "Document", optional: true
   has_many :editions
   has_one :link_set, primary_key: "content_id", foreign_key: "content_id", inverse_of: :documents
-  has_many :link_set_links, class_name: "Link", through: :link_set, source: :links
+  has_many :link_set_links,
+           class_name: "Link",
+           foreign_key: :link_set_content_id,
+           primary_key: :content_id,
+           inverse_of: :source_documents
   has_many :reverse_links,
            class_name: "Link",
            foreign_key: :target_content_id,

--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -19,6 +19,9 @@ class Link < ApplicationRecord
            primary_key: :target_content_id,
            foreign_key: :content_id
 
+  scope :link_set_links, -> { where.not(link_set: nil) }
+  scope :edition_links, -> { where.not(edition: nil) }
+
   validates :target_content_id, presence: true, uuid: true
   validate :link_type_is_valid
   validate :association_presence

--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -1,13 +1,23 @@
 class Link < ApplicationRecord
   include SymbolizeJSON
 
-  belongs_to :link_set, optional: true
+  belongs_to :link_set,
+             optional: true,
+             foreign_key: :link_set_content_id,
+             primary_key: :content_id,
+             inverse_of: :links
   belongs_to :edition, optional: true
 
   # NOTE: links can have more than one source / target document, because there
   # can be multiple documents with the same content_id and different locales
-  has_many :source_documents, class_name: "Document", through: :link_set, source: :documents
-  has_many :target_documents, class_name: "Document", primary_key: :target_content_id, foreign_key: :content_id
+  has_many :source_documents,
+           class_name: "Document",
+           primary_key: :link_set_content_id,
+           foreign_key: :content_id
+  has_many :target_documents,
+           class_name: "Document",
+           primary_key: :target_content_id,
+           foreign_key: :content_id
 
   validates :target_content_id, presence: true, uuid: true
   validate :link_type_is_valid

--- a/app/models/link_set.rb
+++ b/app/models/link_set.rb
@@ -1,10 +1,16 @@
 class LinkSet < ApplicationRecord
+  self.primary_key = "content_id"
+
   include FindOrCreateLocked
 
   # NOTE: link sets can have more than one document, because there
   # can be multiple documents with the same content_id and different locales
   has_many :documents, foreign_key: "content_id", primary_key: "content_id", inverse_of: :link_set
-  has_many :links, -> { order(link_type: :asc, position: :asc) }, dependent: :destroy
+  has_many :links,
+           -> { order(link_type: :asc, position: :asc) },
+           foreign_key: :link_set_content_id,
+           primary_key: :content_id,
+           dependent: :destroy
 
   # We could define the `==` method on `Link` to perform this check but that
   # breaks the strict definition of a model instance being a representation of

--- a/spec/factories/link.rb
+++ b/spec/factories/link.rb
@@ -3,5 +3,12 @@ FactoryBot.define do
     link_set          { create(:link_set) unless edition }
     target_content_id { SecureRandom.uuid }
     link_type         { "organisations" }
+
+    # TODO: ADR-009 - remove when we remove link_set_id
+    after(:build) do |link,|
+      if link.link_set.present?
+        link.link_set_id = link.link_set.attributes["id"]
+      end
+    end
   end
 end

--- a/spec/models/link_set_spec.rb
+++ b/spec/models/link_set_spec.rb
@@ -16,7 +16,16 @@ RSpec.describe LinkSet do
     end
 
     context "with only other links" do
-      let(:other_links) { [build(:link, link_set:)] }
+      let(:other_links) do
+        [
+          build(
+            :link,
+            link_set_content_id: link_set.content_id,
+            # TODO: ADR-009 - remove when we remove link_set_id
+            link_set_id: link_set.attributes["id"],
+          ),
+        ]
+      end
 
       it { is_expected.to be true }
     end

--- a/spec/models/link_spec.rb
+++ b/spec/models/link_spec.rb
@@ -109,4 +109,27 @@ RSpec.describe Link do
       described_class.filter_editions(scope, "organisations" => "12345")
     end
   end
+
+  describe ".link_set_links and .edition_links" do
+    let(:edition) { create(:edition) }
+    let(:link_set) { create(:link_set) }
+
+    before do
+      @link_set_links = Array.new(5) do
+        create(:link, link_set:, target_content_id: SecureRandom.uuid, link_type: "organisations")
+      end
+
+      @edition_links = Array.new(4) do
+        create(:link, edition:, target_content_id: SecureRandom.uuid, link_type: "organisations")
+      end
+    end
+
+    it "returns all link set links" do
+      expect(described_class.link_set_links).to match_array(@link_set_links)
+    end
+
+    it "returns all edition links" do
+      expect(described_class.edition_links).to match_array(@edition_links)
+    end
+  end
 end


### PR DESCRIPTION
This changes the associations to join on link_set_content_id instead of joining through link_sets on link_set_id.

There are a couple of workarounds needed to ensure that link_set_id is still populated when links are created (either in patch link_set, or in the test factories). These should be removed when we're no longer using the link_set_id column.

Because content_id is now the pkey of LinkSet, we can't use LinkSet.last in the tests to get the most recent one anymore (it will get the one with the lexicographically last content_id, which is random). It's more explicit to look them up by content_id anyway.

This change will affect any queries using the associations. For example:

```
some_document.link_set_links
```

will now do

```
SELECT "links".* FROM "links" WHERE "links"."link_set_content_id" = ?
```

whereas before it would have done:

```
SELECT "links".* FROM "links"
INNER JOIN "link_sets" ON "links"."link_set_id" = "link_sets"."id"
WHERE "link_sets"."content_id" = ?
```

There are also several places where the code does the joins explicitly (e.g. `Document.joins(link_set: :links)`). In those cases we'll still join through the `link_sets` table following this PR, but we'll use:

```
INNER JOIN "links" ON "links"."link_set_content_id" = "link_sets"."content_id"
```

instead of

```
INNER JOIN "links" ON "links"."link_set_id" = "link_sets"."id"
```

We can clean these situations up in future PRs so we don't unnecessarily join through link_sets.

I've also added some scopes to Link, so we can get all the link_set_links or edition_links more conveniently. These will be used in future PRs.