### PR TITLE
Skip joining link_sets in graphql queries

### DIFF
--- a/app/graphql/sources/person_current_roles_source.rb
+++ b/app/graphql/sources/person_current_roles_source.rb
@@ -6,12 +6,10 @@ module Sources
         .includes(
           document: {
             reverse_links: { # role -> role_appointment
-              link_set: {
-                documents: [
-                  :editions, # role_appointment
-                  :link_set_links, # role_appointment -> person
-                ],
-              },
+              source_documents: [
+                :editions, # role_appointment
+                :link_set_links, # role_appointment -> person
+              ],
             },
           },
         )
@@ -19,7 +17,7 @@ module Sources
           document_type: "ministerial_role",
           document: { locale: "en" },
           reverse_links: { link_type: "role" },
-          documents: { locale: "en" }, # role_appointment Documents
+          source_documents: { locale: "en" }, # role_appointment Documents
           editions_documents: { document_type: "role_appointment" }, # role_appointment Editions
           link_set_links: { target_content_id: person_content_ids, link_type: "person" },
         )

--- a/app/graphql/sources/reverse_linked_to_editions_source.rb
+++ b/app/graphql/sources/reverse_linked_to_editions_source.rb
@@ -8,7 +8,7 @@ module Sources
 
     def fetch(editions_and_link_types)
       all_selections = {
-        links: %i[target_content_id link_type link_set_id edition_id],
+        links: %i[target_content_id link_type edition_id],
         documents: %i[content_id],
       }
       content_id_tuples = []
@@ -21,8 +21,7 @@ module Sources
 
       link_set_links_source_editions = Edition
         .joins(:document)
-        .joins("INNER JOIN link_sets ON link_sets.content_id = documents.content_id")
-        .joins("INNER JOIN links ON links.link_set_id = link_sets.id")
+        .joins("INNER JOIN links ON links.link_set_content_id = documents.content_id")
         .where(editions: { content_store: @content_store })
         .where(
           '("links"."target_content_id", "links"."link_type") IN (?)',


### PR DESCRIPTION
Now that the link_set_content_id column is populated in all environments, we can join directly from `links` to `documents` without the intermediate join through `link_sets`.

This is a small simplification, and the effect on performance is expected to be minimal. You can compare the query plans before and after here:

Before: https://www.pgexplain.dev/plan/673d9a6f-1df0-4a31-b993-9495c0ee1076
After: https://www.pgexplain.dev/plan/ab34f770-a24d-4792-b1a8-e3152e63eb30

Both take around 1ms to execute, and 2-5ms to plan. I think any actual difference in performance is smaller than the error bars on the measurements.

The code is slightly simpler though.