### PR TITLE
Add headings elements to document collections

### DIFF
--- a/content_schemas/dist/formats/document_collection/frontend/schema.json
+++ b/content_schemas/dist/formats/document_collection/frontend/schema.json
@@ -380,6 +380,9 @@
         "government": {
           "$ref": "#/definitions/government"
         },
+        "headers": {
+          "$ref": "#/definitions/nested_headers"
+        },
         "political": {
           "$ref": "#/definitions/political"
         },
@@ -636,6 +639,33 @@
         "zh-hk",
         "zh-tw"
       ]
+    },
+    "nested_headers": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "text",
+          "level",
+          "id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "headers": {
+            "$ref": "#/definitions/nested_headers"
+          },
+          "id": {
+            "type": "string"
+          },
+          "level": {
+            "type": "integer"
+          },
+          "text": {
+            "type": "string"
+          }
+        }
+      },
+      "minItems": 1
     },
     "political": {
       "description": "If the content is considered political in nature, reflecting views of the government it was published under.",

--- a/content_schemas/dist/formats/document_collection/notification/schema.json
+++ b/content_schemas/dist/formats/document_collection/notification/schema.json
@@ -493,6 +493,9 @@
         "government": {
           "$ref": "#/definitions/government"
         },
+        "headers": {
+          "$ref": "#/definitions/nested_headers"
+        },
         "political": {
           "$ref": "#/definitions/political"
         },
@@ -762,6 +765,33 @@
         "zh-hk",
         "zh-tw"
       ]
+    },
+    "nested_headers": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "text",
+          "level",
+          "id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "headers": {
+            "$ref": "#/definitions/nested_headers"
+          },
+          "id": {
+            "type": "string"
+          },
+          "level": {
+            "type": "integer"
+          },
+          "text": {
+            "type": "string"
+          }
+        }
+      },
+      "minItems": 1
     },
     "payload_version": {
       "description": "Counter to indicate when the payload was generated",

--- a/content_schemas/dist/formats/document_collection/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/document_collection/publisher_v2/schema.json
@@ -313,6 +313,9 @@
         "government": {
           "$ref": "#/definitions/government"
         },
+        "headers": {
+          "$ref": "#/definitions/nested_headers"
+        },
         "political": {
           "$ref": "#/definitions/political"
         },
@@ -443,6 +446,33 @@
         "zh-hk",
         "zh-tw"
       ]
+    },
+    "nested_headers": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "text",
+          "level",
+          "id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "headers": {
+            "$ref": "#/definitions/nested_headers"
+          },
+          "id": {
+            "type": "string"
+          },
+          "level": {
+            "type": "integer"
+          },
+          "text": {
+            "type": "string"
+          }
+        }
+      },
+      "minItems": 1
     },
     "political": {
       "description": "If the content is considered political in nature, reflecting views of the government it was published under.",

--- a/content_schemas/examples/document_collection/frontend/document_collection_with_body.json
+++ b/content_schemas/examples/document_collection/frontend/document_collection_with_body.json
@@ -10,6 +10,25 @@
   "locale": "en",
   "details": {
     "body": "<div class=\"govspeak\"><p>Each regime page provides a current list of asset freeze targets designated by the United Nations (UN), European Union and United Kingdom, under legislation relating to current financial sanctions regimes.</p>\n\n<h2 id=\"consolidated-list\">Consolidated list</h2>\n\n<p>The <a rel=\"external\" href=\"https://www.gov.uk/government/publications/financial-sanctions-consolidated-list-of-targets\">current consolidated list of asset freeze targets</a> designated by the United Nations, European Union and United Kingdom, under legislation relating to current financial sanctions regimes, is also available.</p>\n\n<h3 id=\"subscribing-to-financial-sanctions-mailing-list\">Subscribing to financial sanctions mailing list</h3>\n\n<p><a rel=\"external\" href=\"http://engage.hm-treasury.gov.uk/fin-sanc-subscribe/\">Subscribe to our free e-mail alerts</a> for information on updates to the Treasury’s consolidated list of targets of financial sanctions in effect in the UK.</p>\n\n<p>Enquiries relating to asset freezing or other financial sanctions should be submitted to HM Treasury either by email to <a href=\"mailto:financialsanctions@hmtreasury.gsi.gov.uk\">financialsanctions@hmtreasury.gsi.gov.uk</a> or by post to Financial Sanctions, HM Treasury, 1 Horse Guards Road, London SW1A 2HQ.</p>\n\n<h3 id=\"further-information\">Further information</h3>\n\n<p>For further information on financial sanctions see the <a href=\"https://www.gov.uk/sanctions-embargoes-and-restrictions\">guide to sanctions, embargoes and restrictions.</a></p>\n</div>",
+    "headers": [
+      {
+        "text": "Consolidated list",
+        "level": 2,
+        "id": "consolidated-list",
+        "headers": [
+          {
+            "text": "Subscribing to financial sanctions mailing list",
+            "level": 3,
+            "id": "subscribing-to-financial-sanctions-mailing-list"
+          },
+          {
+            "text": "Further information",
+            "level": 3,
+            "id": "further-information"
+          }
+        ]
+      }
+    ],
     "collection_groups": [
       {
         "title": "Documents",

--- a/content_schemas/formats/document_collection.jsonnet
+++ b/content_schemas/formats/document_collection.jsonnet
@@ -12,6 +12,9 @@
         body: {
           "$ref": "#/definitions/body",
         },
+        headers: {
+          "$ref": "#/definitions/nested_headers",
+        },
         collection_groups: {
           description: "The ordered list of collection groups",
           type: "array",


### PR DESCRIPTION
## What

Update document_collection pages to include a `headers` property which will be included as part of the `details` hash

## Why

As part of app consolidation, we will use this property to help generate the headings in the contents list for document collection pages, amongst others.

Trello card: https://trello.com/c/gCX6e1Kb/674-move-documentcollection-from-government-frontend-to-frontend

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
