### PR TITLE
(CM-187) Add Opening Hours to Telephone contact

### DIFF
--- a/content_schemas/dist/formats/content_block_contact/notification/schema.json
+++ b/content_schemas/dist/formats/content_block_contact/notification/schema.json
@@ -493,6 +493,34 @@
                 "description": {
                   "type": "string"
                 },
+                "opening_hours": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "required": [
+                      "day_from",
+                      "day_to",
+                      "time_from",
+                      "time_to"
+                    ],
+                    "properties": {
+                      "day_from": {
+                        "type": "string"
+                      },
+                      "day_to": {
+                        "type": "string"
+                      },
+                      "time_from": {
+                        "type": "string",
+                        "pattern": "^[0-9]{1,2}:[0-9]{2}AM|PM$"
+                      },
+                      "time_to": {
+                        "type": "string",
+                        "pattern": "^[0-9]{1,2}:[0-9]{2}AM|PM$"
+                      }
+                    }
+                  }
+                },
                 "show_uk_call_charges": {
                   "type": "string",
                   "enum": [

--- a/content_schemas/dist/formats/content_block_contact/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/content_block_contact/publisher_v2/schema.json
@@ -310,6 +310,34 @@
                 "description": {
                   "type": "string"
                 },
+                "opening_hours": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "required": [
+                      "day_from",
+                      "day_to",
+                      "time_from",
+                      "time_to"
+                    ],
+                    "properties": {
+                      "day_from": {
+                        "type": "string"
+                      },
+                      "day_to": {
+                        "type": "string"
+                      },
+                      "time_from": {
+                        "type": "string",
+                        "pattern": "^[0-9]{1,2}:[0-9]{2}AM|PM$"
+                      },
+                      "time_to": {
+                        "type": "string",
+                        "pattern": "^[0-9]{1,2}:[0-9]{2}AM|PM$"
+                      }
+                    }
+                  }
+                },
                 "show_uk_call_charges": {
                   "type": "string",
                   "enum": [

--- a/content_schemas/formats/content_block_contact.jsonnet
+++ b/content_schemas/formats/content_block_contact.jsonnet
@@ -63,7 +63,35 @@ local utils = import "shared/utils/content_block_utils.jsonnet";
                 },
                 description: {
                     type: "string",
-                }
+                },
+                opening_hours: {
+                    type: "array",
+                    items: {
+                        type: "object",
+                        required: [
+                            "day_from",
+                            "day_to",
+                            "time_from",
+                            "time_to",
+                         ],
+                         properties: {
+                           day_from: {
+                             type: "string",
+                           },
+                           day_to: {
+                             type: "string",
+                           },
+                           time_from: {
+                             type: "string",
+                             pattern: "^[0-9]{1,2}:[0-9]{2}AM|PM$",
+                           },
+                           time_to: {
+                             type: "string",
+                             pattern: "^[0-9]{1,2}:[0-9]{2}AM|PM$",
+                           },
+                        }
+                    }
+                },
              },
              ["telephone_numbers", "show_uk_call_charges"],
         ),


### PR DESCRIPTION
This allows 0-many opening hours items to be added to a telephone contact

~~Blocked by https://github.com/alphagov/whitehall/pull/10338~~