### PR TITLE
Fix flaky tests

### DIFF
--- a/spec/lib/tasks/special_routes_spec.rb
+++ b/spec/lib/tasks/special_routes_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe "Rake tasks for publishing special routes" do
 
         expect(Document.count).to eq(3)
         expect(Edition.count).to eq(3)
-        expect(Edition.all.collect(&:title)).to eq(["Account home page", "Save a page", "Government Uploads"])
+        expect(Edition.all.collect(&:title)).to match_array(["Account home page", "Save a page", "Government Uploads"])
       end
     end
 
@@ -39,7 +39,7 @@ RSpec.describe "Rake tasks for publishing special routes" do
 
         expect(Document.count).to eq(2)
         expect(Edition.count).to eq(2)
-        expect(Edition.all.collect(&:title)).to eq(["Account home page", "Save a page"])
+        expect(Edition.all.collect(&:title)).to match_array(["Account home page", "Save a page"])
       end
 
       it "returns a message if there are no routes for that app" do


### PR DESCRIPTION
The editions are not always returned in the same order, so changing the matcher to `match_array` which does not care about the order (only that all the items and nothing else are present).
