### PR TITLE
Remove frozen string literal override

### DIFF
--- a/app/controllers/graphql_controller.rb
+++ b/app/controllers/graphql_controller.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class GraphqlController < ApplicationController
   # If accessing from outside this domain, nullify the session
   # This allows for outside API access while preventing CSRF attacks,

--- a/app/graphql/publishing_api_schema.rb
+++ b/app/graphql/publishing_api_schema.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 class PublishingApiSchema < GraphQL::Schema
   query(Types::QueryType)
 

--- a/app/graphql/resolvers/base_resolver.rb
+++ b/app/graphql/resolvers/base_resolver.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Resolvers
   class BaseResolver < GraphQL::Schema::Resolver
   end

--- a/app/graphql/types/base_argument.rb
+++ b/app/graphql/types/base_argument.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Types
   class BaseArgument < GraphQL::Schema::Argument
     def initialize(*args, camelize: false, **kwargs, &block)

--- a/app/graphql/types/base_connection.rb
+++ b/app/graphql/types/base_connection.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Types
   class BaseConnection < Types::BaseObject
     # add `nodes` and `pageInfo` fields, as well as `edge_type(...)` and `node_nullable(...)` overrides

--- a/app/graphql/types/base_edge.rb
+++ b/app/graphql/types/base_edge.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Types
   class BaseEdge < Types::BaseObject
     # add `node` and `cursor` fields, as well as `node_type(...)` override

--- a/app/graphql/types/base_enum.rb
+++ b/app/graphql/types/base_enum.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Types
   class BaseEnum < GraphQL::Schema::Enum
   end

--- a/app/graphql/types/base_field.rb
+++ b/app/graphql/types/base_field.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Types
   class BaseField < GraphQL::Schema::Field
     argument_class Types::BaseArgument

--- a/app/graphql/types/base_input_object.rb
+++ b/app/graphql/types/base_input_object.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Types
   class BaseInputObject < GraphQL::Schema::InputObject
     argument_class Types::BaseArgument

--- a/app/graphql/types/base_interface.rb
+++ b/app/graphql/types/base_interface.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Types
   module BaseInterface
     include GraphQL::Schema::Interface

--- a/app/graphql/types/base_object.rb
+++ b/app/graphql/types/base_object.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Types
   class BaseObject < GraphQL::Schema::Object
     edge_type_class(Types::BaseEdge)

--- a/app/graphql/types/base_scalar.rb
+++ b/app/graphql/types/base_scalar.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Types
   class BaseScalar < GraphQL::Schema::Scalar
   end

--- a/app/graphql/types/base_union.rb
+++ b/app/graphql/types/base_union.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Types
   class BaseUnion < GraphQL::Schema::Union
     edge_type_class(Types::BaseEdge)

--- a/app/graphql/types/edition_type.rb
+++ b/app/graphql/types/edition_type.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Types
   class EditionType < Types::BaseObject
     class WithdrawnNotice < Types::BaseObject

--- a/app/graphql/types/ministers_index_type.rb
+++ b/app/graphql/types/ministers_index_type.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Types
   class MinistersIndexType < Types::EditionType
     def self.document_types = %w[ministers_index]

--- a/app/graphql/types/node_type.rb
+++ b/app/graphql/types/node_type.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Types
   module NodeType
     include Types::BaseInterface

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Types
   class QueryType < Types::BaseObject
     field :edition, EditionTypeOrSubtype, description: "An edition or one of its subtypes" do

--- a/app/graphql/types/query_type/edition_type_or_subtype.rb
+++ b/app/graphql/types/query_type/edition_type_or_subtype.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 module Types
   class QueryType
     class EditionTypeOrSubtype < Types::BaseUnion


### PR DESCRIPTION
Ruby 3.4 enables frozen string literals by default, so we no longer need to declare it in multiple places across the application.

[Release notes](https://github.com/ruby/ruby/releases/tag/v3_4_0)