### PR TITLE
Avoid generating document_type=redirect editions

### DIFF
--- a/spec/support/random_content_helpers.rb
+++ b/spec/support/random_content_helpers.rb
@@ -2,10 +2,15 @@ require "govuk_schemas"
 
 module RandomContentHelpers
   def build_random_example(seed)
-    GovukSchemas::RandomExample.new(
-      schema: GovukSchemas::Schema.find(publisher_schema: "generic"),
-      seed:,
-    )
+    schema = GovukSchemas::Schema.find(publisher_schema: "generic")
+
+    # The "generic" schema includes ALL document types.
+    #
+    # We don't want to generate editions with special document_type values like "redirect"
+    # as these may be handled by publishing API in special ways which confuse some tests
+    schema["properties"]["document_type"]["enum"] -= %w[gone redirect vanish]
+
+    GovukSchemas::RandomExample.new(schema:, seed:)
   end
 
   def generate_random_edition(random_example, base_path)


### PR DESCRIPTION
These are rare (1/191), but because we put different messages on the queue for redirect document types they upset (at least) the message queue tests.

I've no reason to think that `gone` or `vanish` document types are handled specially, but they smell funny so I'm removing them too.

There are plenty of other document types that aren't weird, so patching the schema to remove the "special" types before using it to generate editions feels pragmatic.
