### PR TITLE
Seed random examples using RSpec's seed

### DIFF
--- a/spec/integration/message_queue_publishing_spec.rb
+++ b/spec/integration/message_queue_publishing_spec.rb
@@ -4,7 +4,8 @@ RSpec.describe "Message queue publishing" do
   it "puts the correct message on the queue" do
     base_path = "/#{SecureRandom.hex}"
     stub_content_store_calls(base_path)
-    edition = generate_random_edition(base_path)
+    random_example = build_random_example(RSpec.configuration.seed)
+    edition = generate_random_edition(random_example, base_path)
 
     put "/v2/content/#{content_id}", params: edition.to_json
     expect(response).to be_ok, random_content_failure_message(response, edition)

--- a/spec/integration/random_content_spec.rb
+++ b/spec/integration/random_content_spec.rb
@@ -1,11 +1,15 @@
 RSpec.describe "Randomised content" do
   include RandomContentHelpers
 
+  before :all do
+    @random_example = build_random_example(RSpec.configuration.seed)
+  end
+
   50.times do |i|
     it "it can publish randomly generated content #{i + 1}/50" do
       base_path = "/#{SecureRandom.hex}"
       stub_content_store_calls(base_path)
-      edition = generate_random_edition(base_path)
+      edition = generate_random_edition(@random_example, base_path)
 
       put "/v2/content/#{content_id}", params: edition.to_json
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -37,6 +37,8 @@ end
 Dir[Rails.root.join("spec/support/**/*.rb")].sort.each { |f| require f }
 
 RSpec.configure do |config|
+  puts "Using seed #{config.seed} for some random number generators"
+
   config.expect_with :rspec do |expectations|
     # This option will default to `true` in RSpec 4.
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true

--- a/spec/support/random_content_helpers.rb
+++ b/spec/support/random_content_helpers.rb
@@ -1,8 +1,15 @@
 require "govuk_schemas"
 
 module RandomContentHelpers
-  def generate_random_edition(base_path)
-    GovukSchemas::RandomExample.for_schema(publisher_schema: "generic") do |content|
+  def build_random_example(seed)
+    GovukSchemas::RandomExample.new(
+      schema: GovukSchemas::Schema.find(publisher_schema: "generic"),
+      seed:,
+    )
+  end
+
+  def generate_random_edition(random_example, base_path)
+    random_example.payload do |content|
       content.merge(
         "base_path" => base_path,
         "update_type" => "major",


### PR DESCRIPTION
One problem with using random examples is that it can be hard to reproduce failures.

For example, we currently have a problem where if an example is generated with document_type: redirect (1 in 191) it will put a different kind of message on the queue, breaking the tests.

Replicating this is very frustrating, because you have to run the tests almost 200 times before you can replicate the failure.

Like with randomly ordered tests, it would be nice if we could specify a seed, and derive the random examples from that seed. That way, if the tests fail with a random issue, it can be reproduced by re-running the tests with the same seed.

We need to ensure that repeated calls to generate_random_edition produce different random editions, because we call it in a loop 50.times and it would be a waste of time if it returned the same edition every time. To achieve this, we extract a seeded RandomExample instance, and then use it repeatedly (each call to payload will produce a new random example, but they'll be deterministic relative to the seed of the entire test run).

We also print RSpec's seed in spec_helper, because it isn't printed by default unless the tests are being run in a random order (which we don't do in this app, yet).