### PR TITLE
Add govuk:content-has-history meta tags to false positive list in graphql diff script

### DIFF
--- a/script/diff_graphql/functions.sh
+++ b/script/diff_graphql/functions.sh
@@ -25,6 +25,7 @@ function curl_and_strip_hashes() {
         -e 's/nonce="[^"]{22}=="/nonce="HASH=="/g' \
         -e 's/ (aria-labelledby|for|id)="([^"]+)-[a-z0-9]{8}"/ \1="\2-HASH"/g' \
         -e 's/<meta name="govuk:updated-at" content=".*">/<meta name="govuk:updated-at" content="TIMESTAMP">/' \
+        -e '/<meta name="govuk:content-has-history" content=".*">/d' \
     > "$output_path"
 }
 


### PR DESCRIPTION

A seperate bug is causing these meta-tags to be applied where they shouldn't be, so they need to be left out of the diff script until that is fixed.

Trello: https://trello.com/c/XqtBMIiR/1729-add-the-govukcontent-has-history-meta-tag-to-the-comparison-script-so-we-dont-get-a-load-of-false-positives-when-comparing-docum

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
