### PR TITLE
fix: correct missing schema_name/document_type in html_publication examples

### DIFF
--- a/content_schemas/examples/html_publication/frontend/arabic_translation.json
+++ b/content_schemas/examples/html_publication/frontend/arabic_translation.json
@@ -26,6 +26,8 @@
     "organisations": [
       {
         "content_id": "90c1be18-70a4-476b-9244-ef4c36e1a042",
+        "schema_name": "organisation",
+        "document_type": "organisation",
         "title": "UK Trade & Investment",
         "details": {
           "brand": "uk-trade-investment",

--- a/content_schemas/examples/html_publication/frontend/fractions_and_unnumbered_headings.json
+++ b/content_schemas/examples/html_publication/frontend/fractions_and_unnumbered_headings.json
@@ -26,6 +26,8 @@
     "organisations": [
       {
         "content_id": "90c1be18-70a4-476b-9244-ef4c36e1a042",
+        "schema_name": "organisation",
+        "document_type": "organisation",
         "title": "Department for Education",
         "details": {
           "brand": "department-for-education",

--- a/content_schemas/examples/html_publication/frontend/long_form_and_automatically_numbered_headings.json
+++ b/content_schemas/examples/html_publication/frontend/long_form_and_automatically_numbered_headings.json
@@ -26,6 +26,8 @@
     "organisations": [
       {
         "content_id": "90c1be18-70a4-476b-9244-ef4c36e1a042",
+        "schema_name": "organisation",
+        "document_type": "organisation",
         "title": "HM Treasury",
         "details": {
           "brand": "hm-treasury",

--- a/content_schemas/examples/html_publication/frontend/multiple_organisations.json
+++ b/content_schemas/examples/html_publication/frontend/multiple_organisations.json
@@ -26,6 +26,8 @@
     "organisations": [
       {
         "content_id": "90c1be18-70a4-476b-9244-ef4c36e1a042",
+        "schema_name": "organisation",
+        "document_type": "organisation",
         "title": "Bona Vacantia",
         "details": {
           "brand": "attorney-generals-office",

--- a/content_schemas/examples/html_publication/frontend/national_applicability_alternative_url_html_publication.json
+++ b/content_schemas/examples/html_publication/frontend/national_applicability_alternative_url_html_publication.json
@@ -36,6 +36,7 @@
         "locale": "en",
         "api_path": "/api/content/government/2010-to-2015-conservative-and-liberal-democrat-coalition-government",
         "base_path": "/government/2010-to-2015-conservative-and-liberal-democrat-coalition-government",
+        "schema_name": "government",
         "document_type": "government",
         "details": {
           "started_on": "2010-05-12T00:00:00+00:00",
@@ -64,6 +65,8 @@
     "organisations": [
       {
         "content_id": "90c1be18-70a4-476b-9244-ef4c36e1a042",
+        "schema_name": "organisation",
+        "document_type": "organisation",
         "title": "Environment Agency",
         "details": {
           "logo": {

--- a/content_schemas/examples/html_publication/frontend/prime_ministers_office.json
+++ b/content_schemas/examples/html_publication/frontend/prime_ministers_office.json
@@ -26,6 +26,8 @@
     "organisations": [
       {
         "content_id": "90c1be18-70a4-476b-9244-ef4c36e1a042",
+        "schema_name": "organisation",
+        "document_type": "organisation",
         "title": "Department for Business, Innovation &amp; Skills",
         "details": {
           "brand": "department-for-business-innovation-skills",
@@ -43,6 +45,8 @@
       },
       {
         "content_id": "83c1be18-70a4-476b-9244-ef4c36e1a042",
+        "schema_name": "organisation",
+        "document_type": "organisation",
         "title": "Foreign & Commonwealth Office",
         "details": {
           "brand": "foreign-commonwealth-office",
@@ -60,6 +64,8 @@
       },
       {
         "content_id": "d994e55c-48c9-4795-b872-58d8ec98af12",
+        "schema_name": "organisation",
+        "document_type": "organisation",
         "title": "Ministry of Defence",
         "details": {
           "brand": "ministry-of-defence",
@@ -77,6 +83,8 @@
       },
       {
         "content_id": "705dbea4-8bd7-422e-ba9c-254557f77f81",
+        "schema_name": "organisation",
+        "document_type": "organisation",
         "title": "Prime Minister's Office, 10 Downing Street",
         "details": {
           "brand": "cabinet-office",
@@ -94,6 +102,8 @@
       },
       {
         "content_id": "90c1be18-70a4-476b-9244-ef4c36e1a042",
+        "schema_name": "organisation",
+        "document_type": "organisation",
         "title": "UK Trade & Investment",
         "details": {
           "brand": "uk-trade-investment",

--- a/content_schemas/examples/html_publication/frontend/print_with_meta_data.json
+++ b/content_schemas/examples/html_publication/frontend/print_with_meta_data.json
@@ -27,6 +27,8 @@
     "organisations": [
       {
         "content_id": "2e7868a8-38f5-4ff6-b62f-9a15d1c22d28",
+        "schema_name": "organisation",
+        "document_type": "organisation",
         "title": "Department for Communities and Local Government",
         "details": {
           "logo": {

--- a/content_schemas/examples/html_publication/frontend/published.json
+++ b/content_schemas/examples/html_publication/frontend/published.json
@@ -26,6 +26,8 @@
     "organisations": [
       {
         "content_id": "90c1be18-70a4-476b-9244-ef4c36e1a042",
+        "schema_name": "organisation",
+        "document_type": "organisation",
         "title": "Environment Agency",
         "details": {
           "logo": {

--- a/content_schemas/examples/html_publication/frontend/published_with_history_mode.json
+++ b/content_schemas/examples/html_publication/frontend/published_with_history_mode.json
@@ -17,6 +17,7 @@
         "locale": "en",
         "api_path": "/api/content/government/2010-to-2015-conservative-and-liberal-democrat-coalition-government",
         "base_path": "/government/2010-to-2015-conservative-and-liberal-democrat-coalition-government",
+        "schema_name": "government",
         "document_type": "government",
         "details": {
           "started_on": "2010-05-12T00:00:00+00:00",

--- a/content_schemas/examples/html_publication/frontend/stats_headline_and_manually_numbered_headings.json
+++ b/content_schemas/examples/html_publication/frontend/stats_headline_and_manually_numbered_headings.json
@@ -26,6 +26,8 @@
     "organisations": [
       {
         "content_id": "90c1be18-70a4-476b-9244-ef4c36e1a042",
+        "schema_name": "organisation",
+        "document_type": "organisation",
         "title": "Department for Work & Pensions",
         "details": {
           "brand": "department-for-work-pensions",

--- a/content_schemas/examples/html_publication/frontend/updated.json
+++ b/content_schemas/examples/html_publication/frontend/updated.json
@@ -26,6 +26,8 @@
     "organisations": [
       {
         "content_id": "90c1be18-70a4-476b-9244-ef4c36e1a042",
+        "schema_name": "organisation",
+        "document_type": "organisation",
         "title": "Environment Agency",
         "details": {
           "logo": {


### PR DESCRIPTION

- lots of these were missing the correct schema_name and document_type for organisations (and a few for governments), causing test failures in frontend (which expects at least schema_name when creating the correct models for linked data items).

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
