### PR TITLE
Support image captions in GraphQL

### DIFF
--- a/app/graphql/types/edition_type.rb
+++ b/app/graphql/types/edition_type.rb
@@ -120,6 +120,7 @@ module Types
     class Details < Types::BaseObject
       class Image < Types::BaseObject
         field :url, String
+        field :caption, String
         field :alt_text, String
       end
 


### PR DESCRIPTION
[Trello](https://trello.com/c/HZRt4r50/1666-make-graphql-version-of-new-articles-the-same-as-regular-version)

We noticed that for news articles - or specifically https://www.gov.uk/government/news/british-high-commission-marks-his-majesty-king-charles-iiis-birthday-with-brilliantly-british-celebrations?graphql=true
- the GraphQL-rendered page was missing an image caption. This adds support for image captions