### PR TITLE
[PP-7319] Introduce GraphQL content item service

### DIFF
--- a/app/controllers/graphql_controller.rb
+++ b/app/controllers/graphql_controller.rb
@@ -30,7 +30,7 @@ class GraphqlController < ApplicationController
         end
 
         result = PublishingApiSchema.execute(query, variables: { base_path: encoded_base_path }).to_hash
-        process_graphql_result(result)
+        report_result(result)
 
         content_item = if result["errors"] && (unpublished_error = result["errors"].find { |error| error["message"] == "Edition has been unpublished" })
                          unpublished_error["extensions"]
@@ -73,7 +73,7 @@ class GraphqlController < ApplicationController
         operation_name:,
       ).to_hash
 
-      process_graphql_result(result)
+      report_result(result)
 
       render json: result
     rescue StandardError => e
@@ -85,7 +85,7 @@ class GraphqlController < ApplicationController
 
 private
 
-  def process_graphql_result(result)
+  def report_result(result)
     set_prometheus_labels(result.dig("data", "edition")&.slice("document_type", "schema_name"))
 
     if result.key?("errors")

--- a/app/controllers/graphql_controller.rb
+++ b/app/controllers/graphql_controller.rb
@@ -32,11 +32,7 @@ class GraphqlController < ApplicationController
         result = PublishingApiSchema.execute(query, variables: { base_path: encoded_base_path }).to_hash
         report_result(result)
 
-        content_item = if result["errors"] && (unpublished_error = result["errors"].find { |error| error["message"] == "Edition has been unpublished" })
-                         unpublished_error["extensions"]
-                       else
-                         result.dig("data", "edition")
-                       end
+        content_item = GraphqlContentItemService.new(result).process
 
         http_status = if content_item["schema_name"] == "gone" && (content_item["details"].nil? || content_item["details"].values.reject(&:blank?).empty?)
                         410

--- a/app/services/graphql_content_item_service.rb
+++ b/app/services/graphql_content_item_service.rb
@@ -12,7 +12,10 @@ class GraphqlContentItemService
 private
 
   def edition
-    query_result.dig("data", "edition")
+    query_result.dig("data", "edition").tap do |content_item|
+      content_item.compact!
+      content_item["details"].compact!
+    end
   end
 
   def unpublishing

--- a/app/services/graphql_content_item_service.rb
+++ b/app/services/graphql_content_item_service.rb
@@ -1,0 +1,23 @@
+class GraphqlContentItemService
+  attr_reader :query_result
+
+  def initialize(query_result)
+    @query_result = query_result
+  end
+
+  def process
+    unpublishing || edition
+  end
+
+private
+
+  def edition
+    query_result.dig("data", "edition")
+  end
+
+  def unpublishing
+    query_result["errors"]
+      &.find { _1["message"] == "Edition has been unpublished" }
+      &.[]("extensions")
+  end
+end

--- a/spec/controllers/graphql_controller_spec.rb
+++ b/spec/controllers/graphql_controller_spec.rb
@@ -138,29 +138,6 @@ RSpec.describe GraphqlController do
       end
     end
 
-    context "a withdrawn content item" do
-      let(:withdrawn_at) { Time.zone.parse("2016-05-17 11:20") }
-      let(:edition) do
-        create(
-          :withdrawn_unpublished_edition,
-          explanation: "This is no longer true",
-          schema_name: "news_article",
-          unpublished_at: withdrawn_at,
-        )
-      end
-
-      before do
-        get :live_content, params: { base_path: base_path_without_leading_slash(edition.base_path) }
-      end
-
-      it "displays the withdrawal explanation and time" do
-        data = JSON.parse(response.body)
-
-        expect(data.dig("withdrawn_notice", "explanation")).to eq("This is no longer true")
-        expect(Time.iso8601(data.dig("withdrawn_notice", "withdrawn_at"))).to eq(withdrawn_at)
-      end
-    end
-
     context "a gone content item without an explanation and without an alternative_path" do
       let(:edition) do
         create(

--- a/spec/services/graphql_content_item_service_spec.rb
+++ b/spec/services/graphql_content_item_service_spec.rb
@@ -1,8 +1,68 @@
 RSpec.describe GraphqlContentItemService do
   it "returns the edition from the query result" do
-    result = { "data" => { "edition" => "The best edition yet!" } }
+    result = {
+      "data" => {
+        "edition" => {
+          "title" => "The best edition yet!",
+          "details" => {},
+        },
+      },
+    }
 
-    expect(GraphqlContentItemService.new(result).process).to eq("The best edition yet!")
+    expect(GraphqlContentItemService.new(result).process).to eq({
+      "details" => {},
+      "title" => "The best edition yet!",
+    })
+  end
+
+  it "removes null top-level fields" do
+    result = {
+      "data" => {
+        "edition" => {
+          "array" => [1, 2, 3],
+          "boolean" => true,
+          "details" => {},
+          "hash" => { "a": 1 },
+          "null" => nil,
+          "number" => 1,
+          "string" => "howdy",
+        },
+      },
+    }
+
+    expect(GraphqlContentItemService.new(result).process).to eq({
+      "array" => [1, 2, 3],
+      "boolean" => true,
+      "details" => {},
+      "hash" => { "a": 1 },
+      "number" => 1,
+      "string" => "howdy",
+    })
+  end
+
+  it "removes null fields from the details hash" do
+    result = {
+      "data" => {
+        "edition" => {
+          "details" => {
+            "array" => [1, 2, 3],
+            "boolean" => true,
+            "hash" => { "a": 1 },
+            "null" => nil,
+            "number" => 1,
+            "string" => "howdy",
+          },
+        },
+      },
+    }
+
+    expect(GraphqlContentItemService.new(result).process).to eq({ "details" => {
+      "array" => [1, 2, 3],
+      "boolean" => true,
+      "hash" => { "a": 1 },
+      "number" => 1,
+      "string" => "howdy",
+    } })
   end
 
   context "when the edition has been unpublished" do

--- a/spec/services/graphql_content_item_service_spec.rb
+++ b/spec/services/graphql_content_item_service_spec.rb
@@ -1,0 +1,25 @@
+RSpec.describe GraphqlContentItemService do
+  it "returns the edition from the query result" do
+    result = { "data" => { "edition" => "The best edition yet!" } }
+
+    expect(GraphqlContentItemService.new(result).process).to eq("The best edition yet!")
+  end
+
+  context "when the edition has been unpublished" do
+    it "returns unpublishing data from the error extensions" do
+      result = {
+        "errors" => [
+          { "message" => "something unrelated" },
+          {
+            "message" => "Edition has been unpublished",
+            "extensions" => "presented unpublishing data",
+          },
+        ],
+        "data" => { "edition" => nil },
+      }
+
+      expect(GraphqlContentItemService.new(result).process)
+        .to eq("presented unpublishing data")
+    end
+  end
+end


### PR DESCRIPTION
- Tidy up a few bits of GraphQL controller code/testing
- Add `GraphqlContentItemService` for transforming a GraphQL query result into a 'content item'
- Remove null data from top-level and details fields for these 'content items'

The last two commits were started in mobbing this week. This work is a (soft) prerequisite for our planned tests to validate `GraphqlController#live_content` responses against the content schema