### PR TITLE
Log graphql execution times

### DIFF
--- a/spec/integration/graphql/generic_edition_spec.rb
+++ b/spec/integration/graphql/generic_edition_spec.rb
@@ -98,6 +98,24 @@ RSpec.describe "GraphQL" do
       expect(request.env["govuk.prometheus_labels"]["schema_name"]).to eq(edition.schema_name)
     end
 
+    it "logs the base_path, document_type, schema_name and timings" do
+      allow(Rails.logger).to receive(:info)
+      expect(Rails.logger).to receive(:info).with(/
+        #{Regexp.escape("GraphQL response for #{edition.base_path}")}
+        .*
+        #{Regexp.escape('(generic / generic_type)')}
+        .*
+        timing:\ utime\ =.*,\ stime\ =.*,\ real\ =.*
+      /x)
+      post "/graphql", params: {
+        query: %({
+          edition(base_path: "#{edition.base_path}") {
+            ... on Edition { base_path, document_type, schema_name }
+          }
+        }),
+      }
+    end
+
     it "sets the contains_errors prometheus label if there is an error" do
       post "/graphql", params: {
         query: "{brokenQuery}",


### PR DESCRIPTION
This will allow us to dig a bit deeper into some of the slow graphql queries. Are there particular documents / base paths that are reproducibly slow?

Ruby's Benchmark#measure method returns a [Benchmark::Tms](https://ruby-doc.org/3.4.1/stdlibs/benchmark/Benchmark/Tms.html) which has various timings. The main ones we're interested in here are utime (user time), stime (system time) and real (elapsed real time). We're not so interested in cstime or cutime because we don't use child processes in this block.

I considered trying to instrument this with tracing instead, but I think the sample rate currently has to be set for the entire application, and it's too low to be useful at the moment, and there's too much other stuff happening in this app for me to want to risk increasing it.
