### PR TITLE
Use Renovate for Ruby version, GitHub Actions, and Docker images

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,7 +6,11 @@
     ":automergePr",
     ":automergeRequireAllStatusChecks"
   ],
-  "enabledManagers": ["ruby-version"],
+  "enabledManagers": [
+    "dockerfile",
+    "github-actions",
+    "ruby-version"
+  ],
   "labels": ["dependencies"],
   "packageRules": [
     {

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:best-practices",
+    ":automergePatch",
+    ":automergePr",
+    ":automergeRequireAllStatusChecks"
+  ],
+  "enabledManagers": ["ruby-version"],
+  "labels": ["dependencies"],
+  "packageRules": [
+    {
+      "matchCategories": "ruby",
+      "labels": ["ruby"]
+    },
+    {
+      "matchCategories": "ruby",
+      "matchUpdateTypes": ["major", "minor"],
+      "prBodyNotes": [
+        ":warning: Make sure the Dockerfile's `ruby_version` argument is updated.",
+        "[Guidance on updating Ruby](https://docs.publishing.service.gov.uk/manual/ruby.html#updating-the-ruby-version-in-apps)"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
[Trello](https://trello.com/c/KYb1Gz92/1653-use-renovate-for-ruby-version-maintenance)

Dependabot doesn't open PRs to upgrade Ruby. It would be good keep up to date where possible, and at least keep updates on our radar, so this sets up Renovate to open PRs to update Ruby. This also sets up Renovate to update GitHub Actions, but leaves Dependabot to manage updates to Ruby gems and Node packages

Renovate won't be enabled until govuk-helm-charts is updated: https://github.com/alphagov/govuk-helm-charts/pull/3111