### PR TITLE
(CM-175) Update address fields in schema

### DIFF
--- a/content_schemas/dist/formats/content_block_contact/notification/schema.json
+++ b/content_schemas/dist/formats/content_block_contact/notification/schema.json
@@ -385,30 +385,27 @@
           "patternProperties": {
             "^[a-z0-9]+(?:-[a-z0-9]+)*$": {
               "type": "object",
-              "required": [
-                "street_address",
-                "locality",
-                "postal_code",
-                "country"
-              ],
               "additionalProperties": false,
               "properties": {
                 "country": {
                   "type": "string"
                 },
-                "locality": {
+                "description": {
                   "type": "string"
                 },
                 "postal_code": {
                   "type": "string"
                 },
-                "region": {
+                "state_or_county": {
                   "type": "string"
                 },
                 "street_address": {
                   "type": "string"
                 },
                 "title": {
+                  "type": "string"
+                },
+                "town_or_city": {
                   "type": "string"
                 }
               }

--- a/content_schemas/dist/formats/content_block_contact/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/content_block_contact/publisher_v2/schema.json
@@ -205,30 +205,27 @@
           "patternProperties": {
             "^[a-z0-9]+(?:-[a-z0-9]+)*$": {
               "type": "object",
-              "required": [
-                "street_address",
-                "locality",
-                "postal_code",
-                "country"
-              ],
               "additionalProperties": false,
               "properties": {
                 "country": {
                   "type": "string"
                 },
-                "locality": {
+                "description": {
                   "type": "string"
                 },
                 "postal_code": {
                   "type": "string"
                 },
-                "region": {
+                "state_or_county": {
                   "type": "string"
                 },
                 "street_address": {
                   "type": "string"
                 },
                 "title": {
+                  "type": "string"
+                },
+                "town_or_city": {
                   "type": "string"
                 }
               }

--- a/content_schemas/examples/content_block_contact/publisher_v2/example.json
+++ b/content_schemas/examples/content_block_contact/publisher_v2/example.json
@@ -25,6 +25,14 @@
         "description": "Another address"
       }
     },
+    "addresses": {
+      "address-1": {
+        "title": "Some address",
+        "street_address": "123 Fake Street",
+        "postal_code": "ABC 123"
+      },
+      "address-2": {}
+    },
     "telephones": {
       "telephone_numbers": [
         {

--- a/content_schemas/formats/content_block_contact.jsonnet
+++ b/content_schemas/formats/content_block_contact.jsonnet
@@ -128,10 +128,10 @@ local utils = import "shared/utils/content_block_utils.jsonnet";
                 street_address: {
                     type: "string",
                 },
-                locality: {
+                town_or_city: {
                     type: "string",
                 },
-                region: {
+                state_or_county: {
                     type: "string",
                 },
                 postal_code: {
@@ -140,8 +140,10 @@ local utils = import "shared/utils/content_block_utils.jsonnet";
                 country: {
                     type: "string",
                 },
+                description: {
+                    type: "string",
+                },
             },
-            ["street_address", "locality", "postal_code", "country"],
         ),
       },
       required: [ "contact_type" ]

--- a/content_schemas/formats/shared/utils/content_block_utils.jsonnet
+++ b/content_schemas/formats/shared/utils/content_block_utils.jsonnet
@@ -1,17 +1,16 @@
 {
-   embedded_object(properties, required):: {
+   embedded_object(properties, required = null):: {
       type: "object",
       patternProperties: {
         "^[a-z0-9]+(?:-[a-z0-9]+)*$": {
             type: "object",
-            required: required,
             additionalProperties: false,
             properties: {
               title: {
                 type: "string"
               }
             } + properties,
-        }
+        } + (if required != null then { required: required } else {})
       }
    }
 }


### PR DESCRIPTION
This updates the schema for addresses in the contact content block to match the current model. No fields are marked as required to ensure the model is as flexible as possible.