### PR TITLE
Remove Contacts Admin from Publishing API CI

### DIFF
--- a/.github/workflows/test-content-schemas-1.yml
+++ b/.github/workflows/test-content-schemas-1.yml
@@ -28,13 +28,6 @@ jobs:
       ref: 'main'
       publishingApiRef: ${{ github.ref }}
 
-  test-contacts-admin:
-    name: Test Contacts Admin
-    uses: alphagov/contacts-admin/.github/workflows/rspec.yml@main
-    with:
-      ref: 'main'
-      publishingApiRef: ${{ github.ref }}
-
   test-content-data-api:
     name: Test Content Data API
     uses: alphagov/content-data-api/.github/workflows/rspec.yml@main


### PR DESCRIPTION
Trello: https://trello.com/c/MiBvG4Xs/3767-retire-contacts-admin

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
