### PR TITLE
Stop document_type being used to set schema name

### DIFF
--- a/lib/data/special_routes.yaml
+++ b/lib/data/special_routes.yaml
@@ -1,6 +1,7 @@
 - :base_path: "/"
   :content_id: "f3bbdec2-0e62-4520-a7fd-6ffd5d36e03a"
   :document_type: "homepage"
+  :schema_name: "homepage"
   :title: "GOV.UK homepage"
   :rendering_app: "frontend"
   :links:
@@ -74,7 +75,7 @@
 - :base_path: "/bank-holidays"
   :content_id: "58f79dbd-e57f-4ab2-ae96-96df5767d1b2"
   :document_type: "calendar"
-  :schema: "calendar"
+  :schema_name: "calendar"
   :title: "UK bank holidays"
   :description: "Find out when bank holidays are in England, Wales, Scotland and Northern Ireland - including past and future bank holidays"
   :rendering_app: "frontend"
@@ -91,6 +92,7 @@
 - :base_path: "/chat"
   :content_id: "62256aa9-f0e8-463a-8483-2f03be24287d"
   :document_type: "gone"
+  :schema_name: "gone"
   # title and description are required to be null for a gone schema
   :title: ~
   :description: ~
@@ -222,6 +224,7 @@
 - :base_path: "/gwyliau-banc"
   :content_id: "58f79dbd-e57f-4ab2-ae96-96df5767d1b2"
   :document_type: "calendar"
+  :schema_name: "calendar"
   :schema: "calendar"
   :locale: "cy"
   :title: "Gwyliau banc y DU"
@@ -360,7 +363,7 @@
 - :base_path: "/when-do-the-clocks-change"
   :content_id: "41c78b38-f70e-4729-815b-680f9b90db30"
   :document_type: "calendar"
-  :schema: "calendar"
+  :schema_name: "calendar"
   :title: "When do the clocks change?"
   :description: "Dates when the clocks go back or forward - includes British Summer Time, Greenwich Mean Time"
   :rendering_app: "frontend"

--- a/lib/special_route_publisher.rb
+++ b/lib/special_route_publisher.rb
@@ -61,7 +61,7 @@ class SpecialRoutePublisher
       content_id:,
       base_path: route.fetch(:base_path),
       document_type: route.fetch(:document_type, "special_route"),
-      schema_name: route.fetch(:document_type, "special_route"),
+      schema_name: route.fetch(:schema_name, "special_route"),
       title: route.fetch(:title),
       description: route.fetch(:description, ""),
       locale: route.fetch(:locale, "en"),

--- a/spec/fixtures/special_routes.yaml
+++ b/spec/fixtures/special_routes.yaml
@@ -18,6 +18,7 @@
 - :content_id: "f3bbdec2-0e62-4520-a7fd-6ffd5d36e03a"
   :base_path: "/"
   :document_type: "homepage"
+  :schema_name: "homepage"
   :title: "GOV.UK homepage"
   :rendering_app: "frontend"
   :links:


### PR DESCRIPTION
- There are a few special routes that aren't actually using the special_route schema: calenders, homepages, and a few gone items for the chat team. Until now, specifying the document_type value has also set the schema name, which is okay in those cases because if you're setting the document type you want to set the schema_name to the same thing. However, special_route does take two document types: special_route and search. Since we've moved the search routes in, we need to support them and the current code doesn't allow you to set the document_type without also setting the schema_name.
- fix is to allow them as separate things, and update the existing items that use document_type to also explicitly specify their schema_name (looks like some of the calendars already had a non-functioning value that was trying to do a similar thing)

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
