### PR TITLE
[PP-7312] Change `sidekiq-unique-jobs` logging

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -53,6 +53,11 @@ SidekiqUniqueJobs.reflect do |on|
     Sidekiq.logger.warn(message)
   end
 
+  on.locked do |job_hash|
+    message = extract_log_from_job("Locked", job_hash)
+    Sidekiq.logger.info(message)
+  end
+
   on.reschedule_failed do |job_hash|
     message = extract_log_from_job("Reschedule failed", job_hash)
     Sidekiq.logger.debug(message)
@@ -71,5 +76,10 @@ SidekiqUniqueJobs.reflect do |on|
   on.unlock_failed do |job_hash|
     message = extract_log_from_job("Unlock failed", job_hash)
     Sidekiq.logger.warn(message)
+  end
+
+  on.unlocked do |job_hash|
+    message = extract_log_from_job("Unlocked", job_hash)
+    Sidekiq.logger.info(message)
   end
 end

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -28,6 +28,7 @@ def extract_log_from_job(message, job_hash)
   {
     message: message,
     args: job_hash["args"],
+    jid: job_hash["jid"],
     lock_args: job_hash["lock_args"],
     queue: job_hash["queue"],
     worker: job_hash["class"],

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -24,35 +24,52 @@ Sidekiq.configure_server do |config|
 end
 
 # Logging for SidekiqUniqueJobs
-# Somewhat copied from https://github.com/mhenrixon/sidekiq-unique-jobs/blob/36ffe8f95b01ab059a34c8093c2410a64ca191b9/UPGRADING.md?plain=1
+def extract_log_from_job(message, job_hash)
+  {
+    message: message,
+    args: job_hash["args"],
+    lock_args: job_hash["lock_args"],
+    queue: job_hash["queue"],
+    worker: job_hash["class"],
+  }
+end
+
 SidekiqUniqueJobs.reflect do |on|
   on.duplicate do |job_hash|
-    logger.warn(job_hash.merge(message: "Duplicate Job"))
+    message = extract_log_from_job("Duplicate Job", job_hash)
+    Sidekiq.logger.warn(message)
   end
 
   on.execution_failed do |job_hash, exception = nil|
-    message = "Execution failed"
-    message += " (#{exception.message})" if exception
-    logger.warn(job_hash.merge(message:))
+    exception_message = "Execution failed"
+    exception_message += " (#{exception.message})" if exception
+
+    message = extract_log_from_job(exception_message, job_hash)
+    Sidekiq.logger.warn(message)
   end
 
   on.lock_failed do |job_hash|
-    logger.warn(job_hash.merge(message: "Lock failed to be acquired"))
+    message = extract_log_from_job("Lock failed to be acquired", job_hash)
+    Sidekiq.logger.warn(message)
   end
 
   on.reschedule_failed do |job_hash|
-    logger.debug(job_hash.merge(message: "Reschedule failed"))
+    message = extract_log_from_job("Reschedule failed", job_hash)
+    Sidekiq.logger.debug(message)
   end
 
   on.timeout do |job_hash|
-    logger.warn(job_hash.merge(message: "Lock acquisition timed out"))
+    message = extract_log_from_job("Lock acquisition timed out", job_hash)
+    Sidekiq.logger.warn(message)
   end
 
   on.unknown_sidekiq_worker do |job_hash|
-    logger.warn(job_hash.merge(message: "Unknown Sidekiq worker"))
+    message = extract_log_from_job("Unknown Sidekiq worker", job_hash)
+    Sidekiq.logger.warn(message)
   end
 
   on.unlock_failed do |job_hash|
-    logger.warn(job_hash.merge(message: "Unlock failed"))
+    message = extract_log_from_job("Unlock failed", job_hash)
+    Sidekiq.logger.warn(message)
   end
 end


### PR DESCRIPTION
This logging does not appear to be working, as we see none of the messages logged when we believe there are failures to unlock a job.

The previous implementation was based on the [upgrade guide](https://github.com/mhenrixon/sidekiq-unique-jobs/blob/36ffe8f95b01ab059a34c8093c2410a64ca191b9/UPGRADING.md?plain=1), whereas this switches the implementation to match the [README](https://github.com/mhenrixon/sidekiq-unique-jobs/blob/fff3f7d02fd5ec20171d80c5fdc28ab3c8e7ecbc/README.md?plain=1#L485-L560).

This also adds logs for an additional two types of events: when locks are created and removed, which should help us debug where locks are not correctly being removed.  Plus adds the job ID, which will make it easier to find the events in Logit.

Screenshots of some manual testing done locally (it's not possible to reproduce all the scenarios, but there's enough to demonstrate we're writing something to the logs):

|Scenario|Screenshot|
|--|--|
|Queuing a job and locking|<img width="1423" height="141" alt="Screenshot 2025-08-21 at 08 11 34" src="https://github.com/user-attachments/assets/92ac881b-0aa0-474a-ad2b-6017d39febff" />|
|Successful completion of the job and unlocking|<img width="1423" height="71" alt="Screenshot 2025-08-21 at 08 11 57" src="https://github.com/user-attachments/assets/9927c656-89b6-4e28-8dfa-9f96d5a690fd" />|
|Lock conflict|<img width="1420" height="193" alt="Screenshot 2025-08-21 at 08 08 02" src="https://github.com/user-attachments/assets/fea9483e-4689-4db1-b970-47920462c962" />|