### PR TITLE
GraphQL Reverse link from role to organisations

### DIFF
--- a/app/graphql/types/ministers_index_type.rb
+++ b/app/graphql/types/ministers_index_type.rb
@@ -27,10 +27,22 @@ module Types
               field :whip_organisation, MinistersIndexRoleDetailsWhipOrganisation
             end
 
+            class MinistersIndexRoleLinks < Types::BaseObject
+              class Organisation < Types::BaseObject
+                field :content_id, String
+              end
+
+              # We can work backwards from the `ordered_roles` link_type which goes:
+              #     Organisation --ordered_roles--> [Role]
+              # To work out which organisations this role belongs to:
+              reverse_links_field :organisations, :ordered_roles, [Organisation]
+            end
+
             field :content_id, String
             field :details, MinistersIndexRoleDetails
             field :title, String
             field :web_url, String
+            field :links, MinistersIndexRoleLinks, method: :itself
           end
 
           field :role, [MinistersIndexRole]
@@ -85,6 +97,7 @@ module Types
       field :links, DepartmentLinks, method: :itself
       field :title, String
       field :web_url, String
+      field :content_id, String
     end
 
     class MinistersIndexLinks < Types::BaseObject


### PR DESCRIPTION
We can use the existing link structure to lookup the organisations that a role belongs to. This relationship is represented by a forward link from an organisation via a "ordered_roles" link to a number of roles, but we can follow it in reverse to go back from a role to a number of organisations it belongs to.

Combining this with adding content_ids to the organisations in the ministers index query lets us check whether a role belongs to a ministerial department in a much more efficient way than querying all of the roles in every department.
