### PR TITLE
(CM-278) Make opening hours free text

### DIFF
--- a/content_schemas/dist/formats/content_block_contact/notification/schema.json
+++ b/content_schemas/dist/formats/content_block_contact/notification/schema.json
@@ -525,31 +525,30 @@
                   "type": "string"
                 },
                 "opening_hours": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "required": [
-                      "day_from",
-                      "day_to",
-                      "time_from",
-                      "time_to"
-                    ],
+                  "type": "object",
+                  "else": {
+                    "required": []
+                  },
+                  "if": {
                     "properties": {
-                      "day_from": {
-                        "type": "string"
-                      },
-                      "day_to": {
-                        "type": "string"
-                      },
-                      "time_from": {
-                        "type": "string",
-                        "pattern": "^[0-9]{1,2}:[0-9]{2}AM|PM$"
-                      },
-                      "time_to": {
-                        "type": "string",
-                        "pattern": "^[0-9]{1,2}:[0-9]{2}AM|PM$"
+                      "show_opening_hours": {
+                        "const": true
                       }
                     }
+                  },
+                  "properties": {
+                    "opening_hours": {
+                      "type": "string"
+                    },
+                    "show_opening_hours": {
+                      "type": "boolean",
+                      "default": false
+                    }
+                  },
+                  "then": {
+                    "required": [
+                      "opening_hours"
+                    ]
                   }
                 },
                 "telephone_numbers": {

--- a/content_schemas/dist/formats/content_block_contact/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/content_block_contact/publisher_v2/schema.json
@@ -342,31 +342,30 @@
                   "type": "string"
                 },
                 "opening_hours": {
-                  "type": "array",
-                  "items": {
-                    "type": "object",
-                    "required": [
-                      "day_from",
-                      "day_to",
-                      "time_from",
-                      "time_to"
-                    ],
+                  "type": "object",
+                  "else": {
+                    "required": []
+                  },
+                  "if": {
                     "properties": {
-                      "day_from": {
-                        "type": "string"
-                      },
-                      "day_to": {
-                        "type": "string"
-                      },
-                      "time_from": {
-                        "type": "string",
-                        "pattern": "^[0-9]{1,2}:[0-9]{2}AM|PM$"
-                      },
-                      "time_to": {
-                        "type": "string",
-                        "pattern": "^[0-9]{1,2}:[0-9]{2}AM|PM$"
+                      "show_opening_hours": {
+                        "const": true
                       }
                     }
+                  },
+                  "properties": {
+                    "opening_hours": {
+                      "type": "string"
+                    },
+                    "show_opening_hours": {
+                      "type": "boolean",
+                      "default": false
+                    }
+                  },
+                  "then": {
+                    "required": [
+                      "opening_hours"
+                    ]
                   }
                 },
                 "telephone_numbers": {

--- a/content_schemas/examples/content_block_contact/publisher_v2/example.json
+++ b/content_schemas/examples/content_block_contact/publisher_v2/example.json
@@ -60,6 +60,10 @@
           "show_uk_call_charges": "true"
         }
       ],
+      "opening_hours": {
+        "show": true,
+        "value": "Monday to Friday, 8am to 6pm (except public holidays)"
+      },
       "video_relay_services": {
         "show": true,
         "prefix": "[Relay UK](https://example.com): 18001 then",

--- a/content_schemas/formats/content_block_contact.jsonnet
+++ b/content_schemas/formats/content_block_contact.jsonnet
@@ -110,32 +110,27 @@ local utils = import "shared/utils/content_block_utils.jsonnet";
                     type: "string",
                 },
                 opening_hours: {
-                    type: "array",
-                    items: {
-                        type: "object",
-                        required: [
-                            "day_from",
-                            "day_to",
-                            "time_from",
-                            "time_to",
-                         ],
-                         properties: {
-                           day_from: {
-                             type: "string",
-                           },
-                           day_to: {
-                             type: "string",
-                           },
-                           time_from: {
-                             type: "string",
-                             pattern: "^[0-9]{1,2}:[0-9]{2}AM|PM$",
-                           },
-                           time_to: {
-                             type: "string",
-                             pattern: "^[0-9]{1,2}:[0-9]{2}AM|PM$",
-                           },
-                        }
-                    }
+                    type: "object",
+                    properties: {
+                        show_opening_hours: {
+                            type: "boolean",
+                            default: false,
+                        },
+                        opening_hours: {
+                            type: "string",
+                        },
+                    },
+                    "if": {
+                      properties: {
+                          show_opening_hours: { const: true },
+                      },
+                    },
+                    "then": {
+                      required: ["opening_hours"],
+                    },
+                    "else": {
+                      required: []
+                    },
                 },
                 bsl_guidance: {
                     type: "object",


### PR DESCRIPTION
This updates the opening hours object to be much simpler and accept only free text, rather than a more strictly modelled form.