### PR TITLE
Don't link to non-renderable Editions in GraphQL

### DIFF
--- a/app/graphql/sources/linked_to_editions_source.rb
+++ b/app/graphql/sources/linked_to_editions_source.rb
@@ -33,6 +33,7 @@ module Sources
           editions: { content_store: @content_store },
           documents: { locale: @locale_with_fallback },
         )
+        .where.not(editions: { document_type: Edition::NON_RENDERABLE_FORMATS })
         .where(
           %["links"."link_type" IN (?) OR "editions"."state" != 'unpublished'],
           Link::PERMITTED_UNPUBLISHED_LINK_TYPES,
@@ -79,6 +80,7 @@ module Sources
           editions: { content_store: @content_store },
           documents: { locale: @locale_with_fallback },
         )
+        .where.not(editions: { document_type: Edition::NON_RENDERABLE_FORMATS })
         .where(
           %["links"."link_type" IN (?) OR "editions"."state" != 'unpublished'],
           Link::PERMITTED_UNPUBLISHED_LINK_TYPES,

--- a/app/graphql/sources/reverse_linked_to_editions_source.rb
+++ b/app/graphql/sources/reverse_linked_to_editions_source.rb
@@ -42,6 +42,7 @@ module Sources
           editions: { content_store: @content_store },
           documents: { locale: @locale_with_fallback },
         )
+        .where.not(editions: { document_type: Edition::NON_RENDERABLE_FORMATS })
         .where(
           '("links"."target_content_id", "links"."link_type") IN (?)',
           Arel.sql(content_id_tuples.join(",")),
@@ -62,6 +63,7 @@ module Sources
           editions: { content_store: @content_store },
           documents: { locale: @locale_with_fallback },
         )
+        .where.not(editions: { document_type: Edition::NON_RENDERABLE_FORMATS })
         .where(
           '("links"."target_content_id", "links"."link_type") IN (?)',
           Arel.sql(content_id_tuples.join(",")),


### PR DESCRIPTION
The code that expands links[^1] before sending them to Content Store is following this same rule already, but our GraphQL dataloader sources aren't.

This solves an issue we noticed where undesirable links were included in our /graphql/content responses that are absent from Content API's versions of the same content items. One example is the "parent" link of "/government/publications/information-note-changes-to-the-remittance-basis".

Note: we don't need to roll this change out to the PersonCurrentRolesSource dataloader source because it already specifies the document_type of the linked-to Editions in its database query. As you can see from the changes made to the other dataloader sources, we can identify non-renderable Editions by their document_type.

[^1]: The existing rule lives in Queries::GetEditionIdsWithFallbacks, but in case it's useful or interesting, we rediscovered it via DownstreamPayload -> Presenters::EditionPresenter -> Presenters::Queries::ExpandedLinkSet -> LinkExpansion -> LinkExpansion::ContentCache -> Queries::GetEditionIdsWithFallbacks