### PR TITLE
Disable SSL

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -19,10 +19,10 @@ Rails.application.configure do
   # config.asset_host = "http://assets.example.com"
 
   # Assume all access to the app is happening through a SSL-terminating reverse proxy.
-  config.assume_ssl = true
+  # config.assume_ssl = true
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  config.force_ssl = true
+  # config.force_ssl = true
 
   # Skip http-to-https redirect for the default health check endpoint.
   # config.ssl_options = { redirect: { exclude: ->(request) { request.path == "/up" } } }


### PR DESCRIPTION
In other apps, when upgrading to Rails 8 we kept these setting commented out. We terminate SSL before requests reach apps, and using force_ssl has resulted in issues in the past

Another team have reported that Content Publisher's resync Rake tasks are failing when trying to page through a collection of Contact editions using the GDS API Adapters `get_paged_editions` method. They suspect that the issue is to do with requests being sent with a HTTP schema (via Plek) but the "next" links in the paged editions using the HTTPS schema

It seems plausible that these settings might be the culprit here, and turning off these SSL settings would bring Publishing API back in line with other apps

https://govuk.zendesk.com/agent/tickets/6075094

[Trello](https://trello.com/c/4opU3EWz/1708-republish-about-700-news-articles)