### PR TITLE
Add new options to social media schema shared definition

### DIFF
--- a/content_schemas/dist/formats/organisation/frontend/schema.json
+++ b/content_schemas/dist/formats/organisation/frontend/schema.json
@@ -582,6 +582,7 @@
                 "type": "string",
                 "enum": [
                   "blog",
+                  "bluesky",
                   "email",
                   "facebook",
                   "flickr",
@@ -591,6 +592,7 @@
                   "linkedin",
                   "other",
                   "pinterest",
+                  "threads",
                   "twitter",
                   "youtube"
                 ]

--- a/content_schemas/dist/formats/organisation/notification/schema.json
+++ b/content_schemas/dist/formats/organisation/notification/schema.json
@@ -729,6 +729,7 @@
                 "type": "string",
                 "enum": [
                   "blog",
+                  "bluesky",
                   "email",
                   "facebook",
                   "flickr",
@@ -738,6 +739,7 @@
                   "linkedin",
                   "other",
                   "pinterest",
+                  "threads",
                   "twitter",
                   "youtube"
                 ]

--- a/content_schemas/dist/formats/organisation/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/organisation/publisher_v2/schema.json
@@ -423,6 +423,7 @@
                 "type": "string",
                 "enum": [
                   "blog",
+                  "bluesky",
                   "email",
                   "facebook",
                   "flickr",
@@ -432,6 +433,7 @@
                   "linkedin",
                   "other",
                   "pinterest",
+                  "threads",
                   "twitter",
                   "youtube"
                 ]

--- a/content_schemas/dist/formats/topical_event/frontend/schema.json
+++ b/content_schemas/dist/formats/topical_event/frontend/schema.json
@@ -352,6 +352,7 @@
                 "type": "string",
                 "enum": [
                   "blog",
+                  "bluesky",
                   "email",
                   "facebook",
                   "flickr",
@@ -361,6 +362,7 @@
                   "linkedin",
                   "other",
                   "pinterest",
+                  "threads",
                   "twitter",
                   "youtube"
                 ]

--- a/content_schemas/dist/formats/topical_event/notification/schema.json
+++ b/content_schemas/dist/formats/topical_event/notification/schema.json
@@ -443,6 +443,7 @@
                 "type": "string",
                 "enum": [
                   "blog",
+                  "bluesky",
                   "email",
                   "facebook",
                   "flickr",
@@ -452,6 +453,7 @@
                   "linkedin",
                   "other",
                   "pinterest",
+                  "threads",
                   "twitter",
                   "youtube"
                 ]

--- a/content_schemas/dist/formats/topical_event/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/topical_event/publisher_v2/schema.json
@@ -249,6 +249,7 @@
                 "type": "string",
                 "enum": [
                   "blog",
+                  "bluesky",
                   "email",
                   "facebook",
                   "flickr",
@@ -258,6 +259,7 @@
                   "linkedin",
                   "other",
                   "pinterest",
+                  "threads",
                   "twitter",
                   "youtube"
                 ]

--- a/content_schemas/dist/formats/worldwide_organisation/frontend/schema.json
+++ b/content_schemas/dist/formats/worldwide_organisation/frontend/schema.json
@@ -469,6 +469,7 @@
                 "type": "string",
                 "enum": [
                   "blog",
+                  "bluesky",
                   "email",
                   "facebook",
                   "flickr",
@@ -478,6 +479,7 @@
                   "linkedin",
                   "other",
                   "pinterest",
+                  "threads",
                   "twitter",
                   "youtube"
                 ]

--- a/content_schemas/dist/formats/worldwide_organisation/notification/schema.json
+++ b/content_schemas/dist/formats/worldwide_organisation/notification/schema.json
@@ -604,6 +604,7 @@
                 "type": "string",
                 "enum": [
                   "blog",
+                  "bluesky",
                   "email",
                   "facebook",
                   "flickr",
@@ -613,6 +614,7 @@
                   "linkedin",
                   "other",
                   "pinterest",
+                  "threads",
                   "twitter",
                   "youtube"
                 ]

--- a/content_schemas/dist/formats/worldwide_organisation/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/worldwide_organisation/publisher_v2/schema.json
@@ -370,6 +370,7 @@
                 "type": "string",
                 "enum": [
                   "blog",
+                  "bluesky",
                   "email",
                   "facebook",
                   "flickr",
@@ -379,6 +380,7 @@
                   "linkedin",
                   "other",
                   "pinterest",
+                  "threads",
                   "twitter",
                   "youtube"
                 ]

--- a/content_schemas/formats/shared/definitions/_social_media_links.jsonnet
+++ b/content_schemas/formats/shared/definitions/_social_media_links.jsonnet
@@ -13,6 +13,7 @@
         type: "string",
         enum: [
           "blog",
+          "bluesky",
           "email",
           "facebook",
           "flickr",
@@ -22,6 +23,7 @@
           "linkedin",
           "other",
           "pinterest",
+          "threads",
           "twitter",
           "youtube",
         ],


### PR DESCRIPTION
The govuk_publishing_components gem supports threads and bluesky as options for the share_links component as of [PR #4918](https://github.com/alphagov/govuk_publishing_components/pull/4918), so we need to allow these as options in the affected schemas as well.

https://trello.com/c/89rP894P/728-add-logos-for-bluesky-and-threads-to-sharelinks-component

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
