### PR TITLE
ADR009 Part 7 - drop link_set_id indexes and foreign key constraints

### DIFF
--- a/db/migrate/20250502153736_remove_indexes_from_links.rb
+++ b/db/migrate/20250502153736_remove_indexes_from_links.rb
@@ -1,0 +1,7 @@
+class RemoveIndexesFromLinks < ActiveRecord::Migration[8.0]
+  def change
+    remove_index :links, name: "index_links_on_link_set_id"
+    remove_index :links, name: "index_links_on_link_set_id_and_target_content_id"
+    remove_index :links, name: "index_links_on_link_set_id_and_link_type"
+  end
+end

--- a/db/migrate/20250502155450_remove_link_set_id_foreign_key.rb
+++ b/db/migrate/20250502155450_remove_link_set_id_foreign_key.rb
@@ -1,0 +1,5 @@
+class RemoveLinkSetIdForeignKey < ActiveRecord::Migration[8.0]
+  def change
+    remove_foreign_key :links, to_table: :link_sets, column: :link_set_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_03_26_155406) do
+ActiveRecord::Schema[8.0].define(version: 2025_05_02_153736) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -162,12 +162,9 @@ ActiveRecord::Schema[8.0].define(version: 2025_03_26_155406) do
     t.uuid "link_set_content_id"
     t.index ["edition_id", "link_type"], name: "index_links_on_edition_id_and_link_type"
     t.index ["edition_id"], name: "index_links_on_edition_id"
-    t.index ["link_set_id", "link_type"], name: "index_links_on_link_set_id_and_link_type"
     t.index ["link_set_content_id", "link_type"], name: "index_links_on_link_set_content_id_and_link_type"
     t.index ["link_set_content_id", "target_content_id"], name: "index_links_on_link_set_content_id_and_target_content_id"
     t.index ["link_set_content_id"], name: "index_links_on_link_set_content_id"
-    t.index ["link_set_id", "target_content_id"], name: "index_links_on_link_set_id_and_target_content_id"
-    t.index ["link_set_id"], name: "index_links_on_link_set_id"
     t.index ["link_type"], name: "index_links_on_link_type"
     t.index ["target_content_id", "link_type"], name: "index_links_on_target_content_id_and_link_type"
     t.index ["target_content_id"], name: "index_links_on_target_content_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_05_02_153736) do
+ActiveRecord::Schema[8.0].define(version: 2025_05_02_155450) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -217,7 +217,6 @@ ActiveRecord::Schema[8.0].define(version: 2025_05_02_153736) do
   add_foreign_key "editions", "documents"
   add_foreign_key "link_changes", "actions", on_delete: :cascade
   add_foreign_key "links", "editions", on_delete: :cascade
-  add_foreign_key "links", "link_sets"
   add_foreign_key "links", "link_sets", column: "link_set_content_id", primary_key: "content_id"
   add_foreign_key "unpublishings", "editions", on_delete: :cascade
 end


### PR DESCRIPTION
As per [ADR009 Part 7](https://github.com/alphagov/publishing-api/blob/main/docs/arch/adr-009-change-linksets-primary-key-to-content-id.md#7---drop-indexes-and-constraints-on-link_set_id), we can remove the unused indexes and foreign key constraints on link_set_id, now that we're using link_set_content_id everywhere.

I've done a quick check to confirm that the indexes are no longer being used by running `rake pg_extras:index_info` and comparing the count of index scans for the ones I'm removing over a ~40 minute period. It hasn't increased at all in that time, which supports my already high level of confidence that these indexes are no longer used. I'll check the current numbers against fresh values next week, just to be doubly sure. Current production counts:

```
% k exec deploy/publishing-api -- rake pg_extras:index_info 2>/dev/null | awk -F '|' '/link_set_id/ { print $2 $6 }'
 index_links_on_link_set_id                                6094270031
 index_links_on_link_set_id_and_target_content_id          10190437328
 index_links_on_link_set_id_and_link_type                  1535748454
 ```

Only a few more steps after this one 😅 