### PR TITLE
Remove accidental n+1 loading link_sets

### DIFF
--- a/app/graphql/sources/person_current_roles_source.rb
+++ b/app/graphql/sources/person_current_roles_source.rb
@@ -2,6 +2,7 @@ module Sources
   class PersonCurrentRolesSource < GraphQL::Dataloader::Source
     def fetch(person_content_ids)
       all_roles = Edition
+        .strict_loading
         .live
         .includes(
           document: {
@@ -43,7 +44,7 @@ module Sources
     def role_appointment_documents_for_role(role)
       role.document.reverse_links
         .select { |link| link.link_type == "role" } # role -> role_appointment
-        .flat_map { |link| link.link_set.documents }
+        .flat_map(&:source_documents)
     end
   end
 end


### PR DESCRIPTION
When I removed the `includes ... link_set` from the query we use to get all the roles, I didn't realise we were explicitly calling .link_set on the roles below. This caused an n+1, where we'd issue a query to get the link set for every one of the roles. I only tested the main query, so I didn't spot this regression.

Calling the .strict_loading method on the relation will ensure that we don't accidentally do this again in future:

https://guides.rubyonrails.org/active_record_querying.html#strict-loading
