### PR TITLE
PP-7342 Don't generate random content_block document types

### DIFF
--- a/spec/support/random_content_helpers.rb
+++ b/spec/support/random_content_helpers.rb
@@ -8,7 +8,9 @@ module RandomContentHelpers
     #
     # We don't want to generate editions with special document_type values like "redirect"
     # as these may be handled by publishing API in special ways which confuse some tests
-    schema["properties"]["document_type"]["enum"] -= %w[gone redirect vanish]
+    schema["properties"]["document_type"]["enum"].reject! do |document_type|
+      %w[gone redirect vanish].include?(document_type) || document_type.start_with?("content_block_")
+    end
 
     GovukSchemas::RandomExample.new(schema:, seed:)
   end


### PR DESCRIPTION
These are handled differently by the queues because we need to enqueue host documents when content_blocks are updated, which complicates the message queue publishing tests.

Simplest just to avoid creating random examples that have document_type="content_block_contact" or
document_type="content_block_pension" (or any future content_blocks). As we already do for gone / redirect / vanish document types.