### PR TITLE
Produce datetimes from our GraphQL endpoint that look like Content API's

### DIFF
--- a/app/graphql/types/content_api_datetime.rb
+++ b/app/graphql/types/content_api_datetime.rb
@@ -1,0 +1,11 @@
+module Types
+  class ContentApiDatetime < Types::BaseScalar
+    def self.coerce_input(input_value, _context)
+      # N/A
+    end
+
+    def self.coerce_result(ruby_value, _context)
+      ruby_value.in_time_zone("Europe/London").iso8601
+    end
+  end
+end

--- a/app/graphql/types/edition_type.rb
+++ b/app/graphql/types/edition_type.rb
@@ -4,7 +4,7 @@ module Types
   class EditionType < Types::BaseObject
     class WithdrawnNotice < Types::BaseObject
       field :explanation, String
-      field :withdrawn_at, GraphQL::Types::ISO8601DateTime
+      field :withdrawn_at, Types::ContentApiDatetime
     end
 
     class EditionLinks < Types::BaseObject
@@ -139,10 +139,10 @@ module Types
       field :change_history, GraphQL::Types::JSON
       field :current, Boolean
       field :default_news_image, Image
-      field :display_date, GraphQL::Types::ISO8601DateTime
+      field :display_date, Types::ContentApiDatetime
       field :emphasised_organisations, GraphQL::Types::JSON
-      field :ended_on, GraphQL::Types::ISO8601DateTime
-      field :first_public_at, GraphQL::Types::ISO8601DateTime
+      field :ended_on, Types::ContentApiDatetime
+      field :first_public_at, Types::ContentApiDatetime
       field :image, Image
       field :international_delegations, [EditionType], null: false
       field :logo, Logo
@@ -150,7 +150,7 @@ module Types
       field :privy_counsellor, Boolean
       field :role_payment_type, String
       field :seniority, Integer
-      field :started_on, GraphQL::Types::ISO8601DateTime
+      field :started_on, Types::ContentApiDatetime
       field :supports_historical_accounts, Boolean
       field :whip_organisation, WhipOrganisation
       field :world_locations, [EditionType], null: false
@@ -165,26 +165,26 @@ module Types
     field :description, String
     field :details, Details, extras: [:lookahead]
     field :document_type, String
-    field :ended_on, GraphQL::Types::ISO8601DateTime
-    field :first_published_at, GraphQL::Types::ISO8601DateTime, null: false
+    field :ended_on, Types::ContentApiDatetime
+    field :first_published_at, Types::ContentApiDatetime, null: false
     field :iso2, String
     field :links, EditionLinks, method: :itself
     field :locale, String, null: false
     field :name, String, null: false
     field :phase, String, null: false
-    field :public_updated_at, GraphQL::Types::ISO8601DateTime, null: false
+    field :public_updated_at, Types::ContentApiDatetime, null: false
     field :publishing_app, String
     field :publishing_request_id, String
-    field :publishing_scheduled_at, GraphQL::Types::ISO8601DateTime
+    field :publishing_scheduled_at, Types::ContentApiDatetime
     field :rendering_app, String
     field :scheduled_publishing_delay_seconds, Int
     field :schema_name, String
     field :slug, String, null: false
-    field :started_on, GraphQL::Types::ISO8601DateTime
+    field :started_on, Types::ContentApiDatetime
     field :state, String
     field :supports_historical_accounts, Boolean
     field :title, String, null: false
-    field :updated_at, GraphQL::Types::ISO8601DateTime
+    field :updated_at, Types::ContentApiDatetime
     field :web_url, String
     field :withdrawn_notice, WithdrawnNotice
 

--- a/spec/integration/graphql/generic_edition_spec.rb
+++ b/spec/integration/graphql/generic_edition_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe "GraphQL" do
           base_path: "/my/withdrawn/edition",
           explanation: "for integration testing",
           document_type: "generic_type",
-          unpublished_at: "2024-10-27 17:00:00.000000000 +0000",
+          unpublished_at: Time.utc(2024, 10, 27, 17, 0, 0),
         )
       end
 

--- a/spec/integration/graphql/generic_edition_spec.rb
+++ b/spec/integration/graphql/generic_edition_spec.rb
@@ -2,7 +2,15 @@ RSpec.describe "GraphQL" do
   describe "generic edition" do
     before do
       document = create(:document, content_id: "d53db33f-d4ac-4eb3-839a-d415174eb906")
-      @edition = create(:live_edition, document:, document_type: "generic_type", base_path: "/my/generic/edition")
+      @edition = create(
+        :live_edition,
+        document:,
+        document_type: "generic_type",
+        base_path: "/my/generic/edition",
+        first_published_at: Time.utc(2025, 1, 1, 0, 0, 0),
+        public_updated_at: Time.utc(2025, 4, 1, 0, 0, 0),
+        updated_at: Time.utc(2025, 4, 1, 0, 0, 0),
+      )
     end
 
     it "exposes generic edition fields" do
@@ -51,10 +59,10 @@ RSpec.describe "GraphQL" do
               "body": @edition.details[:body],
             },
             "document_type": @edition.document_type,
-            "first_published_at": @edition.first_published_at.iso8601,
+            "first_published_at": "2025-01-01T00:00:00+00:00",
             "locale": @edition.locale,
             "phase": @edition.phase,
-            "public_updated_at": @edition.public_updated_at.iso8601,
+            "public_updated_at": "2025-04-01T01:00:00+01:00",
             "publishing_app": @edition.publishing_app,
             "publishing_request_id": @edition.publishing_request_id,
             "publishing_scheduled_at": nil,
@@ -62,7 +70,7 @@ RSpec.describe "GraphQL" do
             "scheduled_publishing_delay_seconds": nil,
             "schema_name": @edition.schema_name,
             "title": @edition.title,
-            "updated_at": @edition.updated_at.iso8601,
+            "updated_at": "2025-04-01T01:00:00+01:00",
             "withdrawn_notice": nil,
           },
         },
@@ -80,7 +88,7 @@ RSpec.describe "GraphQL" do
           base_path: "/my/withdrawn/edition",
           explanation: "for integration testing",
           document_type: "generic_type",
-          unpublished_at: Time.utc(2024, 10, 27, 17, 0, 0),
+          unpublished_at: Time.utc(2024, 10, 28, 17, 0, 0),
         )
       end
 
@@ -104,7 +112,7 @@ RSpec.describe "GraphQL" do
             "edition": {
               "withdrawn_notice": {
                 "explanation": "for integration testing",
-                "withdrawn_at": "2024-10-27T17:00:00Z",
+                "withdrawn_at": "2024-10-28T17:00:00+00:00",
               },
             },
           },

--- a/spec/integration/graphql/roles_spec.rb
+++ b/spec/integration/graphql/roles_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe "GraphQL" do
         schema_name: "role_appointment",
         details: {
           current: false,
-          started_on: Time.utc(2022, 10, 25),
+          started_on: Time.utc(2022, 11, 25),
           ended_on: Time.utc(2024, 7, 5),
         },
       ).tap do |role_appointment|
@@ -185,7 +185,7 @@ RSpec.describe "GraphQL" do
                   details: {
                     current: true,
                     ended_on: nil,
-                    started_on: "2024-07-05T00:00:00Z",
+                    started_on: "2024-07-05T01:00:00+01:00",
                   },
                   links: {
                     person: [
@@ -200,8 +200,8 @@ RSpec.describe "GraphQL" do
                 {
                   details: {
                     current: false,
-                    ended_on: "2024-07-05T00:00:00Z",
-                    started_on: "2022-10-25T00:00:00Z",
+                    ended_on: "2024-07-05T01:00:00+01:00",
+                    started_on: "2022-11-25T00:00:00+00:00",
                   },
                   links: {
                     person: [

--- a/spec/integration/graphql/roles_spec.rb
+++ b/spec/integration/graphql/roles_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe "GraphQL" do
         schema_name: "role_appointment",
         details: {
           current: true,
-          started_on: Time.zone.local(2024, 7, 5),
+          started_on: Time.utc(2024, 7, 5),
         },
       ).tap do |role_appointment|
         person = create(
@@ -61,8 +61,8 @@ RSpec.describe "GraphQL" do
         schema_name: "role_appointment",
         details: {
           current: false,
-          started_on: Time.zone.local(2022, 10, 25),
-          ended_on: Time.zone.local(2024, 7, 5),
+          started_on: Time.utc(2022, 10, 25),
+          ended_on: Time.utc(2024, 7, 5),
         },
       ).tap do |role_appointment|
         person = create(


### PR DESCRIPTION
Content Store's datetimes are in GMT/BST. When they're stringified, its GMT ones end with timezone "+00:00" (and its BST ones end in "+01:00").

Until now GraphQL datetimes have been in UTC and when stringified they end with just a "Z".

We want to produce data as close to Content API's as is reasonable. This seems reasonable, right?

https://trello.com/c/ezCkqbaq/1665-make-graphql-version-of-world-index-the-same-as-the-regular-version