### PR TITLE
Add UK call charges and description to Contact schema

### DIFF
--- a/content_schemas/dist/formats/content_block_contact/notification/schema.json
+++ b/content_schemas/dist/formats/content_block_contact/notification/schema.json
@@ -490,6 +490,9 @@
               ],
               "additionalProperties": false,
               "properties": {
+                "description": {
+                  "type": "string"
+                },
                 "show_uk_call_charges": {
                   "type": "string",
                   "enum": [

--- a/content_schemas/dist/formats/content_block_contact/notification/schema.json
+++ b/content_schemas/dist/formats/content_block_contact/notification/schema.json
@@ -485,10 +485,18 @@
               "type": "object",
               "required": [
                 "title",
-                "telephone_numbers"
+                "telephone_numbers",
+                "show_uk_call_charges"
               ],
               "additionalProperties": false,
               "properties": {
+                "show_uk_call_charges": {
+                  "type": "string",
+                  "enum": [
+                    "true",
+                    "false"
+                  ]
+                },
                 "telephone_numbers": {
                   "type": "array",
                   "items": {

--- a/content_schemas/dist/formats/content_block_contact/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/content_block_contact/publisher_v2/schema.json
@@ -302,10 +302,18 @@
               "type": "object",
               "required": [
                 "title",
-                "telephone_numbers"
+                "telephone_numbers",
+                "show_uk_call_charges"
               ],
               "additionalProperties": false,
               "properties": {
+                "show_uk_call_charges": {
+                  "type": "string",
+                  "enum": [
+                    "true",
+                    "false"
+                  ]
+                },
                 "telephone_numbers": {
                   "type": "array",
                   "items": {

--- a/content_schemas/dist/formats/content_block_contact/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/content_block_contact/publisher_v2/schema.json
@@ -307,6 +307,9 @@
               ],
               "additionalProperties": false,
               "properties": {
+                "description": {
+                  "type": "string"
+                },
                 "show_uk_call_charges": {
                   "type": "string",
                   "enum": [

--- a/content_schemas/examples/content_block_contact/publisher_v2/example.json
+++ b/content_schemas/examples/content_block_contact/publisher_v2/example.json
@@ -30,17 +30,20 @@
         {
           "label": "Telephone 1",
           "telephone": "1234 567 89",
-          "type": "telephone"
+          "type": "telephone",
+          "show_uk_call_charges": "false"
         },
         {
           "label": "Telephone 2",
           "telephone": "1234 567 89",
-          "type": "textphone"
+          "type": "textphone",
+          "show_uk_call_charges": "true"
         },
         {
           "label": "Telephone 3",
           "telephone": "1234 567 89",
-          "type": "welsh_language"
+          "type": "welsh_language",
+          "show_uk_call_charges": "true"
         }
       ]
     }

--- a/content_schemas/examples/content_block_contact/publisher_v2/example.json
+++ b/content_schemas/examples/content_block_contact/publisher_v2/example.json
@@ -31,7 +31,8 @@
           "label": "Telephone 1",
           "telephone": "1234 567 89",
           "type": "telephone",
-          "show_uk_call_charges": "false"
+          "show_uk_call_charges": "false",
+          "description": "A Telephone line"
         },
         {
           "label": "Telephone 2",

--- a/content_schemas/formats/content_block_contact.jsonnet
+++ b/content_schemas/formats/content_block_contact.jsonnet
@@ -61,6 +61,9 @@ local utils = import "shared/utils/content_block_utils.jsonnet";
                     type: "string",
                     enum: ["true", "false"]
                 },
+                description: {
+                    type: "string",
+                }
              },
              ["telephone_numbers", "show_uk_call_charges"],
         ),

--- a/content_schemas/formats/content_block_contact.jsonnet
+++ b/content_schemas/formats/content_block_contact.jsonnet
@@ -57,8 +57,12 @@ local utils = import "shared/utils/content_block_utils.jsonnet";
                         }
                    }
                 },
+                show_uk_call_charges: {
+                    type: "string",
+                    enum: ["true", "false"]
+                },
              },
-             ["telephone_numbers"],
+             ["telephone_numbers", "show_uk_call_charges"],
         ),
         contact_forms: utils.embedded_object(
             {


### PR DESCRIPTION
Can be merged after the Whitehall repo setup to handle the field http://github.com/alphagov/whitehall/pull/10320

`show_uk_call_charges` is a boolean value, but we cannot use the `boolean` type in the schema because this value is saved in the `details` hash of an Edition, so when the form values are submitted they get converted to strings in the params, and we just save the input in a hash, and it never gets converted to a proper `boolean`. (If it were a top level field in the active record Rails would figure it out)

I have not yet added formatting for the value within review pages/summary cards... will follow up in another PR



----

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
