### PR TITLE
Remove query string from default relay value

### DIFF
--- a/content_schemas/dist/formats/content_block_contact/notification/schema.json
+++ b/content_schemas/dist/formats/content_block_contact/notification/schema.json
@@ -497,7 +497,7 @@
                     },
                     "value": {
                       "type": "string",
-                      "default": "British Sign Language (BSL) [video relay service](https://connect.interpreterslive.co.uk/vrs?ilc=DWP) if you’re on a computer - find out how to [use the service on mobile or tablet](https://www.youtube.com/watch?v=oELNMfAvDxw)"
+                      "default": "British Sign Language (BSL) [video relay service](https://connect.interpreterslive.co.uk/vrs) if you’re on a computer - find out how to [use the service on mobile or tablet](https://www.youtube.com/watch?v=oELNMfAvDxw)"
                     }
                   }
                 },

--- a/content_schemas/dist/formats/content_block_contact/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/content_block_contact/publisher_v2/schema.json
@@ -314,7 +314,7 @@
                     },
                     "value": {
                       "type": "string",
-                      "default": "British Sign Language (BSL) [video relay service](https://connect.interpreterslive.co.uk/vrs?ilc=DWP) if you’re on a computer - find out how to [use the service on mobile or tablet](https://www.youtube.com/watch?v=oELNMfAvDxw)"
+                      "default": "British Sign Language (BSL) [video relay service](https://connect.interpreterslive.co.uk/vrs) if you’re on a computer - find out how to [use the service on mobile or tablet](https://www.youtube.com/watch?v=oELNMfAvDxw)"
                     }
                   }
                 },

--- a/content_schemas/formats/content_block_contact.jsonnet
+++ b/content_schemas/formats/content_block_contact.jsonnet
@@ -137,7 +137,7 @@ local utils = import "shared/utils/content_block_utils.jsonnet";
                         },
                         value: {
                             type: "string",
-                            default: "British Sign Language (BSL) [video relay service](https://connect.interpreterslive.co.uk/vrs?ilc=DWP) if you’re on a computer - find out how to [use the service on mobile or tablet](https://www.youtube.com/watch?v=oELNMfAvDxw)",
+                            default: "British Sign Language (BSL) [video relay service](https://connect.interpreterslive.co.uk/vrs) if you’re on a computer - find out how to [use the service on mobile or tablet](https://www.youtube.com/watch?v=oELNMfAvDxw)",
                         },
                     }
                 }


### PR DESCRIPTION
This sends users to DWP by default, which we don’t want. This link takes users to select a company instead. Ideally, users will change the link to deep link to their chosen organisation, but we need to see if this assumption gets borne out in research