### PR TITLE
[WHIT-2374] Delete documents and editions for the history document type

### DIFF
--- a/db/migrate/20250828082024_delete_history_page_documents_and_editions.rb
+++ b/db/migrate/20250828082024_delete_history_page_documents_and_editions.rb
@@ -1,0 +1,25 @@
+# This will delete all editions with the following base paths, as well as their parent documents:
+#       /government/history/10-downing-street
+#       /government/history/11-downing-street
+#       /government/history/king-charles-street
+#       /government/history/lancaster-house
+#       /government/history/1-horse-guards-road
+#       /government/history
+
+class DeleteHistoryPageDocumentsAndEditions < ActiveRecord::Migration[8.0]
+  def up
+    Edition.where(document_type: "history").pluck(:document_id).uniq.each do |document_id|
+      document = Document.find(document_id)
+      base_path = document.editions.last.base_path
+
+      Rails.logger.info "Deleting editions for document #{document_id}, with base path #{base_path}"
+      document.editions.destroy_all
+
+      Rails.logger.info "Deleting document #{document_id}"
+      document.destroy!
+
+      Rails.logger.info "Deleting path reservation #{base_path}"
+      PathReservation.find_by(base_path: base_path).destroy!
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_07_17_090305) do
+ActiveRecord::Schema[8.0].define(version: 2025_08_28_082024) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 


### PR DESCRIPTION
This will delete all editions with the following base paths, as well as their parent documents:
-  /government/history/10-downing-street
- /government/history/11-downing-street
- /government/history/king-charles-street
- /government/history/lancaster-house
- /government/history/1-horse-guards-road
- /government/history

These will be subsequently re-drafted and published as brand new documents and editions, from the Whitehall publisher, as config-driven standard document types.

Tested locally and in a deployed environment. After merging, got:
```
Edition.where(document_type: "history").pluck(:document_id).uniq
=> []
```

[Jira](https://gov-uk.atlassian.net/jira/software/c/projects/WHIT/boards/401?selectedIssue=WHIT-2374)
