### PR TITLE
CM-154: add a contact_type enum to Contact blocks

### DIFF
--- a/content_schemas/dist/formats/content_block_contact/notification/schema.json
+++ b/content_schemas/dist/formats/content_block_contact/notification/schema.json
@@ -375,6 +375,9 @@
     },
     "details": {
       "type": "object",
+      "required": [
+        "contact_type"
+      ],
       "additionalProperties": false,
       "properties": {
         "addresses": {
@@ -437,6 +440,15 @@
               }
             }
           }
+        },
+        "contact_type": {
+          "type": "string",
+          "default": "General",
+          "enum": [
+            "General",
+            "Freedom of Information",
+            "Media enquiries"
+          ]
         },
         "description": {
           "type": "string"

--- a/content_schemas/dist/formats/content_block_contact/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/content_block_contact/publisher_v2/schema.json
@@ -195,6 +195,9 @@
     },
     "details": {
       "type": "object",
+      "required": [
+        "contact_type"
+      ],
       "additionalProperties": false,
       "properties": {
         "addresses": {
@@ -254,6 +257,15 @@
               }
             }
           }
+        },
+        "contact_type": {
+          "type": "string",
+          "default": "General",
+          "enum": [
+            "General",
+            "Freedom of Information",
+            "Media enquiries"
+          ]
         },
         "description": {
           "type": "string"

--- a/content_schemas/examples/content_block_contact/publisher_v2/example.json
+++ b/content_schemas/examples/content_block_contact/publisher_v2/example.json
@@ -7,6 +7,7 @@
   "content_id_alias": "hmrc-media",
   "details": {
     "description": "Description goes here",
+    "contact_type": "General",
     "email_addresses": {
       "email-1": {
         "title": "Email 1",

--- a/content_schemas/formats/content_block_contact.jsonnet
+++ b/content_schemas/formats/content_block_contact.jsonnet
@@ -10,6 +10,15 @@ local utils = import "shared/utils/content_block_utils.jsonnet";
         description: {
           type: "string"
         },
+        contact_type: {
+          type: "string",
+          enum: [
+            "General",
+            "Freedom of Information",
+            "Media enquiries",
+          ],
+          default: "General"
+        },
         email_addresses: utils.embedded_object(
           {
             email_address: {
@@ -58,8 +67,9 @@ local utils = import "shared/utils/content_block_utils.jsonnet";
                 },
             },
             ["street_address", "locality", "postal_code", "country"],
-        )
+        ),
       },
+      required: [ "contact_type" ]
     },
   },
 }


### PR DESCRIPTION
Not to be merged until frontend work completed: https://github.com/alphagov/publishing-api/pull/3389

This will provide a set selection of types to categorise a Contact 

https://gov-uk.atlassian.net/browse/CM-153 

Because we have an `enum` on `Pension` that is a string that needs to be set as a human readable string, e.g. "a week", "a day", I've had to set the enum as it would be rendered on the screen, otherwise it would get a bit complicated trying to write unique logic for the rendering of different types of enum... 

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
