### PR TITLE
Change `change_history` timestamps to iso8601

### DIFF
--- a/app/presenters/change_history_presenter.rb
+++ b/app/presenters/change_history_presenter.rb
@@ -24,7 +24,7 @@ module Presenters
     def format_change_note(history)
       {
         note: history[:note],
-        public_timestamp: convert_timestamp_to_utc(history[:public_timestamp]).to_s,
+        public_timestamp: convert_timestamp_to_utc(history[:public_timestamp]).iso8601,
       }
     end
 

--- a/spec/integration/graphql/news_article_spec.rb
+++ b/spec/integration/graphql/news_article_spec.rb
@@ -210,7 +210,7 @@ RSpec.describe "GraphQL" do
             description: @edition.description,
             details: {
               body: @edition.details[:body],
-              change_history: [{ note: "Info", public_timestamp: "2025-01-01 00:01:00 UTC" }],
+              change_history: [{ note: "Info", public_timestamp: "2025-01-01T00:01:00Z" }],
               default_news_image: @edition.details[:default_news_image],
               display_date: @edition.details[:display_date],
               emphasised_organisations: @edition.details[:emphasised_organisations],

--- a/spec/presenters/change_history_presenter_spec.rb
+++ b/spec/presenters/change_history_presenter_spec.rb
@@ -32,9 +32,9 @@ RSpec.describe Presenters::ChangeHistoryPresenter do
 
       it "returns the change notes from the database sorted by date" do
         expect(subject).to eq([
-          { public_timestamp: change_notes[2].public_timestamp.utc.to_s, note: change_notes[2].note },
-          { public_timestamp: change_notes[1].public_timestamp.utc.to_s, note: change_notes[1].note },
-          { public_timestamp: change_notes[0].public_timestamp.utc.to_s, note: change_notes[0].note },
+          { public_timestamp: change_notes[2].public_timestamp.utc.iso8601, note: change_notes[2].note },
+          { public_timestamp: change_notes[1].public_timestamp.utc.iso8601, note: change_notes[1].note },
+          { public_timestamp: change_notes[0].public_timestamp.utc.iso8601, note: change_notes[0].note },
         ])
       end
     end
@@ -61,8 +61,8 @@ RSpec.describe Presenters::ChangeHistoryPresenter do
 
         it "returns content_history from details hash" do
           expect(subject).to eq([
-            { public_timestamp: one_day_ago.utc.to_s, note: "note 1" },
-            { public_timestamp: two_days_ago.utc.to_s, note: "note 2" },
+            { public_timestamp: one_day_ago.utc.iso8601, note: "note 1" },
+            { public_timestamp: two_days_ago.utc.iso8601, note: "note 2" },
           ])
         end
       end
@@ -77,10 +77,10 @@ RSpec.describe Presenters::ChangeHistoryPresenter do
 
         it "merges the original change notes with the change notes from the linked editions in date order" do
           expect(subject).to eq([
-            { public_timestamp: query_response[1].public_timestamp.utc.to_s, note: query_response[1].note },
-            { public_timestamp: one_day_ago.utc.to_s, note: "note 1" },
-            { public_timestamp: two_days_ago.utc.to_s, note: "note 2" },
-            { public_timestamp: query_response[0].public_timestamp.utc.to_s, note: query_response[0].note },
+            { public_timestamp: query_response[1].public_timestamp.utc.iso8601, note: query_response[1].note },
+            { public_timestamp: one_day_ago.utc.iso8601, note: "note 1" },
+            { public_timestamp: two_days_ago.utc.iso8601, note: "note 2" },
+            { public_timestamp: query_response[0].public_timestamp.utc.iso8601, note: query_response[0].note },
           ])
         end
       end

--- a/spec/presenters/edition_presenter_spec.rb
+++ b/spec/presenters/edition_presenter_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe Presenters::EditionPresenter do
   let(:present_drafts) { false }
-  let(:change_history) { { note: "Note", public_timestamp: 1.day.ago.to_s } }
+  let(:change_history) { { note: "Note", public_timestamp: 1.day.ago.iso8601 } }
   let(:details) { { body: "<p>Text</p>\n", change_history: [change_history] } }
   let(:payload_version) { 1 }
 


### PR DESCRIPTION
Fixes a flaky message queue consumer test.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
