### PR TITLE
temp: add three special routes that have been removed but not correctly unpublished

### DIFF
--- a/lib/data/special_routes.yaml
+++ b/lib/data/special_routes.yaml
@@ -316,3 +316,21 @@
     - :base_path: "/chat/support"
     - :base_path: "/chat/privacy"
     - :base_path: "/chat/accessibility"
+
+# These are being added solely so they can be unpublished correctly, after which they'll be removed
+
+- :base_path: "/robots.txt"
+  :content_id: "c5dad62e-c21a-4fe4-841b-7bcb8a901e52"
+  :title: "robots.txt"
+  :description: "Provides rules for which parts of GOV.UK are permitted to be crawled by different bots."
+  :rendering_app: "static"
+
+- :base_path: "/account/cookies-and-feedback"
+  :content_id: "19c4cef8-d0ad-483b-93ea-e07f7ed4734a"
+  :title: "Cookie and feedback settings"
+  :rendering_app: "frontend"
+
+- :base_path: "/sign-in/first-time"
+  :content_id: "ff675fc1-2f0b-4f07-8dd3-bfe24d4318f8"
+  :title: "Control how we use information about you"
+  :rendering_app: "frontend"


### PR DESCRIPTION

- Once they have been unpublished, we will remove these lines.

/robots.txt has been provided directly by nginx since: https://github.com/alphagov/govuk-helm-charts/pull/179
/account/cookies-and-feedback has not been supported in frontend since:
https://github.com/alphagov/frontend/pull/3225
/sign-in/first-time has not been supported in frontend since:
https://github.com/alphagov/frontend/pull/3251

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
