### PR TITLE
(CM-97) Fetch organisations from documents with link set links, as well as edition links

### DIFF
--- a/app/queries/get_host_content.rb
+++ b/app/queries/get_host_content.rb
@@ -151,7 +151,11 @@ module Queries
           TABLES[:documents][:id].eq(TABLES[:editions][:document_id]),
         )
         .join(TABLES[:primary_links], Arel::Nodes::OuterJoin).on(
-          TABLES[:primary_links][:edition_id].eq(TABLES[:editions][:id]),
+          TABLES[:primary_links][:edition_id].eq(
+            TABLES[:editions][:id],
+          ).or(
+            TABLES[:primary_links][:link_set_content_id].eq(TABLES[:documents][:content_id]),
+          ),
           TABLES[:primary_links][:link_type].eq("primary_publishing_organisation"),
         )
         .join(TABLES[:org_documents], Arel::Nodes::OuterJoin).on(


### PR DESCRIPTION
We now want to fetch linked Organisations where the link is a link set link (in the case of Mainstream docs) or an edition link.