### PR TITLE
[PP-7319] 'Handle' GraphQL query errors

### DIFF
--- a/app/services/graphql_content_item_service.rb
+++ b/app/services/graphql_content_item_service.rb
@@ -1,4 +1,6 @@
 class GraphqlContentItemService
+  class QueryResultError < StandardError; end
+
   attr_reader :query_result
 
   def initialize(query_result)
@@ -6,6 +8,10 @@ class GraphqlContentItemService
   end
 
   def process
+    if error_messages.present?
+      raise QueryResultError, error_messages.join("\n")
+    end
+
     unpublishing || edition
   end
 
@@ -22,5 +28,13 @@ private
     query_result["errors"]
       &.find { _1["message"] == "Edition has been unpublished" }
       &.[]("extensions")
+  end
+
+  def error_messages
+    return @error_messages if defined?(@error_messages)
+
+    @error_messages = query_result["errors"]
+      &.map { _1["message"] }
+      &.reject { _1 == "Edition has been unpublished" }
   end
 end


### PR DESCRIPTION
If an invalid GraphQL query is executed against the schema, we get an object containing errors back. For example, if we request a field that's not defined on one of our GraphQL types (like Edition or Details), we get undefined field errors

We previously weren't checking for this anywhere, so we'd end up returning the error object with a 200 response from the GraphqlController. Hopefully we wouldn't roll out `GraphqlController#live_content` support for schemas with invalid queries, but this change catches any such cases by raising instead of returning a non-content item object