### PR TITLE
Add credit to GraphQL image type

### DIFF
--- a/app/graphql/types/edition_type.rb
+++ b/app/graphql/types/edition_type.rb
@@ -129,6 +129,7 @@ module Types
       class Image < Types::BaseObject
         field :alt_text, String
         field :caption, String
+        field :credit, String
         field :high_resolution_url, String
         field :url, String
       end

--- a/spec/integration/graphql/news_article_spec.rb
+++ b/spec/integration/graphql/news_article_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe "GraphQL" do
           image: {
             alt_text: "Some alt text",
             caption: "Some caption",
+            credit: "Some credit",
             high_resolution_url: "https://assets.publishing.service.gov.uk/media/324438lksdjalsdj/s960_my_lovely_hd_image.jpg",
             url: "https://assets.publishing.service.gov.uk/media/29843nksdfjhdsfj/s300_my_lovely_image.jpg",
           },
@@ -122,6 +123,7 @@ RSpec.describe "GraphQL" do
                   image {
                     alt_text
                     caption
+                    credit
                     high_resolution_url
                     url
                   }


### PR DESCRIPTION
We need to be able to retrieve the credit string for images, in order to be able to serve them on news article pages.

[Trello card](https://trello.com/c/i5VltxEI)