### PR TITLE
Add /government/feed special route

### DIFF
--- a/lib/data/special_routes.yaml
+++ b/lib/data/special_routes.yaml
@@ -138,6 +138,13 @@
   :rendering_app: "static"
   :override_existing: true
 
+- :base_path: "/government/feed"
+  :content_id: "725a346f-9e5b-486d-873d-2b050c126e09"
+  :title: "Government feed"
+  :description: "This route serves the feed of published content"
+  :rendering_app: "collections"
+  :override_existing: true
+
 - :base_path: "/government/history/past-chancellors"
   :content_id: "ac47f738-b6c3-4369-8d22-ce143c947442"
   :title: "Past Chancellors of the Exchequer"


### PR DESCRIPTION
This is being removed from Whitehall:
https://github.com/alphagov/whitehall/pull/10219

Trello: https://trello.com/c/4b7Rlfgt/3736-remove-specialroute-logic-from-whitehall

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
