### PR TITLE
Documentation: add example for "call_charges" in Contact content block's "telephones"

### DIFF
--- a/content_schemas/examples/content_block_contact/publisher_v2/example.json
+++ b/content_schemas/examples/content_block_contact/publisher_v2/example.json
@@ -46,7 +46,12 @@
           "type": "welsh_language",
           "show_uk_call_charges": "true"
         }
-      ]
+      ],
+      "call_charges": {
+        "label": "Find out about call charges",
+        "call_charges_info_url": "https://gov.uk/call-charges/overseas",
+        "show_call_charges_info_url": "on"
+      }
     }
   },
   "links": {


### PR DESCRIPTION
The example was missed when adding this `call_charges` object to the "Contact" content block's `telephones` sub-object.


