### PR TITLE
Skip edition specific prom labels if no edition

### DIFF
--- a/app/controllers/graphql_controller.rb
+++ b/app/controllers/graphql_controller.rb
@@ -80,6 +80,8 @@ private
   end
 
   def set_prometheus_labels(edition)
+    return unless edition
+
     prometheus_labels = request.env.fetch("govuk.prometheus_labels", {})
 
     request.env["govuk.prometheus_labels"] = prometheus_labels.merge(


### PR DESCRIPTION
At the moment, the code assumes that there will always be an edition in the graphql response, and that we can therefore look up the document_type / schema_name from the edition.

There are a few scenarios where this isn't true however

- the /graphql endpoint is also used to load the graphql schema for introspection, but no query is executed there so there's no edition.
- a query that doesn't return an edition is executed (e.g. `query { __typename }`)
- we try to load an edition, but there's an error like a 404 or something

In all of these cases currently, the code will raise a NoMethodError because `nil` doesn't have the `[]` method.

Instead, we should just not try to set prometheus labels in this situation.
