### PR TITLE
fix: remove /humans.txt from special routes

### DIFF
--- a/lib/data/special_routes.yaml
+++ b/lib/data/special_routes.yaml
@@ -131,13 +131,6 @@
   :rendering_app: "frontend"
   :type: "prefix"
 
-- :base_path: "/humans.txt"
-  :content_id: "6e92af59-3a73-4db6-b58b-740a02b229d0"
-  :title: "humans.txt"
-  :description: "In opposition to robots.txt, humans.txt provides information about GOV.UK to interested readers, such as developers interested in joining GDS."
-  :rendering_app: "static"
-  :override_existing: true
-
 - :base_path: "/government/feed"
   :content_id: "725a346f-9e5b-486d-873d-2b050c126e09"
   :title: "Government feed"
@@ -167,7 +160,7 @@
   :title: "HM Passport Office webchat"
   :description: "Handles the webchat view for HM Passport Office"
   :rendering_app: "government-frontend"
- 
+
 - :base_path: "/government/uploads"
   :content_id: "5a0ca87e-0e91-4d4c-bd26-29feb24f98ab"
   :title: "Government Uploads"


### PR DESCRIPTION
- this special route has been unpublished, /humans.txt is now served directly from nginx and configured in govuk-helm-charts.

https://trello.com/c/asviqafg/704-move-humanstxt-from-static-to-govuk-helm-charts

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
