### PR TITLE
Change the org name earch ype for UKHSA

### DIFF
--- a/content_schemas/dist/formats/specialist_document/frontend/schema.json
+++ b/content_schemas/dist/formats/specialist_document/frontend/schema.json
@@ -2168,9 +2168,6 @@
       "ukhsa_access_type": {
         "type": "string"
       },
-      "ukhsa_applicant_organisation_name": {
-        "type": "string"
-      },
       "ukhsa_applicant_organisation_type": {
         "type": "array",
         "items": {
@@ -2192,6 +2189,9 @@
         "items": {
           "type": "string"
         }
+      },
+      "ukhsa_organisation_name": {
+        "type": "string"
       }
     },
     "utaac_decision_metadata": {

--- a/content_schemas/dist/formats/specialist_document/notification/schema.json
+++ b/content_schemas/dist/formats/specialist_document/notification/schema.json
@@ -2309,9 +2309,6 @@
       "ukhsa_access_type": {
         "type": "string"
       },
-      "ukhsa_applicant_organisation_name": {
-        "type": "string"
-      },
       "ukhsa_applicant_organisation_type": {
         "type": "array",
         "items": {
@@ -2333,6 +2330,9 @@
         "items": {
           "type": "string"
         }
+      },
+      "ukhsa_organisation_name": {
+        "type": "string"
       }
     },
     "update_type": {

--- a/content_schemas/dist/formats/specialist_document/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/specialist_document/publisher_v2/schema.json
@@ -2001,9 +2001,6 @@
       "ukhsa_access_type": {
         "type": "string"
       },
-      "ukhsa_applicant_organisation_name": {
-        "type": "string"
-      },
       "ukhsa_applicant_organisation_type": {
         "type": "array",
         "items": {
@@ -2025,6 +2022,9 @@
         "items": {
           "type": "string"
         }
+      },
+      "ukhsa_organisation_name": {
+        "type": "string"
       }
     },
     "update_type": {

--- a/content_schemas/formats/shared/definitions/_specialist_document.jsonnet
+++ b/content_schemas/formats/shared/definitions/_specialist_document.jsonnet
@@ -1318,7 +1318,7 @@
     "ukhsa_access_type": {
       type: "string",
     },
-    "ukhsa_applicant_organisation_name": {
+    "ukhsa_organisation_name": {
       type: "string",
     },
     "ukhsa_applicant_organisation_type": {


### PR DESCRIPTION
We're chaning the organisation name field type from text to identifiers in search-api. This typically requires a reindex; in order to avoid that, we're renaming the field.

[Trello](https://trello.com/c/zubgVL1V/3569-specialist-finder-for-ukhsa-data-releases)
