### PR TITLE
ADR-009 - Ignore the link_set_id column

### DIFF
--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -1,4 +1,6 @@
 class Link < ApplicationRecord
+  self.ignored_columns += %w[link_set_id]
+
   include SymbolizeJSON
 
   belongs_to :link_set,


### PR DESCRIPTION
This is preparation to remove the column. strong_migrations warns me that removing columns can cause problems with ActiveRecord caching database columns, so we need to ignore it first, deploy that, and then remove it afterwards:

https://github.com/ankane/strong_migrations/blob/master/README.md#removing-a-column
