### PR TITLE
fix: make the destroy work in batches

### DIFF
--- a/lib/tasks/temp_tidy_local_authority_editions.rake
+++ b/lib/tasks/temp_tidy_local_authority_editions.rake
@@ -11,6 +11,6 @@ namespace :temp_tidy_local_authority_editions do
 
   desc "Destroys all local authority editions"
   task all: :environment do
-    Edition.where(publishing_app: "local-links-manager", schema_name: "external_content").destroy_all
+    Edition.where(publishing_app: "local-links-manager", schema_name: "external_content").in_batches(of: 1000).destroy_all
   end
 end


### PR DESCRIPTION
- this is 1.4 million records, too big to load in one gulp

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
