### PR TITLE
Add /government/get-involved to list of special routes

### DIFF
--- a/lib/data/special_routes.yaml
+++ b/lib/data/special_routes.yaml
@@ -145,6 +145,13 @@
   :rendering_app: "collections"
   :override_existing: true
 
+- :base_path: "/government/get-involved"
+  :content_id: "dbe329f1-359c-43f7-8944-580d4742aa91"
+  :title: "Get involved"
+  :description: "Find out how you can engage with government directly, and take part locally, nationally or internationally."
+  :rendering_app: "frontend"
+  :override_existing: true
+
 - :base_path: "/government/history/past-chancellors"
   :content_id: "ac47f738-b6c3-4369-8d22-ce143c947442"
   :title: "Past Chancellors of the Exchequer"


### PR DESCRIPTION
There are now no more Get Involved / Take Part pages _individually_ in Whitehall: https://github.com/alphagov/whitehall/pull/10188

The `/government/get-involved` route, which used to be published from Whitehall, is no longer updated via Whitehall and is made up on hard-coded content in Frontend. We should therefore make it a special route in Publishing API, to sever its ties from Whitehall for good.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
