### PR TITLE
ADR-009 - Remove the link_set_id column

### DIFF
--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -1,6 +1,4 @@
 class Link < ApplicationRecord
-  self.ignored_columns += %w[link_set_id]
-
   include SymbolizeJSON
 
   belongs_to :link_set,

--- a/db/migrate/20250507112152_remove_link_set_id.rb
+++ b/db/migrate/20250507112152_remove_link_set_id.rb
@@ -1,0 +1,5 @@
+class RemoveLinkSetId < ActiveRecord::Migration[8.0]
+  def change
+    safety_assured { remove_column :links, :link_set_id, :integer }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_05_02_155450) do
+ActiveRecord::Schema[8.0].define(version: 2025_05_07_112152) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -152,7 +152,6 @@ ActiveRecord::Schema[8.0].define(version: 2025_05_02_155450) do
   end
 
   create_table "links", id: :serial, force: :cascade do |t|
-    t.integer "link_set_id"
     t.uuid "target_content_id"
     t.string "link_type", null: false
     t.datetime "created_at", precision: nil, null: false


### PR DESCRIPTION
Now that we've ignored the link_set_id column, it's safe to remove it.

The safety_assured block tells the strong_migrations gem that we've done the steps needed to make this migration safe, so it should allow it to proceed.
