### PR TITLE
Ignore withdrawn timestamps in diff script + small fix

### DIFF
--- a/script/diff_graphql/functions.sh
+++ b/script/diff_graphql/functions.sh
@@ -24,7 +24,7 @@ function curl_and_strip_hashes() {
         -e 's/\?graphql=true//g' \
         -e 's/nonce="[^"]{22}=="/nonce="HASH=="/g' \
         -e 's/ (aria-labelledby|for|id)="([^"]+)-[a-z0-9]{8}"/ \1="\2-HASH"/g' \
-        -e 's/<meta name="govuk:updated-at" content=".*">/<meta name="govuk:updated-at" content="TIMESTAMP">/' \
+        -e 's/<(meta name="govuk:updated-at" content=)"[^"]+">/<\1"TIMESTAMP">/' \
         -e '/<meta name="govuk:content-has-history" content=".*">/d' \
         -e 's/(This news article was withdrawn on &lt;time datetime=)"[^"]+"/\1"TIMESTAMP"/' \
         -e 's/(This news article was withdrawn on <time datetime=)"[^"]+"/\1"TIMESTAMP"/' \

--- a/script/diff_graphql/functions.sh
+++ b/script/diff_graphql/functions.sh
@@ -26,6 +26,8 @@ function curl_and_strip_hashes() {
         -e 's/ (aria-labelledby|for|id)="([^"]+)-[a-z0-9]{8}"/ \1="\2-HASH"/g' \
         -e 's/<meta name="govuk:updated-at" content=".*">/<meta name="govuk:updated-at" content="TIMESTAMP">/' \
         -e '/<meta name="govuk:content-has-history" content=".*">/d' \
+        -e 's/(This news article was withdrawn on &lt;time datetime=)"[^"]+"/\1"TIMESTAMP"/' \
+        -e 's/(This news article was withdrawn on <time datetime=)"[^"]+"/\1"TIMESTAMP"/' \
     > "$output_path"
 }
 

--- a/script/diff_graphql/run.sh
+++ b/script/diff_graphql/run.sh
@@ -28,7 +28,7 @@ if [[ $download_html == @(y|yes) ]]; then
     done
   fi
 
-  mkdir -p tmp
+  mkdir -p tmp/diff_graphql
 
   echo ''
   prepare_html \


### PR DESCRIPTION
https://trello.com/c/qvdSDZ7b/1727-make-sure-the-news-articles-pages-are-good-to-go-and-go-them

Content Store and GraphQL present this timestamp in different timezones
and with different string formatting.

E.g. on the page /government/news/zika-virus-data-update, Content Store
has the withdrawn time as "2019-06-25T14:36:51Z" while GraphQL has it as
"2019-06-25T15:36:51+01:00".

Because the GraphQL version is actually consistent with Content Store's
own usual timezone and time string formatting rules, we'll look into
fixing the issue in Content Store (possibly the underlying data) and for
the time being allow the difference.