### PR TITLE
Do not return the same document twice in reverse links

### DIFF
--- a/app/graphql/sources/reverse_linked_to_editions_source.rb
+++ b/app/graphql/sources/reverse_linked_to_editions_source.rb
@@ -51,7 +51,9 @@ module Sources
       all_editions.each_with_object(link_types_map) { |edition, hash|
         next if edition.state == "unpublished" && %w[children parent related_statistical_data_sets].exclude?(edition.link_type)
 
-        hash[[edition.target_content_id, edition.link_type]] << edition
+        unless hash[[edition.target_content_id, edition.link_type]].include?(edition)
+          hash[[edition.target_content_id, edition.link_type]] << edition
+        end
       }.values
     end
   end


### PR DESCRIPTION
There are cases where the same links appear as both link set links and edition links (e.g. [document collections published by Whitehall](https://github.com/alphagov/whitehall/blob/03d5b51948b367d4484bd22ca78708eeb6dda017/app/presenters/publishing_api/document_collection_presenter.rb#L33-L48)).

When sent to Content Store, the document is only included in the reverse links array once.  However GraphQL is returning the link twice, meaning the same link in repeated twice on the website.

Updating the logic of the source to only return the link once, even if it appears as both a link set and edition link.

This phenomenon can be seen on some documents, such as [this press release](https://www.gov.uk/government/news/government-publishes-second-transformation-consultation-response?graphql=true).

[Trello card](https://trello.com/c/bBztfL8K)