### PR TITLE
Use link_set_content_id in Queries.Links

### DIFF
--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -18,18 +18,21 @@
       },
       "user_input": "sql",
       "confidence": "Weak",
+      "cwe_id": [
+        89
+      ],
       "note": "The included SQL is a constant string with no user input."
     },
     {
       "warning_type": "SQL Injection",
       "warning_code": 0,
-      "fingerprint": "d0811d2c0f8a29d7aca527231dab7c00fcc62bd08556ba114c0a934618ecc9d7",
+      "fingerprint": "683209c49b28a5b8dcf1f540dbba77d2ef430831a7b3391c7484bd0418bba104",
       "check_name": "SQL",
       "message": "Possible SQL injection",
       "file": "app/queries/links.rb",
-      "line": 211,
+      "line": 210,
       "link": "https://brakemanscanner.org/docs/warning_types/sql_injection/",
-      "code": "Arel.sql(\"\\n        EXISTS(\\n          SELECT nested_links.id\\n          FROM links AS nested_links\\n          INNER JOIN link_sets AS nested_link_sets\\n          ON nested_link_sets.id = nested_links.link_set_id\\n          WHERE #{where}\\n          LIMIT 1\\n        )\\n      \")",
+      "code": "Arel.sql(\"\\n        EXISTS(\\n          SELECT nested_links.id\\n          FROM links AS nested_links\\n          WHERE link_set_content_id IS NOT NULL\\n          AND #{where}\\n          LIMIT 1\\n        )\\n      \")",
       "render_path": null,
       "location": {
         "type": "method",
@@ -38,6 +41,9 @@
       },
       "user_input": "where",
       "confidence": "Medium",
+      "cwe_id": [
+        89
+      ],
       "note": "This SQL is generated using valid content IDs and configuration data, not with arbitrary user input"
     },
     {
@@ -58,6 +64,9 @@
       },
       "user_input": "{ :draft => 0, :published => 1, :unpublished => 1, :superseded => 2 }.slice(*states).map do\n \"WHEN '#{k}' THEN #{v} \"\n end.join",
       "confidence": "Medium",
+      "cwe_id": [
+        89
+      ],
       "note": "The included SQL are constant strings and integers with no user input."
     },
     {
@@ -78,9 +87,12 @@
       },
       "user_input": "values.size",
       "confidence": "Medium",
+      "cwe_id": [
+        89
+      ],
       "note": "The SQL is generated only with valid locales and edition states, not with arbitrary user input"
     }
   ],
-  "updated": "2021-06-10 09:17:56 +0000",
-  "brakeman_version": "5.0.4"
+  "updated": "2025-03-31 11:08:00 +0000",
+  "brakeman_version": "7.0.0"
 }


### PR DESCRIPTION
This query is used in the link expansion code, so it is called a lot.

To build some confidence that this change doesn't break anything, I ran the link expansion of the ministers index page before and after this change, and recorded the `EXPLAIN (ANALYZE)` query plans.

To expand the ministers index page:

```ruby
e = Edition.live.joins(:document).find_by(base_path: "/government/ministers", document: { locale: "en" })
ep = Presenters::EditionPresenter.new(e)
result = ep.for_content_store(0)
File.write("before|after.json", result.to_json)
```

The before / after JSON results are identical, as they should be.

The query affected by this PR is made 457 times while expanding the ministers index page. For want of a better way of comparing the query plans, I've dumped them into this git repository: https://github.com/richardTowers/query-plan-comparisons

I've plotted the difference in planning and execution time here, and it looks like there's a fair improvement (although the old queries only took low numbers of ms, so it was already reasonably fast).

<img width="837" alt="image" src="https://github.com/user-attachments/assets/0fa10715-0371-4f98-a109-01437a45b43b" />

As an example, [plan 353 went from 9.712 ms execution time to 0.047 ms execution time](https://github.com/richardTowers/query-plan-comparisons/commit/d772b2e19865ed0f1b4def8a0adbb8cfe510a87d).

Using pgexplain to compare these:

- [before PR3258](https://www.pgexplain.dev/plan/c70fa026-42b7-4c1f-af0c-1ec130d778f5)
- [after PR3258](https://www.pgexplain.dev/plan/339fc7e0-c09a-4f8d-8cab-6d5d821dac3a)

Shows the main reason for the performance improvement. Before the change, postgres needed to look at three different indexes (`index_link_sets_on_content_id`, `index_links_on_link_set_id`, `index_links_on_link_type`) to find the nested links (i.e. find all the links with a particular content id and link type). After the change, it only needs to look at `index_links_on_link_set_content_id_and_link_type` because the content_id and the link_type are on the same table / in the same index.

| Before | After |
|----|----|
| <img width="763" alt="image" src="https://github.com/user-attachments/assets/25f8845d-46ee-493a-8d7f-e409a399c015" /> | <img width="261" alt="image" src="https://github.com/user-attachments/assets/8399b8eb-49ec-44b1-9bf4-0fe2c0784678" /> |

🚀 

