### PR TITLE
Add temporary task to publish a new edition of /find-a-registered-childminder with new fields

### DIFF
--- a/lib/tasks/add_additional_fields_to_local_transactions.rake
+++ b/lib/tasks/add_additional_fields_to_local_transactions.rake
@@ -1,0 +1,52 @@
+desc "Create editions of two existing local_transaction documents with specific fields added"
+task add_additional_fields_to_local_transactions: :environment do
+  additional_fields = {
+    cta_text: "Find a registered childminder in your area",
+    before_results: [
+      {
+        content: "<h2>Find a registered childminder through your local council</h2>",
+        content_type: "text/govspeak",
+      },
+    ],
+    after_results: [
+      {
+        content: "<h2 id=\"find-a-childminder-through-a-registered-childminding-agency\">Find a childminder through a registered childminding agency</h2>
+                  <p>You can also search for a childminder using the following childminding agencies:</p>
+
+                  <ul>
+                    <li>
+                      <p><a rel=\"external\" href=\"https://scachildcare.co.uk/our-childminders/\">Suffolk Childcare Agency</a> (national)</p>
+                    </li>
+                    <li>
+                      <p><a rel=\"external\" href=\"https://www.tiney.co/childminders/\">Tiney</a> (national)</p>
+                    </li>
+                    <li>
+                      <p><a rel=\"external\" href=\"https://www.athomechildcare.co.uk/looking-for-childcare\">@Home Childcare</a> (regional)</p>
+                    </li>
+                    <li>
+                      <p><a rel=\"external\" href=\"https://usearlyyears.co.uk/\">Unique Support Early Years Agency</a> (regional)</p>
+                    </li>
+                  </ul>",
+        content_type: "text/govspeak",
+      },
+    ],
+  }
+
+  doc = Document.where(content_id: "2f2ee25a-30c8-4ded-a160-88783f978206").first
+  edition = doc.live
+  payload = {
+    base_path: edition.base_path,
+    content_id: edition.content_id,
+    description: edition.description,
+    details: edition.details.merge(additional_fields),
+    document_type: edition.document_type,
+    publishing_app: edition.publishing_app,
+    rendering_app: edition.rendering_app,
+    routes: edition.routes,
+    update_type: "minor",
+  }
+
+  response = Commands::V2::PutContent.call(payload)
+
+  puts("Response: [#{response}]")
+end


### PR DESCRIPTION
- Ideally, we would be able to deploy this through the Publisher UI. However,
  due to the PG change freeze, that won't be possible until later in August.
  To allow us to do this early, this task mimics a call to PUT /v2/content/:content_id
  to make a new edition with the required fields inserted.
- Once the UI version of Publisher is available, we can simply republish
  the correct way and remove this task.

https://trello.com/c/3ZomQTGq/753-update-find-a-registered-childminder-postcode-finder


⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
