### PR TITLE
Add assets to file attachments

### DIFF
--- a/content_schemas/dist/formats/call_for_evidence/frontend/schema.json
+++ b/content_schemas/dist/formats/call_for_evidence/frontend/schema.json
@@ -773,8 +773,24 @@
             "alternative_format_contact_email": {
               "type": "string"
             },
-            "asset_manager_id": {
-              "type": "string"
+            "assets": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": [
+                  "asset_manager_id",
+                  "filename"
+                ],
+                "additionalProperties": false,
+                "properties": {
+                  "asset_manager_id": {
+                    "type": "string"
+                  },
+                  "filename": {
+                    "type": "string"
+                  }
+                }
+              }
             },
             "attachment_type": {
               "type": "string",

--- a/content_schemas/dist/formats/call_for_evidence/notification/schema.json
+++ b/content_schemas/dist/formats/call_for_evidence/notification/schema.json
@@ -897,8 +897,24 @@
             "alternative_format_contact_email": {
               "type": "string"
             },
-            "asset_manager_id": {
-              "type": "string"
+            "assets": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": [
+                  "asset_manager_id",
+                  "filename"
+                ],
+                "additionalProperties": false,
+                "properties": {
+                  "asset_manager_id": {
+                    "type": "string"
+                  },
+                  "filename": {
+                    "type": "string"
+                  }
+                }
+              }
             },
             "attachment_type": {
               "type": "string",

--- a/content_schemas/dist/formats/call_for_evidence/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/call_for_evidence/publisher_v2/schema.json
@@ -586,8 +586,24 @@
             "alternative_format_contact_email": {
               "type": "string"
             },
-            "asset_manager_id": {
-              "type": "string"
+            "assets": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": [
+                  "asset_manager_id",
+                  "filename"
+                ],
+                "additionalProperties": false,
+                "properties": {
+                  "asset_manager_id": {
+                    "type": "string"
+                  },
+                  "filename": {
+                    "type": "string"
+                  }
+                }
+              }
             },
             "attachment_type": {
               "type": "string",

--- a/content_schemas/dist/formats/consultation/frontend/schema.json
+++ b/content_schemas/dist/formats/consultation/frontend/schema.json
@@ -790,8 +790,24 @@
             "alternative_format_contact_email": {
               "type": "string"
             },
-            "asset_manager_id": {
-              "type": "string"
+            "assets": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": [
+                  "asset_manager_id",
+                  "filename"
+                ],
+                "additionalProperties": false,
+                "properties": {
+                  "asset_manager_id": {
+                    "type": "string"
+                  },
+                  "filename": {
+                    "type": "string"
+                  }
+                }
+              }
             },
             "attachment_type": {
               "type": "string",

--- a/content_schemas/dist/formats/consultation/notification/schema.json
+++ b/content_schemas/dist/formats/consultation/notification/schema.json
@@ -914,8 +914,24 @@
             "alternative_format_contact_email": {
               "type": "string"
             },
-            "asset_manager_id": {
-              "type": "string"
+            "assets": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": [
+                  "asset_manager_id",
+                  "filename"
+                ],
+                "additionalProperties": false,
+                "properties": {
+                  "asset_manager_id": {
+                    "type": "string"
+                  },
+                  "filename": {
+                    "type": "string"
+                  }
+                }
+              }
             },
             "attachment_type": {
               "type": "string",

--- a/content_schemas/dist/formats/consultation/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/consultation/publisher_v2/schema.json
@@ -603,8 +603,24 @@
             "alternative_format_contact_email": {
               "type": "string"
             },
-            "asset_manager_id": {
-              "type": "string"
+            "assets": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": [
+                  "asset_manager_id",
+                  "filename"
+                ],
+                "additionalProperties": false,
+                "properties": {
+                  "asset_manager_id": {
+                    "type": "string"
+                  },
+                  "filename": {
+                    "type": "string"
+                  }
+                }
+              }
             },
             "attachment_type": {
               "type": "string",

--- a/content_schemas/dist/formats/corporate_information_page/frontend/schema.json
+++ b/content_schemas/dist/formats/corporate_information_page/frontend/schema.json
@@ -384,8 +384,24 @@
         "alternative_format_contact_email": {
           "type": "string"
         },
-        "asset_manager_id": {
-          "type": "string"
+        "assets": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "asset_manager_id",
+              "filename"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "asset_manager_id": {
+                "type": "string"
+              },
+              "filename": {
+                "type": "string"
+              }
+            }
+          }
         },
         "attachment_type": {
           "type": "string",

--- a/content_schemas/dist/formats/corporate_information_page/notification/schema.json
+++ b/content_schemas/dist/formats/corporate_information_page/notification/schema.json
@@ -479,8 +479,24 @@
         "alternative_format_contact_email": {
           "type": "string"
         },
-        "asset_manager_id": {
-          "type": "string"
+        "assets": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "asset_manager_id",
+              "filename"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "asset_manager_id": {
+                "type": "string"
+              },
+              "filename": {
+                "type": "string"
+              }
+            }
+          }
         },
         "attachment_type": {
           "type": "string",

--- a/content_schemas/dist/formats/corporate_information_page/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/corporate_information_page/publisher_v2/schema.json
@@ -319,8 +319,24 @@
         "alternative_format_contact_email": {
           "type": "string"
         },
-        "asset_manager_id": {
-          "type": "string"
+        "assets": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "asset_manager_id",
+              "filename"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "asset_manager_id": {
+                "type": "string"
+              },
+              "filename": {
+                "type": "string"
+              }
+            }
+          }
         },
         "attachment_type": {
           "type": "string",

--- a/content_schemas/dist/formats/detailed_guide/frontend/schema.json
+++ b/content_schemas/dist/formats/detailed_guide/frontend/schema.json
@@ -404,8 +404,24 @@
         "alternative_format_contact_email": {
           "type": "string"
         },
-        "asset_manager_id": {
-          "type": "string"
+        "assets": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "asset_manager_id",
+              "filename"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "asset_manager_id": {
+                "type": "string"
+              },
+              "filename": {
+                "type": "string"
+              }
+            }
+          }
         },
         "attachment_type": {
           "type": "string",

--- a/content_schemas/dist/formats/detailed_guide/notification/schema.json
+++ b/content_schemas/dist/formats/detailed_guide/notification/schema.json
@@ -509,8 +509,24 @@
         "alternative_format_contact_email": {
           "type": "string"
         },
-        "asset_manager_id": {
-          "type": "string"
+        "assets": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "asset_manager_id",
+              "filename"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "asset_manager_id": {
+                "type": "string"
+              },
+              "filename": {
+                "type": "string"
+              }
+            }
+          }
         },
         "attachment_type": {
           "type": "string",

--- a/content_schemas/dist/formats/detailed_guide/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/detailed_guide/publisher_v2/schema.json
@@ -343,8 +343,24 @@
         "alternative_format_contact_email": {
           "type": "string"
         },
-        "asset_manager_id": {
-          "type": "string"
+        "assets": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "asset_manager_id",
+              "filename"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "asset_manager_id": {
+                "type": "string"
+              },
+              "filename": {
+                "type": "string"
+              }
+            }
+          }
         },
         "attachment_type": {
           "type": "string",

--- a/content_schemas/dist/formats/manual_section/frontend/schema.json
+++ b/content_schemas/dist/formats/manual_section/frontend/schema.json
@@ -339,8 +339,24 @@
         "alternative_format_contact_email": {
           "type": "string"
         },
-        "asset_manager_id": {
-          "type": "string"
+        "assets": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "asset_manager_id",
+              "filename"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "asset_manager_id": {
+                "type": "string"
+              },
+              "filename": {
+                "type": "string"
+              }
+            }
+          }
         },
         "attachment_type": {
           "type": "string",

--- a/content_schemas/dist/formats/manual_section/notification/schema.json
+++ b/content_schemas/dist/formats/manual_section/notification/schema.json
@@ -435,8 +435,24 @@
         "alternative_format_contact_email": {
           "type": "string"
         },
-        "asset_manager_id": {
-          "type": "string"
+        "assets": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "asset_manager_id",
+              "filename"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "asset_manager_id": {
+                "type": "string"
+              },
+              "filename": {
+                "type": "string"
+              }
+            }
+          }
         },
         "attachment_type": {
           "type": "string",

--- a/content_schemas/dist/formats/manual_section/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/manual_section/publisher_v2/schema.json
@@ -235,8 +235,24 @@
         "alternative_format_contact_email": {
           "type": "string"
         },
-        "asset_manager_id": {
-          "type": "string"
+        "assets": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "asset_manager_id",
+              "filename"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "asset_manager_id": {
+                "type": "string"
+              },
+              "filename": {
+                "type": "string"
+              }
+            }
+          }
         },
         "attachment_type": {
           "type": "string",

--- a/content_schemas/dist/formats/news_article/frontend/schema.json
+++ b/content_schemas/dist/formats/news_article/frontend/schema.json
@@ -378,8 +378,24 @@
         "alternative_format_contact_email": {
           "type": "string"
         },
-        "asset_manager_id": {
-          "type": "string"
+        "assets": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "asset_manager_id",
+              "filename"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "asset_manager_id": {
+                "type": "string"
+              },
+              "filename": {
+                "type": "string"
+              }
+            }
+          }
         },
         "attachment_type": {
           "type": "string",

--- a/content_schemas/dist/formats/news_article/notification/schema.json
+++ b/content_schemas/dist/formats/news_article/notification/schema.json
@@ -497,8 +497,24 @@
         "alternative_format_contact_email": {
           "type": "string"
         },
-        "asset_manager_id": {
-          "type": "string"
+        "assets": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "asset_manager_id",
+              "filename"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "asset_manager_id": {
+                "type": "string"
+              },
+              "filename": {
+                "type": "string"
+              }
+            }
+          }
         },
         "attachment_type": {
           "type": "string",

--- a/content_schemas/dist/formats/news_article/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/news_article/publisher_v2/schema.json
@@ -305,8 +305,24 @@
         "alternative_format_contact_email": {
           "type": "string"
         },
-        "asset_manager_id": {
-          "type": "string"
+        "assets": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "asset_manager_id",
+              "filename"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "asset_manager_id": {
+                "type": "string"
+              },
+              "filename": {
+                "type": "string"
+              }
+            }
+          }
         },
         "attachment_type": {
           "type": "string",

--- a/content_schemas/dist/formats/publication/frontend/schema.json
+++ b/content_schemas/dist/formats/publication/frontend/schema.json
@@ -727,8 +727,24 @@
             "alternative_format_contact_email": {
               "type": "string"
             },
-            "asset_manager_id": {
-              "type": "string"
+            "assets": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": [
+                  "asset_manager_id",
+                  "filename"
+                ],
+                "additionalProperties": false,
+                "properties": {
+                  "asset_manager_id": {
+                    "type": "string"
+                  },
+                  "filename": {
+                    "type": "string"
+                  }
+                }
+              }
             },
             "attachment_type": {
               "type": "string",

--- a/content_schemas/dist/formats/publication/notification/schema.json
+++ b/content_schemas/dist/formats/publication/notification/schema.json
@@ -857,8 +857,24 @@
             "alternative_format_contact_email": {
               "type": "string"
             },
-            "asset_manager_id": {
-              "type": "string"
+            "assets": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": [
+                  "asset_manager_id",
+                  "filename"
+                ],
+                "additionalProperties": false,
+                "properties": {
+                  "asset_manager_id": {
+                    "type": "string"
+                  },
+                  "filename": {
+                    "type": "string"
+                  }
+                }
+              }
             },
             "attachment_type": {
               "type": "string",

--- a/content_schemas/dist/formats/publication/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/publication/publisher_v2/schema.json
@@ -540,8 +540,24 @@
             "alternative_format_contact_email": {
               "type": "string"
             },
-            "asset_manager_id": {
-              "type": "string"
+            "assets": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": [
+                  "asset_manager_id",
+                  "filename"
+                ],
+                "additionalProperties": false,
+                "properties": {
+                  "asset_manager_id": {
+                    "type": "string"
+                  },
+                  "filename": {
+                    "type": "string"
+                  }
+                }
+              }
             },
             "attachment_type": {
               "type": "string",

--- a/content_schemas/dist/formats/specialist_document/frontend/schema.json
+++ b/content_schemas/dist/formats/specialist_document/frontend/schema.json
@@ -1990,8 +1990,24 @@
         "alternative_format_contact_email": {
           "type": "string"
         },
-        "asset_manager_id": {
-          "type": "string"
+        "assets": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "asset_manager_id",
+              "filename"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "asset_manager_id": {
+                "type": "string"
+              },
+              "filename": {
+                "type": "string"
+              }
+            }
+          }
         },
         "attachment_type": {
           "type": "string",

--- a/content_schemas/dist/formats/specialist_document/notification/schema.json
+++ b/content_schemas/dist/formats/specialist_document/notification/schema.json
@@ -2131,8 +2131,24 @@
         "alternative_format_contact_email": {
           "type": "string"
         },
-        "asset_manager_id": {
-          "type": "string"
+        "assets": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "asset_manager_id",
+              "filename"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "asset_manager_id": {
+                "type": "string"
+              },
+              "filename": {
+                "type": "string"
+              }
+            }
+          }
         },
         "attachment_type": {
           "type": "string",

--- a/content_schemas/dist/formats/specialist_document/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/specialist_document/publisher_v2/schema.json
@@ -1823,8 +1823,24 @@
         "alternative_format_contact_email": {
           "type": "string"
         },
-        "asset_manager_id": {
-          "type": "string"
+        "assets": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "asset_manager_id",
+              "filename"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "asset_manager_id": {
+                "type": "string"
+              },
+              "filename": {
+                "type": "string"
+              }
+            }
+          }
         },
         "attachment_type": {
           "type": "string",

--- a/content_schemas/dist/formats/statistical_data_set/frontend/schema.json
+++ b/content_schemas/dist/formats/statistical_data_set/frontend/schema.json
@@ -602,8 +602,24 @@
             "alternative_format_contact_email": {
               "type": "string"
             },
-            "asset_manager_id": {
-              "type": "string"
+            "assets": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": [
+                  "asset_manager_id",
+                  "filename"
+                ],
+                "additionalProperties": false,
+                "properties": {
+                  "asset_manager_id": {
+                    "type": "string"
+                  },
+                  "filename": {
+                    "type": "string"
+                  }
+                }
+              }
             },
             "attachment_type": {
               "type": "string",

--- a/content_schemas/dist/formats/statistical_data_set/notification/schema.json
+++ b/content_schemas/dist/formats/statistical_data_set/notification/schema.json
@@ -714,8 +714,24 @@
             "alternative_format_contact_email": {
               "type": "string"
             },
-            "asset_manager_id": {
-              "type": "string"
+            "assets": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": [
+                  "asset_manager_id",
+                  "filename"
+                ],
+                "additionalProperties": false,
+                "properties": {
+                  "asset_manager_id": {
+                    "type": "string"
+                  },
+                  "filename": {
+                    "type": "string"
+                  }
+                }
+              }
             },
             "attachment_type": {
               "type": "string",

--- a/content_schemas/dist/formats/statistical_data_set/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/statistical_data_set/publisher_v2/schema.json
@@ -402,8 +402,24 @@
             "alternative_format_contact_email": {
               "type": "string"
             },
-            "asset_manager_id": {
-              "type": "string"
+            "assets": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "required": [
+                  "asset_manager_id",
+                  "filename"
+                ],
+                "additionalProperties": false,
+                "properties": {
+                  "asset_manager_id": {
+                    "type": "string"
+                  },
+                  "filename": {
+                    "type": "string"
+                  }
+                }
+              }
             },
             "attachment_type": {
               "type": "string",

--- a/content_schemas/dist/formats/travel_advice/frontend/schema.json
+++ b/content_schemas/dist/formats/travel_advice/frontend/schema.json
@@ -390,8 +390,24 @@
         "alternative_format_contact_email": {
           "type": "string"
         },
-        "asset_manager_id": {
-          "type": "string"
+        "assets": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "asset_manager_id",
+              "filename"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "asset_manager_id": {
+                "type": "string"
+              },
+              "filename": {
+                "type": "string"
+              }
+            }
+          }
         },
         "attachment_type": {
           "type": "string",

--- a/content_schemas/dist/formats/travel_advice/notification/schema.json
+++ b/content_schemas/dist/formats/travel_advice/notification/schema.json
@@ -484,8 +484,24 @@
         "alternative_format_contact_email": {
           "type": "string"
         },
-        "asset_manager_id": {
-          "type": "string"
+        "assets": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "asset_manager_id",
+              "filename"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "asset_manager_id": {
+                "type": "string"
+              },
+              "filename": {
+                "type": "string"
+              }
+            }
+          }
         },
         "attachment_type": {
           "type": "string",

--- a/content_schemas/dist/formats/travel_advice/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/travel_advice/publisher_v2/schema.json
@@ -284,8 +284,24 @@
         "alternative_format_contact_email": {
           "type": "string"
         },
-        "asset_manager_id": {
-          "type": "string"
+        "assets": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "asset_manager_id",
+              "filename"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "asset_manager_id": {
+                "type": "string"
+              },
+              "filename": {
+                "type": "string"
+              }
+            }
+          }
         },
         "attachment_type": {
           "type": "string",

--- a/content_schemas/dist/formats/working_group/frontend/schema.json
+++ b/content_schemas/dist/formats/working_group/frontend/schema.json
@@ -322,8 +322,24 @@
         "alternative_format_contact_email": {
           "type": "string"
         },
-        "asset_manager_id": {
-          "type": "string"
+        "assets": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "asset_manager_id",
+              "filename"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "asset_manager_id": {
+                "type": "string"
+              },
+              "filename": {
+                "type": "string"
+              }
+            }
+          }
         },
         "attachment_type": {
           "type": "string",

--- a/content_schemas/dist/formats/working_group/notification/schema.json
+++ b/content_schemas/dist/formats/working_group/notification/schema.json
@@ -413,8 +413,24 @@
         "alternative_format_contact_email": {
           "type": "string"
         },
-        "asset_manager_id": {
-          "type": "string"
+        "assets": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "asset_manager_id",
+              "filename"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "asset_manager_id": {
+                "type": "string"
+              },
+              "filename": {
+                "type": "string"
+              }
+            }
+          }
         },
         "attachment_type": {
           "type": "string",

--- a/content_schemas/dist/formats/working_group/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/working_group/publisher_v2/schema.json
@@ -219,8 +219,24 @@
         "alternative_format_contact_email": {
           "type": "string"
         },
-        "asset_manager_id": {
-          "type": "string"
+        "assets": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "asset_manager_id",
+              "filename"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "asset_manager_id": {
+                "type": "string"
+              },
+              "filename": {
+                "type": "string"
+              }
+            }
+          }
         },
         "attachment_type": {
           "type": "string",

--- a/content_schemas/formats/shared/definitions/asset_links.jsonnet
+++ b/content_schemas/formats/shared/definitions/asset_links.jsonnet
@@ -1,7 +1,21 @@
 local FileAttachmentAssetProperties = {
   accessible: { type: "boolean", },
   alternative_format_contact_email: { type: "string", },
-  asset_manager_id: { type: "string", },
+  assets: {
+    type: "array",
+    items: {
+      type: "object",
+      additionalProperties: false,
+      required: [
+        "asset_manager_id",
+        "filename"
+      ],
+      properties: {
+        asset_manager_id: { type: "string", },
+        filename: { type: "string", },
+      },
+    },
+  },
   attachment_type: { type: "string", enum: ["file"], },
   content_type: { type: "string", },
   file_size: { type: "integer", },


### PR DESCRIPTION
We decided we would require returning all assets array for file attachments, instead of returning only the `asset_manager_id` of the first asset. 
Here is the whitehall PR for sending this information https://github.com/alphagov/whitehall/pull/9641

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
