### PR TITLE
Deterministic ordering for graphql reverse links

### DIFF
--- a/app/graphql/sources/reverse_linked_to_editions_source.rb
+++ b/app/graphql/sources/reverse_linked_to_editions_source.rb
@@ -47,7 +47,7 @@ module Sources
             #{edition_links_source_editions.to_sql}
           ) AS editions
         SQL
-      )
+      ).order("editions.id")
 
       all_editions.each_with_object(link_types_map) { |edition, hash|
         hash[[edition.target_content_id, edition.link_type]] << edition


### PR DESCRIPTION
Without an explicit ORDER BY on this query, the order of the linked editions will be whatever the database thinks is easiest. This depends on the query planner, which means it's potentially changeable depending on the mood that postgres is in on any particular day.

This also causes tests that assert a particular order of editions to be flaky.

The "position" column on links isn't useful for sorting reverse links, because if you imagine:

    Document collection X
      1 - Document A
      2 - Document B
    Document collection Y
      1 - Document Alpha
      2 - Document B

Document B appears in two Document collections, and it makes sense to follow the links in reverse to find those collections. However, it appears in position 2 in both collections, so we can't use that position to order the collections (and even if it appeared in different positions, it wouldn't make sense to order the collections based on that).

Given that there isn't a well-defined order that reverse links are supposed to be sorted in, edition id at least makes some sense (earlier editions will come first), and is fast to search on (because it's the primary key, so it's indexed).