### PR TITLE
(CM-239) Make titles optional in subobjects

### DIFF
--- a/content_schemas/dist/formats/content_block_contact/notification/schema.json
+++ b/content_schemas/dist/formats/content_block_contact/notification/schema.json
@@ -386,7 +386,6 @@
             "^[a-z0-9]+(?:-[a-z0-9]+)*$": {
               "type": "object",
               "required": [
-                "title",
                 "street_address",
                 "locality",
                 "postal_code",
@@ -425,7 +424,6 @@
             "^[a-z0-9]+(?:-[a-z0-9]+)*$": {
               "type": "object",
               "required": [
-                "title",
                 "url"
               ],
               "additionalProperties": false,
@@ -459,7 +457,6 @@
             "^[a-z0-9]+(?:-[a-z0-9]+)*$": {
               "type": "object",
               "required": [
-                "title",
                 "email_address"
               ],
               "additionalProperties": false,
@@ -490,7 +487,6 @@
             "^[a-z0-9]+(?:-[a-z0-9]+)*$": {
               "type": "object",
               "required": [
-                "title",
                 "telephone_numbers",
                 "show_uk_call_charges"
               ],

--- a/content_schemas/dist/formats/content_block_contact/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/content_block_contact/publisher_v2/schema.json
@@ -206,7 +206,6 @@
             "^[a-z0-9]+(?:-[a-z0-9]+)*$": {
               "type": "object",
               "required": [
-                "title",
                 "street_address",
                 "locality",
                 "postal_code",
@@ -242,7 +241,6 @@
             "^[a-z0-9]+(?:-[a-z0-9]+)*$": {
               "type": "object",
               "required": [
-                "title",
                 "url"
               ],
               "additionalProperties": false,
@@ -276,7 +274,6 @@
             "^[a-z0-9]+(?:-[a-z0-9]+)*$": {
               "type": "object",
               "required": [
-                "title",
                 "email_address"
               ],
               "additionalProperties": false,
@@ -307,7 +304,6 @@
             "^[a-z0-9]+(?:-[a-z0-9]+)*$": {
               "type": "object",
               "required": [
-                "title",
                 "telephone_numbers",
                 "show_uk_call_charges"
               ],

--- a/content_schemas/dist/formats/content_block_pension/notification/schema.json
+++ b/content_schemas/dist/formats/content_block_pension/notification/schema.json
@@ -389,7 +389,6 @@
             "^[a-z0-9]+(?:-[a-z0-9]+)*$": {
               "type": "object",
               "required": [
-                "title",
                 "amount",
                 "frequency"
               ],

--- a/content_schemas/dist/formats/content_block_pension/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/content_block_pension/publisher_v2/schema.json
@@ -206,7 +206,6 @@
             "^[a-z0-9]+(?:-[a-z0-9]+)*$": {
               "type": "object",
               "required": [
-                "title",
                 "amount",
                 "frequency"
               ],

--- a/content_schemas/formats/shared/utils/content_block_utils.jsonnet
+++ b/content_schemas/formats/shared/utils/content_block_utils.jsonnet
@@ -4,7 +4,7 @@
       patternProperties: {
         "^[a-z0-9]+(?:-[a-z0-9]+)*$": {
             type: "object",
-            required: ["title"] + required,
+            required: required,
             additionalProperties: false,
             properties: {
               title: {


### PR DESCRIPTION
The initial thinking behind making sure embedded objects had titles was because we needed a title to generate a slug for embed codes. We’ve since worked out that we can generate an automatic slug if the title is missing (see https://github.com/alphagov/whitehall/pull/10411), so let’s keep title around as a default attribute, but make it optional.