### PR TITLE
Update call_for_evidence examples

### DIFF
--- a/content_schemas/examples/call_for_evidence/frontend/open_call_for_evidence.json
+++ b/content_schemas/examples/call_for_evidence/frontend/open_call_for_evidence.json
@@ -1,6 +1,6 @@
 {
   "content_id": "bc6eceb8-377e-40f8-911f-f715bc2e5b93",
-  "base_path": "/government/call_for_evidence/youth-vaping-call-for-evidence",
+  "base_path": "/government/calls-for-evidence/youth-vaping-call-for-evidence",
   "description": "A call for evidence seeking information on a range of themes about children and vaping (using an e-cigarette) to inform evidence-based policy decisions.",
   "public_updated_at": "2023-05-15T15:52:59.000+00:00",
   "title": "Youth Vaping",

--- a/content_schemas/examples/call_for_evidence/frontend/open_call_for_evidence.json
+++ b/content_schemas/examples/call_for_evidence/frontend/open_call_for_evidence.json
@@ -13,7 +13,7 @@
     "body": "<div class=\"govspeak\"><p>The government is holding this call for evidence to identify opportunities to reduce the number of children (people aged under 18) accessing and using vape products, while ensuring they are still easily available as a quit aid for adult smokers.</p>\n</div>",
     "first_public_at": "2023-04-11T13:01:57.000+00:00",
     "opening_date": "2023-04-11T13:01:57.000+00:00",
-    "closing_date": "2231-04-16T13:01:57.000+00:00",
+    "closing_date": "2023-04-16T13:01:57.000+00:00",
     "change_history": [
       {
         "public_timestamp": "2021-11-07T16:00:00+00:00",

--- a/content_schemas/examples/call_for_evidence/frontend/unopened_call_for_evidence.json
+++ b/content_schemas/examples/call_for_evidence/frontend/unopened_call_for_evidence.json
@@ -1,6 +1,6 @@
 {
   "content_id": "74522b3f-0416-49ad-85d2-9d4b40b414fa",
-  "base_path": "/government/call_for_evidence/access-to-elections",
+  "base_path": "/government/calls-for-evidence/access-to-elections",
   "description": "A Call for Evidence asking for views on how people with disabilities experience registering to vote and voting itself.",
   "public_updated_at": "2023-05-24T16:04:58.000+00:00",
   "title": "Access to elections",


### PR DESCRIPTION
Trello card: https://trello.com/c/GzNmv0Ag/647-move-callforevidence-from-government-frontend-to-frontend

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
