### PR TITLE
Support filtering base paths via Content Store

### DIFF
--- a/docs/graphql/checking-parity-with-content-store.md
+++ b/docs/graphql/checking-parity-with-content-store.md
@@ -25,7 +25,9 @@ example Trino SQL query. You just need to edit the dates.
 Save the output to `tmp/diff_graphql/unfiltered_base_paths` and then run the
 `script/diff_graphql/filter_base_paths.sh` script to filter the base paths by
 one or more schema names in preparation for running the bulk script. You will
-need a replicated Publishing API database for this script to work properly.
+need a replicated Publishing API or Content Store database for this script to
+work properly. If using Content Store, pass the `--with-content-store` flag to
+the script.
 
 ```sql
 SELECT DISTINCT

--- a/script/diff_graphql/filter_base_paths.rb
+++ b/script/diff_graphql/filter_base_paths.rb
@@ -8,22 +8,44 @@ batch_count = (unfiltered_base_paths.count.to_f / batch_size).ceil
 filtered_base_paths = []
 
 puts "Filtering #{unfiltered_base_paths.count} base paths by schema name in #{batch_count} batch(es) of up to #{batch_size}
-Target schema names: #{schema_name.sort.join(', ')}
+Target schema names: #{schema_name.sort.join(', ')}\n\n"
+
+case Rails.application.name
+when "publishing-api"
+  puts "Filtering with Publishing API
 
 Note: this requires a replicated Publishing API database\n\n"
+
+  def query(unfiltered_base_paths, schema_name)
+    Edition
+      .live
+      .where(
+        base_path: unfiltered_base_paths,
+        schema_name:,
+      )
+      .pluck(:base_path)
+  end
+when "content-store"
+  puts "Filtering with Content Store
+
+Note: this requires a replicated Content Store database\n\n"
+
+  def query(unfiltered_base_paths, schema_name) # rubocop:disable Lint/DuplicateMethods
+    ContentItem
+      .where(
+        base_path: unfiltered_base_paths,
+        schema_name:,
+      )
+      .pluck(:base_path)
+  end
+end
 
 unfiltered_base_paths
   .each_slice(batch_size)
   .with_index do |unfiltered_base_paths_slice, index|
   puts "Processing batch #{index + 1} of #{batch_count}"
 
-  filtered_base_paths += Edition
-    .live
-    .where(
-      base_path: unfiltered_base_paths_slice,
-      schema_name:,
-    )
-    .pluck(:base_path)
+  filtered_base_paths += query(unfiltered_base_paths_slice, schema_name)
 end
 
 File.open("script/diff_graphql/filtered_base_paths", "w") do |file|


### PR DESCRIPTION
Content Store's database and database dumps are far smaller than those of Publishing API: around 20x smaller based on my copies, which were downloaded a week apart (Publishing API: 14 April, 74GB; Content Store: 21 April, 3.7GB). This makes it much quicker to replicate and less problematic when local disk space is limited. Not many people have clean, recently-replicated Publishing API databases

This adds an option to filter base paths using Content Store, which reduces the barrier to entry for diffing Content Store and Publishing API's GraphQL endpoint

[Trello](https://trello.com/c/e6WaxpHA/1676-automate-detecting-differences-between-pages-rendered-by-graphql-and-content-store)