### PR TITLE
(CM-422) Add `content-block-manager` Publishing app

### DIFF
--- a/content_schemas/dist/formats/answer/frontend/schema.json
+++ b/content_schemas/dist/formats/answer/frontend/schema.json
@@ -546,6 +546,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/answer/notification/schema.json
+++ b/content_schemas/dist/formats/answer/notification/schema.json
@@ -669,6 +669,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/answer/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/answer/publisher_v2/schema.json
@@ -340,6 +340,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/calendar/frontend/schema.json
+++ b/content_schemas/dist/formats/calendar/frontend/schema.json
@@ -516,6 +516,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/calendar/notification/schema.json
+++ b/content_schemas/dist/formats/calendar/notification/schema.json
@@ -620,6 +620,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/calendar/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/calendar/publisher_v2/schema.json
@@ -291,6 +291,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/call_for_evidence/frontend/schema.json
+++ b/content_schemas/dist/formats/call_for_evidence/frontend/schema.json
@@ -956,6 +956,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/call_for_evidence/notification/schema.json
+++ b/content_schemas/dist/formats/call_for_evidence/notification/schema.json
@@ -1076,6 +1076,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/call_for_evidence/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/call_for_evidence/publisher_v2/schema.json
@@ -773,6 +773,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/case_study/frontend/schema.json
+++ b/content_schemas/dist/formats/case_study/frontend/schema.json
@@ -652,6 +652,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/case_study/notification/schema.json
+++ b/content_schemas/dist/formats/case_study/notification/schema.json
@@ -770,6 +770,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/case_study/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/case_study/publisher_v2/schema.json
@@ -437,6 +437,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/completed_transaction/frontend/schema.json
+++ b/content_schemas/dist/formats/completed_transaction/frontend/schema.json
@@ -624,6 +624,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/completed_transaction/notification/schema.json
+++ b/content_schemas/dist/formats/completed_transaction/notification/schema.json
@@ -728,6 +728,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/completed_transaction/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/completed_transaction/publisher_v2/schema.json
@@ -399,6 +399,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/consultation/frontend/schema.json
+++ b/content_schemas/dist/formats/consultation/frontend/schema.json
@@ -973,6 +973,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/consultation/notification/schema.json
+++ b/content_schemas/dist/formats/consultation/notification/schema.json
@@ -1093,6 +1093,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/consultation/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/consultation/publisher_v2/schema.json
@@ -790,6 +790,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/contact/frontend/schema.json
+++ b/content_schemas/dist/formats/contact/frontend/schema.json
@@ -747,6 +747,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/contact/notification/schema.json
+++ b/content_schemas/dist/formats/contact/notification/schema.json
@@ -867,6 +867,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/contact/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/contact/publisher_v2/schema.json
@@ -523,6 +523,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/content_block_contact/notification/schema.json
+++ b/content_schemas/dist/formats/content_block_contact/notification/schema.json
@@ -865,6 +865,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/content_block_contact/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/content_block_contact/publisher_v2/schema.json
@@ -557,6 +557,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/content_block_pension/notification/schema.json
+++ b/content_schemas/dist/formats/content_block_pension/notification/schema.json
@@ -652,6 +652,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/content_block_pension/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/content_block_pension/publisher_v2/schema.json
@@ -344,6 +344,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/coronavirus_landing_page/frontend/schema.json
+++ b/content_schemas/dist/formats/coronavirus_landing_page/frontend/schema.json
@@ -509,6 +509,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/coronavirus_landing_page/notification/schema.json
+++ b/content_schemas/dist/formats/coronavirus_landing_page/notification/schema.json
@@ -613,6 +613,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/coronavirus_landing_page/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/coronavirus_landing_page/publisher_v2/schema.json
@@ -283,6 +283,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/corporate_information_page/frontend/schema.json
+++ b/content_schemas/dist/formats/corporate_information_page/frontend/schema.json
@@ -742,6 +742,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/corporate_information_page/notification/schema.json
+++ b/content_schemas/dist/formats/corporate_information_page/notification/schema.json
@@ -850,6 +850,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/corporate_information_page/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/corporate_information_page/publisher_v2/schema.json
@@ -555,6 +555,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/detailed_guide/frontend/schema.json
+++ b/content_schemas/dist/formats/detailed_guide/frontend/schema.json
@@ -828,6 +828,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/detailed_guide/notification/schema.json
+++ b/content_schemas/dist/formats/detailed_guide/notification/schema.json
@@ -946,6 +946,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/detailed_guide/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/detailed_guide/publisher_v2/schema.json
@@ -645,6 +645,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/document_collection/frontend/schema.json
+++ b/content_schemas/dist/formats/document_collection/frontend/schema.json
@@ -678,6 +678,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/document_collection/notification/schema.json
+++ b/content_schemas/dist/formats/document_collection/notification/schema.json
@@ -804,6 +804,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/document_collection/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/document_collection/publisher_v2/schema.json
@@ -489,6 +489,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/email_alert_signup/frontend/schema.json
+++ b/content_schemas/dist/formats/email_alert_signup/frontend/schema.json
@@ -580,6 +580,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/email_alert_signup/notification/schema.json
+++ b/content_schemas/dist/formats/email_alert_signup/notification/schema.json
@@ -684,6 +684,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/email_alert_signup/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/email_alert_signup/publisher_v2/schema.json
@@ -355,6 +355,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/embassies_index/frontend/schema.json
+++ b/content_schemas/dist/formats/embassies_index/frontend/schema.json
@@ -595,6 +595,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/embassies_index/notification/schema.json
+++ b/content_schemas/dist/formats/embassies_index/notification/schema.json
@@ -699,6 +699,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/embassies_index/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/embassies_index/publisher_v2/schema.json
@@ -370,6 +370,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/external_content/notification/schema.json
+++ b/content_schemas/dist/formats/external_content/notification/schema.json
@@ -507,6 +507,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/external_content/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/external_content/publisher_v2/schema.json
@@ -278,6 +278,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/facet/frontend/schema.json
+++ b/content_schemas/dist/formats/facet/frontend/schema.json
@@ -582,6 +582,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/facet/notification/schema.json
+++ b/content_schemas/dist/formats/facet/notification/schema.json
@@ -696,6 +696,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/facet/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/facet/publisher_v2/schema.json
@@ -364,6 +364,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/fatality_notice/frontend/schema.json
+++ b/content_schemas/dist/formats/fatality_notice/frontend/schema.json
@@ -561,6 +561,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/fatality_notice/notification/schema.json
+++ b/content_schemas/dist/formats/fatality_notice/notification/schema.json
@@ -678,6 +678,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/fatality_notice/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/fatality_notice/publisher_v2/schema.json
@@ -374,6 +374,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/field_of_operation/frontend/schema.json
+++ b/content_schemas/dist/formats/field_of_operation/frontend/schema.json
@@ -513,6 +513,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/field_of_operation/notification/schema.json
+++ b/content_schemas/dist/formats/field_of_operation/notification/schema.json
@@ -621,6 +621,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/field_of_operation/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/field_of_operation/publisher_v2/schema.json
@@ -283,6 +283,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/fields_of_operation/frontend/schema.json
+++ b/content_schemas/dist/formats/fields_of_operation/frontend/schema.json
@@ -513,6 +513,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/fields_of_operation/notification/schema.json
+++ b/content_schemas/dist/formats/fields_of_operation/notification/schema.json
@@ -621,6 +621,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/fields_of_operation/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/fields_of_operation/publisher_v2/schema.json
@@ -283,6 +283,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/finder/frontend/schema.json
+++ b/content_schemas/dist/formats/finder/frontend/schema.json
@@ -963,6 +963,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/finder/notification/schema.json
+++ b/content_schemas/dist/formats/finder/notification/schema.json
@@ -1095,6 +1095,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/finder/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/finder/publisher_v2/schema.json
@@ -752,6 +752,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/finder_email_signup/frontend/schema.json
+++ b/content_schemas/dist/formats/finder_email_signup/frontend/schema.json
@@ -663,6 +663,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/finder_email_signup/notification/schema.json
+++ b/content_schemas/dist/formats/finder_email_signup/notification/schema.json
@@ -769,6 +769,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/finder_email_signup/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/finder_email_signup/publisher_v2/schema.json
@@ -436,6 +436,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/generic/frontend/schema.json
+++ b/content_schemas/dist/formats/generic/frontend/schema.json
@@ -699,6 +699,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/generic/notification/schema.json
+++ b/content_schemas/dist/formats/generic/notification/schema.json
@@ -803,6 +803,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/generic/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/generic/publisher_v2/schema.json
@@ -473,6 +473,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/generic_with_external_related_links/frontend/schema.json
+++ b/content_schemas/dist/formats/generic_with_external_related_links/frontend/schema.json
@@ -725,6 +725,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/generic_with_external_related_links/notification/schema.json
+++ b/content_schemas/dist/formats/generic_with_external_related_links/notification/schema.json
@@ -829,6 +829,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/generic_with_external_related_links/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/generic_with_external_related_links/publisher_v2/schema.json
@@ -500,6 +500,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/get_involved/frontend/schema.json
+++ b/content_schemas/dist/formats/get_involved/frontend/schema.json
@@ -603,6 +603,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/get_involved/notification/schema.json
+++ b/content_schemas/dist/formats/get_involved/notification/schema.json
@@ -711,6 +711,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/get_involved/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/get_involved/publisher_v2/schema.json
@@ -374,6 +374,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/gone/frontend/schema.json
+++ b/content_schemas/dist/formats/gone/frontend/schema.json
@@ -465,6 +465,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/gone/notification/schema.json
+++ b/content_schemas/dist/formats/gone/notification/schema.json
@@ -491,6 +491,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/gone/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/gone/publisher_v2/schema.json
@@ -280,6 +280,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/government/frontend/schema.json
+++ b/content_schemas/dist/formats/government/frontend/schema.json
@@ -523,6 +523,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/government/notification/schema.json
+++ b/content_schemas/dist/formats/government/notification/schema.json
@@ -627,6 +627,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/government/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/government/publisher_v2/schema.json
@@ -298,6 +298,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/guide/frontend/schema.json
+++ b/content_schemas/dist/formats/guide/frontend/schema.json
@@ -575,6 +575,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/guide/notification/schema.json
+++ b/content_schemas/dist/formats/guide/notification/schema.json
@@ -698,6 +698,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/guide/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/guide/publisher_v2/schema.json
@@ -369,6 +369,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/help_page/frontend/schema.json
+++ b/content_schemas/dist/formats/help_page/frontend/schema.json
@@ -546,6 +546,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/help_page/notification/schema.json
+++ b/content_schemas/dist/formats/help_page/notification/schema.json
@@ -669,6 +669,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/help_page/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/help_page/publisher_v2/schema.json
@@ -340,6 +340,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/historic_appointment/frontend/schema.json
+++ b/content_schemas/dist/formats/historic_appointment/frontend/schema.json
@@ -556,6 +556,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/historic_appointment/notification/schema.json
+++ b/content_schemas/dist/formats/historic_appointment/notification/schema.json
@@ -664,6 +664,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/historic_appointment/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/historic_appointment/publisher_v2/schema.json
@@ -327,6 +327,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/historic_appointments/frontend/schema.json
+++ b/content_schemas/dist/formats/historic_appointments/frontend/schema.json
@@ -593,6 +593,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/historic_appointments/notification/schema.json
+++ b/content_schemas/dist/formats/historic_appointments/notification/schema.json
@@ -701,6 +701,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/historic_appointments/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/historic_appointments/publisher_v2/schema.json
@@ -364,6 +364,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/history/frontend/schema.json
+++ b/content_schemas/dist/formats/history/frontend/schema.json
@@ -603,6 +603,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/history/notification/schema.json
+++ b/content_schemas/dist/formats/history/notification/schema.json
@@ -707,6 +707,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/history/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/history/publisher_v2/schema.json
@@ -378,6 +378,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/hmrc_manual/frontend/schema.json
+++ b/content_schemas/dist/formats/hmrc_manual/frontend/schema.json
@@ -630,6 +630,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/hmrc_manual/notification/schema.json
+++ b/content_schemas/dist/formats/hmrc_manual/notification/schema.json
@@ -734,6 +734,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/hmrc_manual/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/hmrc_manual/publisher_v2/schema.json
@@ -405,6 +405,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/hmrc_manual_section/frontend/schema.json
+++ b/content_schemas/dist/formats/hmrc_manual_section/frontend/schema.json
@@ -635,6 +635,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/hmrc_manual_section/notification/schema.json
+++ b/content_schemas/dist/formats/hmrc_manual_section/notification/schema.json
@@ -739,6 +739,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/hmrc_manual_section/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/hmrc_manual_section/publisher_v2/schema.json
@@ -410,6 +410,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/homepage/frontend/schema.json
+++ b/content_schemas/dist/formats/homepage/frontend/schema.json
@@ -467,6 +467,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/homepage/notification/schema.json
+++ b/content_schemas/dist/formats/homepage/notification/schema.json
@@ -529,6 +529,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/homepage/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/homepage/publisher_v2/schema.json
@@ -283,6 +283,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/how_government_works/frontend/schema.json
+++ b/content_schemas/dist/formats/how_government_works/frontend/schema.json
@@ -571,6 +571,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/how_government_works/notification/schema.json
+++ b/content_schemas/dist/formats/how_government_works/notification/schema.json
@@ -679,6 +679,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/how_government_works/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/how_government_works/publisher_v2/schema.json
@@ -342,6 +342,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/html_publication/frontend/schema.json
+++ b/content_schemas/dist/formats/html_publication/frontend/schema.json
@@ -610,6 +610,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/html_publication/notification/schema.json
+++ b/content_schemas/dist/formats/html_publication/notification/schema.json
@@ -716,6 +716,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/html_publication/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/html_publication/publisher_v2/schema.json
@@ -403,6 +403,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/landing_page/frontend/schema.json
+++ b/content_schemas/dist/formats/landing_page/frontend/schema.json
@@ -521,6 +521,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/landing_page/notification/schema.json
+++ b/content_schemas/dist/formats/landing_page/notification/schema.json
@@ -637,6 +637,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/landing_page/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/landing_page/publisher_v2/schema.json
@@ -313,6 +313,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/licence/frontend/schema.json
+++ b/content_schemas/dist/formats/licence/frontend/schema.json
@@ -565,6 +565,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/licence/notification/schema.json
+++ b/content_schemas/dist/formats/licence/notification/schema.json
@@ -688,6 +688,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/licence/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/licence/publisher_v2/schema.json
@@ -359,6 +359,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/link_collection/frontend/schema.json
+++ b/content_schemas/dist/formats/link_collection/frontend/schema.json
@@ -528,6 +528,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/link_collection/notification/schema.json
+++ b/content_schemas/dist/formats/link_collection/notification/schema.json
@@ -640,6 +640,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/link_collection/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/link_collection/publisher_v2/schema.json
@@ -308,6 +308,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/local_transaction/frontend/schema.json
+++ b/content_schemas/dist/formats/local_transaction/frontend/schema.json
@@ -648,6 +648,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/local_transaction/notification/schema.json
+++ b/content_schemas/dist/formats/local_transaction/notification/schema.json
@@ -771,6 +771,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/local_transaction/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/local_transaction/publisher_v2/schema.json
@@ -442,6 +442,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/mainstream_browse_page/frontend/schema.json
+++ b/content_schemas/dist/formats/mainstream_browse_page/frontend/schema.json
@@ -548,6 +548,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/mainstream_browse_page/notification/schema.json
+++ b/content_schemas/dist/formats/mainstream_browse_page/notification/schema.json
@@ -661,6 +661,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/mainstream_browse_page/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/mainstream_browse_page/publisher_v2/schema.json
@@ -300,6 +300,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/manual/frontend/schema.json
+++ b/content_schemas/dist/formats/manual/frontend/schema.json
@@ -625,6 +625,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/manual/notification/schema.json
+++ b/content_schemas/dist/formats/manual/notification/schema.json
@@ -753,6 +753,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/manual/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/manual/publisher_v2/schema.json
@@ -418,6 +418,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/manual_section/frontend/schema.json
+++ b/content_schemas/dist/formats/manual_section/frontend/schema.json
@@ -652,6 +652,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/manual_section/notification/schema.json
+++ b/content_schemas/dist/formats/manual_section/notification/schema.json
@@ -780,6 +780,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/manual_section/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/manual_section/publisher_v2/schema.json
@@ -445,6 +445,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/ministers_index/frontend/schema.json
+++ b/content_schemas/dist/formats/ministers_index/frontend/schema.json
@@ -556,6 +556,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/ministers_index/notification/schema.json
+++ b/content_schemas/dist/formats/ministers_index/notification/schema.json
@@ -692,6 +692,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/ministers_index/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/ministers_index/publisher_v2/schema.json
@@ -299,6 +299,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/news_article/frontend/schema.json
+++ b/content_schemas/dist/formats/news_article/frontend/schema.json
@@ -734,6 +734,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/news_article/notification/schema.json
+++ b/content_schemas/dist/formats/news_article/notification/schema.json
@@ -866,6 +866,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/news_article/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/news_article/publisher_v2/schema.json
@@ -539,6 +539,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/organisation/frontend/schema.json
+++ b/content_schemas/dist/formats/organisation/frontend/schema.json
@@ -1064,6 +1064,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/organisation/notification/schema.json
+++ b/content_schemas/dist/formats/organisation/notification/schema.json
@@ -1224,6 +1224,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/organisation/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/organisation/publisher_v2/schema.json
@@ -783,6 +783,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/organisations_homepage/frontend/schema.json
+++ b/content_schemas/dist/formats/organisations_homepage/frontend/schema.json
@@ -597,6 +597,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/organisations_homepage/notification/schema.json
+++ b/content_schemas/dist/formats/organisations_homepage/notification/schema.json
@@ -701,6 +701,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/organisations_homepage/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/organisations_homepage/publisher_v2/schema.json
@@ -372,6 +372,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/person/frontend/schema.json
+++ b/content_schemas/dist/formats/person/frontend/schema.json
@@ -583,6 +583,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/person/notification/schema.json
+++ b/content_schemas/dist/formats/person/notification/schema.json
@@ -706,6 +706,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/person/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/person/publisher_v2/schema.json
@@ -377,6 +377,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/place/frontend/schema.json
+++ b/content_schemas/dist/formats/place/frontend/schema.json
@@ -555,6 +555,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/place/notification/schema.json
+++ b/content_schemas/dist/formats/place/notification/schema.json
@@ -678,6 +678,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/place/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/place/publisher_v2/schema.json
@@ -349,6 +349,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/publication/frontend/schema.json
+++ b/content_schemas/dist/formats/publication/frontend/schema.json
@@ -910,6 +910,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/publication/notification/schema.json
+++ b/content_schemas/dist/formats/publication/notification/schema.json
@@ -1036,6 +1036,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/publication/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/publication/publisher_v2/schema.json
@@ -727,6 +727,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/redirect/frontend/schema.json
+++ b/content_schemas/dist/formats/redirect/frontend/schema.json
@@ -427,6 +427,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/redirect/notification/schema.json
+++ b/content_schemas/dist/formats/redirect/notification/schema.json
@@ -440,6 +440,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/redirect/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/redirect/publisher_v2/schema.json
@@ -255,6 +255,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/role/frontend/schema.json
+++ b/content_schemas/dist/formats/role/frontend/schema.json
@@ -581,6 +581,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/role/notification/schema.json
+++ b/content_schemas/dist/formats/role/notification/schema.json
@@ -723,6 +723,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/role/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/role/publisher_v2/schema.json
@@ -374,6 +374,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/role_appointment/frontend/schema.json
+++ b/content_schemas/dist/formats/role_appointment/frontend/schema.json
@@ -534,6 +534,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/role_appointment/notification/schema.json
+++ b/content_schemas/dist/formats/role_appointment/notification/schema.json
@@ -656,6 +656,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/role_appointment/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/role_appointment/publisher_v2/schema.json
@@ -308,6 +308,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/service_manual_guide/frontend/schema.json
+++ b/content_schemas/dist/formats/service_manual_guide/frontend/schema.json
@@ -567,6 +567,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/service_manual_guide/notification/schema.json
+++ b/content_schemas/dist/formats/service_manual_guide/notification/schema.json
@@ -679,6 +679,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/service_manual_guide/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/service_manual_guide/publisher_v2/schema.json
@@ -358,6 +358,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/service_manual_homepage/frontend/schema.json
+++ b/content_schemas/dist/formats/service_manual_homepage/frontend/schema.json
@@ -509,6 +509,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/service_manual_homepage/notification/schema.json
+++ b/content_schemas/dist/formats/service_manual_homepage/notification/schema.json
@@ -613,6 +613,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/service_manual_homepage/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/service_manual_homepage/publisher_v2/schema.json
@@ -283,6 +283,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/service_manual_service_standard/frontend/schema.json
+++ b/content_schemas/dist/formats/service_manual_service_standard/frontend/schema.json
@@ -525,6 +525,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/service_manual_service_standard/notification/schema.json
+++ b/content_schemas/dist/formats/service_manual_service_standard/notification/schema.json
@@ -633,6 +633,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/service_manual_service_standard/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/service_manual_service_standard/publisher_v2/schema.json
@@ -296,6 +296,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/service_manual_service_toolkit/frontend/schema.json
+++ b/content_schemas/dist/formats/service_manual_service_toolkit/frontend/schema.json
@@ -558,6 +558,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/service_manual_service_toolkit/notification/schema.json
+++ b/content_schemas/dist/formats/service_manual_service_toolkit/notification/schema.json
@@ -662,6 +662,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/service_manual_service_toolkit/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/service_manual_service_toolkit/publisher_v2/schema.json
@@ -333,6 +333,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/service_manual_topic/frontend/schema.json
+++ b/content_schemas/dist/formats/service_manual_topic/frontend/schema.json
@@ -538,6 +538,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/service_manual_topic/notification/schema.json
+++ b/content_schemas/dist/formats/service_manual_topic/notification/schema.json
@@ -647,6 +647,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/service_manual_topic/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/service_manual_topic/publisher_v2/schema.json
@@ -294,6 +294,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/service_sign_in/frontend/schema.json
+++ b/content_schemas/dist/formats/service_sign_in/frontend/schema.json
@@ -600,6 +600,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/service_sign_in/notification/schema.json
+++ b/content_schemas/dist/formats/service_sign_in/notification/schema.json
@@ -723,6 +723,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/service_sign_in/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/service_sign_in/publisher_v2/schema.json
@@ -394,6 +394,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/simple_smart_answer/frontend/schema.json
+++ b/content_schemas/dist/formats/simple_smart_answer/frontend/schema.json
@@ -608,6 +608,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/simple_smart_answer/notification/schema.json
+++ b/content_schemas/dist/formats/simple_smart_answer/notification/schema.json
@@ -731,6 +731,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/simple_smart_answer/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/simple_smart_answer/publisher_v2/schema.json
@@ -402,6 +402,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/smart_answer/frontend/schema.json
+++ b/content_schemas/dist/formats/smart_answer/frontend/schema.json
@@ -545,6 +545,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/smart_answer/notification/schema.json
+++ b/content_schemas/dist/formats/smart_answer/notification/schema.json
@@ -649,6 +649,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/smart_answer/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/smart_answer/publisher_v2/schema.json
@@ -320,6 +320,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/special_route/frontend/schema.json
+++ b/content_schemas/dist/formats/special_route/frontend/schema.json
@@ -482,6 +482,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/special_route/notification/schema.json
+++ b/content_schemas/dist/formats/special_route/notification/schema.json
@@ -586,6 +586,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/special_route/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/special_route/publisher_v2/schema.json
@@ -278,6 +278,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/specialist_document/frontend/schema.json
+++ b/content_schemas/dist/formats/specialist_document/frontend/schema.json
@@ -1795,6 +1795,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/specialist_document/notification/schema.json
+++ b/content_schemas/dist/formats/specialist_document/notification/schema.json
@@ -1915,6 +1915,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/specialist_document/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/specialist_document/publisher_v2/schema.json
@@ -1626,6 +1626,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/speech/frontend/schema.json
+++ b/content_schemas/dist/formats/speech/frontend/schema.json
@@ -671,6 +671,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/speech/notification/schema.json
+++ b/content_schemas/dist/formats/speech/notification/schema.json
@@ -802,6 +802,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/speech/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/speech/publisher_v2/schema.json
@@ -443,6 +443,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/statistical_data_set/frontend/schema.json
+++ b/content_schemas/dist/formats/statistical_data_set/frontend/schema.json
@@ -815,6 +815,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/statistical_data_set/notification/schema.json
+++ b/content_schemas/dist/formats/statistical_data_set/notification/schema.json
@@ -923,6 +923,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/statistical_data_set/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/statistical_data_set/publisher_v2/schema.json
@@ -619,6 +619,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/statistics_announcement/frontend/schema.json
+++ b/content_schemas/dist/formats/statistics_announcement/frontend/schema.json
@@ -548,6 +548,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/statistics_announcement/notification/schema.json
+++ b/content_schemas/dist/formats/statistics_announcement/notification/schema.json
@@ -651,6 +651,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/statistics_announcement/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/statistics_announcement/publisher_v2/schema.json
@@ -324,6 +324,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/step_by_step_nav/frontend/schema.json
+++ b/content_schemas/dist/formats/step_by_step_nav/frontend/schema.json
@@ -529,6 +529,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/step_by_step_nav/notification/schema.json
+++ b/content_schemas/dist/formats/step_by_step_nav/notification/schema.json
@@ -618,6 +618,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/step_by_step_nav/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/step_by_step_nav/publisher_v2/schema.json
@@ -369,6 +369,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/substitute/notification/schema.json
+++ b/content_schemas/dist/formats/substitute/notification/schema.json
@@ -440,6 +440,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/take_part/frontend/schema.json
+++ b/content_schemas/dist/formats/take_part/frontend/schema.json
@@ -573,6 +573,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/take_part/notification/schema.json
+++ b/content_schemas/dist/formats/take_part/notification/schema.json
@@ -677,6 +677,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/take_part/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/take_part/publisher_v2/schema.json
@@ -348,6 +348,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/taxon/frontend/schema.json
+++ b/content_schemas/dist/formats/taxon/frontend/schema.json
@@ -535,6 +535,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/taxon/notification/schema.json
+++ b/content_schemas/dist/formats/taxon/notification/schema.json
@@ -651,6 +651,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/taxon/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/taxon/publisher_v2/schema.json
@@ -306,6 +306,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/topical_event/frontend/schema.json
+++ b/content_schemas/dist/formats/topical_event/frontend/schema.json
@@ -653,6 +653,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/topical_event/notification/schema.json
+++ b/content_schemas/dist/formats/topical_event/notification/schema.json
@@ -757,6 +757,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/topical_event/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/topical_event/publisher_v2/schema.json
@@ -428,6 +428,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/topical_event_about_page/frontend/schema.json
+++ b/content_schemas/dist/formats/topical_event_about_page/frontend/schema.json
@@ -523,6 +523,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/topical_event_about_page/notification/schema.json
+++ b/content_schemas/dist/formats/topical_event_about_page/notification/schema.json
@@ -627,6 +627,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/topical_event_about_page/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/topical_event_about_page/publisher_v2/schema.json
@@ -298,6 +298,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/transaction/frontend/schema.json
+++ b/content_schemas/dist/formats/transaction/frontend/schema.json
@@ -619,6 +619,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/transaction/notification/schema.json
+++ b/content_schemas/dist/formats/transaction/notification/schema.json
@@ -742,6 +742,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/transaction/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/transaction/publisher_v2/schema.json
@@ -413,6 +413,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/travel_advice/frontend/schema.json
+++ b/content_schemas/dist/formats/travel_advice/frontend/schema.json
@@ -717,6 +717,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/travel_advice/notification/schema.json
+++ b/content_schemas/dist/formats/travel_advice/notification/schema.json
@@ -843,6 +843,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/travel_advice/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/travel_advice/publisher_v2/schema.json
@@ -508,6 +508,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/travel_advice_index/frontend/schema.json
+++ b/content_schemas/dist/formats/travel_advice_index/frontend/schema.json
@@ -533,6 +533,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/travel_advice_index/notification/schema.json
+++ b/content_schemas/dist/formats/travel_advice_index/notification/schema.json
@@ -640,6 +640,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/travel_advice_index/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/travel_advice_index/publisher_v2/schema.json
@@ -305,6 +305,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/vanish/notification/schema.json
+++ b/content_schemas/dist/formats/vanish/notification/schema.json
@@ -440,6 +440,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/working_group/frontend/schema.json
+++ b/content_schemas/dist/formats/working_group/frontend/schema.json
@@ -598,6 +598,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/working_group/notification/schema.json
+++ b/content_schemas/dist/formats/working_group/notification/schema.json
@@ -702,6 +702,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/working_group/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/working_group/publisher_v2/schema.json
@@ -373,6 +373,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/world_index/frontend/schema.json
+++ b/content_schemas/dist/formats/world_index/frontend/schema.json
@@ -616,6 +616,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/world_index/notification/schema.json
+++ b/content_schemas/dist/formats/world_index/notification/schema.json
@@ -720,6 +720,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/world_index/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/world_index/publisher_v2/schema.json
@@ -391,6 +391,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/world_location/frontend/schema.json
+++ b/content_schemas/dist/formats/world_location/frontend/schema.json
@@ -555,6 +555,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/world_location/notification/schema.json
+++ b/content_schemas/dist/formats/world_location/notification/schema.json
@@ -673,6 +673,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/world_location/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/world_location/publisher_v2/schema.json
@@ -337,6 +337,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/world_location_news/frontend/schema.json
+++ b/content_schemas/dist/formats/world_location_news/frontend/schema.json
@@ -647,6 +647,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/world_location_news/notification/schema.json
+++ b/content_schemas/dist/formats/world_location_news/notification/schema.json
@@ -759,6 +759,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/world_location_news/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/world_location_news/publisher_v2/schema.json
@@ -414,6 +414,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/worldwide_corporate_information_page/frontend/schema.json
+++ b/content_schemas/dist/formats/worldwide_corporate_information_page/frontend/schema.json
@@ -541,6 +541,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/worldwide_corporate_information_page/notification/schema.json
+++ b/content_schemas/dist/formats/worldwide_corporate_information_page/notification/schema.json
@@ -649,6 +649,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/worldwide_corporate_information_page/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/worldwide_corporate_information_page/publisher_v2/schema.json
@@ -321,6 +321,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/worldwide_office/frontend/schema.json
+++ b/content_schemas/dist/formats/worldwide_office/frontend/schema.json
@@ -555,6 +555,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/worldwide_office/notification/schema.json
+++ b/content_schemas/dist/formats/worldwide_office/notification/schema.json
@@ -667,6 +667,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/worldwide_office/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/worldwide_office/publisher_v2/schema.json
@@ -335,6 +335,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/worldwide_organisation/frontend/schema.json
+++ b/content_schemas/dist/formats/worldwide_organisation/frontend/schema.json
@@ -779,6 +779,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/worldwide_organisation/notification/schema.json
+++ b/content_schemas/dist/formats/worldwide_organisation/notification/schema.json
@@ -927,6 +927,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/dist/formats/worldwide_organisation/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/worldwide_organisation/publisher_v2/schema.json
@@ -558,6 +558,7 @@
         "calendars",
         "collections-publisher",
         "contacts",
+        "content-block-manager",
         "content-publisher",
         "content-tagger",
         "email-alert-frontend",

--- a/content_schemas/formats/shared/definitions/publishing_app.jsonnet
+++ b/content_schemas/formats/shared/definitions/publishing_app.jsonnet
@@ -8,6 +8,7 @@
       "calendars",
       "collections-publisher",
       "contacts",
+      "content-block-manager",
       "content-publisher",
       "content-tagger",
       "email-alert-frontend",


### PR DESCRIPTION
We are currently in the process of replatforming Content Block Manager, and moving it to its [own repo](https://github.com/alphagov/content-block-manager/). As part of this, we'll need to add a new Publishing app to the list of valid publishing apps.