### PR TITLE
PP-7281 script/build_graphql_query

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -314,7 +314,7 @@ GEM
       reline (>= 0.4.2)
     jmespath (1.6.2)
     json (2.12.2)
-    json-schema (5.1.1)
+    json-schema (6.0.0)
       addressable (~> 2.8)
       bigdecimal (~> 3.1)
     jsonnet (0.6.0)

--- a/app/graphql/queries/ministers_index.graphql
+++ b/app/graphql/queries/ministers_index.graphql
@@ -55,10 +55,7 @@ query ministers_index($base_path: String!) {
           details {
             brand
 
-            logo {
-              crest
-              formatted_title
-            }
+            logo
           }
 
           links {
@@ -84,10 +81,7 @@ fragment basePersonInfo on MinistersIndexPerson {
   details {
     privy_counsellor
 
-    image {
-      url
-      alt_text
-    }
+    image
   }
 
   links {
@@ -105,10 +99,7 @@ fragment basePersonInfo on MinistersIndexPerson {
           details {
             role_payment_type
             seniority
-            whip_organisation {
-              label
-              sort_order
-            }
+            whip_organisation
           }
         }
       }

--- a/app/graphql/queries/news_article.graphql
+++ b/app/graphql/queries/news_article.graphql
@@ -12,13 +12,7 @@ query news_article($base_path: String!) {
         change_history
         emphasised_organisations
         first_public_at
-        image {
-          alt_text
-          caption
-          credit
-          high_resolution_url
-          url
-        }
+        image
         political
       }
       document_type
@@ -72,10 +66,7 @@ query news_article($base_path: String!) {
         primary_publishing_organisation {
           base_path
           details {
-            default_news_image {
-              alt_text
-              url
-            }
+            default_news_image
           }
           title
         }

--- a/app/graphql/queries/world_index.graphql
+++ b/app/graphql/queries/world_index.graphql
@@ -15,13 +15,8 @@ query world_index($base_path: String!) {
       updated_at
 
       details {
-        world_locations {
-          ...worldLocationInfo
-        }
-
-        international_delegations {
-          ...worldLocationInfo
-        }
+        world_locations
+        international_delegations
       }
 
       links {
@@ -34,10 +29,4 @@ query world_index($base_path: String!) {
       }
     }
   }
-}
-
-fragment worldLocationInfo on Edition {
-  active
-  name
-  slug
 }

--- a/app/graphql/types/edition_type.rb
+++ b/app/graphql/types/edition_type.rb
@@ -125,32 +125,237 @@ module Types
     end
 
     class Details < Types::BaseObject
+      field :about_page_link_text, GraphQL::Types::JSON
+      field :access_and_opening_times, GraphQL::Types::JSON
+      field :acronym, String
+      field :alert_status, GraphQL::Types::JSON
+      field :alternative_format_contact_email, GraphQL::Types::JSON
+      field :appointments_without_historical_accounts, GraphQL::Types::JSON
+      field :attachments, [GraphQL::Types::JSON]
+      field :attends_cabinet_type, GraphQL::Types::JSON
+      field :beta_message, GraphQL::Types::JSON
+      field :beta, GraphQL::Types::JSON
+      field :blocks, GraphQL::Types::JSON
       field :body, String
+      field :born, GraphQL::Types::JSON
       field :brand, String
+      field :breadcrumbs, GraphQL::Types::JSON
+      field :brexit_no_deal_notice, GraphQL::Types::JSON
+      field :cancellation_reason, GraphQL::Types::JSON
+      field :cancelled_at, GraphQL::Types::JSON
+      field :casualties, GraphQL::Types::JSON
+      field :change_description, GraphQL::Types::JSON
       field :change_history, GraphQL::Types::JSON
+      field :change_note, GraphQL::Types::JSON
+      field :change_notes, GraphQL::Types::JSON
+      field :child_section_groups, GraphQL::Types::JSON
+      field :choose_sign_in, GraphQL::Types::JSON
+      field :closing_date, GraphQL::Types::JSON
+      field :collection_groups, GraphQL::Types::JSON
+      field :collections, GraphQL::Types::JSON
+      field :combine_mode, GraphQL::Types::JSON
+      field :contact_form_links, [GraphQL::Types::JSON]
+      field :contact_groups, GraphQL::Types::JSON
+      field :contact_type, GraphQL::Types::JSON
+      field :corporate_information_groups, GraphQL::Types::JSON
+      field :country, GraphQL::Types::JSON
       field :current, Boolean
+      field :dates_in_office, GraphQL::Types::JSON
+      field :default_documents_per_page, GraphQL::Types::JSON
       field :default_news_image, GraphQL::Types::JSON
+      field :default_order, GraphQL::Types::JSON
+      field :delivered_on, GraphQL::Types::JSON
+      field :department_analytics_profile, GraphQL::Types::JSON
+      field :department_counts, GraphQL::Types::JSON
+      field :description, String
+      field :died, GraphQL::Types::JSON
+      field :display_as_result_metadata, GraphQL::Types::JSON
       field :display_date, Types::ContentApiDatetime
+      field :document_noun, GraphQL::Types::JSON
+      field :document, GraphQL::Types::JSON
+      field :document_type_label, GraphQL::Types::JSON
+      field :documents, GraphQL::Types::JSON
+      field :downtime_message, String
+      field :email_address, GraphQL::Types::JSON
+      field :email_addresses, [GraphQL::Types::JSON]
+      field :email_filter_by, GraphQL::Types::JSON
+      field :email_filter_facets, GraphQL::Types::JSON
+      field :email_signup_link, GraphQL::Types::JSON
+      field :email, GraphQL::Types::JSON
       field :emphasised_organisations, GraphQL::Types::JSON
+      field :end_date, GraphQL::Types::JSON
       field :ended_on, Types::ContentApiDatetime
+      field :external_related_links, GraphQL::Types::JSON
+      field :facets, GraphQL::Types::JSON
+      field :featured_attachments, GraphQL::Types::JSON
+      field :filter_key, GraphQL::Types::JSON
+      field :filter, GraphQL::Types::JSON
+      field :filterable, GraphQL::Types::JSON
+      field :final_outcome_attachments, GraphQL::Types::JSON
+      field :final_outcome_detail, GraphQL::Types::JSON
+      field :final_outcome_documents, GraphQL::Types::JSON
       field :first_public_at, Types::ContentApiDatetime
+      field :first_published_version, GraphQL::Types::JSON
+      field :foi_exempt, GraphQL::Types::JSON
+      field :format_display_type, GraphQL::Types::JSON
+      field :format_name, GraphQL::Types::JSON
+      field :format_sub_type, GraphQL::Types::JSON
+      field :full_name, GraphQL::Types::JSON
+      field :govdelivery_title, GraphQL::Types::JSON
+      field :government, GraphQL::Types::JSON
+      field :groups, GraphQL::Types::JSON
+      field :header_links, GraphQL::Types::JSON
+      field :header_section, GraphQL::Types::JSON
+      field :headers, GraphQL::Types::JSON
+      field :headings, GraphQL::Types::JSON
+      field :held_on_another_website_url, GraphQL::Types::JSON
+      field :hidden_search_terms, GraphQL::Types::JSON
+      field :hide_chapter_navigation, GraphQL::Types::JSON
       field :image, GraphQL::Types::JSON
+      field :important_board_members, GraphQL::Types::JSON
+      field :interesting_facts, GraphQL::Types::JSON
+      field :internal_name, String
       field :international_delegations, [GraphQL::Types::JSON], null: false
+      field :introduction, GraphQL::Types::JSON
+      field :introductory_paragraph, GraphQL::Types::JSON
+      field :key, GraphQL::Types::JSON
+      field :label_text, GraphQL::Types::JSON
+      field :label, GraphQL::Types::JSON
+      field :language, GraphQL::Types::JSON
+      field :latest_change_note, GraphQL::Types::JSON
+      field :lgil_code, GraphQL::Types::JSON
+      field :lgsl_code, GraphQL::Types::JSON
+      field :link_items, GraphQL::Types::JSON
+      field :location, GraphQL::Types::JSON
       field :logo, GraphQL::Types::JSON
+      field :major_acts, GraphQL::Types::JSON
+      field :manual, GraphQL::Types::JSON
+      field :mapped_specialist_topic_content_id, GraphQL::Types::JSON
+      field :max_cache_time, GraphQL::Types::JSON
+      field :metadata, GraphQL::Types::JSON
+      field :ministerial_role_counts, GraphQL::Types::JSON
+      field :mission_statement, GraphQL::Types::JSON
+      field :more_info_contact_form, GraphQL::Types::JSON
+      field :more_info_email_address, GraphQL::Types::JSON
+      field :more_info_phone_number, GraphQL::Types::JSON
+      field :more_info_post_address, GraphQL::Types::JSON
+      field :more_info_webchat, GraphQL::Types::JSON
+      field :more_information, GraphQL::Types::JSON
+      field :name, GraphQL::Types::JSON
+      field :national_applicability, GraphQL::Types::JSON
+      field :navigation_groups, GraphQL::Types::JSON
+      field :need_to_know, GraphQL::Types::JSON
+      field :nodes, GraphQL::Types::JSON
+      field :northern_ireland_availability, GraphQL::Types::JSON
+      field :notes_for_editors, String
+      field :office_contact_associations, GraphQL::Types::JSON
+      field :open_filter_on_load, GraphQL::Types::JSON
+      field :opening_date, GraphQL::Types::JSON
+      field :ordered_agencies_and_other_public_bodies, GraphQL::Types::JSON
+      field :ordered_corporate_information_pages, GraphQL::Types::JSON
+      field :ordered_devolved_administrations, GraphQL::Types::JSON
+      field :ordered_executive_offices, GraphQL::Types::JSON
+      field :ordered_featured_documents, GraphQL::Types::JSON
+      field :ordered_featured_links, GraphQL::Types::JSON
+      field :ordered_high_profile_groups, GraphQL::Types::JSON
+      field :ordered_ministerial_departments, GraphQL::Types::JSON
+      field :ordered_non_ministerial_departments, GraphQL::Types::JSON
+      field :ordered_promotional_features, GraphQL::Types::JSON
+      field :ordered_public_corporations, GraphQL::Types::JSON
+      field :ordered_second_level_browse_pages, GraphQL::Types::JSON
+      field :ordering, GraphQL::Types::JSON
+      field :organisation_featuring_priority, GraphQL::Types::JSON
+      field :organisation_govuk_status, String
+      field :organisation_political, GraphQL::Types::JSON
+      field :organisation_type, GraphQL::Types::JSON
+      field :organisation, GraphQL::Types::JSON
+      field :organisations, GraphQL::Types::JSON
+      field :other_ways_to_apply, GraphQL::Types::JSON
+      field :outcome_attachments, GraphQL::Types::JSON
+      field :outcome_detail, GraphQL::Types::JSON
+      field :outcome_documents, GraphQL::Types::JSON
+      field :parts, GraphQL::Types::JSON
+      field :people_role_associations, GraphQL::Types::JSON
+      field :person_appointment_order, GraphQL::Types::JSON
+      field :phone_numbers, [GraphQL::Types::JSON]
+      field :place_type, GraphQL::Types::JSON
+      field :political_party, GraphQL::Types::JSON
       field :political, Boolean
+      field :post_addresses, [GraphQL::Types::JSON]
+      field :preposition, GraphQL::Types::JSON
+      field :previous_display_date, GraphQL::Types::JSON
       field :privy_counsellor, Boolean
+      field :promotion, GraphQL::Types::JSON
+      field :public_feedback_attachments, GraphQL::Types::JSON
+      field :public_feedback_detail, GraphQL::Types::JSON
+      field :public_feedback_documents, GraphQL::Types::JSON
+      field :public_feedback_publication_date, GraphQL::Types::JSON
+      field :public_timestamp, GraphQL::Types::JSON
+      field :query_response_time, GraphQL::Types::JSON
+      field :quick_links, GraphQL::Types::JSON
+      field :rates, GraphQL::Types::JSON
+      field :read_more, GraphQL::Types::JSON
+      field :reject, GraphQL::Types::JSON
+      field :related_mainstream_content, GraphQL::Types::JSON
+      field :reshuffle_in_progress, GraphQL::Types::JSON
       field :reshuffle, GraphQL::Types::JSON
+      field :reviewed_at, GraphQL::Types::JSON
       field :role_payment_type, String
+      field :roll_call_introduction, GraphQL::Types::JSON
+      field :second_level_ordering, GraphQL::Types::JSON
+      field :secondary_corporate_information_pages, GraphQL::Types::JSON
+      field :section_id, GraphQL::Types::JSON
+      field :sections, GraphQL::Types::JSON
       field :seniority, Integer
+      field :service_tiers, GraphQL::Types::JSON
+      field :services, GraphQL::Types::JSON
+      field :short_name, GraphQL::Types::JSON
+      field :show_description, GraphQL::Types::JSON
+      field :show_metadata_block, GraphQL::Types::JSON
+      field :show_summaries, GraphQL::Types::JSON
+      field :show_table_of_contents, GraphQL::Types::JSON
+      field :signup_link, GraphQL::Types::JSON
+      field :slug, GraphQL::Types::JSON
+      field :social_media_links, GraphQL::Types::JSON
+      field :sort, GraphQL::Types::JSON
+      field :speaker_without_profile, GraphQL::Types::JSON
+      field :speech_type_explanation, GraphQL::Types::JSON
+      field :start_button_text, GraphQL::Types::JSON
+      field :start_date, GraphQL::Types::JSON
       field :started_on, Types::ContentApiDatetime
+      field :state, GraphQL::Types::JSON
+      field :step_by_step_nav, GraphQL::Types::JSON
+      field :subscriber_list, GraphQL::Types::JSON
+      field :subscription_list_title_prefix, GraphQL::Types::JSON
+      field :summary, GraphQL::Types::JSON
       field :supports_historical_accounts, Boolean
+      field :tags, GraphQL::Types::JSON
+      field :temporary_update_type, GraphQL::Types::JSON
+      field :theme, GraphQL::Types::JSON
+      field :title, String
+      field :transaction_start_link, GraphQL::Types::JSON
+      field :type, GraphQL::Types::JSON
+      field :updated_at, GraphQL::Types::JSON
       field :url_override, String
+      field :url, GraphQL::Types::JSON
+      field :value, GraphQL::Types::JSON
+      field :variants, GraphQL::Types::JSON
+      field :visible_to_departmental_editors, Boolean
+      field :visually_collapsed, GraphQL::Types::JSON
+      field :visually_expanded, GraphQL::Types::JSON
+      field :ways_to_respond, GraphQL::Types::JSON
+      field :what_you_need_to_know, GraphQL::Types::JSON
       field :whip_organisation, GraphQL::Types::JSON
+      field :will_continue_on, GraphQL::Types::JSON
+      field :world_location_names, [GraphQL::Types::JSON]
+      field :world_location_news_type, GraphQL::Types::JSON
       field :world_locations, [GraphQL::Types::JSON], null: false
     end
 
     field :active, Boolean, null: false
     field :analytics_identifier, String
+    field :api_path, String
+    field :api_url, String
     field :base_path, String
     field :change_history, GraphQL::Types::JSON
     field :content_id, ID

--- a/app/graphql/types/edition_type.rb
+++ b/app/graphql/types/edition_type.rb
@@ -215,7 +215,7 @@ module Types
       field :important_board_members, GraphQL::Types::JSON
       field :interesting_facts, GraphQL::Types::JSON
       field :internal_name, String
-      field :international_delegations, [GraphQL::Types::JSON], null: false
+      field :international_delegations, [GraphQL::Types::JSON]
       field :introduction, GraphQL::Types::JSON
       field :introductory_paragraph, GraphQL::Types::JSON
       field :key, GraphQL::Types::JSON
@@ -349,7 +349,7 @@ module Types
       field :will_continue_on, GraphQL::Types::JSON
       field :world_location_names, [GraphQL::Types::JSON]
       field :world_location_news_type, GraphQL::Types::JSON
-      field :world_locations, [GraphQL::Types::JSON], null: false
+      field :world_locations, [GraphQL::Types::JSON]
     end
 
     field :active, Boolean, null: false

--- a/app/graphql/types/edition_type.rb
+++ b/app/graphql/types/edition_type.rb
@@ -125,36 +125,18 @@ module Types
     end
 
     class Details < Types::BaseObject
-      class Image < Types::BaseObject
-        field :alt_text, String
-        field :caption, String
-        field :credit, String
-        field :high_resolution_url, String
-        field :url, String
-      end
-
-      class Logo < Types::BaseObject
-        field :crest, String
-        field :formatted_title, String
-      end
-
-      class WhipOrganisation < Types::BaseObject
-        field :label, String
-        field :sort_order, Integer
-      end
-
       field :body, String
       field :brand, String
       field :change_history, GraphQL::Types::JSON
       field :current, Boolean
-      field :default_news_image, Image
+      field :default_news_image, GraphQL::Types::JSON
       field :display_date, Types::ContentApiDatetime
       field :emphasised_organisations, GraphQL::Types::JSON
       field :ended_on, Types::ContentApiDatetime
       field :first_public_at, Types::ContentApiDatetime
-      field :image, Image
-      field :international_delegations, [EditionType], null: false
-      field :logo, Logo
+      field :image, GraphQL::Types::JSON
+      field :international_delegations, [GraphQL::Types::JSON], null: false
+      field :logo, GraphQL::Types::JSON
       field :political, Boolean
       field :privy_counsellor, Boolean
       field :reshuffle, GraphQL::Types::JSON
@@ -163,8 +145,8 @@ module Types
       field :started_on, Types::ContentApiDatetime
       field :supports_historical_accounts, Boolean
       field :url_override, String
-      field :whip_organisation, WhipOrganisation
-      field :world_locations, [EditionType], null: false
+      field :whip_organisation, GraphQL::Types::JSON
+      field :world_locations, [GraphQL::Types::JSON], null: false
     end
 
     field :active, Boolean, null: false

--- a/app/graphql/types/ministers_index_type.rb
+++ b/app/graphql/types/ministers_index_type.rb
@@ -17,14 +17,9 @@ module Types
         class MinistersIndexRoleAppointmentLinks < Types::BaseObject
           class MinistersIndexRole < Types::BaseObject
             class MinistersIndexRoleDetails < Types::BaseObject
-              class MinistersIndexRoleDetailsWhipOrganisation < Types::BaseObject
-                field :label, String
-                field :sort_order, Integer
-              end
-
               field :role_payment_type, String
               field :seniority, Integer
-              field :whip_organisation, MinistersIndexRoleDetailsWhipOrganisation
+              field :whip_organisation, GraphQL::Types::JSON
             end
 
             class MinistersIndexRoleLinks < Types::BaseObject
@@ -58,7 +53,7 @@ module Types
       end
 
       class MinistersIndexPersonDetails < Types::BaseObject
-        field :image, EditionType::Details::Image
+        field :image, GraphQL::Types::JSON
         field :privy_counsellor, Boolean
       end
 
@@ -85,7 +80,7 @@ module Types
 
       class DepartmentDetails < Types::BaseObject
         field :brand, String
-        field :logo, EditionType::Details::Logo
+        field :logo, GraphQL::Types::JSON
       end
 
       class DepartmentLinks < Types::BaseObject

--- a/content_schemas/dist/formats/ministers_index/frontend/schema.json
+++ b/content_schemas/dist/formats/ministers_index/frontend/schema.json
@@ -317,7 +317,12 @@
           "$ref": "#/definitions/change_history"
         },
         "reshuffle": {
-          "message": "string"
+          "type": "object",
+          "properties": {
+            "message": {
+              "type": "string"
+            }
+          }
         }
       }
     },

--- a/content_schemas/dist/formats/ministers_index/notification/schema.json
+++ b/content_schemas/dist/formats/ministers_index/notification/schema.json
@@ -436,7 +436,12 @@
           "$ref": "#/definitions/change_history"
         },
         "reshuffle": {
-          "message": "string"
+          "type": "object",
+          "properties": {
+            "message": {
+              "type": "string"
+            }
+          }
         }
       }
     },

--- a/content_schemas/dist/formats/ministers_index/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/ministers_index/publisher_v2/schema.json
@@ -186,7 +186,12 @@
           "type": "string"
         },
         "reshuffle": {
-          "message": "string"
+          "type": "object",
+          "properties": {
+            "message": {
+              "type": "string"
+            }
+          }
         }
       }
     },

--- a/content_schemas/dist/formats/travel_advice/frontend/schema.json
+++ b/content_schemas/dist/formats/travel_advice/frontend/schema.json
@@ -346,9 +346,6 @@
         "parts": {
           "$ref": "#/definitions/parts"
         },
-        "publishing_request_id": {
-          "$ref": "#/definitions/publishing_request_id"
-        },
         "reviewed_at": {
           "type": "string",
           "format": "date-time"

--- a/content_schemas/dist/formats/travel_advice/notification/schema.json
+++ b/content_schemas/dist/formats/travel_advice/notification/schema.json
@@ -436,9 +436,6 @@
         "parts": {
           "$ref": "#/definitions/parts"
         },
-        "publishing_request_id": {
-          "$ref": "#/definitions/publishing_request_id"
-        },
         "reviewed_at": {
           "type": "string",
           "format": "date-time"

--- a/content_schemas/dist/formats/travel_advice/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/travel_advice/publisher_v2/schema.json
@@ -244,9 +244,6 @@
         "parts": {
           "$ref": "#/definitions/parts"
         },
-        "publishing_request_id": {
-          "$ref": "#/definitions/publishing_request_id"
-        },
         "reviewed_at": {
           "type": "string",
           "format": "date-time"
@@ -536,17 +533,6 @@
         "tariff",
         "travel-advice-publisher",
         "whitehall"
-      ]
-    },
-    "publishing_request_id": {
-      "description": "A unique identifier used to track publishing requests to rendered content",
-      "oneOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
       ]
     },
     "rendering_app": {

--- a/content_schemas/examples/travel_advice/frontend/alt-country.json
+++ b/content_schemas/examples/travel_advice/frontend/alt-country.json
@@ -8,6 +8,7 @@
   "phase": "live",
   "public_updated_at": "2017-02-14T15:33:43.000+00:00",
   "publishing_app": "travel-advice-publisher",
+  "publishing_request_id": "30560-1487285522.281-51.6.236.25-42152",
   "schema_name": "travel_advice",
   "title": "Turkey travel advice",
   "updated_at": "2017-02-17T12:52:44.142Z",
@@ -513,7 +514,6 @@
       "id": "eafa9819-f395-4f2d-9236-4e5d573f9f1e",
       "url": "https://assets.publishing.service.gov.uk/media/57909c3ded915d3cfd00018d/FCO_311_-_Turkey_Travel_Advice_Ed6.pdf",
       "content_type": "application/pdf"
-    },
-    "publishing_request_id": "30560-1487285522.281-51.6.236.25-42152"
+    }
   }
 }

--- a/content_schemas/examples/travel_advice/frontend/full-country-without-summary.json
+++ b/content_schemas/examples/travel_advice/frontend/full-country-without-summary.json
@@ -8,6 +8,7 @@
   "phase": "live",
   "public_updated_at": "2017-02-14T15:42:21.000+00:00",
   "publishing_app": "travel-advice-publisher",
+  "publishing_request_id": "30559-1487239320.697-62.232.86.100-23977",
   "schema_name": "travel_advice",
   "title": "Albania travel advice",
   "updated_at": "2017-02-17T12:52:43.537Z",
@@ -508,7 +509,6 @@
       "id": "43be2ac0-ea23-4b34-a73c-e2ac268e7f6c",
       "url": "https://assets.publishing.service.gov.uk/media/513a0efced915d4261000001/120613_Albania_Travel_Advice_Ed2_pdf.pdf",
       "content_type": "application/pdf"
-    },
-    "publishing_request_id": "30559-1487239320.697-62.232.86.100-23977"
+    }
   }
 }

--- a/content_schemas/examples/travel_advice/frontend/full-country.json
+++ b/content_schemas/examples/travel_advice/frontend/full-country.json
@@ -8,6 +8,7 @@
   "phase": "live",
   "public_updated_at": "2017-02-14T15:42:21.000+00:00",
   "publishing_app": "travel-advice-publisher",
+  "publishing_request_id": "30559-1487239320.697-62.232.86.100-23977",
   "schema_name": "travel_advice",
   "title": "Albania travel advice",
   "updated_at": "2017-02-17T12:52:43.537Z",
@@ -513,7 +514,6 @@
       "id": "43be2ac0-ea23-4b34-a73c-e2ac268e7f6c",
       "url": "https://assets.publishing.service.gov.uk/media/513a0efced915d4261000001/120613_Albania_Travel_Advice_Ed2_pdf.pdf",
       "content_type": "application/pdf"
-    },
-    "publishing_request_id": "30559-1487239320.697-62.232.86.100-23977"
+    }
   }
 }

--- a/content_schemas/examples/travel_advice/frontend/no-parts.json
+++ b/content_schemas/examples/travel_advice/frontend/no-parts.json
@@ -17,8 +17,7 @@
     "parts": [
 
     ],
-    "max_cache_time": 10,
-    "publishing_request_id": "2546-1460985144476-19268198-3242"
+    "max_cache_time": 10
   },
   "links": {
     "mainstream_browse_pages": [
@@ -131,6 +130,7 @@
   },
   "locale": "en",
   "public_updated_at": "2015-04-28T17:11:23+01:00",
+  "publishing_request_id": "2546-1460985144476-19268198-3242",
   "title": "Antarctica travel advice",
   "updated_at": "2015-08-28T17:16:43+01:00",
   "schema_name": "travel_advice",

--- a/content_schemas/examples/travel_advice/frontend/withdrawn-full-country.json
+++ b/content_schemas/examples/travel_advice/frontend/withdrawn-full-country.json
@@ -8,6 +8,7 @@
   "phase": "live",
   "public_updated_at": "2017-02-14T15:42:21.000+00:00",
   "publishing_app": "travel-advice-publisher",
+  "publishing_request_id": "30559-1487239320.697-62.232.86.100-23977",
   "schema_name": "travel_advice",
   "title": "Albania travel advice",
   "updated_at": "2017-02-17T12:52:43.537Z",
@@ -515,7 +516,6 @@
       "id": "43be2ac0-ea23-4b34-a73c-e2ac268e7f6c",
       "url": "https://assets.publishing.service.gov.uk/media/513a0efced915d4261000001/120613_Albania_Travel_Advice_Ed2_pdf.pdf",
       "content_type": "application/pdf"
-    },
-    "publishing_request_id": "30559-1487239320.697-62.232.86.100-23977"
+    }
   }
 }

--- a/content_schemas/examples/travel_advice/publisher_v2/travel_advice.json
+++ b/content_schemas/examples/travel_advice/publisher_v2/travel_advice.json
@@ -152,8 +152,7 @@
         ]
       }
     ],
-    "max_cache_time": 10,
-    "publishing_request_id": "2546-1460985144476-19268198-3242"
+    "max_cache_time": 10
   },
   "locale": "en",
   "public_updated_at": "2015-10-15T11:00:20+01:00",

--- a/content_schemas/formats/ministers_index.jsonnet
+++ b/content_schemas/formats/ministers_index.jsonnet
@@ -7,7 +7,12 @@
       optional: ['reshuffle'],
       properties: {
         reshuffle: {
-          message: "string",
+          type: "object",
+          properties: {
+            message: {
+              type: "string",
+            },
+          },
         },
         body: {
           description: "The main text to show on the page",

--- a/content_schemas/formats/travel_advice.jsonnet
+++ b/content_schemas/formats/travel_advice.jsonnet
@@ -49,9 +49,6 @@
         max_cache_time: {
           "$ref": "#/definitions/max_cache_time",
         },
-        publishing_request_id: {
-          "$ref": "#/definitions/publishing_request_id",
-        },
       },
     },
     country: {

--- a/lib/graphql_query_builder.rb
+++ b/lib/graphql_query_builder.rb
@@ -1,0 +1,255 @@
+class GraphqlQueryBuilder
+  MAX_LINK_DEPTH = 5
+
+  def initialize(schema_name)
+    @schema_name = schema_name
+    @content_item = GovukSchemas::RandomExample.for_schema(
+      frontend_schema: @schema_name,
+      strategy: :one_of_everything,
+    )
+  end
+
+  def build_query
+    parts = [
+      "query #{@schema_name}($base_path: String!) {",
+      "  edition(base_path: $base_path) {",
+      "    ... on #{edition_type_or_subtype} {",
+      build_fields(@content_item, indent: 6),
+      "    }",
+      "  }",
+      "}",
+    ]
+
+    parts.join("\n")
+  end
+
+private
+
+  def build_fields(data, indent: 2, link_path: [])
+    fields = data.sort_by(&:first).flat_map do |entry|
+      case entry
+      in ["withdrawn", *]
+        nil
+      in [String, {} | []]
+        nil
+      in ["details" | "withdrawn_notice" => key, Hash => hash]
+        [
+          "#{key} {",
+          hash.map { |hash_key, _| "  #{hash_key}" },
+          "}",
+        ]
+      in ["links", Hash => links]
+        [
+          "links {",
+          links.map { |link_key, array| build_links_query(link_path + [link_key.to_sym], array) }.compact,
+          "}",
+        ]
+      in [String => key, String | Numeric | true | false | nil]
+        key
+      end
+    end
+    fields.compact.join("\n").indent(indent)
+  end
+
+  def is_reverse_link_type?(link_path)
+    # if "role_appointments" is at the root of the link_path, it's not the
+    # reverse kind ':|
+    return false if link_path == %i[role_appointments]
+
+    link_type = link_path.last
+
+    ExpansionRules.is_reverse_link_type?(link_type)
+  end
+
+  def build_links_query(link_path, links)
+    link_type = link_path.last
+
+    document_types = if is_reverse_link_type?(link_path)
+                       flip_reversed_link_types = ExpansionRules.reverse_to_direct_link_type(link_type)
+
+                       flip_reversed_link_types
+                         .flat_map {
+                           link_types_source_document_types.fetch(_1, [])
+                         }.uniq
+                     else
+                       link_types_target_document_types.fetch(link_type, [])
+                     end
+
+    link = links.first || {}
+
+    return if document_types.empty? && link.empty?
+
+    unless document_types.empty?
+      link = document_types.map { |document_type|
+               # ExpansionRules.expand_fields returns its fields in the form of
+               # a hash that looks like a content item, but with null values,
+               # e.g.
+               #
+               # { base_path: nil, content_id: nil }
+               ExpansionRules.expand_fields({ document_type: }, link_type:, draft: false)
+                 .deep_stringify_keys
+             }
+               .inject(link) do |link, expanded_fields_item|
+                 expanded_fields_item.deep_merge(link)
+               end
+    end
+
+    link.delete("details") if link["details"].blank?
+    link.delete("links") if link["links"].blank?
+
+    if link_path.size < MAX_LINK_DEPTH
+      next_level_links = allowed_link_types(link_path)
+
+      unless next_level_links.empty?
+        link["links"] ||= {}
+
+        next_level_links.each do |next_link_type|
+          if link["links"][next_link_type.to_s].nil?
+            link["links"][next_link_type.to_s] = []
+          end
+        end
+      end
+    end
+
+    [
+      "#{link_type} {",
+      build_fields(link, link_path:),
+      "}",
+    ].join("\n").indent(2)
+  end
+
+  def allowed_link_types(link_path)
+    ExpansionRules::MultiLevelLinks
+      .new(ExpansionRules::MULTI_LEVEL_LINK_PATHS)
+      .allowed_link_types(link_path)
+  end
+
+  def edition_type_or_subtype
+    if @schema_name == "ministers_index"
+      "MinistersIndex"
+    else
+      "Edition"
+    end
+  end
+
+  def link_types_target_document_types
+    @link_types_target_document_types ||= {
+      active_top_level_browse_page: %w[mainstream_browse_page],
+      associated_taxons: %w[taxon],
+      children: %w[mainstream_browse_page redirect],
+      contact: %w[contact],
+      contacts: %w[contact],
+      content_owners: %w[service_manual_guide],
+      corporate_information_pages: %w[about about_our_services access_and_opening accessible_documents_policy complaints_procedure equality_and_diversity media_enquiries membership modern_slavery_statement our_energy_use our_governance personal_information_charter petitions_and_campaigns procurement publication_scheme recruitment redirect research social_media_use staff_update statistics terms_of_reference welsh_language_scheme],
+      current_prime_minister: %w[person],
+      documents: %w[about about_our_services access_and_opening accessible_documents_policy answer authored_article call_for_evidence_outcome case_study closed_call_for_evidence closed_consultation cma_case coming_soon complaints_procedure consultation_outcome contact coronavirus_landing_page corporate_report correspondence countryside_stewardship_grant decision detailed_guide document_collection drcf_digital_markets_research drug_safety_update equality_and_diversity export_health_certificate finder flood_and_coastal_erosion_risk_management_research_report foi_release form government_response guidance guide hmrc_manual hmrc_manual_section html_publication impact_assessment independent_report international_treaty local_transaction maib_report mainstream_browse_page manual manual_section map medical_safety_alert ministerial_role national_statistics national_statistics_announcement news_story notice official_statistics official_statistics_announcement open_call_for_evidence open_consultation oral_statement organisation our_governance personal_information_charter place placeholder policy_paper press_release procurement promotional recruitment redirect regulation research service_manual_guide service_manual_homepage simple_smart_answer smart_answer special_route speech staff_update standard statistical_data_set statistics statutory_guidance step_by_step_nav taxon terms_of_reference topical_event transaction transparency travel_advice travel_advice_index working_group world_news_story written_statement],
+      email_alert_signup: %w[email_alert_signup finder_email_signup],
+      embed: %w[content_block_pension],
+      facet_group: %w[facet_group],
+      facet_groups: %w[facet_group],
+      facet_values: %w[facet_value],
+      facets: %w[facet],
+      fatality_notices: %w[fatality_notice],
+      featured_policies: %w[policy],
+      field_of_operation: %w[field_of_operation],
+      fields_of_operation: %w[field_of_operation],
+      finder: %w[finder],
+      government: %w[government],
+      historical_accounts: %w[historic_appointment],
+      home_page_offices: %w[worldwide_office],
+      lead_organisations: %w[organisation],
+      linked_items: %w[service_manual_guide],
+      main_office: %w[worldwide_office],
+      mainstream_browse_pages: %w[mainstream_browse_page redirect],
+      manual: %w[manual],
+      ministerial: %w[ministers_index],
+      office_staff: %w[person],
+      ordered_also_attends_cabinet: %w[person],
+      ordered_assistant_whips: %w[person],
+      ordered_baronesses_and_lords_in_waiting_whips: %w[person],
+      ordered_board_members: %w[person],
+      ordered_cabinet_ministers: %w[person],
+      ordered_chief_professional_officers: %w[person],
+      ordered_child_organisations: %w[organisation],
+      ordered_contacts: %w[contact],
+      ordered_current_appointments: %w[role_appointment],
+      ordered_featured_policies: %w[policy],
+      ordered_foi_contacts: %w[contact],
+      ordered_high_profile_groups: %w[organisation],
+      ordered_house_lords_whips: %w[person],
+      ordered_house_of_commons_whips: %w[person],
+      ordered_junior_lords_of_the_treasury_whips: %w[person],
+      ordered_military_personnel: %w[person],
+      ordered_ministerial_departments: %w[organisation],
+      ordered_ministers: %w[person],
+      ordered_parent_organisations: %w[organisation],
+      ordered_previous_appointments: %w[role_appointment],
+      ordered_related_items: %w[about about_our_services answer business_support business_support_finder calendar call_for_evidence_outcome campaign case_study closed_call_for_evidence cma_case complaints_procedure consultation_outcome contact coronavirus_landing_page corporate_report correspondence decision detailed_guide document_collection finder flood_and_coastal_erosion_risk_management_research_report form government_response guidance guide help_page historic_appointment hmrc_manual hmrc_manual_section html_publication independent_report landing_page licence licence_transaction local_transaction mainstream_browse_page manual manual_section national_statistics news_story notice official_statistics our_governance person personal_information_charter place policy_paper press_release promotional redirect research simple_smart_answer smart_answer special_route speech standard statistical_data_set statistics statutory_guidance step_by_step_nav taxon topical_event transaction transparency travel_advice travel_advice_index video world_location_news written_statement],
+      ordered_related_items_overrides: %w[answer call_for_evidence_outcome consultation_outcome correspondence detailed_guide document_collection finder guidance guide html_publication independent_report local_transaction manual national_statistics news_story place policy_paper press_release simple_smart_answer smart_answer statistical_data_set taxon transaction written_statement],
+      ordered_roles: %w[ambassador_role board_member_role chief_professional_officer_role chief_scientific_advisor_role deputy_head_of_mission_role governor_role high_commissioner_role military_role ministerial_role special_representative_role traffic_commissioner_role worldwide_office_staff_role],
+      ordered_special_representatives: %w[person],
+      ordered_successor_organisations: %w[organisation],
+      ordered_traffic_commissioners: %w[person],
+      organisations: %w[contact organisation worldwide_office worldwide_organisation],
+      original_primary_publishing_organisation: %w[organisation],
+      pages_part_of_step_nav: %w[answer completed_transaction contact detailed_guide document_collection finder form guidance guide html_publication licence_transaction local_transaction manual notice place placeholder redirect simple_smart_answer smart_answer step_by_step_nav transaction travel_advice_index],
+      pages_related_to_step_nav: %w[answer detailed_guide document_collection guidance guide html_publication local_transaction manual place simple_smart_answer smart_answer step_by_step_nav transaction travel_advice_index],
+      pages_secondary_to_step_nav: %w[answer completed_transaction detailed_guide document_collection form guidance guide html_publication notice statutory_guidance transaction],
+      parent: %w[answer call_for_evidence_outcome closed_call_for_evidence closed_consultation coming_soon consultation_outcome corporate_report correspondence decision facet facet_group finder foi_release form guidance guide history impact_assessment independent_report international_treaty mainstream_browse_page map national_statistics notice official_statistics open_call_for_evidence open_consultation organisation placeholder policy policy_paper promotional redirect regulation research service_manual_homepage service_manual_service_standard standard statutory_guidance topical_event transaction transparency travel_advice_index world_index worldwide_organisation],
+      parent_taxons: %w[taxon],
+      people: %w[person],
+      person: %w[person placeholder_person],
+      policies: %w[placeholder policy],
+      policy_areas: %w[policy_area],
+      popular_links: %w[link_collection],
+      press_releases: %w[financial_release redirect],
+      primary_publishing_organisation: %w[finder organisation],
+      primary_role_person: %w[person],
+      related: %w[contact detailed_guide document_collection finder guidance guide html_publication mainstream_browse_page smart_answer statutory_guidance transaction],
+      related_guides: %w[detailed_guide],
+      related_mainstream: %w[answer business_support_finder detailed_guide document_collection guidance guide local_transaction mainstream_browse_page placeholder simple_smart_answer smart_answer transaction travel_advice_index world_location],
+      related_mainstream_content: %w[about accessible_documents_policy answer business_support_finder case_study contact coronavirus_landing_page corporate_report detailed_guide document_collection equality_and_diversity flood_and_coastal_erosion_risk_management_research_report form guidance guide html_publication licence local_transaction mainstream_browse_page manual manual_section news_story notice organisation personal_information_charter place placeholder policy_paper redirect research simple_smart_answer smart_answer statutory_guidance step_by_step_nav taxon topical_event transaction transparency travel_advice travel_advice_index working_group],
+      related_policies: %w[placeholder policy redirect],
+      related_statistical_data_sets: %w[statistical_data_set],
+      related_topics: %w[redirect],
+      role: %w[ambassador_role board_member_role chief_professional_officer_role chief_scientific_advisor_role deputy_head_of_mission_role governor_role high_commissioner_role military_role ministerial_role special_representative_role traffic_commissioner_role worldwide_office_staff_role],
+      role_appointments: %w[role_appointment],
+      roles: %w[ambassador_role board_member_role chief_scientific_advisor_role deputy_head_of_mission_role governor_role high_commissioner_role military_role ministerial_role special_representative_role worldwide_office_staff_role],
+      root_taxon: %w[homepage],
+      second_level_browse_pages: %w[mainstream_browse_page redirect],
+      secondary_role_person: %w[person],
+      sections: %w[manual_section],
+      service_manual_topics: %w[service_manual_topic],
+      speaker: %w[person],
+      sponsoring_organisations: %w[organisation],
+      suggested_ordered_related_items: %w[aaib_report about about_our_services access_and_opening accessible_documents_policy animal_disease_case answer asylum_support_decision authored_article business_finance_support_scheme calendar case_study cma_case complaints_procedure coronavirus_landing_page corporate_report correspondence countryside_stewardship_grant decision detailed_guide document_collection drcf_digital_markets_research drug_safety_update employment_appeal_tribunal_decision employment_tribunal_decision equality_and_diversity esi_fund export_health_certificate flood_and_coastal_erosion_risk_management_research_report foi_release form get_involved gone government_response guidance guide help_page history hmrc_manual impact_assessment independent_report international_development_fund international_treaty licence local_transaction maib_report manual map media_enquiries medical_safety_alert membership ministers_index modern_slavery_statement national_statistics national_statistics_announcement news_story notice official_statistics official_statistics_announcement oim_project oral_statement our_energy_use our_governance personal_information_charter petitions_and_campaigns place placeholder policy_paper press_release procurement product_safety_alert_report_recall promotional protected_food_drink_name publication_scheme raib_report recruitment redirect regulation research research_for_development_output residential_property_tribunal_decision service_manual_guide service_manual_service_standard service_manual_service_toolkit service_sign_in service_standard_report simple_smart_answer smart_answer social_media_use special_route speech staff_update standard statistical_data_set statistics statistics_announcement statutory_guidance statutory_instrument step_by_step_nav tax_tribunal_decision terms_of_reference topical_event_about_page transaction transparency travel_advice travel_advice_index uk_market_conformity_assessment_body utaac_decision welsh_language_scheme working_group world_news_story written_statement],
+      supporting_organisations: %w[organisation],
+      taxonomy_topic_email_override: %w[taxon],
+      taxons: %w[taxon],
+      top_level_browse_pages: %w[mainstream_browse_page],
+      topical_events: %w[topical_event],
+      topics: %w[redirect service_manual_topic],
+      working_groups: %w[working_group],
+      world_locations: %w[world_location world_location_news],
+      worldwide_organisation: %w[worldwide_organisation],
+      worldwide_organisations: %w[worldwide_organisation],
+      worldwide_priorities: %w[placeholder],
+    }
+  end
+
+  def link_types_source_document_types
+    @link_types_source_document_types ||= {
+      documents: %w[document_collection placeholder],
+      ministerial: %w[ministerial_role],
+      pages_part_of_step_nav: %w[step_by_step_nav],
+      pages_related_to_step_nav: %w[step_by_step_nav],
+      pages_secondary_to_step_nav: %w[step_by_step_nav],
+      parent: %w[about about_our_services access_and_opening accessible_documents_policy answer authored_article business_support calendar call_for_evidence_outcome case_study closed_call_for_evidence closed_consultation coming_soon complaints_procedure consultation_outcome contact corporate_report correspondence decision detailed_guide document_collection email_alert_signup embassies_index equality_and_diversity facet facet_value finder foi_release form government_response guidance guide historic_appointment historic_appointments html_publication impact_assessment independent_report international_treaty licence local_transaction mainstream_browse_page manual map media_enquiries membership national_statistics news_story notice official_statistics oral_statement our_governance personal_information_charter place placeholder policy_paper press_release procurement programme promotional publication_scheme recruitment redirect regulation research service_manual_guide service_manual_topic service_sign_in services_and_information simple_smart_answer smart_answer social_media_use special_route speech staff_update standard statistical_data_set statistics statutory_guidance step_by_step_nav terms_of_reference topical_event_about_page transaction transparency travel_advice travel_advice_index video welsh_language_scheme world_news_story worldwide_office written_statement],
+      parent_taxons: %w[taxon],
+      person: %w[historic_appointment role_appointment],
+      role: %w[role_appointment],
+      root_taxon: %w[taxon],
+      working_groups: %w[policy],
+    }
+  end
+end

--- a/script/build_graphql_query
+++ b/script/build_graphql_query
@@ -1,0 +1,29 @@
+#!/usr/bin/env ruby
+
+$LOAD_PATH << File.expand_path("../", File.dirname(__FILE__))
+
+require "config/environment"
+
+def usage_and_abort
+  abort("Usage:\n\t#{$PROGRAM_NAME} a_schema_name")
+end
+
+def validate_schema_name!(schema_name)
+  GovukSchemas::Schema.find(publisher_schema: schema_name)
+rescue Errno::ENOENT
+  warn("Error: is that meant to be a schema name?")
+  usage_and_abort
+end
+
+schema_name = ARGV[0]
+
+validate_schema_name!(schema_name)
+
+query_filename = "app/graphql/queries/#{schema_name}.graphql"
+
+query_builder = GraphqlQueryBuilder.new(schema_name)
+query = query_builder.build_query
+
+File.open(query_filename, "w") { |f| f.puts(query) }
+
+puts("👍")

--- a/spec/integration/graphql/ministers_index_spec.rb
+++ b/spec/integration/graphql/ministers_index_spec.rb
@@ -69,10 +69,7 @@ RSpec.describe "GraphQL" do
                   details {
                     brand
 
-                    logo {
-                      crest
-                      formatted_title
-                    }
+                    logo
                   }
 
                   links {
@@ -98,10 +95,7 @@ RSpec.describe "GraphQL" do
           details {
             privy_counsellor
 
-            image {
-              url
-              alt_text
-            }
+            image
           }
 
           links {
@@ -119,10 +113,7 @@ RSpec.describe "GraphQL" do
                   details {
                     role_payment_type
                     seniority
-                    whip_organisation {
-                      label
-                      sort_order
-                    }
+                    whip_organisation
                   }
                 }
               }

--- a/spec/integration/graphql/news_article_spec.rb
+++ b/spec/integration/graphql/news_article_spec.rb
@@ -113,20 +113,11 @@ RSpec.describe "GraphQL" do
                 details {
                   body
                   change_history
-                  default_news_image {
-                    alt_text
-                    url
-                  }
+                  default_news_image
                   display_date
                   emphasised_organisations
                   first_public_at
-                  image {
-                    alt_text
-                    caption
-                    credit
-                    high_resolution_url
-                    url
-                  }
+                  image
                   political
                 }
                 document_type

--- a/spec/integration/graphql/world_index_spec.rb
+++ b/spec/integration/graphql/world_index_spec.rb
@@ -37,28 +37,14 @@ RSpec.describe "GraphQL" do
     it "has world index specific fields in the generic edition type" do
       post "/graphql", params: {
         query:
-          "fragment worldLocationInfo on Edition {
-            active
-            analytics_identifier
-            content_id
-            name
-            slug
-            updated_at
-          }
-
-          {
+          "{
             edition(base_path: \"/world\") {
               ... on Edition {
                 title
 
                 details {
-                  world_locations {
-                    ...worldLocationInfo
-                  }
-
-                  international_delegations {
-                    ...worldLocationInfo
-                  }
+                  world_locations
+                  international_delegations
                 }
               }
             }
@@ -75,9 +61,10 @@ RSpec.describe "GraphQL" do
                   active: true,
                   analytics_identifier: "WL1",
                   content_id: "d3b7ba48-5027-4a98-a594-1108d205dc66",
+                  iso2: "WL",
                   name: "Test World Location",
                   slug: "test-world-location",
-                  updated_at: "2024-10-18T14:22:38+01:00",
+                  updated_at: "2024-10-18T14:22:38.000+01:00",
                 },
               ],
               international_delegations: [
@@ -85,9 +72,10 @@ RSpec.describe "GraphQL" do
                   active: false,
                   analytics_identifier: "WL2",
                   content_id: "f0313f16-e25c-4bfe-a0fc-e561833f705f",
+                  iso2: "ID",
                   name: "Test International Delegation",
                   slug: "test-international-delegation",
-                  updated_at: "2024-10-19T15:07:44+01:00",
+                  updated_at: "2024-10-19T15:07:44.000+01:00",
                 },
               ],
             },


### PR DESCRIPTION
There are some big diffs here but I'm hoping the commits are clear enough when looked at individually.

Changes:
* Introduce a script for building a GraphQL query for a given content type
* Make some changes to our GraphQL types to address issues highlighted by the newly-built queries
* Make some changes to content schemas to address issues discovered the same way