### PR TITLE
Support high_resolution_url for images in GraphQL

### DIFF
--- a/app/graphql/types/edition_type.rb
+++ b/app/graphql/types/edition_type.rb
@@ -119,9 +119,9 @@ module Types
 
     class Details < Types::BaseObject
       class Image < Types::BaseObject
-        field :url, String
-        field :caption, String
         field :alt_text, String
+        field :caption, String
+        field :url, String
       end
 
       class Logo < Types::BaseObject

--- a/app/graphql/types/edition_type.rb
+++ b/app/graphql/types/edition_type.rb
@@ -121,6 +121,7 @@ module Types
       class Image < Types::BaseObject
         field :alt_text, String
         field :caption, String
+        field :high_resolution_url, String
         field :url, String
       end
 

--- a/spec/integration/graphql/news_article_spec.rb
+++ b/spec/integration/graphql/news_article_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe "GraphQL" do
           image: {
             alt_text: "Some alt text",
             caption: "Some caption",
+            high_resolution_url: "https://assets.publishing.service.gov.uk/media/324438lksdjalsdj/s960_my_lovely_hd_image.jpg",
             url: "https://assets.publishing.service.gov.uk/media/29843nksdfjhdsfj/s300_my_lovely_image.jpg",
           },
           political: false,
@@ -121,6 +122,7 @@ RSpec.describe "GraphQL" do
                   image {
                     alt_text
                     caption
+                    high_resolution_url
                     url
                   }
                   political


### PR DESCRIPTION
[Trello](https://trello.com/c/wZY6HFxy/1673-make-graphql-version-of-news-articles-reference-the-same-image-src-as-regular-version)

We need to request this for news articles in Frontend