### PR TITLE
(CM-248) Remove default number from the Relay UK field

### DIFF
--- a/content_schemas/dist/formats/content_block_contact/notification/schema.json
+++ b/content_schemas/dist/formats/content_block_contact/notification/schema.json
@@ -581,6 +581,16 @@
                 },
                 "video_relay_service": {
                   "type": "object",
+                  "else": {
+                    "required": []
+                  },
+                  "if": {
+                    "properties": {
+                      "show": {
+                        "const": true
+                      }
+                    }
+                  },
                   "properties": {
                     "prefix": {
                       "type": "string",
@@ -593,6 +603,12 @@
                     "telephone_number": {
                       "type": "string"
                     }
+                  },
+                  "then": {
+                    "required": [
+                      "prefix",
+                      "telephone_number"
+                    ]
                   }
                 }
               }

--- a/content_schemas/dist/formats/content_block_contact/notification/schema.json
+++ b/content_schemas/dist/formats/content_block_contact/notification/schema.json
@@ -591,8 +591,7 @@
                       "default": false
                     },
                     "telephone_number": {
-                      "type": "string",
-                      "default": "0800 328 5644"
+                      "type": "string"
                     }
                   }
                 }

--- a/content_schemas/dist/formats/content_block_contact/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/content_block_contact/publisher_v2/schema.json
@@ -398,6 +398,16 @@
                 },
                 "video_relay_service": {
                   "type": "object",
+                  "else": {
+                    "required": []
+                  },
+                  "if": {
+                    "properties": {
+                      "show": {
+                        "const": true
+                      }
+                    }
+                  },
                   "properties": {
                     "prefix": {
                       "type": "string",
@@ -410,6 +420,12 @@
                     "telephone_number": {
                       "type": "string"
                     }
+                  },
+                  "then": {
+                    "required": [
+                      "prefix",
+                      "telephone_number"
+                    ]
                   }
                 }
               }

--- a/content_schemas/dist/formats/content_block_contact/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/content_block_contact/publisher_v2/schema.json
@@ -408,8 +408,7 @@
                       "default": false
                     },
                     "telephone_number": {
-                      "type": "string",
-                      "default": "0800 328 5644"
+                      "type": "string"
                     }
                   }
                 }

--- a/content_schemas/examples/content_block_contact/publisher_v2/without-relay-service.json
+++ b/content_schemas/examples/content_block_contact/publisher_v2/without-relay-service.json
@@ -1,0 +1,78 @@
+{
+  "locale": "en",
+  "schema_name": "content_block_contact",
+  "document_type": "content_block_contact",
+  "title": "HMRC - Media enquiries",
+  "instructions_to_publishers": "Media and press contact email address for HMRC",
+  "content_id_alias": "hmrc-media",
+  "details": {
+    "description": "Description goes here",
+    "contact_type": "General",
+    "email_addresses": {
+      "email-1": {
+        "title": "Email 1",
+        "email_address": "hello@example.com",
+        "description": "General enquiries"
+      },
+      "email-2": {
+        "title": "Email 2",
+        "email_address": "hiagain@example.com",
+        "description": "More enquiries"
+      },
+      "email-3": {
+        "title": "Email 3",
+        "email_address": "bye@example.com",
+        "description": "Another address"
+      }
+    },
+    "addresses": {
+      "address-1": {
+        "title": "Some address",
+        "street_address": "123 Fake Street",
+        "postal_code": "ABC 123"
+      },
+      "address-2": {}
+    },
+    "telephones": {
+      "telephone_numbers": [
+        {
+          "label": "Telephone 1",
+          "telephone": "1234 567 89",
+          "type": "telephone",
+          "show_uk_call_charges": "false",
+          "description": "A Telephone line"
+        },
+        {
+          "label": "Telephone 2",
+          "telephone": "1234 567 89",
+          "type": "textphone",
+          "show_uk_call_charges": "true"
+        },
+        {
+          "label": "Telephone 3",
+          "telephone": "1234 567 89",
+          "type": "welsh_language",
+          "show_uk_call_charges": "true"
+        }
+      ],
+      "video_relay_services": {
+        "show": false
+      },
+      "call_charges": {
+        "label": "Find out about call charges",
+        "call_charges_info_url": "https://gov.uk/call-charges/overseas",
+        "show_call_charges_info_url": "on"
+      },
+      "bsl_guidance": {
+        "show": true,
+        "value": "Some value"
+      }
+    }
+  },
+  "links": {
+    "primary_publishing_organisation": [
+      "dcc907d6-433c-42df-9ffb-d9c68be5dc4d"
+    ]
+  },
+  "publishing_app": "whitehall"
+}

--- a/content_schemas/formats/content_block_contact.jsonnet
+++ b/content_schemas/formats/content_block_contact.jsonnet
@@ -76,7 +76,18 @@ local utils = import "shared/utils/content_block_utils.jsonnet";
                     telephone_number: {
                       type: "string",
                     },
-                  }
+                  },
+                  "if": {
+                    properties: {
+                        show: { const: true },
+                    },
+                  },
+                  "then": {
+                    required: ["prefix", "telephone_number"],
+                  },
+                  "else": {
+                    required: []
+                  },
                 },
                 call_charges: {
                   type: "object",

--- a/content_schemas/formats/content_block_contact.jsonnet
+++ b/content_schemas/formats/content_block_contact.jsonnet
@@ -75,7 +75,6 @@ local utils = import "shared/utils/content_block_utils.jsonnet";
                     },
                     telephone_number: {
                       type: "string",
-                      default: "0800 328 5644"
                     },
                   }
                 },


### PR DESCRIPTION
This removes the default telephone number from the Relay UK telephone number field, as well as adding some validation to ensure the field is populated if the user opts to show the Relay UK details.