### PR TITLE
Remove pin for `sidekiq-unique-jobs`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,7 +28,7 @@ gem "rack-cache"
 gem "rails-pg-extras"
 gem "sentry-sidekiq"
 gem "sidekiq-scheduler"
-gem "sidekiq-unique-jobs", "< 8.0.12"
+gem "sidekiq-unique-jobs"
 gem "strong_migrations"
 gem "with_advisory_lock"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -982,7 +982,7 @@ DEPENDENCIES
   rubocop-govuk
   sentry-sidekiq
   sidekiq-scheduler
-  sidekiq-unique-jobs (< 8.0.12)
+  sidekiq-unique-jobs
   simplecov
   strong_migrations
   timecop


### PR DESCRIPTION
This dependency was pinned to a specific version in 6e3a0edbf845cca0324182f552f8e0b4376319d5, however dependabot has bumped it anyway.

We aren't aware of any issues as a result of this version change, so removing the pinning as it now seems pointless.