### PR TITLE
Add one-off task to delete local authority external content editions

### DIFF
--- a/lib/tasks/temp_tidy_local_authority_editions.rake
+++ b/lib/tasks/temp_tidy_local_authority_editions.rake
@@ -1,0 +1,16 @@
+namespace :temp_tidy_local_authority_editions do
+  desc "Destroys all local authority editions for a single local authority"
+  task :by_content_id, [:content_id] => :environment do |_, args|
+    doc = Document.find_by(content_id: args.content_id)
+    if doc
+      doc.editions.where(publishing_app: "local-links-manager", schema_name: "external_content").destroy_all
+    else
+      puts("Can't find document for #{args.content_id}")
+    end
+  end
+
+  desc "Destroys all local authority editions"
+  task all: :environment do
+    Edition.where(publishing_app: "local-links-manager", schema_name: "external_content").destroy_all
+  end
+end


### PR DESCRIPTION
- Due to an error in local links manager in March 2024, thousands of editions were created for these external links. They make up about 8% of the editions table, and serve no useful purpose. Due to a later error, they are all unpublished (and may cause issues in search results if any of them are published), so a simple solution is to delete all editions, then the now fixed Local Links Manager can republish them sanely.

https://trello.com/c/YDkfN7A3/638-delete-dataset-from-local-links-manager

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
