### PR TITLE
Send Content Block update jobs to the HIGH_QUEUE

### DIFF
--- a/app/sidekiq/host_content_update_job.rb
+++ b/app/sidekiq/host_content_update_job.rb
@@ -18,7 +18,7 @@ private
 
     EventLogger.log_command(self.class, event_payload) do |_event|
       DownstreamLiveJob.perform_async_in_queue(
-        DownstreamLiveJob::LOW_QUEUE,
+        DownstreamLiveJob::HIGH_QUEUE,
         "content_id" => dependent_content_id,
         "locale" => locale,
         "message_queue_event_type" => "host_content",

--- a/spec/sidekiq/host_content_update_job_spec.rb
+++ b/spec/sidekiq/host_content_update_job_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe HostContentUpdateJob, :perform do
 
   it "queues the Live host content for update" do
     expect(DownstreamLiveJob).to receive(:perform_async_in_queue).with(
-      "downstream_low",
+      "downstream_high",
       {
         "content_id" => dependent_content_id,
         "dependency_resolution_source_content_id" =>


### PR DESCRIPTION
We’ve had a lot of experiences with content block updates getting stuck behing bulk update jobs, which is causing confusion for users when carrying out user research, as well as causing intermittent failure with e2e tests.

Because content block updates are a different type of update to other types of dependency resolution updates (for example, listing pages), it’s more important that they’re updated in a timely manner.