### PR TITLE
(CM-148) Include content block's changes in host change notes

### DIFF
--- a/app/commands/v2/publish.rb
+++ b/app/commands/v2/publish.rb
@@ -261,7 +261,7 @@ module Commands
         {
           "content_id" => content_id,
           "locale" => locale,
-          "update_dependencies" => edition_diff.present?,
+          "update_dependencies" => edition.is_content_block? || edition_diff.present?,
           "source_command" => "publish",
           "source_fields" => edition_diff.has_previous_edition? ? edition_diff.fields.map(&:to_s) : [],
         }

--- a/app/commands/v2/publish.rb
+++ b/app/commands/v2/publish.rb
@@ -253,6 +253,7 @@ module Commands
         worker_params.merge(
           "message_queue_event_type" => update_type,
           "orphaned_content_ids" => orphaned_content_ids,
+          "is_content_block" => edition.is_content_block?,
         )
       end
 

--- a/app/downstream_payload.rb
+++ b/app/downstream_payload.rb
@@ -1,10 +1,11 @@
 class DownstreamPayload
-  attr_reader :edition, :payload_version, :draft
+  attr_reader :edition, :payload_version, :draft, :triggered_by_edition
 
-  def initialize(edition, payload_version, draft: false)
+  def initialize(edition, payload_version, draft: false, triggered_by_edition: nil)
     @edition = edition
     @payload_version = payload_version
     @draft = draft
+    @triggered_by_edition = triggered_by_edition
   end
 
   delegate :state, to: :edition
@@ -41,7 +42,7 @@ private
   end
 
   def content_presenter
-    @content_presenter ||= Presenters::EditionPresenter.new(edition, draft:)
+    @content_presenter ||= Presenters::EditionPresenter.new(edition, draft:, triggered_by_edition:)
   end
 
   def redirect_presenter

--- a/app/models/edition.rb
+++ b/app/models/edition.rb
@@ -223,6 +223,10 @@ class Edition < ApplicationRecord
     Plek.website_root + base_path
   end
 
+  def is_content_block?
+    document_type.start_with?(CONTENT_BLOCK_PREFIX)
+  end
+
 private
 
   def renderable_content?
@@ -231,9 +235,5 @@ private
 
   def requires_rendering_app?
     !is_content_block? && renderable_content? && NO_RENDERING_APP_FORMATS.exclude?(document_type)
-  end
-
-  def is_content_block?
-    document_type.start_with?(CONTENT_BLOCK_PREFIX)
   end
 end

--- a/app/presenters/edition_presenter.rb
+++ b/app/presenters/edition_presenter.rb
@@ -25,9 +25,10 @@ module Presenters
       withdrawn
     ].freeze
 
-    def initialize(edition, draft: false)
+    def initialize(edition, draft: false, triggered_by_edition: nil)
       @edition = edition
       @draft = draft
+      @triggered_by_edition = triggered_by_edition
     end
 
     def for_content_store(payload_version)
@@ -53,6 +54,7 @@ module Presenters
         .merge(document_supertypes)
         .merge(withdrawal_notice)
         .merge(publishing_request_id)
+        .merge(public_updated_at)
     end
 
     def expanded_links
@@ -65,7 +67,7 @@ module Presenters
 
   private
 
-    attr_reader :draft, :edition
+    attr_reader :draft, :edition, :triggered_by_edition
 
     def auth_bypass_ids
       return {} unless draft
@@ -169,6 +171,12 @@ module Presenters
       else
         {}
       end
+    end
+
+    def public_updated_at
+      return {} unless triggered_by_edition&.is_content_block?
+
+      { public_updated_at: triggered_by_edition.to_h[:public_updated_at] }
     end
   end
 end

--- a/app/presenters/queries/change_history.rb
+++ b/app/presenters/queries/change_history.rb
@@ -1,0 +1,57 @@
+module Presenters
+  module Queries
+    class ChangeHistory
+      def initialize(edition, include_edition_change_history:)
+        @edition = edition
+        @include_edition_change_history = include_edition_change_history
+      end
+
+      def call
+        results = include_edition_change_history ? notes_for_edition_and_linked_content_blocks : change_notes_for_linked_content_blocks
+        results.order(:public_timestamp)
+      end
+
+    private
+
+      attr_reader :edition, :include_edition_change_history
+
+      def notes_for_edition_and_linked_content_blocks
+        unioned = Arel::Nodes::UnionAll.new(
+          change_notes_for_edition.arel,
+          change_notes_for_linked_content_blocks.arel,
+        )
+
+        # Wrap the unioned subquery so ActiveRecord can use it
+        ChangeNote
+          .from(Arel::Nodes::TableAlias.new(unioned, ChangeNote.table_name))
+      end
+
+      def change_notes_for_edition
+        ChangeNote
+          .joins(:edition)
+          .where(editions: { document: edition.document })
+          .where("user_facing_version <= ?", edition.user_facing_version)
+          .where.not(public_timestamp: nil)
+      end
+
+      def change_notes_for_linked_content_blocks
+        return ChangeNote.none if embed_links.empty?
+
+        conditions = embed_links.map do |(target_content_id, created_at)|
+          ChangeNote.joins(edition: :document)
+                    .where(documents: { content_id: target_content_id })
+                    .where("public_timestamp > ?", created_at)
+        end
+
+        conditions.reduce { |acc, q| acc.or(q) }
+      end
+
+      def embed_links
+        @embed_links ||= Link
+                          .where(link_type: "embed", edition_id: edition.document.editions.select(:id))
+                          .group(:target_content_id)
+                          .minimum(:created_at)
+      end
+    end
+  end
+end

--- a/app/sidekiq/downstream_live_job.rb
+++ b/app/sidekiq/downstream_live_job.rb
@@ -80,10 +80,11 @@ private
     )
     @source_command = attributes[:source_command]
     @source_fields = attributes.fetch(:source_fields, [])
+    @is_content_block = attributes.fetch(:is_content_block, false)
   end
 
   def enqueue_dependencies
-    dependency_job_klass = @message_queue_event_type == "content_block" ? HostContentUpdateJob : DependencyResolutionJob
+    dependency_job_klass = @is_content_block ? HostContentUpdateJob : DependencyResolutionJob
     dependency_job_klass.perform_async(
       "content_store" => "Adapters::ContentStore",
       "content_id" => content_id,

--- a/app/sidekiq/downstream_live_job.rb
+++ b/app/sidekiq/downstream_live_job.rb
@@ -34,7 +34,12 @@ class DownstreamLiveJob
       )
     end
 
-    payload = DownstreamPayload.new(edition, payload_version, draft: false)
+    payload = DownstreamPayload.new(
+      edition,
+      payload_version,
+      draft: false,
+      triggered_by_edition: dependency_resolution_source_edition,
+    )
 
     update_expanded_links(payload)
     DownstreamService.update_live_content_store(payload) if edition.base_path
@@ -108,5 +113,11 @@ private
       payload_version:,
       expanded_links: downstream_payload.expanded_links,
     )
+  end
+
+  def dependency_resolution_source_edition
+    @dependency_resolution_source_edition ||= if dependency_resolution_source_content_id
+                                                Document.find_by(content_id: dependency_resolution_source_content_id).live
+                                              end
   end
 end

--- a/app/sidekiq/host_content_update_job.rb
+++ b/app/sidekiq/host_content_update_job.rb
@@ -21,7 +21,7 @@ private
         DownstreamLiveJob::HIGH_QUEUE,
         "content_id" => dependent_content_id,
         "locale" => locale,
-        "message_queue_event_type" => "host_content",
+        "message_queue_event_type" => source_edition.update_type,
         "update_dependencies" => false,
         "dependency_resolution_source_content_id" => content_id,
         "source_command" => source_command,

--- a/docs/arch/adr-010-add-content-block-information-to-the-downstream-payload.md
+++ b/docs/arch/adr-010-add-content-block-information-to-the-downstream-payload.md
@@ -1,0 +1,35 @@
+# Decision Record: Include Content Block Change Notes in Downstream Payloads
+
+## Context
+
+The content modelling team needs email alerts to be triggered when a **major update** is made to a **content block**, 
+especially when that update affects other pieces of content that embed it.
+
+This is challenging because changes to dependent content happen indirectly - when the embedding content is republished, 
+it pulls in the updated content block. However, to users subscribed to email alerts for that content, these changes 
+are invisible since no alert is triggered (even though the content has effectively changed).
+
+To fix this, we need to ensure that change notes from content blocks are sent to the 
+[email-alert-service](https://github.com/alphagov/email-alert-service), so that subscribers receive notifications when 
+embedded content is updated.
+
+## Solution
+
+We will update the `EditionPresenter` to include **change notes from embedded content blocks**, in addition to the 
+change notes for the content itself.
+
+This involves:
+- Fetching all links of type `embed` from the Publishing API
+- Retrieving change notes for those embedded content blocks
+- Including these change notes in the payload alongside those of the host document
+
+## Consequences
+
+Currently, the `EditionPresenter` returns the `change_notes` from the `details` hash of the edition if they are present,
+as there are circumstances where we the change notes are contained within the details hash, and don't have Change Note
+records stored within Publishing API, if a `change_note` hash is present we only fetch the change note for dependent
+content blocks and merge the two together. 
+
+There are also soms discrepancies in time zones - specifically, Whitehall's Edition#details uses local time, whereas 
+the Publishing API's presenter queries use UTC - so we will also ensure that all times change notes have UTC timestamps
+for consistency.

--- a/spec/commands/v2/publish_spec.rb
+++ b/spec/commands/v2/publish_spec.rb
@@ -351,6 +351,30 @@ RSpec.describe Commands::V2::Publish do
 
         described_class.call(payload)
       end
+
+      context "and the edition is a content block" do
+        let!(:draft_item) do
+          create(
+            :draft_edition,
+            document:,
+            base_path:,
+            user_facing_version:,
+            document_type: "content_block_pension",
+          )
+        end
+
+        it "updates the dependencies" do
+          expect(DownstreamDraftJob)
+            .to receive(:perform_async_in_queue)
+                  .with("downstream_high", a_hash_including("update_dependencies" => true))
+
+          expect(DownstreamLiveJob)
+            .to receive(:perform_async_in_queue)
+                  .with("downstream_high", a_hash_including("update_dependencies" => true))
+
+          described_class.call(payload)
+        end
+      end
     end
 
     context "when the edition was previously published" do

--- a/spec/commands/v2/publish_spec.rb
+++ b/spec/commands/v2/publish_spec.rb
@@ -203,7 +203,6 @@ RSpec.describe Commands::V2::Publish do
 
     context "publishing a content block update" do
       before do
-        payload[:update_type] = "content_block"
         draft_item.update!(document_type: "content_block_pension")
         ChangeNote.create!(edition: draft_item)
       end
@@ -221,13 +220,14 @@ RSpec.describe Commands::V2::Publish do
                 .with(
                   "downstream_high",
                   {
-                    "message_queue_event_type" => "content_block",
+                    "message_queue_event_type" => "major",
                     "orphaned_content_ids" => [],
                     "content_id" => document.content_id,
                     "locale" => locale,
                     "update_dependencies" => true,
                     "source_command" => "publish",
                     "source_fields" => [],
+                    "is_content_block" => true,
                   },
                 )
 

--- a/spec/downstream_payload_spec.rb
+++ b/spec/downstream_payload_spec.rb
@@ -5,11 +5,14 @@ RSpec.describe DownstreamPayload do
 
   let(:payload_version) { 1 }
   let(:draft) { false }
+  let(:triggered_by_edition) { nil }
+
   subject(:downstream_payload) do
     DownstreamPayload.new(
       edition,
       payload_version,
       draft:,
+      triggered_by_edition:,
     )
   end
 
@@ -115,6 +118,18 @@ RSpec.describe DownstreamPayload do
         it "returns a content store payload" do
           expect(downstream_payload.content_store_payload).to include(content_store_payload_hash)
         end
+
+        context "when a triggered_by_edition is set" do
+          let(:triggered_by_edition) { build(:edition) }
+
+          it "passes triggered_by_edition to the content_presenter" do
+            content_store_response = double("response")
+            stub = double("Presenters::EditionPresenter", for_content_store: content_store_response)
+            expect(Presenters::EditionPresenter).to receive(:new).with(edition, draft:, triggered_by_edition:).and_return(stub)
+
+            expect(downstream_payload.content_store_payload).to eq(content_store_response)
+          end
+        end
       end
 
       context "redirect edition" do
@@ -134,6 +149,18 @@ RSpec.describe DownstreamPayload do
 
       it "returns a content store payload" do
         expect(downstream_payload.content_store_payload).to include(content_store_payload_hash)
+      end
+
+      context "when a triggered_by_edition is set" do
+        let(:triggered_by_edition) { build(:edition) }
+
+        it "passes triggered_by_edition to the content_presenter" do
+          content_store_response = double("response")
+          stub = double("Presenters::EditionPresenter", for_content_store: content_store_response)
+          expect(Presenters::EditionPresenter).to receive(:new).with(edition, draft:, triggered_by_edition:).and_return(stub)
+
+          expect(downstream_payload.content_store_payload).to eq(content_store_response)
+        end
       end
     end
 
@@ -193,6 +220,18 @@ RSpec.describe DownstreamPayload do
       it "uses the edition presenter" do
         expect_any_instance_of(Presenters::EditionPresenter).to receive(:for_message_queue).with(payload_version)
         downstream_payload.message_queue_payload
+      end
+
+      context "when a triggered_by_edition is set" do
+        let(:triggered_by_edition) { build(:edition) }
+
+        it "passes triggered_by_edition to the content_presenter" do
+          message_queue_response = double("response")
+          stub = double("Presenters::EditionPresenter", for_message_queue: message_queue_response)
+          expect(Presenters::EditionPresenter).to receive(:new).with(edition, draft:, triggered_by_edition:).and_return(stub)
+
+          expect(downstream_payload.message_queue_payload).to eq(message_queue_response)
+        end
       end
     end
 

--- a/spec/integration/content_block_publish_spec.rb
+++ b/spec/integration/content_block_publish_spec.rb
@@ -1,0 +1,86 @@
+RSpec.describe "Content Block Publish" do
+  let(:content_block_document) { create(:document) }
+
+  let(:document_type) { "content_block_pension" }
+  let!(:content_block_superseded_edition) { create(:edition, document: content_block_document, state: "superseded", content_store: nil, user_facing_version: 1, document_type:) }
+  let!(:content_block_live_edition) { create(:edition, document: content_block_document, state: "published", content_store: "live", user_facing_version: 2, document_type:) }
+  let(:content_block) { create(:draft_edition, update_type:, document: content_block_document, user_facing_version: 3, document_type:) }
+
+  let!(:change_note) { create(:change_note, note: "Some note goes here", edition: content_block, created_at: 1.day.ago) }
+
+  let(:editions_with_content_blocks) { create_list(:edition, 2, state: "published", content_store: "live") }
+
+  let(:user_uuid) { SecureRandom.uuid }
+
+  before do
+    editions_with_content_blocks.each do |item|
+      item.links.create!({ link_type: "embed", target_content_id: content_block.content_id, created_at: 2.days.ago })
+    end
+
+    allow(PublishingAPI.service(:queue_publisher)).to receive(:send_message)
+    stub_request(:put, %r{.*content-store.*/content/.*})
+  end
+
+  context "when the edition's update type is `major`" do
+    let(:update_type) { "major" }
+
+    it "sends details of the embedded content changes made to editions with content blocks" do
+      expect(PublishingAPI.service(:queue_publisher)).to receive(:send_message)
+                                                           .with(hash_including(content_id: content_block.content_id), event_type: "major")
+
+      editions_with_content_blocks.each do |item|
+        expect(PublishingAPI.service(:queue_publisher)).to receive(:send_message)
+                                                             .with(
+                                                               expected_message(item),
+                                                               event_type: "major",
+                                                             )
+      end
+
+      post "/v2/content/#{content_block.content_id}/publish",
+           params: {}.to_json,
+           headers: {
+             "X-GOVUK-AUTHENTICATED-USER" => user_uuid,
+           }
+
+      expect(response).to be_ok, response.body
+    end
+  end
+
+  context "when the edition's update type is `minor`" do
+    let(:update_type) { "minor" }
+
+    it "should not send the change history payload to the queue" do
+      expect(PublishingAPI.service(:queue_publisher)).to receive(:send_message)
+                                                           .with(hash_including(content_id: content_block.content_id), event_type: "minor")
+
+      editions_with_content_blocks.each do |item|
+        expect(PublishingAPI.service(:queue_publisher)).not_to receive(:send_message)
+                                                             .with(
+                                                               expected_message(item),
+                                                               event_type: anything,
+                                                             )
+      end
+
+      post "/v2/content/#{content_block.content_id}/publish",
+           params: {}.to_json,
+           headers: {
+             "X-GOVUK-AUTHENTICATED-USER" => user_uuid,
+           }
+
+      expect(response).to be_ok, response.body
+    end
+  end
+
+  def expected_message(item)
+    hash_including(
+      content_id: item.content_id,
+      details: hash_including(
+        change_history: array_including(
+          hash_including(
+            note: change_note.note,
+          ),
+        ),
+      ),
+    )
+  end
+end

--- a/spec/integration/content_block_publish_spec.rb
+++ b/spec/integration/content_block_publish_spec.rb
@@ -4,11 +4,11 @@ RSpec.describe "Content Block Publish" do
   let(:document_type) { "content_block_pension" }
   let!(:content_block_superseded_edition) { create(:edition, document: content_block_document, state: "superseded", content_store: nil, user_facing_version: 1, document_type:) }
   let!(:content_block_live_edition) { create(:edition, document: content_block_document, state: "published", content_store: "live", user_facing_version: 2, document_type:) }
-  let(:content_block) { create(:draft_edition, update_type:, document: content_block_document, user_facing_version: 3, document_type:) }
+  let(:content_block) { create(:draft_edition, update_type:, document: content_block_document, user_facing_version: 3, document_type:, public_updated_at: 1.minute.ago) }
 
   let!(:change_note) { create(:change_note, note: "Some note goes here", edition: content_block, created_at: 1.day.ago) }
 
-  let(:editions_with_content_blocks) { create_list(:edition, 2, state: "published", content_store: "live") }
+  let(:editions_with_content_blocks) { create_list(:edition, 2, state: "published", content_store: "live", public_updated_at: 5.days.ago) }
 
   let(:user_uuid) { SecureRandom.uuid }
 
@@ -74,6 +74,7 @@ RSpec.describe "Content Block Publish" do
   def expected_message(item)
     hash_including(
       content_id: item.content_id,
+      public_updated_at: content_block.to_h[:public_updated_at],
       details: hash_including(
         change_history: array_including(
           hash_including(

--- a/spec/integration/graphql/news_article_spec.rb
+++ b/spec/integration/graphql/news_article_spec.rb
@@ -210,7 +210,7 @@ RSpec.describe "GraphQL" do
             description: @edition.description,
             details: {
               body: @edition.details[:body],
-              change_history: [{ note: "Info", public_timestamp: "2025-01-01 00:01:00" }],
+              change_history: [{ note: "Info", public_timestamp: "2025-01-01 00:01:00 UTC" }],
               default_news_image: @edition.details[:default_news_image],
               display_date: @edition.details[:display_date],
               emphasised_organisations: @edition.details[:emphasised_organisations],

--- a/spec/models/edition_spec.rb
+++ b/spec/models/edition_spec.rb
@@ -320,4 +320,26 @@ RSpec.describe Edition do
       expect { subject.unpublish(type: "substitute") }.to change { subject.state }.from("published").to("unpublished")
     end
   end
+
+  describe "#is_content_block?" do
+    GovukSchemas::Schema.schema_names.select { |schema| schema.start_with?(Edition::CONTENT_BLOCK_PREFIX) }.each do |document_type|
+      context "when the schema is `#{document_type}`" do
+        subject { build(:edition, document_type:) }
+
+        it "returns true" do
+          expect(subject.is_content_block?).to be true
+        end
+      end
+    end
+
+    GovukSchemas::Schema.schema_names.reject { |schema| schema.start_with?(Edition::CONTENT_BLOCK_PREFIX) }.each do |document_type|
+      context "when the schema is `#{document_type}`" do
+        subject { build(:edition, document_type:) }
+
+        it "returns false" do
+          expect(subject.is_content_block?).to be false
+        end
+      end
+    end
+  end
 end

--- a/spec/presenters/queries/change_history_spec.rb
+++ b/spec/presenters/queries/change_history_spec.rb
@@ -1,0 +1,80 @@
+RSpec.describe Presenters::Queries::ChangeHistory do
+  let(:document) { create(:document) }
+
+  let(:edition) do
+    create(:edition, document:, state: "published", user_facing_version: "2")
+  end
+
+  let(:include_edition_change_history) { true }
+  let(:subject) { described_class.new(edition, include_edition_change_history:).call }
+
+  describe "when there are no embed links" do
+    it "constructs content history from change notes" do
+      2.times do |i|
+        create(:change_note, edition:, note: i.to_s, public_timestamp: Time.zone.now.utc)
+      end
+      expect(subject.map(&:note)).to eq %w[0 1]
+    end
+
+    it "orders change notes by public_timestamp (ascending)" do
+      [1, 3, 2].to_a.each do |i|
+        create(:change_note, edition:, note: i.to_s, public_timestamp: i.days.ago)
+      end
+      expect(subject.map(&:note)).to eq %w[3 2 1]
+    end
+
+    it "omits change notes that don't have a public timestamp" do
+      create(:change_note, edition:, note: "with-timestamp", public_timestamp: 1.day.ago)
+      create(:change_note, edition:, note: "without-timestamp", public_timestamp: nil)
+      expect(subject.map(&:note)).to eq %w[with-timestamp]
+    end
+  end
+
+  describe "when links exist" do
+    before do
+      content_block = create(:edition, created_at: 2.weeks.ago)
+      older_edition = create(:edition, document:, created_at: 2.days.ago, state: "superseded", user_facing_version: "1", content_store: nil)
+
+      # This is where the document was first linked with the content_block
+      create(:link,
+             edition: older_edition,
+             target_content_id: content_block.content_id,
+             link_type: "embed",
+             created_at: 3.days.ago)
+
+      create(:link,
+             edition: edition,
+             target_content_id: content_block.content_id,
+             link_type: "embed",
+             created_at: 1.day.ago)
+
+      # This link should not be included
+      create(:link,
+             edition: edition,
+             target_content_id: content_block.content_id,
+             link_type: "ministers")
+
+      # Create change notes for the content block - the first one was created before the document was linked, so should
+      # not show
+      create(:change_note, edition: content_block, note: "should-not-show", public_timestamp: 1.week.ago)
+      create(:change_note, edition: content_block, note: "linked-edition-note-1", public_timestamp: 2.days.ago)
+      create(:change_note, edition: content_block, note: "linked-edition-note-2", public_timestamp: 1.day.ago)
+
+      # Create change notes for the editions
+      create(:change_note, edition: older_edition, note: "note-2", public_timestamp: 3.days.ago)
+      create(:change_note, edition:, note: "note-1", public_timestamp: 1.hour.ago)
+    end
+
+    it "should include change notes that were created after the link was created" do
+      expect(subject.map(&:note)).to eq %w[note-2 linked-edition-note-1 linked-edition-note-2 note-1]
+    end
+
+    context "when include_edition_change_history is false" do
+      let(:include_edition_change_history) { false }
+
+      it "should only include the change notes for the linked editions" do
+        expect(subject.map(&:note)).to eq %w[linked-edition-note-1 linked-edition-note-2]
+      end
+    end
+  end
+end

--- a/spec/sidekiq/downstream_live_job_spec.rb
+++ b/spec/sidekiq/downstream_live_job_spec.rb
@@ -151,6 +151,17 @@ RSpec.describe DownstreamLiveJob do
       end
     end
 
+    context "when is_content_block is true" do
+      let(:arguments) do
+        base_arguments.merge("update_dependencies" => true, "source_command" => "command", "is_content_block" => true)
+      end
+
+      it "enqueues dependencies with HostContentUpdateJob" do
+        expect(HostContentUpdateJob).to receive(:perform_async)
+        subject.perform(arguments)
+      end
+    end
+
     context "can not update dependencies" do
       it "doesn't enqueue dependencies" do
         expect(DependencyResolutionJob).to_not receive(:perform_async)

--- a/spec/sidekiq/host_content_update_job_spec.rb
+++ b/spec/sidekiq/host_content_update_job_spec.rb
@@ -26,21 +26,50 @@ RSpec.describe HostContentUpdateJob, :perform do
     allow(Document).to receive(:find_by).with(content_id:).and_return(document)
   end
 
-  it "queues the Live host content for update" do
-    expect(DownstreamLiveJob).to receive(:perform_async_in_queue).with(
-      "downstream_high",
-      {
-        "content_id" => dependent_content_id,
-        "dependency_resolution_source_content_id" =>
-         content_id,
-        "locale" => "en",
-        "message_queue_event_type" => "host_content",
-        "source_command" => nil,
-        "source_fields" => [],
-        "update_dependencies" => false,
-      },
-    )
-    worker_perform
+  context "when the edition's update type is `major`" do
+    before do
+      edition.update_type = "major"
+    end
+
+    it "queues the Live host content for update" do
+      expect(DownstreamLiveJob).to receive(:perform_async_in_queue).with(
+        "downstream_high",
+        {
+          "content_id" => dependent_content_id,
+          "dependency_resolution_source_content_id" =>
+            content_id,
+          "locale" => "en",
+          "message_queue_event_type" => "major",
+          "source_command" => nil,
+          "source_fields" => [],
+          "update_dependencies" => false,
+        },
+      )
+      worker_perform
+    end
+  end
+
+  context "when the edition's update type is `minor`" do
+    before do
+      edition.update_type = "minor"
+    end
+
+    it "queues the Live host content for update" do
+      expect(DownstreamLiveJob).to receive(:perform_async_in_queue).with(
+        "downstream_high",
+        {
+          "content_id" => dependent_content_id,
+          "dependency_resolution_source_content_id" =>
+            content_id,
+          "locale" => "en",
+          "message_queue_event_type" => "minor",
+          "source_command" => nil,
+          "source_fields" => [],
+          "update_dependencies" => false,
+        },
+      )
+      worker_perform
+    end
   end
 
   it "creates an event" do


### PR DESCRIPTION
This makes some updates to the downstream payload so when a content block is updated with a `major` update type,  we can trigger email alerts for dependent content.

We've had to make a few changes here, namely:

- Adding the change notes for dependent content blocks to the `EditionPresenter` payload
- Removing the recently added `content_block` update type (Additional work in Whitehall here https://github.com/alphagov/whitehall/pull/10405)
- Changing the `public_updated_at` value to be the `public_updated_at` of a content block, if the edition is republished by a content block

I've also added an ADR to document all this - would appreciate a look over by some Publishing Platform devs too, to ensure I'm on the right track 👍 