### PR TITLE
CM-170: Add subject and body to email address in "Contact" content block

### DIFF
--- a/content_schemas/dist/formats/content_block_contact/notification/schema.json
+++ b/content_schemas/dist/formats/content_block_contact/notification/schema.json
@@ -464,12 +464,18 @@
               ],
               "additionalProperties": false,
               "properties": {
+                "body": {
+                  "type": "string"
+                },
                 "description": {
                   "type": "string"
                 },
                 "email_address": {
                   "type": "string",
                   "format": "email"
+                },
+                "subject": {
+                  "type": "string"
                 },
                 "title": {
                   "type": "string"

--- a/content_schemas/dist/formats/content_block_contact/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/content_block_contact/publisher_v2/schema.json
@@ -281,12 +281,18 @@
               ],
               "additionalProperties": false,
               "properties": {
+                "body": {
+                  "type": "string"
+                },
                 "description": {
                   "type": "string"
                 },
                 "email_address": {
                   "type": "string",
                   "format": "email"
+                },
+                "subject": {
+                  "type": "string"
                 },
                 "title": {
                   "type": "string"

--- a/content_schemas/formats/content_block_contact.jsonnet
+++ b/content_schemas/formats/content_block_contact.jsonnet
@@ -28,6 +28,12 @@ local utils = import "shared/utils/content_block_utils.jsonnet";
             description: {
               type: "string",
             },
+            subject: {
+              type: "string",
+            },
+            body: {
+              type: "string", 
+            },
           },
           ["email_address"],
         ),


### PR DESCRIPTION
## Content modelling
### [CM-170](https://gov-uk.atlassian.net/browse/CM-170) Add subject and body to email address object within "Contact" content block

In this PR we add two fields to the content schema at `content_block_contact.jsonnet`

(Required by [Whitehall PR 10374](https://github.com/alphagov/whitehall/pull/10374))


[CM-170]: https://gov-uk.atlassian.net/browse/CM-170?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ