### PR TITLE
Add headings elements to statistical_data_set items

### DIFF
--- a/content_schemas/dist/formats/statistical_data_set/frontend/schema.json
+++ b/content_schemas/dist/formats/statistical_data_set/frontend/schema.json
@@ -318,6 +318,9 @@
         "government": {
           "$ref": "#/definitions/government"
         },
+        "headers": {
+          "$ref": "#/definitions/nested_headers"
+        },
         "political": {
           "$ref": "#/definitions/political"
         },
@@ -574,6 +577,33 @@
         "zh-hk",
         "zh-tw"
       ]
+    },
+    "nested_headers": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "text",
+          "level",
+          "id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "headers": {
+            "$ref": "#/definitions/nested_headers"
+          },
+          "id": {
+            "type": "string"
+          },
+          "level": {
+            "type": "integer"
+          },
+          "text": {
+            "type": "string"
+          }
+        }
+      },
+      "minItems": 1
     },
     "political": {
       "description": "If the content is considered political in nature, reflecting views of the government it was published under.",

--- a/content_schemas/dist/formats/statistical_data_set/notification/schema.json
+++ b/content_schemas/dist/formats/statistical_data_set/notification/schema.json
@@ -413,6 +413,9 @@
         "government": {
           "$ref": "#/definitions/government"
         },
+        "headers": {
+          "$ref": "#/definitions/nested_headers"
+        },
         "political": {
           "$ref": "#/definitions/political"
         },
@@ -682,6 +685,33 @@
         "zh-hk",
         "zh-tw"
       ]
+    },
+    "nested_headers": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "text",
+          "level",
+          "id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "headers": {
+            "$ref": "#/definitions/nested_headers"
+          },
+          "id": {
+            "type": "string"
+          },
+          "level": {
+            "type": "integer"
+          },
+          "text": {
+            "type": "string"
+          }
+        }
+      },
+      "minItems": 1
     },
     "payload_version": {
       "description": "Counter to indicate when the payload was generated",

--- a/content_schemas/dist/formats/statistical_data_set/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/statistical_data_set/publisher_v2/schema.json
@@ -244,6 +244,9 @@
         "government": {
           "$ref": "#/definitions/government"
         },
+        "headers": {
+          "$ref": "#/definitions/nested_headers"
+        },
         "political": {
           "$ref": "#/definitions/political"
         },
@@ -374,6 +377,33 @@
         "zh-hk",
         "zh-tw"
       ]
+    },
+    "nested_headers": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "text",
+          "level",
+          "id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "headers": {
+            "$ref": "#/definitions/nested_headers"
+          },
+          "id": {
+            "type": "string"
+          },
+          "level": {
+            "type": "integer"
+          },
+          "text": {
+            "type": "string"
+          }
+        }
+      },
+      "minItems": 1
     },
     "political": {
       "description": "If the content is considered political in nature, reflecting views of the government it was published under.",

--- a/content_schemas/examples/statistical_data_set/frontend/statistical_data_set.json
+++ b/content_schemas/examples/statistical_data_set/frontend/statistical_data_set.json
@@ -9,6 +9,38 @@
   "first_published_at": "2012-12-13T09:30:00+00:00",
   "details": {
     "body": "<div class=\"govspeak\"><p>This is not intended to be a comprehensive review of transport performance in London or Great Britain during the Games, but supplements evidence from other sources.</p><h2 id=\"olympics\">Olympics</h2><p><span id=\"attachment_385319\" class=\"attachment-inline\"> <a href=\"/government/uploads/system/uploads/attachment_data/file/35761/tsgb_2012_-_olympics_summary.pdf\">Olympics</a> (<span class=\"type\"><abbr title=\"Portable Document Format\">PDF</abbr></span>, <span class=\"file-size\">243KB</span>)</span></p><h2 id=\"table-tsgb1001\">Table TSGB1001</h2><p><span id=\"attachment_385320\" class=\"attachment-inline\"> <a href=\"/government/uploads/system/uploads/attachment_data/file/36591/TSGB1001.xls\">Sea passenger statistics at United Kingdom ports, July to September, 2011 and 2012</a> (<span class=\"type\">MS Excel Spreadsheet</span>, <span class=\"file-size\">48KB</span>)</span></p><h2 id=\"table-tsgb1002\">Table TSGB1002</h2><p><span id=\"attachment_385315\" class=\"attachment-inline\"> <a href=\"/government/uploads/system/uploads/attachment_data/file/35757/TSGB1002.xls\">Air traffic at United Kingdom airports, July to September, 2011 and 2012</a> (<span class=\"type\">MS Excel Spreadsheet</span>, <span class=\"file-size\">59KB</span>)</span></p><h2 id=\"table-tsgb1003\">Table TSGB1003</h2><p><span id=\"attachment_385316\" class=\"attachment-inline\"> <a href=\"/government/uploads/system/uploads/attachment_data/file/35758/TSGB1003.xls\">Punctuality at selected United Kingdom airports, July to August, 2011 and 2012</a> (<span class=\"type\">MS Excel Spreadsheet</span>, <span class=\"file-size\">52.5KB</span>)</span></p><h2 id=\"table-tsgb1004\">Table TSGB1004</h2><p><span id=\"attachment_385317\" class=\"attachment-inline\"> <a href=\"/government/uploads/system/uploads/attachment_data/file/35759/TSGB1004.xls\">National Rail Games Tickets (NRGT) revenue and sales</a> (<span class=\"type\">MS Excel Spreadsheet</span>, <span class=\"file-size\">53.5KB</span>)</span></p><h2 id=\"table-tsgb1005\">Table TSGB1005</h2><p><span id=\"attachment_385318\" class=\"attachment-inline\"> <a href=\"/government/uploads/system/uploads/attachment_data/file/35760/TSGB1005.xls\">Average week day speed (miles per hour) on local 'A' roads in the six London host boroughs</a> (<span class=\"type\">MS Excel Spreadsheet</span>, <span class=\"file-size\">44.5KB</span>)</span></p></div>",
+    "headers": [
+      {
+        "text": "Olympics",
+        "level": 2,
+        "id": "olympics"
+      },
+      {
+        "text": "Table TSGB1001",
+        "level": 2,
+        "id": "table-tsgb1001"
+      },
+      {
+        "text": "Table TSGB1002",
+        "level": 2,
+        "id": "table-tsgb1002"
+      },
+      {
+        "text": "Table TSGB1003",
+        "level": 2,
+        "id": "table-tsgb1003"
+      },
+      {
+        "text": "Table TSGB1004",
+        "level": 2,
+        "id": "table-tsgb1004"
+      },
+      {
+        "text": "Table TSGB1005",
+        "level": 2,
+        "id": "table-tsgb1005"
+      }
+    ],
     "first_public_at": "2012-12-13T09:30:00+00:00",
     "government": {
       "current": false,

--- a/content_schemas/examples/statistical_data_set/frontend/statistical_data_set_political.json
+++ b/content_schemas/examples/statistical_data_set/frontend/statistical_data_set_political.json
@@ -16,6 +16,38 @@
       "slug": "2010-to-2015-conservative-and-liberal-democrat-coalition-government",
       "title": "2010 to 2015 Conservative and Liberal Democrat coalition government"
     },
+    "headers": [
+      {
+        "text": "Olympics",
+        "level": 2,
+        "id": "olympics"
+      },
+      {
+        "text": "Table TSGB1001",
+        "level": 2,
+        "id": "table-tsgb1001"
+      },
+      {
+        "text": "Table TSGB1002",
+        "level": 2,
+        "id": "table-tsgb1002"
+      },
+      {
+        "text": "Table TSGB1003",
+        "level": 2,
+        "id": "table-tsgb1003"
+      },
+      {
+        "text": "Table TSGB1004",
+        "level": 2,
+        "id": "table-tsgb1004"
+      },
+      {
+        "text": "Table TSGB1005",
+        "level": 2,
+        "id": "table-tsgb1005"
+      }
+    ],
     "political": true,
     "tags": {
       "browse_pages": [

--- a/content_schemas/examples/statistical_data_set/frontend/statistical_data_set_with_csv.json
+++ b/content_schemas/examples/statistical_data_set/frontend/statistical_data_set_with_csv.json
@@ -16,6 +16,33 @@
       "slug": "2010-to-2015-conservative-and-liberal-democrat-coalition-government",
       "title": "2010 to 2015 Conservative and Liberal Democrat coalition government"
     },
+    "headers": [
+      {
+        "text": "About this data set",
+        "level": 2,
+        "id": "about-this-data-set"
+      },
+      {
+        "text": "MOT test results by class",
+        "level": 2,
+        "id": "mot-test-results-by-class"
+      },
+      {
+        "text": "Initial failures by defect category",
+        "level": 2,
+        "id": "initial-failures-by-defect-category"
+      },
+      {
+        "text": "MOT test stations and testers",
+        "level": 2,
+        "id": "mot-test-stations-and-testers"
+      },
+      {
+        "text": "Action against MOT authorised examiners and MOT testers",
+        "level": 2,
+        "id": "action-against-mot-authorised-examiners-and-mot-testers"
+      }
+    ],
     "political": false,
     "tags": {
       "browse_pages": [

--- a/content_schemas/examples/statistical_data_set/frontend/statistical_data_set_withdrawn.json
+++ b/content_schemas/examples/statistical_data_set/frontend/statistical_data_set_withdrawn.json
@@ -20,6 +20,32 @@
       "slug": "2010-to-2015-conservative-and-liberal-democrat-coalition-government",
       "title": "2010 to 2015 Conservative and Liberal Democrat coalition government"
     },
+    "headers": [
+      {
+        "text": "Table CW0401",
+        "level": 2,
+        "id": "table-cw0401"
+      },
+      {
+        "text": "Table CW0402",
+        "level": 2,
+        "id": "table-cw0402"
+      },      {
+        "text": "Table CW0411",
+        "level": 2,
+        "id": "table-cw0411"
+      },
+      {
+        "text": "Table CW0412",
+        "level": 2,
+        "id": "table-cw0412"
+      },
+      {
+        "text": "Contact us:",
+        "level": 2,
+        "id": "contact-us"
+      }
+    ],
     "political": false,
     "change_history": [
       {

--- a/content_schemas/formats/statistical_data_set.jsonnet
+++ b/content_schemas/formats/statistical_data_set.jsonnet
@@ -22,6 +22,9 @@
         first_public_at: {
           "$ref": "#/definitions/first_public_at",
         },
+        headers: {
+          "$ref": "#/definitions/nested_headers",
+        },
         change_history: {
           "$ref": "#/definitions/change_history",
         },


### PR DESCRIPTION
Needed to provide information for contents lists following patterns in previous PRS:

- https://github.com/alphagov/publishing-api/pull/3280
- https://github.com/alphagov/publishing-api/pull/3320
- https://github.com/alphagov/publishing-api/pull/3426

...where header creation is moved from render time to publishing time.

https://trello.com/c/q60Z9Xrk/433-move-statisticaldataset-from-government-frontend-to-frontend

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
