### PR TITLE
[PP-7332] Order events by their id

### DIFF
--- a/app/queries/get_events.rb
+++ b/app/queries/get_events.rb
@@ -9,7 +9,7 @@ module Queries
       result = result.where("created_at >= ?", from) if from.present?
       result = result.where("created_at <= ?", to) if to.present?
 
-      result
+      result.order(:id)
     end
 
   private


### PR DESCRIPTION
With no default order on this query, it's up to the database which order to return the results - it'll do whatever it thinks is most efficient.

Unfortunately, this makes testing the query a little more difficult - if we expect an array of results in a specific order, the test will be flaky if the database decides to give us things in a different order.

This could also be potentially confusing for users of the API - one time they call it the results come back in one order, the next time it's the same results, but in a different order because the database has decided on a subtly different execution strategy.

We could update the tests not to expect a specific order, but I think it's better in general for results to be given in a predictable order.

I don't think this will cause any performance issues, because the maximum number of events for a given content id is about 4,000 (at least in my database dump), and sorting 4,000 items takes less than 1ms.

To check, I picked a content_id with a lot of items:

    select count(*) from events
    where content_id='23c9bb78-9344-4107-b6d8-7b45bfcc3b59'
    # => 4266

And checked the query plan / timings:

    explain analyze
    select id from events
    where content_id='23c9bb78-9344-4107-b6d8-7b45bfcc3b59'
    order by id

     Sort  (cost=14587.48..14598.96 rows=4591 width=4) (actual time=4.829..5.121 rows=4266 loops=1)
      Sort Key: id
      Sort Method: quicksort  Memory: 193kB
      ->  Bitmap Heap Scan on events  (cost=72.01..14308.24 rows=4591 width=4) (actual time=1.385..4.145 rows=4266 loops=1)
            Recheck Cond: (content_id = '23c9bb78-9344-4107-b6d8-7b45bfcc3b59'::uuid)
            Heap Blocks: exact=3212
            ->  Bitmap Index Scan on index_events_on_content_id  (cost=0.00..70.86 rows=4591 width=0) (actual time=0.725..0.726 rows=4266 loops=1)
                  Index Cond: (content_id = '23c9bb78-9344-4107-b6d8-7b45bfcc3b59'::uuid)
    Planning Time: 0.177 ms
    Execution Time: 5.457 ms


Note the small difference between the start / done times for the Sort (5.339..5.670).
