### PR TITLE
Only return published role appointments on ministers index page

### DIFF
--- a/app/graphql/sources/person_current_roles_source.rb
+++ b/app/graphql/sources/person_current_roles_source.rb
@@ -19,7 +19,10 @@ module Sources
           document: { locale: "en" },
           reverse_links: { link_type: "role" },
           source_documents: { locale: "en" }, # role_appointment Documents
-          editions_documents: { document_type: "role_appointment" }, # role_appointment Editions
+          editions_documents: { # role_appointment Editions
+            document_type: "role_appointment",
+            state: "published",
+          },
           link_set_links: { target_content_id: person_content_ids, link_type: "person" },
         )
         .where("editions_documents.details ->> 'current' = 'true'") # editions_documents is the alias that Active Record gives to the role_appointment Editions in the SQL query

--- a/spec/graphql/sources/person_current_roles_source_spec.rb
+++ b/spec/graphql/sources/person_current_roles_source_spec.rb
@@ -16,4 +16,36 @@ RSpec.describe Sources::PersonCurrentRolesSource do
       expect(request.load).to eq([role_1, role_3])
     end
   end
+
+  it "does not return draft roles for a person" do
+    person_1 = create_person("Person 1")
+    published_role = create_role("Role")
+    draft_role = create_role("Draft role")
+    non_current_draft_role = create_role("Non-current draft role")
+    appoint_person_to_role(person_1, published_role)
+    appoint_person_to_role(person_1, draft_role, state: "draft")
+    appoint_person_to_role(person_1, non_current_draft_role, state: "draft", current: false)
+
+    GraphQL::Dataloader.with_dataloading do |dataloader|
+      request = dataloader.with(described_class).request(person_1.content_id)
+
+      expect(request.load).to eq([published_role])
+    end
+  end
+
+  it "does not return unpublished roles for a person" do
+    person_1 = create_person("Person 1")
+    published_role = create_role("Role")
+    unpublished_role = create_role("Unpublished role")
+    non_current_unpublished_role = create_role("Non-current unpublished role")
+    appoint_person_to_role(person_1, published_role)
+    appoint_person_to_role(person_1, unpublished_role, state: "unpublished")
+    appoint_person_to_role(person_1, non_current_unpublished_role, state: "unpublished", current: false)
+
+    GraphQL::Dataloader.with_dataloading do |dataloader|
+      request = dataloader.with(described_class).request(person_1.content_id)
+
+      expect(request.load).to eq([published_role])
+    end
+  end
 end

--- a/spec/support/ministers_index_helpers.rb
+++ b/spec/support/ministers_index_helpers.rb
@@ -29,7 +29,7 @@ module MinistersIndexHelpers
     )
   end
 
-  def appoint_person_to_role(person, role, current: true)
+  def appoint_person_to_role(person, role, current: true, state: "published")
     role_appointment = create(
       :live_edition,
       title: "#{person.title} - #{role.title}",
@@ -39,6 +39,7 @@ module MinistersIndexHelpers
         current:,
         started_on: Time.zone.local(2024, 7, 5),
       },
+      state:,
     )
 
     create(


### PR DESCRIPTION
We are currently returning unpublished role appointments attached to a published role on the ministers index page (when rendered using GraphQL), resulting in ministers appearing to have roles that they do not hold.

For example, Angela Rayner has a current but unpublished role appointment which we are currently returning:

```
 #<Edition:0x0000ffff8f3c62e0
  id: 14474060,
  title: "The Rt Hon Angela Rayner MP - Secretary of State f...",
  public_updated_at: "2024-07-05 14:39:57.000000000 +0000",
  publishing_app: "whitehall",
  update_type: "major",
  phase: "live",
  analytics_identifier: nil,
  created_at: "2024-07-05 14:39:57.381491000 +0000",
  updated_at: "2024-07-10 12:33:27.619460000 +0000",
  document_type: "role_appointment",
  schema_name: "role_appointment",
  first_published_at: "2024-07-05 14:39:57.433063000 +0000",
  last_edited_at: "2024-07-05 14:39:57.386136000 +0000",
  state: "unpublished",
  user_facing_version: 1,
  base_path: nil,
  content_store: "live",
  document_id: 1602112,
  description: nil,
  publishing_request_id: "21-1720190397.253-10.13.22.63-2739",
  major_published_at: "2024-07-05 14:39:57.433063000 +0000",
  published_at: "2024-07-05 14:39:57.433063000 +0000",
  publishing_api_first_published_at: "2024-07-05 14:39:57.433063000 +0000",
  publishing_api_last_edited_at: "2024-07-05 14:39:57.386136000 +0000",
  auth_bypass_ids: [],
  details: {"current"=>true, "started_on"=>"2024-07-05T00:00:00+01:00", "person_appointment_order"=>1},
  routes: [],
  redirects: [],
  last_edited_by_editor_id: nil,
  rendering_app: nil>]
```

Adding an extra constraint here to ensure we only retrieve the published role appointments.

[Trello card](https://trello.com/c/HcOHeixw)