### PR TITLE
Fix sed command

### DIFF
--- a/script/diff_graphql/filter_base_paths.sh
+++ b/script/diff_graphql/filter_base_paths.sh
@@ -53,7 +53,7 @@ if [ ${#schema_names[@]} -eq 0 ]; then
   exit 1
 fi
 
-sed -i -r -e '/^"url_path"$/d' -e 's/"//g' $data_dir/unfiltered_base_paths
+sed -i '' -r -e '/^"url_path"$/d' -e 's/"//g' $data_dir/unfiltered_base_paths
 
 echo "Unfiltered base paths: $(grep -c '^' $data_dir/unfiltered_base_paths)"
 


### PR DESCRIPTION
When using `-i` on macOS, the next argument is taken as a suffix to add to a backup copy before the in-place edit, so this was creating a backup with the suffix `-r`. Providing an empty string skips the backup. The `-r` for extended regex probably isn't needed in this case (given it wasn't being used as a flag before), but to keep things consistent with other `sed` usage across these script files, I'll keep it

[Trello](https://trello.com/c/e6WaxpHA/1676-automate-detecting-differences-between-pages-rendered-by-graphql-and-content-store)