### PR TITLE
Create UKHSA chemical hazards finder (WHIT-1467) 

### DIFF
--- a/content_schemas/allowed_document_types.yml
+++ b/content_schemas/allowed_document_types.yml
@@ -174,6 +174,7 @@
 - transparency
 - travel_advice
 - travel_advice_index
+- ukhsa_chemical_hazard
 - ukhsa_data_access_approval
 - utaac_decision
 - vanish # Not in the content store

--- a/content_schemas/dist/formats/generic/frontend/schema.json
+++ b/content_schemas/dist/formats/generic/frontend/schema.json
@@ -210,6 +210,7 @@
         "transparency",
         "travel_advice",
         "travel_advice_index",
+        "ukhsa_chemical_hazard",
         "ukhsa_data_access_approval",
         "utaac_decision",
         "vanish",

--- a/content_schemas/dist/formats/generic/notification/schema.json
+++ b/content_schemas/dist/formats/generic/notification/schema.json
@@ -234,6 +234,7 @@
         "transparency",
         "travel_advice",
         "travel_advice_index",
+        "ukhsa_chemical_hazard",
         "ukhsa_data_access_approval",
         "utaac_decision",
         "vanish",

--- a/content_schemas/dist/formats/generic/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/generic/publisher_v2/schema.json
@@ -223,6 +223,7 @@
         "transparency",
         "travel_advice",
         "travel_advice_index",
+        "ukhsa_chemical_hazard",
         "ukhsa_data_access_approval",
         "utaac_decision",
         "vanish",

--- a/content_schemas/dist/formats/generic_with_external_related_links/frontend/schema.json
+++ b/content_schemas/dist/formats/generic_with_external_related_links/frontend/schema.json
@@ -210,6 +210,7 @@
         "transparency",
         "travel_advice",
         "travel_advice_index",
+        "ukhsa_chemical_hazard",
         "ukhsa_data_access_approval",
         "utaac_decision",
         "vanish",

--- a/content_schemas/dist/formats/generic_with_external_related_links/notification/schema.json
+++ b/content_schemas/dist/formats/generic_with_external_related_links/notification/schema.json
@@ -234,6 +234,7 @@
         "transparency",
         "travel_advice",
         "travel_advice_index",
+        "ukhsa_chemical_hazard",
         "ukhsa_data_access_approval",
         "utaac_decision",
         "vanish",

--- a/content_schemas/dist/formats/generic_with_external_related_links/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/generic_with_external_related_links/publisher_v2/schema.json
@@ -223,6 +223,7 @@
         "transparency",
         "travel_advice",
         "travel_advice_index",
+        "ukhsa_chemical_hazard",
         "ukhsa_data_access_approval",
         "utaac_decision",
         "vanish",

--- a/content_schemas/dist/formats/specialist_document/frontend/schema.json
+++ b/content_schemas/dist/formats/specialist_document/frontend/schema.json
@@ -210,6 +210,7 @@
         "transparency",
         "travel_advice",
         "travel_advice_index",
+        "ukhsa_chemical_hazard",
         "ukhsa_data_access_approval",
         "utaac_decision",
         "vanish",
@@ -707,6 +708,9 @@
         },
         {
           "$ref": "#/definitions/traffic_commissioner_regulatory_decision_metadata"
+        },
+        {
+          "$ref": "#/definitions/ukhsa_chemical_hazard_metadata"
         },
         {
           "$ref": "#/definitions/ukhsa_data_access_approval_metadata"
@@ -2160,6 +2164,27 @@
           }
         },
         "regions": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "ukhsa_chemical_hazard_metadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "bulk_published": {
+          "type": "boolean"
+        },
+        "ukhsa_chemical_name": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "ukhsa_product_category": {
           "type": "array",
           "items": {
             "type": "string"

--- a/content_schemas/dist/formats/specialist_document/notification/schema.json
+++ b/content_schemas/dist/formats/specialist_document/notification/schema.json
@@ -234,6 +234,7 @@
         "transparency",
         "travel_advice",
         "travel_advice_index",
+        "ukhsa_chemical_hazard",
         "ukhsa_data_access_approval",
         "utaac_decision",
         "vanish",
@@ -795,6 +796,9 @@
         },
         {
           "$ref": "#/definitions/traffic_commissioner_regulatory_decision_metadata"
+        },
+        {
+          "$ref": "#/definitions/ukhsa_chemical_hazard_metadata"
         },
         {
           "$ref": "#/definitions/ukhsa_data_access_approval_metadata"
@@ -2301,6 +2305,27 @@
           }
         },
         "regions": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "ukhsa_chemical_hazard_metadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "bulk_published": {
+          "type": "boolean"
+        },
+        "ukhsa_chemical_name": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "ukhsa_product_category": {
           "type": "array",
           "items": {
             "type": "string"

--- a/content_schemas/dist/formats/specialist_document/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/specialist_document/publisher_v2/schema.json
@@ -223,6 +223,7 @@
         "transparency",
         "travel_advice",
         "travel_advice_index",
+        "ukhsa_chemical_hazard",
         "ukhsa_data_access_approval",
         "utaac_decision",
         "vanish",
@@ -641,6 +642,9 @@
         },
         {
           "$ref": "#/definitions/traffic_commissioner_regulatory_decision_metadata"
+        },
+        {
+          "$ref": "#/definitions/ukhsa_chemical_hazard_metadata"
         },
         {
           "$ref": "#/definitions/ukhsa_data_access_approval_metadata"
@@ -1993,6 +1997,27 @@
           }
         },
         "regions": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "ukhsa_chemical_hazard_metadata": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "bulk_published": {
+          "type": "boolean"
+        },
+        "ukhsa_chemical_name": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "ukhsa_product_category": {
           "type": "array",
           "items": {
             "type": "string"

--- a/content_schemas/formats/shared/definitions/_specialist_document.jsonnet
+++ b/content_schemas/formats/shared/definitions/_specialist_document.jsonnet
@@ -114,6 +114,9 @@
         "$ref": "#/definitions/traffic_commissioner_regulatory_decision_metadata",
       },
       {
+        "$ref": "#/definitions/ukhsa_chemical_hazard_metadata",
+      },
+      {
         "$ref": "#/definitions/ukhsa_data_access_approval_metadata",
       },
       {
@@ -1269,6 +1272,27 @@
       },
       hidden_indexable_content: {
         type: "string",
+      },
+    },
+  },
+  ukhsa_chemical_hazard_metadata: {
+    type: "object",
+    additionalProperties: false,
+    properties: {
+      bulk_published: {
+        type: "boolean",
+      },
+      ukhsa_chemical_name: {
+        type: "array",
+        items: {
+          type: "string",
+        },
+      },
+      ukhsa_product_category: {
+        type: "array",
+        items: {
+          type: "string",
+        },
       },
     },
   },


### PR DESCRIPTION
UKSHA have identified the need for a new finder. This PR adds ukhsa_chemical_hazard as an allowed value and adds the required finder properties to the schemas. 

More detail can be [found here](https://gov-uk.atlassian.net/jira/software/c/projects/WHIT/boards/401?assignee=61eecab7e218f0006ad495ba&assignee=5caf4d888c2c1a75f3e46ef6&selectedIssue=WHIT-1467)