### PR TITLE
Remove /media special route

### DIFF
--- a/lib/data/special_routes.yaml
+++ b/lib/data/special_routes.yaml
@@ -214,13 +214,6 @@
   :description: "You can choose which cookies you're happy for GOV.UK to use."
   :rendering_app: "frontend"
 
-- :base_path: "/media"
-  :content_id: "cdcad470-21c6-4e19-b644-9e499de1ad12"
-  :title: "Government Uploads"
-  :description: "Handles redirects for /media/:id/:filename path for asset manager"
-  :type: "prefix"
-  :rendering_app: "government-frontend"
-
 - :base_path: "/random"
   :content_id: "3c991cea-cdee-4e58-b8d1-d38e7c0e6327"
   :title: "GOV.UK random page"


### PR DESCRIPTION
This route was added when assets were moved from Whitehall to Asset Manager, and the urls for downloading and previewing attachments changed format from /government/upload to /media/.
Its purpose is to redirect www.gov.uk/media/<asset_id>/<filename> to https://assets.publishing.service.gov.uk/media/<asset_id>/<filename>.

This route is not needed anymore. Here is the PR for removing it from government-frontend https://github.com/alphagov/government-frontend/pull/3828. 

Jira card: https://gov-uk.atlassian.net/jira/software/c/projects/NAV/boards/1422?selectedIssue=NAV-18195

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
