### PR TITLE
Fix Renovate Ruby labels

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -15,7 +15,7 @@
   "packageRules": [
     {
       "matchCategories": "ruby",
-      "labels": ["ruby"]
+      "labels": ["dependencies", "ruby"]
     },
     {
       "matchCategories": "ruby",


### PR DESCRIPTION
[Trello](https://trello.com/c/KYb1Gz92/1653-use-renovate-for-ruby-version-maintenance)

I assumed the labels in package rules were in addition to the default ones, not a replacement. Turns out we need to respecify the default ones if we want them to apply here also