### PR TITLE
Remove Sidekiq class aliases

### DIFF
--- a/app/sidekiq/delete_publish_intent_job.rb
+++ b/app/sidekiq/delete_publish_intent_job.rb
@@ -23,5 +23,3 @@ class DeletePublishIntentJob
     notify_airbrake(e, args)
   end
 end
-
-DeletePublishIntentWorker = DeletePublishIntentJob

--- a/app/sidekiq/dependency_resolution_job.rb
+++ b/app/sidekiq/dependency_resolution_job.rb
@@ -108,5 +108,3 @@ private
     )
   end
 end
-
-DependencyResolutionWorker = DependencyResolutionJob

--- a/app/sidekiq/downstream_discard_draft_job.rb
+++ b/app/sidekiq/downstream_discard_draft_job.rb
@@ -80,5 +80,3 @@ private
     @downstream_payload ||= DownstreamPayload.new(edition, payload_version, draft: true)
   end
 end
-
-DownstreamDiscardDraftWorker = DownstreamDiscardDraftJob

--- a/app/sidekiq/downstream_draft_job.rb
+++ b/app/sidekiq/downstream_draft_job.rb
@@ -114,5 +114,3 @@ private
     )
   end
 end
-
-DownstreamDraftWorker = DownstreamDraftJob

--- a/app/sidekiq/downstream_live_job.rb
+++ b/app/sidekiq/downstream_live_job.rb
@@ -109,5 +109,3 @@ private
     )
   end
 end
-
-DownstreamLiveWorker = DownstreamLiveJob

--- a/app/sidekiq/put_publish_intent_job.rb
+++ b/app/sidekiq/put_publish_intent_job.rb
@@ -23,5 +23,3 @@ class PutPublishIntentJob
     notify_airbrake(e, args)
   end
 end
-
-PutPublishIntentWorker = PutPublishIntentJob


### PR DESCRIPTION
These aliases were added in https://github.com/alphagov/publishing-api/pull/2883 when the classes were renamed.

The intention was they would exist until the queues were drained and all jobs with the previous name had been processed.

However it appears to next step of checking all jobs had been processed then removing the aliases was forgotten. Therefore doing this now.