### PR TITLE
[PP-9319] Validate GraphQL response against content schemas

### DIFF
--- a/app/graphql/queries/ministers_index.graphql
+++ b/app/graphql/queries/ministers_index.graphql
@@ -3,6 +3,7 @@ query ministers_index($base_path: String!) {
     ... on MinistersIndex {
       base_path
       content_id
+      description
       document_type
       first_published_at
       locale
@@ -10,6 +11,7 @@ query ministers_index($base_path: String!) {
       publishing_app
       rendering_app
       schema_name
+      title
       updated_at
 
       details {

--- a/app/graphql/queries/news_article.graphql
+++ b/app/graphql/queries/news_article.graphql
@@ -10,7 +10,6 @@ query news_article($base_path: String!) {
       details {
         body
         change_history
-        display_date
         emphasised_organisations
         first_public_at
         image {
@@ -27,7 +26,9 @@ query news_article($base_path: String!) {
       links {
         available_translations {
           base_path
+          content_id
           locale
+          title
         }
         document_collections {
           ...RelatedItem
@@ -77,18 +78,6 @@ query news_article($base_path: String!) {
             }
           }
           title
-        }
-        related {
-          ...RelatedItem
-        }
-        related_guides {
-          ...RelatedItem
-        }
-        related_mainstream_content {
-          ...RelatedItem
-        }
-        related_statistical_data_sets {
-          ...RelatedItem
         }
         suggested_ordered_related_items {
           ...RelatedItem

--- a/app/graphql/queries/role.graphql
+++ b/app/graphql/queries/role.graphql
@@ -3,6 +3,7 @@ query role($base_path: String!) {
     ... on Edition {
       base_path
       content_id
+      description
       document_type
       first_published_at
       locale
@@ -21,7 +22,9 @@ query role($base_path: String!) {
       links {
         available_translations {
           base_path
+          content_id
           locale
+          title
         }
 
         role_appointments {

--- a/app/graphql/queries/world_index.graphql
+++ b/app/graphql/queries/world_index.graphql
@@ -1,7 +1,9 @@
 query world_index($base_path: String!) {
   edition(base_path: $base_path) {
     ... on Edition {
+      base_path
       content_id
+      description
       document_type
       first_published_at
       locale
@@ -19,6 +21,15 @@ query world_index($base_path: String!) {
 
         international_delegations {
           ...worldLocationInfo
+        }
+      }
+
+      links {
+        available_translations {
+          base_path
+          content_id
+          locale
+          title
         }
       }
     }

--- a/spec/integration/graphql/live_content_spec.rb
+++ b/spec/integration/graphql/live_content_spec.rb
@@ -1,0 +1,32 @@
+RSpec.describe "Requesting live content by base path" do
+  schema_specific_fields = {
+    news_article: { details: { body: "" } },
+    world_index: {
+      details: { world_locations: [], international_delegations: [] },
+    },
+  }
+
+  Dir.children(Rails.root.join("app/graphql/queries")).each do |query_filename|
+    schema_name = query_filename.split(".").first
+
+    context "when the edition is a #{schema_name}" do
+      it "produces a response that is valid against the schema" do
+        schema = GovukSchemas::Schema.find(frontend_schema: schema_name)
+        document_type = schema.dig("properties", "document_type", "enum").sample
+        edition = create(
+          :live_edition,
+          schema_name:,
+          document_type:,
+          **schema_specific_fields.fetch(schema_name.to_sym, {}),
+        )
+
+        get "/graphql/content/#{edition.base_path}"
+
+        parsed_response = JSON.parse(response.body)
+        errors = JSON::Validator.fully_validate(schema, parsed_response)
+
+        expect(errors).to eql([])
+      end
+    end
+  end
+end


### PR DESCRIPTION
... and update the GraphQL queries to address validation errors

A few notes:
- This introduces a bit of metaprogramming, but that does mean we get validation out of the box for any new queries
- All frontend schemas require links via `SchemaGenerator::FrontendSchemaGenerator#required`. Some schemas, like world index, don't have any custom links. Without a links field, the content item wouldn't be valid against the schema. With a links field, GraphQL requires you to select one of its properties. I considered keeping a list of schemas without custom links and ignoring their missing links field errors, but given Content Store does return a couple of link types for the world index (the only example we have), I've opted instead to add the most common of those link types to its query
- I've included a hash of schema-specific field values to include in the factory-generated edition. We need these overrides to ensure the edition is valid before we retrieve and process it with our GraphQL code