### PR TITLE
[PP-7303] Use RSpec's native transactions

### DIFF
--- a/spec/integration/put_content/race_conditions_spec.rb
+++ b/spec/integration/put_content/race_conditions_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe Commands::V2::PutContent do
   include_context "PutContent call"
 
-  describe "race conditions", skip_cleaning: true do
+  describe "race conditions" do
     let(:document) do
       create(
         :document,
@@ -18,10 +18,6 @@ RSpec.describe Commands::V2::PutContent do
         first_published_at: 1.year.ago,
         base_path:,
       )
-    end
-
-    after do
-      DatabaseCleaner.clean_with :truncation
     end
 
     it "copes with race conditions" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -60,6 +60,8 @@ RSpec.configure do |config|
   config.include AuthenticationHelper::RequestMixin, type: :request
   config.include AuthenticationHelper::ControllerMixin, type: :controller
 
+  config.use_transactional_fixtures = true
+
   config.after do
     Timecop.return
     GDS::SSO.test_user = nil
@@ -67,16 +69,7 @@ RSpec.configure do |config|
 
   config.before(:suite) do
     Rails.application.load_tasks
-    DatabaseCleaner.strategy = :transaction
     DatabaseCleaner.clean_with(:truncation)
-  end
-
-  config.around(:each) do |example|
-    if example.metadata[:skip_cleaning]
-      example.run
-    else
-      DatabaseCleaner.cleaning { example.run }
-    end
   end
 
   %i[controller request].each do |spec_type|


### PR DESCRIPTION
RSpec [natively supports transactions](https://rspec.info/features/8-0/rspec-rails/Transactions/), putting each example inside a transaction and rolling it back after.

Therefore we don't need to use the `database_cleaner` gem to wrap around each spec.

This fixes an issue where `database_cleaner` was not correctly rolling back the database after running some GraphQL tests locally and not correctly cleaning before running the test suite, resulting in a validation error as an edition with duplicated Content ID was being created in some tests.

```ruby
Failures:

  1) GraphQL roles exposes Role-specific fields, generic Edition fields and Role's links
     Failure/Error:
       role = create(
         :live_edition,
         title: "Prime Minister",
         document_type: "ministerial_role",
         base_path: "/government/ministers/prime-minister",
         details:
         {
           "attends_cabinet_type": nil,
           "body": [{
             "content_type": "text/govspeak",

     ActiveRecord::RecordInvalid:
       Validation failed: base path=/government/ministers/prime-minister conflicts with content_id=894bcb8b-4f0c-41b3-b21b-0d67d081d80f and locale=en
     # ./spec/integration/graphql/roles_spec.rb:4:in 'block (3 levels) in <top (required)>'
     # ./spec/spec_helper.rb:78:in 'block (3 levels) in <top (required)>'
     # ./spec/spec_helper.rb:78:in 'block (2 levels) in <top (required)>'

Finished in 0.49083 seconds (files took 1.63 seconds to load)
1 example, 1 failure
```

Note: removing the `skip_cleaning` argument from the race conditions test as it appears to serve no purpose. There is a single example block, so the whole block will be executed inside one transaction.