### PR TITLE
Retain postgres major version in GitHub Actions

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -24,6 +24,10 @@
         ":warning: Make sure the Dockerfile's `ruby_version` argument is updated.",
         "[Guidance on updating Ruby](https://docs.publishing.service.gov.uk/manual/ruby.html#updating-the-ruby-version-in-apps)"
       ]
+    },
+    {
+      "matchPackageNames": ["postgres"],
+      "allowedVersions": "<14"
     }
   ]
 }


### PR DESCRIPTION
[Trello](https://trello.com/c/KYb1Gz92/1653-use-renovate-for-ruby-version-maintenance)

Renovate opened a [PR] to upgrade the major version of postgres used in a GitHub action. We don't update our app's postgres version very often, and this action should be kept in sync, so this disables major bumps of postgres in GitHub actions. Hopefully by disabling this only for major bumps, Renovate will still pin the dependency to a digest rather than a version tag (this is [more secure])

[more secure]: https://github.com/alphagov/publishing-api/commit/6053b22d536ece8f93ae1006f99c9a513bc1d381
[PR]: https://github.com/alphagov/publishing-api/pull/3271