### PR TITLE
Add document type to prometheus label for graphql requests

### DIFF
--- a/spec/integration/graphql/generic_edition_spec.rb
+++ b/spec/integration/graphql/generic_edition_spec.rb
@@ -81,6 +81,24 @@ RSpec.describe "GraphQL" do
       expect(parsed_response).to eq(expected)
     end
 
+    it "sets the document type as a prometheus label" do
+      post "/graphql", params: {
+        query:
+          "{
+            edition(base_path: \"/my/generic/edition\") {
+              ... on Edition {
+                title
+                document_type
+                schema_name
+              }
+            }
+          }",
+      }
+
+      expect(request.env["govuk.prometheus_labels"][:document_type]).to eq(@edition.document_type)
+      expect(request.env["govuk.prometheus_labels"][:schema_name]).to eq(@edition.schema_name)
+    end
+
     context "when there is a withdrawn notice" do
       before do
         create(


### PR DESCRIPTION
This should allow us to build a funky table of average response times by content type or something else fun like that 

Trello - https://trello.com/c/d0zL17OH/1662-add-content-type-specific-metrics-to-dashboard

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
