### PR TITLE
feat: add /government/history special_route to frontend

### DIFF
--- a/lib/data/special_routes.yaml
+++ b/lib/data/special_routes.yaml
@@ -191,6 +191,13 @@
   :rendering_app: "frontend"
   :override_existing: true
 
+- :base_path: "/government/history"
+  :content_id: "db95a864-874f-4f50-a483-352a5bc7ba18"
+  :title: "History of the UK government"
+  :description: "In this section you can read short biographies of notable people and explore the history of government buildings. You can also search our online records and read articles and blog posts by historians."
+  :rendering_app: "frontend"
+  :override_existing: true
+
 - :base_path: "/government/history/past-chancellors"
   :content_id: "ac47f738-b6c3-4369-8d22-ce143c947442"
   :title: "Past Chancellors of the Exchequer"


### PR DESCRIPTION
- This route has been served by government-frontend, but we want to allow it to be editable as a standard edition. Standard editions currently can't publish hierarchies, so this homepage's content item will actually be at /government/history/history-of-the-uk-government. This special route will allow /government/history to be routed to frontend, which will handle it with an exception: https://github.com/alphagov/frontend/commit/0f0b9455e02abb424ea5dd0ee058d0f711f905ca

Note that the content_id in this special route matches the one from the current live item - it should **not** be changed to match the content item of /government/history/history-of-the-uk-government when that is published!

https://trello.com/c/pMEJlBME/796-build-history-pages-from-content-item

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
