### PR TITLE
Add `reshuffle` to `details` for GraphQL queries

### DIFF
--- a/app/graphql/types/edition_type.rb
+++ b/app/graphql/types/edition_type.rb
@@ -148,6 +148,7 @@ module Types
       field :logo, Logo
       field :political, Boolean
       field :privy_counsellor, Boolean
+      field :reshuffle, GraphQL::Types::JSON
       field :role_payment_type, String
       field :seniority, Integer
       field :started_on, Types::ContentApiDatetime


### PR DESCRIPTION
The `reshuffle` field is needed in https://github.com/alphagov/collections/pull/4053, therefore we need to be able to return that value in GraphQL queries.

This value allows us to show a 'reshuffle in progress' message on the ministers index page.

[Trello card](https://trello.com/c/HcOHeixw)