### PR TITLE
Add `url_override` field to GraphQL edition type details

### DIFF
--- a/app/graphql/types/edition_type.rb
+++ b/app/graphql/types/edition_type.rb
@@ -154,6 +154,7 @@ module Types
       field :seniority, Integer
       field :started_on, Types::ContentApiDatetime
       field :supports_historical_accounts, Boolean
+      field :url_override, String
       field :whip_organisation, WhipOrganisation
       field :world_locations, [EditionType], null: false
     end


### PR DESCRIPTION
This field is needed to correctly render the taxonomy in frontend applications and was added to a GraphQL query in
https://github.com/alphagov/frontend/pull/4820.

Therefore enabling the field to be requested in a GraphQL query.

[Trello card](https://trello.com/c/iTATIUv4)