### PR TITLE
(553) Update embed codes to support Content ID aliases

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -120,7 +120,7 @@ GEM
     climate_control (1.2.0)
     concurrent-ruby (1.3.5)
     connection_pool (2.5.0)
-    content_block_tools (0.4.6)
+    content_block_tools (0.5.0)
       actionview (>= 6)
     crack (1.0.0)
       bigdecimal

--- a/app/presenters/content_embed_presenter.rb
+++ b/app/presenters/content_embed_presenter.rb
@@ -45,7 +45,7 @@ module Presenters
 
       embedded_content_references.uniq.each do |content_reference|
         embed_code = content_reference.embed_code
-        embedded_edition = embedded_editions[content_reference.content_id]
+        embedded_edition = embedded_editions[content_reference.identifier]
         if embedded_edition.present?
           content = content.gsub(
             embed_code,
@@ -54,7 +54,7 @@ module Presenters
         else
           GovukError.notify(CommandError.new(
                               code: 422,
-                              message: "Could not find a live edition for embedded content ID: #{content_reference.content_id}",
+                              message: "Could not find a live edition for embedded content ID: #{content_reference.identifier}",
                             ))
         end
       end

--- a/app/services/embedded_content_finder_service.rb
+++ b/app/services/embedded_content_finder_service.rb
@@ -14,7 +14,8 @@ class EmbeddedContentFinderService
     when Hash
       value.map { |_, v| find_content_references(v) }.flatten
     when String
-      ContentBlockTools::ContentBlockReference.find_all_in_document(value)
+      content_references = ContentBlockTools::ContentBlockReference.find_all_in_document(value)
+      transform_aliases_to_content_ids(content_references)
     else
       []
     end
@@ -24,7 +25,7 @@ private
 
   def live_content_ids(content_references)
     found_editions = live_editions(content_references.uniq)
-    not_found_content_ids = content_references.map(&:content_id) - found_editions.map(&:content_id)
+    not_found_content_ids = content_references.map(&:identifier) - found_editions.map(&:content_id)
 
     if not_found_content_ids.any?
       GovukError.notify(CommandError.new(
@@ -32,7 +33,31 @@ private
                           message: "Could not find any live editions for embedded content IDs: #{not_found_content_ids.join(', ')}",
                         ))
     end
-    content_references.map(&:content_id) - not_found_content_ids
+    content_references.map(&:identifier) - not_found_content_ids
+  end
+
+  def transform_aliases_to_content_ids(content_references)
+    embedded_aliases = content_references.select(&:identifier_is_alias?).map(&:identifier)
+    content_id_aliases = ContentIdAlias.where(name: embedded_aliases).map { |a| [a.name, a.content_id] }.to_h
+    content_references.map do |reference|
+      if reference.identifier_is_alias?
+        identifier = content_id_aliases[reference.identifier]
+        if identifier.nil?
+          GovukError.notify(
+            CommandError.new(
+              code: 422,
+              message: "Could not find a Content ID for alias #{reference.identifier}",
+            ),
+          )
+          next
+        end
+        ContentBlockTools::ContentBlockReference.new(
+          **reference.to_h.merge(identifier:),
+        )
+      else
+        reference
+      end
+    end
   end
 
   def live_editions(content_references)
@@ -40,7 +65,7 @@ private
       state: "published",
       content_store: "live",
       document_type: content_references.map(&:document_type),
-      documents: { content_id: content_references.map(&:content_id) },
+      documents: { content_id: content_references.map(&:identifier) },
     )
   end
 end

--- a/spec/presenters/content_embed_presenter_spec.rb
+++ b/spec/presenters/content_embed_presenter_spec.rb
@@ -1,6 +1,5 @@
 RSpec.describe Presenters::ContentEmbedPresenter do
   let(:embedded_content_id) { SecureRandom.uuid }
-  let(:embed_code) { "{{embed:contact:#{embedded_content_id}}}" }
   let(:document) { create(:document) }
   let(:edition) do
     create(
@@ -29,6 +28,10 @@ RSpec.describe Presenters::ContentEmbedPresenter do
     )
   end
 
+  let!(:embedded_content_id_alias) do
+    create(:content_id_alias, content_id: embedded_content_id)
+  end
+
   let(:fake_content_id) { SecureRandom.uuid }
 
   describe "#render_embedded_content" do
@@ -48,221 +51,14 @@ RSpec.describe Presenters::ContentEmbedPresenter do
       end
     end
 
-    context "when there are live editions for the embedded content" do
-      let(:expected_value) do
-        "<span class=\"content-embed content-embed__contact\"
-          data-content-block=\"\"
-          data-document-type=\"contact\"
-          data-content-id=\"#{embedded_content_id}\"
-          data-embed-code=\"#{embed_code}\">VALUE</span>".squish
-      end
-      let(:stub_block) { double(ContentBlockTools::ContentBlock, render: expected_value) }
+    context "When the embed code has a UUID" do
+      let(:embed_code) { "{{embed:contact:#{embedded_content_id}}}" }
+      it_behaves_like "renders embedded content"
+    end
 
-      before do
-        expect(ContentBlockTools::ContentBlock).to receive(:new).with(
-          document_type: embedded_edition.document_type,
-          content_id: embedded_edition.document.content_id,
-          title: embedded_edition.title,
-          details: embedded_edition.details,
-          embed_code: embed_code,
-        ).at_least(:once).and_return(stub_block)
-      end
-
-      context "when body is a string" do
-        context "when there is a mix of existing and not existing live editions" do
-          let(:details) { { body: "some string with a reference: {{embed:contact:#{embedded_content_id}}} {{embed:contact:#{fake_content_id}}}" } }
-
-          it "alerts Sentry and returns the expected content" do
-            expect(GovukError).to receive(:notify).with(CommandError.new(
-                                                          code: 422,
-                                                          message: "Could not find a live edition for embedded content ID: #{fake_content_id}",
-                                                        ))
-            expect(described_class.new(edition).render_embedded_content(details)).to eq({
-              body: "some string with a reference: #{expected_value} {{embed:contact:#{fake_content_id}}}",
-            })
-          end
-        end
-
-        context "when there is only one embed" do
-          let(:details) { { body: "some string with a reference: {{embed:contact:#{embedded_content_id}}}" } }
-          it "returns embedded content references with values from their editions" do
-            expect(described_class.new(edition).render_embedded_content(details)).to eq({
-              body: "some string with a reference: #{expected_value}",
-            })
-          end
-        end
-
-        context "when there are multiple embeds" do
-          context "when there are multiple embeds to the same block" do
-            let(:details) { { body: "some string with a reference: #{embed_code} and another: #{embed_code}" } }
-            it "returns embedded content" do
-              expect(described_class.new(edition).render_embedded_content(details)).to eq({
-                body: "some string with a reference: #{expected_value} and another: #{expected_value}",
-              })
-            end
-          end
-
-          context "when there are multiple embeds for different blocks" do
-            let(:embedded_content_id_2) { SecureRandom.uuid }
-            let!(:embedded_edition_2) do
-              embedded_document = create(:document, content_id: embedded_content_id_2)
-              create(
-                :edition,
-                document: embedded_document,
-                state: "published",
-                content_store: "live",
-                document_type: "content_block_pension",
-                title: "VALUE2",
-              )
-            end
-            let(:embed_code_2) { "{{embed:content_block_pension:#{embedded_content_id_2}}}" }
-            let(:links_hash) do
-              {
-                embed: [embedded_content_id, embedded_content_id_2],
-              }
-            end
-            let(:expected_value_2) do
-              "<span class=\"content-embed content-embed__contact\"
-          data-content-block=\"\"
-          data-document-type=\"contact\"
-          data-content-id=\"#{embedded_content_id_2}\"
-          data-embed-code=\"#{embed_code_2}\">VALUE2</span>".squish
-            end
-            let(:stub_block_2) { double(ContentBlockTools::ContentBlock, render: expected_value_2) }
-
-            before do
-              expect(ContentBlockTools::ContentBlock).to receive(:new).with(
-                document_type: embedded_edition_2.document_type,
-                content_id: embedded_edition_2.document.content_id,
-                title: embedded_edition_2.title,
-                details: embedded_edition_2.details,
-                embed_code: embed_code_2,
-              ).and_return(stub_block_2)
-            end
-            let(:details) { { body: "some string with a reference: #{embed_code} and another: #{embed_code_2}" } }
-
-            it "returns embedded content" do
-              expect(described_class.new(edition).render_embedded_content(details)).to eq({
-                body: "some string with a reference: #{expected_value} and another: #{expected_value_2}",
-              })
-            end
-          end
-        end
-      end
-
-      context "when body is an array" do
-        let(:details) do
-          { body: [
-            { content_type: "text/govspeak", content: "some string with a reference: {{embed:contact:#{embedded_content_id}}}" },
-            { content_type: "text/html", content: "some string with a reference: {{embed:contact:#{embedded_content_id}}}" },
-          ] }
-        end
-
-        it "returns embedded content references with values from their editions" do
-          expect(described_class.new(edition).render_embedded_content(details)).to eq({
-            body: [
-              { content_type: "text/govspeak", content: "some string with a reference: #{expected_value}" },
-              { content_type: "text/html", content: "some string with a reference: #{expected_value}" },
-            ],
-          })
-        end
-      end
-
-      context "when body is a hash" do
-        let(:details) do
-          { body: { title: "some string with a reference: {{embed:contact:#{embedded_content_id}}}" } }
-        end
-
-        it "returns embedded content references with values from their editions" do
-          expect(described_class.new(edition).render_embedded_content(details)).to eq({
-            body: { title: "some string with a reference: #{expected_value}" },
-          })
-        end
-      end
-
-      context "when body is a multipart document" do
-        let(:details) do
-          {
-            parts: [
-              body: [
-                {
-                  content: "some string with a reference: {{embed:contact:#{embedded_content_id}}}",
-                  content_type: "text/govspeak",
-                },
-              ],
-              slug: "some-slug",
-              title: "Some title",
-            ],
-          }
-        end
-
-        it "returns embedded content references with values from their editions" do
-          expect(described_class.new(edition).render_embedded_content(details)).to eq(
-            {
-              parts: [
-                body: [
-                  {
-                    content: "some string with a reference: #{expected_value}",
-                    content_type: "text/govspeak",
-                  },
-                ],
-                slug: "some-slug",
-                title: "Some title",
-              ],
-            },
-          )
-        end
-      end
-
-      context "when multiple documents are embedded in different parts of the document" do
-        let(:other_embedded_content_id) { SecureRandom.uuid }
-        let(:other_embed_code) { "{{embed:contact:#{other_embedded_content_id}}}" }
-
-        let!(:other_embedded_edition) do
-          embedded_document = create(:document, content_id: other_embedded_content_id)
-          create(
-            :edition,
-            document: embedded_document,
-            state: "published",
-            content_store: "live",
-            document_type: "contact",
-            title: "VALUE2",
-          )
-        end
-
-        let(:other_expected_value) { "VALUE2" }
-        let(:other_stub_block) { double(ContentBlockTools::ContentBlock, render: other_expected_value) }
-
-        before do
-          expect(ContentBlockTools::ContentBlock).to receive(:new).with(
-            document_type: other_embedded_edition.document_type,
-            content_id: other_embedded_edition.document.content_id,
-            title: other_embedded_edition.title,
-            details: other_embedded_edition.details,
-            embed_code: other_embed_code,
-          ).at_least(:once).and_return(other_stub_block)
-        end
-
-        let(:links_hash) do
-          {
-            embed: [embedded_content_id, other_embedded_content_id],
-          }
-        end
-
-        let(:details) do
-          {
-            title: "title string with reference: {{embed:contact:#{other_embedded_content_id}}}",
-            body: "some string with a reference: {{embed:contact:#{embedded_content_id}}}",
-          }
-        end
-
-        it "returns embedded content references with values from their editions" do
-          expect(described_class.new(edition).render_embedded_content(details)).to eq({
-            title: "title string with reference: #{other_expected_value}",
-            body: "some string with a reference: #{expected_value}",
-          })
-        end
-      end
+    context "When the embed code has a content ID alias" do
+      let(:embed_code) { "{{embed:contact:#{embedded_content_id_alias.name}}}" }
+      it_behaves_like "renders embedded content"
     end
   end
 end

--- a/spec/presenters/details_presenter_spec.rb
+++ b/spec/presenters/details_presenter_spec.rb
@@ -185,6 +185,17 @@ RSpec.describe Presenters::DetailsPresenter do
           it "embeds the contact details" do
             is_expected.to match(expected_details)
           end
+
+          context "when the embed code contains an alias" do
+            let(:content_id_alias) do
+              create(:content_id_alias, name: "a-friendly-name", content_id: embeddable_content.document.content_id)
+            end
+            let(:field_value) { "{{embed:contact:#{content_id_alias.name}}}" }
+
+            it "embeds the contact details" do
+              is_expected.to match(expected_details)
+            end
+          end
         end
 
         context "when we're passed details with govspeak and HTML" do

--- a/spec/presenters/queries/expanded_link_set_spec.rb
+++ b/spec/presenters/queries/expanded_link_set_spec.rb
@@ -120,6 +120,28 @@ RSpec.describe Presenters::Queries::ExpandedLinkSet do
           },
         ])
       end
+
+      context "when embed code contains an alias" do
+        let(:content_id_alias) do
+          create(:content_id_alias, name: "a-friendly-name", content_id: contact.document.content_id)
+        end
+        let(:embed_code) { "{{embed:contact:#{content_id_alias.name}}}" }
+
+        it "recursively calls the details presenter and embeds content inside expanded links" do
+          b = expanded_links[:role_appointments].first
+          c = b[:links][:role].first
+          expect(c[:details][:body]).to match([
+            {
+              content_type: "text/govspeak",
+              content: presented_details_for(contact, embed_code),
+            },
+            {
+              content_type: "text/html",
+              content: "<p>#{presented_details_for(contact, embed_code)}</p>\n",
+            },
+          ])
+        end
+      end
     end
   end
 end

--- a/spec/support/shared_examples/renders_embedded_content.rb
+++ b/spec/support/shared_examples/renders_embedded_content.rb
@@ -1,0 +1,218 @@
+RSpec.shared_examples "renders embedded content" do
+  context "when there are live editions for the embedded content" do
+    let(:expected_value) do
+      "<span class=\"content-embed content-embed__contact\"
+          data-content-block=\"\"
+          data-document-type=\"contact\"
+          data-content-id=\"#{embedded_content_id}\"
+          data-embed-code=\"#{embed_code}\">VALUE</span>".squish
+    end
+    let(:stub_block) { double(ContentBlockTools::ContentBlock, render: expected_value) }
+
+    before do
+      expect(ContentBlockTools::ContentBlock).to receive(:new).with(
+        document_type: embedded_edition.document_type,
+        content_id: embedded_edition.document.content_id,
+        title: embedded_edition.title,
+        details: embedded_edition.details,
+        embed_code: embed_code,
+      ).at_least(:once).and_return(stub_block)
+    end
+
+    context "when body is a string" do
+      context "when there is a mix of existing and not existing live editions" do
+        let(:details) { { body: "some string with a reference: #{embed_code} {{embed:contact:#{fake_content_id}}}" } }
+
+        it "alerts Sentry and returns the expected content" do
+          expect(GovukError).to receive(:notify).with(CommandError.new(
+                                                        code: 422,
+                                                        message: "Could not find a live edition for embedded content ID: #{fake_content_id}",
+                                                      ))
+          expect(described_class.new(edition).render_embedded_content(details)).to eq({
+            body: "some string with a reference: #{expected_value} {{embed:contact:#{fake_content_id}}}",
+          })
+        end
+      end
+
+      context "when there is only one embed" do
+        let(:details) { { body: "some string with a reference: #{embed_code}" } }
+        it "returns embedded content references with values from their editions" do
+          expect(described_class.new(edition).render_embedded_content(details)).to eq({
+            body: "some string with a reference: #{expected_value}",
+          })
+        end
+      end
+
+      context "when there are multiple embeds" do
+        context "when there are multiple embeds to the same block" do
+          let(:details) { { body: "some string with a reference: #{embed_code} and another: #{embed_code}" } }
+          it "returns embedded content" do
+            expect(described_class.new(edition).render_embedded_content(details)).to eq({
+              body: "some string with a reference: #{expected_value} and another: #{expected_value}",
+            })
+          end
+        end
+
+        context "when there are multiple embeds for different blocks" do
+          let(:embedded_content_id_2) { SecureRandom.uuid }
+          let!(:embedded_edition_2) do
+            embedded_document = create(:document, content_id: embedded_content_id_2)
+            create(
+              :edition,
+              document: embedded_document,
+              state: "published",
+              content_store: "live",
+              document_type: "content_block_pension",
+              title: "VALUE2",
+            )
+          end
+          let(:embed_code_2) { "{{embed:content_block_pension:#{embedded_content_id_2}}}" }
+          let(:links_hash) do
+            {
+              embed: [embedded_content_id, embedded_content_id_2],
+            }
+          end
+          let(:expected_value_2) do
+            "<span class=\"content-embed content-embed__contact\"
+          data-content-block=\"\"
+          data-document-type=\"contact\"
+          data-content-id=\"#{embedded_content_id_2}\"
+          data-embed-code=\"#{embed_code_2}\">VALUE2</span>".squish
+          end
+          let(:stub_block_2) { double(ContentBlockTools::ContentBlock, render: expected_value_2) }
+
+          before do
+            expect(ContentBlockTools::ContentBlock).to receive(:new).with(
+              document_type: embedded_edition_2.document_type,
+              content_id: embedded_edition_2.document.content_id,
+              title: embedded_edition_2.title,
+              details: embedded_edition_2.details,
+              embed_code: embed_code_2,
+            ).and_return(stub_block_2)
+          end
+          let(:details) { { body: "some string with a reference: #{embed_code} and another: #{embed_code_2}" } }
+
+          it "returns embedded content" do
+            expect(described_class.new(edition).render_embedded_content(details)).to eq({
+              body: "some string with a reference: #{expected_value} and another: #{expected_value_2}",
+            })
+          end
+        end
+      end
+    end
+
+    context "when body is an array" do
+      let(:details) do
+        { body: [
+          { content_type: "text/govspeak", content: "some string with a reference: #{embed_code}" },
+          { content_type: "text/html", content: "some string with a reference: #{embed_code}" },
+        ] }
+      end
+
+      it "returns embedded content references with values from their editions" do
+        expect(described_class.new(edition).render_embedded_content(details)).to eq({
+          body: [
+            { content_type: "text/govspeak", content: "some string with a reference: #{expected_value}" },
+            { content_type: "text/html", content: "some string with a reference: #{expected_value}" },
+          ],
+        })
+      end
+    end
+
+    context "when body is a hash" do
+      let(:details) do
+        { body: { title: "some string with a reference: #{embed_code}" } }
+      end
+
+      it "returns embedded content references with values from their editions" do
+        expect(described_class.new(edition).render_embedded_content(details)).to eq({
+          body: { title: "some string with a reference: #{expected_value}" },
+        })
+      end
+    end
+
+    context "when body is a multipart document" do
+      let(:details) do
+        {
+          parts: [
+            body: [
+              {
+                content: "some string with a reference: #{embed_code}",
+                content_type: "text/govspeak",
+              },
+            ],
+            slug: "some-slug",
+            title: "Some title",
+          ],
+        }
+      end
+
+      it "returns embedded content references with values from their editions" do
+        expect(described_class.new(edition).render_embedded_content(details)).to eq(
+          {
+            parts: [
+              body: [
+                {
+                  content: "some string with a reference: #{expected_value}",
+                  content_type: "text/govspeak",
+                },
+              ],
+              slug: "some-slug",
+              title: "Some title",
+            ],
+          },
+        )
+      end
+    end
+
+    context "when multiple documents are embedded in different parts of the document" do
+      let(:other_embedded_content_id) { SecureRandom.uuid }
+      let(:other_embed_code) { "{{embed:contact:#{other_embedded_content_id}}}" }
+
+      let!(:other_embedded_edition) do
+        embedded_document = create(:document, content_id: other_embedded_content_id)
+        create(
+          :edition,
+          document: embedded_document,
+          state: "published",
+          content_store: "live",
+          document_type: "contact",
+          title: "VALUE2",
+        )
+      end
+
+      let(:other_expected_value) { "VALUE2" }
+      let(:other_stub_block) { double(ContentBlockTools::ContentBlock, render: other_expected_value) }
+
+      before do
+        expect(ContentBlockTools::ContentBlock).to receive(:new).with(
+          document_type: other_embedded_edition.document_type,
+          content_id: other_embedded_edition.document.content_id,
+          title: other_embedded_edition.title,
+          details: other_embedded_edition.details,
+          embed_code: other_embed_code,
+        ).at_least(:once).and_return(other_stub_block)
+      end
+
+      let(:links_hash) do
+        {
+          embed: [embedded_content_id, other_embedded_content_id],
+        }
+      end
+
+      let(:details) do
+        {
+          title: "title string with reference: {{embed:contact:#{other_embedded_content_id}}}",
+          body: "some string with a reference: #{embed_code}",
+        }
+      end
+
+      it "returns embedded content references with values from their editions" do
+        expect(described_class.new(edition).render_embedded_content(details)).to eq({
+          title: "title string with reference: #{other_expected_value}",
+          body: "some string with a reference: #{expected_value}",
+        })
+      end
+    end
+  end
+end


### PR DESCRIPTION
Trello card: https://trello.com/c/fdJtXlmL/553-tech-spike-investigate-friendly-names-for-content-blocks-embed-codes

This updates the content block tools gem to support friendly names in embed codes, I've also had to tweak the embedded content finder a bit to ensure both UUIDs and friendly IDs are supported. We may change this in future, but for backwards compatibility, it seems sensible to have both.

The rest of the commits are mainly updates to tests to give us confidence that both methods work right the way through the flow.