### PR TITLE
Toggle table of contents

### DIFF
--- a/content_schemas/dist/formats/finder/frontend/schema.json
+++ b/content_schemas/dist/formats/finder/frontend/schema.json
@@ -352,6 +352,9 @@
         "show_summaries": {
           "$ref": "#/definitions/finder_show_summaries"
         },
+        "show_table_of_contents": {
+          "$ref": "#/definitions/finder_show_table_of_contents"
+        },
         "signup_link": {
           "$ref": "#/definitions/finder_signup_link"
         },
@@ -625,6 +628,9 @@
       "type": "boolean"
     },
     "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_show_table_of_contents": {
       "type": "boolean"
     },
     "finder_signup_link": {

--- a/content_schemas/dist/formats/finder/notification/schema.json
+++ b/content_schemas/dist/formats/finder/notification/schema.json
@@ -452,6 +452,9 @@
         "show_summaries": {
           "$ref": "#/definitions/finder_show_summaries"
         },
+        "show_table_of_contents": {
+          "$ref": "#/definitions/finder_show_table_of_contents"
+        },
         "signup_link": {
           "$ref": "#/definitions/finder_signup_link"
         },
@@ -725,6 +728,9 @@
       "type": "boolean"
     },
     "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_show_table_of_contents": {
       "type": "boolean"
     },
     "finder_signup_link": {

--- a/content_schemas/dist/formats/finder/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/finder/publisher_v2/schema.json
@@ -244,6 +244,9 @@
         "show_summaries": {
           "$ref": "#/definitions/finder_show_summaries"
         },
+        "show_table_of_contents": {
+          "$ref": "#/definitions/finder_show_table_of_contents"
+        },
         "signup_link": {
           "$ref": "#/definitions/finder_signup_link"
         },
@@ -517,6 +520,9 @@
       "type": "boolean"
     },
     "finder_show_summaries": {
+      "type": "boolean"
+    },
+    "finder_show_table_of_contents": {
       "type": "boolean"
     },
     "finder_signup_link": {

--- a/content_schemas/examples/specialist_document/frontend/aaib-reports.json
+++ b/content_schemas/examples/specialist_document/frontend/aaib-reports.json
@@ -207,7 +207,8 @@
               "display_as_result_metadata": false,
               "filterable": false
             }
-          ]
+          ],
+          "show_table_of_contents": true
         },
         "links": {
         },

--- a/content_schemas/examples/specialist_document/frontend/business-finance-support-scheme.json
+++ b/content_schemas/examples/specialist_document/frontend/business-finance-support-scheme.json
@@ -274,7 +274,8 @@
               "preposition": "for businesses in",
               "type": "text"
             }
-          ]
+          ],
+          "show_table_of_contents": true
         },
         "document_type": "finder",
         "links": {},

--- a/content_schemas/examples/specialist_document/frontend/cma-cases.json
+++ b/content_schemas/examples/specialist_document/frontend/cma-cases.json
@@ -462,7 +462,8 @@
               "display_as_result_metadata": true,
               "filterable": true
             }
-          ]
+          ],
+          "show_table_of_contents": false
         },
         "links": {
         },

--- a/content_schemas/examples/specialist_document/frontend/countryside-stewardship-grants.json
+++ b/content_schemas/examples/specialist_document/frontend/countryside-stewardship-grants.json
@@ -316,6 +316,7 @@
               ]
             }
           ],
+          "show_table_of_contents": true,
           "show_metadata_block": true
         },
         "links": {

--- a/content_schemas/examples/specialist_document/frontend/drug-device-alerts.json
+++ b/content_schemas/examples/specialist_document/frontend/drug-device-alerts.json
@@ -316,6 +316,7 @@
               "filterable": true
             }
           ],
+          "show_table_of_contents": true,
           "show_metadata_block": true
         },
         "links": {

--- a/content_schemas/examples/specialist_document/frontend/eu-withdrawal-act-2018-statutory-instruments.json
+++ b/content_schemas/examples/specialist_document/frontend/eu-withdrawal-act-2018-statutory-instruments.json
@@ -249,7 +249,8 @@
                 }
               ]
             }
-          ]
+          ],
+          "show_table_of_contents": true
         },
         "links": {
         },

--- a/content_schemas/examples/specialist_document/frontend/protected-food-drink-names.json
+++ b/content_schemas/examples/specialist_document/frontend/protected-food-drink-names.json
@@ -1174,7 +1174,8 @@
               "name": "Internal notes",
               "type": "text"
             }
-          ]
+          ],
+          "show_table_of_contents": true
         },
         "document_type": "finder",
         "links": {},

--- a/content_schemas/formats/finder.jsonnet
+++ b/content_schemas/formats/finder.jsonnet
@@ -67,6 +67,9 @@
         show_metadata_block: {
           "$ref": "#/definitions/finder_show_metadata_block",
         },
+        show_table_of_contents: {
+          "$ref": "#/definitions/finder_show_table_of_contents",
+        },
         signup_link: {
           "$ref": "#/definitions/finder_signup_link",
         },

--- a/content_schemas/formats/shared/definitions/finder.jsonnet
+++ b/content_schemas/formats/shared/definitions/finder.jsonnet
@@ -278,6 +278,9 @@
   finder_show_metadata_block: {
     type: "boolean",
   },
+  finder_show_table_of_contents: {
+    type: "boolean",
+  },
   finder_signup_link: {
     anyOf: [
       {

--- a/lib/expansion_rules.rb
+++ b/lib/expansion_rules.rb
@@ -99,7 +99,7 @@ module_function
   ORGANISATION_FIELDS = (DEFAULT_FIELDS - [:public_updated_at] + details_fields(:acronym, :logo, :brand, :default_news_image, :organisation_govuk_status)).freeze
   TAXON_FIELDS = (DEFAULT_FIELDS + %i[description details phase]).freeze
   NEED_FIELDS = (DEFAULT_FIELDS + details_fields(:role, :goal, :benefit, :met_when, :justifications)).freeze
-  FINDER_FIELDS = (DEFAULT_FIELDS + details_fields(:facets, :show_metadata_block)).freeze
+  FINDER_FIELDS = (DEFAULT_FIELDS + details_fields(:facets, :show_metadata_block, :show_table_of_contents)).freeze
   FATALITY_NOTICE_FIELDS = (DEFAULT_FIELDS + details_fields(:roll_call_introduction, :casualties))
   HISTORIC_APPOINTMENT_FIELDS = (DEFAULT_FIELDS + details_fields(:political_party, :dates_in_office))
   MINISTERIAL_ROLE_FIELDS = (DEFAULT_FIELDS + details_fields(:body, :role_payment_type, :seniority, :whip_organisation)).freeze

--- a/spec/lib/expansion_rules_spec.rb
+++ b/spec/lib/expansion_rules_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe ExpansionRules do
     let(:default_fields_and_description) { default_fields + %i[description] }
     let(:need_fields) { default_fields + [%i[details role], %i[details goal], %i[details benefit], %i[details met_when], %i[details justifications]] }
     let(:fatality_notice_fields) { default_fields + [%i[details roll_call_introduction], %i[details casualties]] }
-    let(:finder_fields) { default_fields + [%i[details facets], %i[details show_metadata_block]] }
+    let(:finder_fields) { default_fields + [%i[details facets], %i[details show_metadata_block], %i[details show_table_of_contents]] }
     let(:historic_appointment_fields) { default_fields + [%i[details political_party], %i[details dates_in_office]] }
     let(:ministerial_role_fields) { role_fields + [%i[details seniority], %i[details whip_organisation]] }
     let(:person_fields) { default_fields + [%i[details body], %i[details image]] }


### PR DESCRIPTION
These change is necessary to make the rendering the table of contents list in specialist documents dependent on a value defined in the schema of each finder. We recently implemented a [similar feature for the metadata block.](https://github.com/alphagov/publishing-api/pull/3241) 

**Associated PRs**

[Specialist Publisher](https://github.com/alphagov/specialist-publisher/pull/3083)
[Frontend](https://github.com/alphagov/frontend/pull/4740)
[Government-Frontend](https://github.com/alphagov/government-frontend/pull/3645)

[Trello](https://trello.com/c/2eakEGOo/3570-make-it-possible-to-hide-the-table-of-contents-on-specialist-documents)



This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
