### PR TITLE
Simplify query_link_set_links

### DIFF
--- a/app/queries/links_for_edition_ids.rb
+++ b/app/queries/links_for_edition_ids.rb
@@ -33,23 +33,11 @@ module Queries
     end
 
     def query_link_set_links
-      # This may seem strange to be 3 queries but it was 10-100x more performant
-      # than a single one which seemed to struggle on joining link_sets.content_id
-      edition_id_content_id = Edition.with_document.where(id: edition_ids).pluck(:id, :content_id).to_h
-      content_ids = edition_id_content_id.map(&:last)
-      content_id_link_set_id = LinkSet.where(content_id: content_ids).pluck(:content_id, :id).to_h
-      links = Link
-                .where(link_set_id: content_id_link_set_id.map(&:last))
-                .order(:link_set_id, :link_type, :position)
-                .pluck(:link_set_id, :link_type, :target_content_id)
-                .group_by(&:first)
-
-      edition_id_content_id.flat_map do |(edition_id, content_id)|
-        link_set_id = content_id_link_set_id[content_id]
-        links.fetch(link_set_id, []).map do |(_, link_type, target_content_id)|
-          [edition_id, link_type, target_content_id]
-        end
-      end
+      Link
+        .joins(source_documents: :editions)
+        .where(source_documents: { editions: { id: edition_ids } })
+        .order("editions.id", :link_type, :position)
+        .pluck("editions.id", :link_type, :target_content_id)
     end
 
     def group_by_edition_id_and_link_type(links)


### PR DESCRIPTION
Now that we don't have to join link_sets, we don't need to split this query into three to make it fast.

The query plans (using EXPLAIN ANALYZE for the ministers index page link_set_links) are below.

```ruby
e = Edition.live.joins(:document).find_by(base_path: "/government/ministers", document: { locale: "en" })
lfei = Queries::LinksForEditionIds.new([e.id])
lfei.link_set_links
```

<details>
<summary>Query plans before</summary>

```
EXPLAIN (ANALYZE) SELECT "editions"."id", "content_id" FROM "editions" INNER JOIN "documents" ON "documents"."id" = "editions"."document_id" WHERE "editions"."id" = 14331719 /*application='PublishingAPI'*/
                                                                      QUERY PLAN
-------------------------------------------------------------------------------------------------------------------------------------------------------
 Nested Loop  (cost=0.86..16.90 rows=1 width=20) (actual time=0.016..0.017 rows=1 loops=1)
   ->  Index Scan using index_editions_on_id_and_content_store on editions  (cost=0.43..8.45 rows=1 width=8) (actual time=0.007..0.007 rows=1 loops=1)
         Index Cond: (id = 14331719)
   ->  Index Scan using index_documents_on_id_and_locale on documents  (cost=0.43..8.45 rows=1 width=20) (actual time=0.007..0.007 rows=1 loops=1)
         Index Cond: (id = editions.document_id)
 Planning Time: 0.284 ms
 Execution Time: 0.036 ms
(7 rows)

EXPLAIN (ANALYZE) SELECT "link_sets"."content_id", "link_sets"."id" FROM "link_sets" WHERE "link_sets"."content_id" = '324e4708-2285-40a0-b3aa-cb13af14ec5f' /*application='PublishingAPI'*/
                                                                QUERY PLAN
------------------------------------------------------------------------------------------------------------------------------------------
 Index Scan using index_link_sets_on_content_id on link_sets  (cost=0.42..8.44 rows=1 width=20) (actual time=0.015..0.016 rows=1 loops=1)
   Index Cond: (content_id = '324e4708-2285-40a0-b3aa-cb13af14ec5f'::uuid)
 Planning Time: 0.077 ms
 Execution Time: 0.029 ms
(4 rows)

EXPLAIN (ANALYZE) SELECT "links"."link_set_id", "links"."link_type", "links"."target_content_id" FROM "links" WHERE "links"."link_set_id" = 401712 ORDER BY "links"."link_set_id" ASC, "links"."link_type" ASC, "links"."position" ASC /*application='PublishingAPI'*/
                                                                  QUERY PLAN
----------------------------------------------------------------------------------------------------------------------------------------------
 Sort  (cost=386.92..387.20 rows=113 width=43) (actual time=0.479..0.485 rows=82 loops=1)
   Sort Key: link_type, "position"
   Sort Method: quicksort  Memory: 32kB
   ->  Index Scan using index_links_on_link_set_id on links  (cost=0.44..383.06 rows=113 width=43) (actual time=0.031..0.349 rows=82 loops=1)
         Index Cond: (link_set_id = 401712)
 Planning Time: 0.096 ms
 Execution Time: 0.509 ms
(7 rows)
```

</details>

<details>
<summary>Query plans after</summary>

```
EXPLAIN (ANALYZE) SELECT "editions"."id", "links"."link_type", "links"."target_content_id" FROM "links" INNER JOIN "documents" "source_documents" ON "source_documents"."content_id" = "links"."link_set_content_id" INNER JOIN "editions" ON "editions"."document_id" = "source_documents"."id" WHERE "editions"."id" = 14331719 ORDER BY editions.id, "links"."link_type" ASC, "links"."position" ASC /*application='PublishingAPI'*/
                                                                                   QUERY PLAN
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Sort  (cost=359.78..359.79 rows=4 width=43) (actual time=0.149..0.156 rows=82 loops=1)
   Sort Key: links.link_type, links."position"
   Sort Method: quicksort  Memory: 32kB
   ->  Nested Loop  (cost=1.30..359.74 rows=4 width=43) (actual time=0.038..0.076 rows=82 loops=1)
         ->  Nested Loop  (cost=0.86..16.90 rows=1 width=20) (actual time=0.021..0.022 rows=1 loops=1)
               ->  Index Scan using index_editions_on_id_and_content_store on editions  (cost=0.43..8.45 rows=1 width=8) (actual time=0.010..0.010 rows=1 loops=1)
                     Index Cond: (id = 14331719)
               ->  Index Scan using index_documents_on_id_and_locale on documents source_documents  (cost=0.43..8.45 rows=1 width=20) (actual time=0.009..0.009 rows=1 loops=1)
                     Index Cond: (id = editions.document_id)
         ->  Index Scan using index_links_on_link_set_content_id on links  (cost=0.44..341.71 rows=113 width=55) (actual time=0.015..0.041 rows=82 loops=1)
               Index Cond: (link_set_content_id = source_documents.content_id)
 Planning Time: 0.498 ms
 Execution Time: 0.191 ms
(13 rows)
```

</details>

The key things to note are:
- One query instead of three
- The new query executes efficiently, taking 0.5ms to plan and 0.191ms to execute

This performance change isn't likely to make a massive difference to anything, but it's reassuring that it performs well enough.

The big improvement in this PR is to code simplicity. 