### PR TITLE
Remove unnecessary join in GetLinked query

### DIFF
--- a/app/queries/get_linked.rb
+++ b/app/queries/get_linked.rb
@@ -13,10 +13,8 @@ module Queries
       validate_fields!
 
       content_ids = Link
-        .where(target_content_id:)
-        .where(link_type:)
-        .joins(:link_set)
-        .pluck(:content_id)
+                      .where(target_content_id:, link_type:)
+                      .pluck(:link_set_content_id)
 
       editions = Edition.with_document.where("documents.content_id": content_ids)
 


### PR DESCRIPTION
This code path [gets hardly any usage](https://kibana.logit.io/s/13d1a0b1-f54f-407b-a4e5-f53ba653fac3/goto/2f23f141a164741d1eb23cb8f47cb2cf?security_tenant=global), so this should be a very low risk change.

The code wasn't exactly complicated before, but it's still a nice simplification.

The query plan is also simpler (just one index scan instead of a nested loop with two index scans), but it was plenty fast before and this code path doesn't get much exercise so it won't make any difference.

Query plan before: https://www.pgexplain.dev/plan/8139dcf5-fd71-4fb8-a754-d941889fa8d4
Query plan after: https://www.pgexplain.dev/plan/2526729c-3518-46ab-a36d-eecab139532d