### PR TITLE
Normalise keys in generate_random_edition

### DIFF
--- a/spec/support/random_content_helpers.rb
+++ b/spec/support/random_content_helpers.rb
@@ -4,14 +4,14 @@ module RandomContentHelpers
   def generate_random_edition(base_path)
     GovukSchemas::RandomExample.for_schema(publisher_schema: "generic") do |content|
       content.merge(
-        base_path:,
-        update_type: "major",
+        "base_path" => base_path,
+        "update_type" => "major",
 
-        title: "Something not empty", # TODO: make schemas validate title length
-        routes: [
-          { path: base_path, type: "prefix" },
+        "title" => "Something not empty", # TODO: make schemas validate title length
+        "routes" => [
+          { "path" => base_path, "type" => "prefix" },
         ],
-        redirects: [],
+        "redirects" => [],
       )
     end
   end


### PR DESCRIPTION
Found while working on a flaky test fix, confusing and results in inconsistent keys in the final random content hash. 

Needed fixing in advance of the flaky fix anyway, but belonged in a separate PR.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
