### PR TITLE
(CM-255) Remove `contact_type` from contact schema

### DIFF
--- a/content_schemas/dist/formats/content_block_contact/notification/schema.json
+++ b/content_schemas/dist/formats/content_block_contact/notification/schema.json
@@ -375,9 +375,6 @@
     },
     "details": {
       "type": "object",
-      "required": [
-        "contact_type"
-      ],
       "additionalProperties": false,
       "properties": {
         "addresses": {
@@ -438,15 +435,6 @@
               }
             }
           }
-        },
-        "contact_type": {
-          "type": "string",
-          "default": "General",
-          "enum": [
-            "General",
-            "Freedom of Information",
-            "Media enquiries"
-          ]
         },
         "description": {
           "type": "string"

--- a/content_schemas/dist/formats/content_block_contact/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/content_block_contact/publisher_v2/schema.json
@@ -195,9 +195,6 @@
     },
     "details": {
       "type": "object",
-      "required": [
-        "contact_type"
-      ],
       "additionalProperties": false,
       "properties": {
         "addresses": {
@@ -255,15 +252,6 @@
               }
             }
           }
-        },
-        "contact_type": {
-          "type": "string",
-          "default": "General",
-          "enum": [
-            "General",
-            "Freedom of Information",
-            "Media enquiries"
-          ]
         },
         "description": {
           "type": "string"

--- a/content_schemas/examples/content_block_contact/publisher_v2/example.json
+++ b/content_schemas/examples/content_block_contact/publisher_v2/example.json
@@ -7,7 +7,6 @@
   "content_id_alias": "hmrc-media",
   "details": {
     "description": "Description goes here",
-    "contact_type": "General",
     "email_addresses": {
       "email-1": {
         "title": "Email 1",

--- a/content_schemas/examples/content_block_contact/publisher_v2/without-relay-service.json
+++ b/content_schemas/examples/content_block_contact/publisher_v2/without-relay-service.json
@@ -7,7 +7,6 @@
   "content_id_alias": "hmrc-media",
   "details": {
     "description": "Description goes here",
-    "contact_type": "General",
     "email_addresses": {
       "email-1": {
         "title": "Email 1",

--- a/content_schemas/formats/content_block_contact.jsonnet
+++ b/content_schemas/formats/content_block_contact.jsonnet
@@ -10,15 +10,6 @@ local utils = import "shared/utils/content_block_utils.jsonnet";
         description: {
           type: "string"
         },
-        contact_type: {
-          type: "string",
-          enum: [
-            "General",
-            "Freedom of Information",
-            "Media enquiries",
-          ],
-          default: "General"
-        },
         email_addresses: utils.embedded_object(
           {
             email_address: {
@@ -183,7 +174,6 @@ local utils = import "shared/utils/content_block_utils.jsonnet";
             },
         ),
       },
-      required: [ "contact_type" ]
     },
   },
 }


### PR DESCRIPTION
We agreed previously that 'Contact type' attribute is out of scope for MVP