### PR TITLE
Get GraphQL links that match primary locale or "en"

### DIFF
--- a/app/graphql/types/base_object.rb
+++ b/app/graphql/types/base_object.rb
@@ -13,7 +13,7 @@ module Types
         dataloader.with(
           Sources::LinkedToEditionsSource,
           content_store: object.content_store,
-          locale: "en",
+          locale: context[:root_edition].locale,
         )
           .load([object, link_type.to_s])
       end
@@ -26,7 +26,7 @@ module Types
         dataloader.with(
           Sources::ReverseLinkedToEditionsSource,
           content_store: object.content_store,
-          locale: "en",
+          locale: context[:root_edition].locale,
         )
           .load([object, link_type.to_s])
       end

--- a/app/graphql/types/edition_type.rb
+++ b/app/graphql/types/edition_type.rb
@@ -106,14 +106,14 @@ module Types
           dataloader.with(
             Sources::ReverseLinkedToEditionsSource,
             content_store: object.content_store,
-            locale: "en",
+            locale: context[:root_edition].locale,
           )
             .load([object, "role"])
         else
           dataloader.with(
             Sources::ReverseLinkedToEditionsSource,
             content_store: object.content_store,
-            locale: "en",
+            locale: context[:root_edition].locale,
           )
             .load([object, "person"])
         end


### PR DESCRIPTION
This reapplies a new-and-improved version of the final commit from https://github.com/alphagov/publishing-api/pull/3371. We decided to revert that commit this morning because of an issue it introduced to our live GraphQL-backed pages.

The issue resulted from my slapdash partitioning of `row_number()`. Linked-to Editions were being compared and scored against each other when they should've been in separate windows, which meant that Editions we actually wanted were inadvertently excluded from the database query's results.

https://trello.com/c/Dqvtk09M/1668-fix-diff-we-only-return-the-english-links-even-if-a-translation-is-requested