### PR TITLE
Add contains_errors label to graphql prom metrics

### DIFF
--- a/spec/integration/graphql/generic_edition_spec.rb
+++ b/spec/integration/graphql/generic_edition_spec.rb
@@ -94,8 +94,16 @@ RSpec.describe "GraphQL" do
           }",
       }
 
-      expect(request.env["govuk.prometheus_labels"][:document_type]).to eq(edition.document_type)
-      expect(request.env["govuk.prometheus_labels"][:schema_name]).to eq(edition.schema_name)
+      expect(request.env["govuk.prometheus_labels"]["document_type"]).to eq(edition.document_type)
+      expect(request.env["govuk.prometheus_labels"]["schema_name"]).to eq(edition.schema_name)
+    end
+
+    it "sets the contains_errors prometheus label if there is an error" do
+      post "/graphql", params: {
+        query: "{brokenQuery}",
+      }
+
+      expect(request.env["govuk.prometheus_labels"]["contains_errors"]).to eq(true)
     end
 
     context "when the edition is unpublished" do


### PR DESCRIPTION
GraphQL can return HTTP 200 responses which contain errors, like in the good old days of SOAP.

This means it's hard to say what the error rate for GraphQL endpoints is using HTTP level metrics.

We're adding a new label for "contains_errors" so we can get this metric.