### PR TITLE
Always select `api_url` and `web_url` fields for links and support them in `available_translations`

### DIFF
--- a/app/graphql/types/edition_type.rb
+++ b/app/graphql/types/edition_type.rb
@@ -120,7 +120,7 @@ module Types
 
       def available_translations
         Presenters::Queries::AvailableTranslations.by_edition(object)
-          .translations.fetch(:available_translations, [])
+          .translation_editions
       end
     end
 

--- a/app/presenters/queries/available_translations.rb
+++ b/app/presenters/queries/available_translations.rb
@@ -20,6 +20,15 @@ module Presenters
         { available_translations: expanded_translations }
       end
 
+      def translation_editions
+        exclude_ids = [edition&.id].compact
+
+        Edition.strict_loading
+          .includes(:document)
+          .where(id: edition_ids - exclude_ids) +
+          [edition].compact
+      end
+
     private
 
       attr_reader :options, :with_drafts
@@ -52,8 +61,12 @@ module Presenters
         edition_for_id(id).to_h
       end
 
+      def edition_ids
+        @edition_ids ||= grouped_translations.map { |_, (id, _, _)| id }
+      end
+
       def expanded_translations
-        @expanded_translations ||= grouped_translations.map do |_, (id, _, _)|
+        @expanded_translations ||= edition_ids.map do |id|
           expand_translation(id)
         end
       end

--- a/app/presenters/queries/available_translations.rb
+++ b/app/presenters/queries/available_translations.rb
@@ -53,7 +53,7 @@ module Presenters
       end
 
       def expanded_translations
-        @expanded_translations ||= grouped_translations.map do |_, (id)|
+        @expanded_translations ||= grouped_translations.map do |_, (id, _, _)|
           expand_translation(id)
         end
       end

--- a/spec/graphql/types/edition_type_spec.rb
+++ b/spec/graphql/types/edition_type_spec.rb
@@ -1,6 +1,54 @@
 RSpec.describe "Types::EditionType" do
   include GraphQL::Testing::Helpers
 
+  describe "available_translations links" do
+    it "returns available_translations as Editions" do
+      content_id = SecureRandom.uuid
+      edition = create(
+        :live_edition,
+        base_path: "/a",
+        document: create(:document, locale: "en", content_id:),
+      )
+      create(
+        :live_edition,
+        base_path: "/a.ar",
+        document: create(:document, locale: "ar", content_id:),
+      )
+      create(
+        :live_edition,
+        base_path: "/a.es",
+        document: create(:document, locale: "es", content_id:),
+      )
+
+      expect(
+        run_graphql_field(
+          PublishingApiSchema,
+          "Edition.links.available_translations",
+          edition,
+        ),
+      ).to match_array([
+        have_attributes(
+          class: Edition,
+          base_path: "/a",
+          locale: "en",
+          web_url: "http://www.dev.gov.uk/a",
+        ),
+        have_attributes(
+          class: Edition,
+          base_path: "/a.ar",
+          locale: "ar",
+          web_url: "http://www.dev.gov.uk/a.ar",
+        ),
+        have_attributes(
+          class: Edition,
+          base_path: "/a.es",
+          locale: "es",
+          web_url: "http://www.dev.gov.uk/a.es",
+        ),
+      ])
+    end
+  end
+
   describe "#withdrawn_notice" do
     context "when the edition is withdrawn" do
       it "returns a withdrawal notice" do

--- a/spec/presenters/queries/available_translations_spec.rb
+++ b/spec/presenters/queries/available_translations_spec.rb
@@ -11,6 +11,10 @@ RSpec.describe Presenters::Queries::AvailableTranslations do
       .translations[:available_translations]
   end
 
+  subject(:translation_editions_by_edition) do
+    described_class.by_edition(edition).translation_editions
+  end
+
   let(:content_id) { link_set.content_id }
   let(:edition) { nil }
 
@@ -29,9 +33,9 @@ RSpec.describe Presenters::Queries::AvailableTranslations do
 
   context "with items in a matching state" do
     let(:with_drafts) { false }
+    let!(:edition) { create_edition("/a", "published") }
 
     before do
-      create_edition("/a", "published")
       create_edition("/a.ar", "published", "ar")
       create_edition("/a.es", "published", "es")
     end
@@ -41,6 +45,14 @@ RSpec.describe Presenters::Queries::AvailableTranslations do
         a_hash_including(base_path: "/a", locale: "en"),
         a_hash_including(base_path: "/a.ar", locale: "ar"),
         a_hash_including(base_path: "/a.es", locale: "es"),
+      ])
+    end
+
+    it "returns all the items as Editions from #translation_editions" do
+      expect(translation_editions_by_edition).to match_array([
+        have_attributes(class: Edition, base_path: "/a", locale: "en"),
+        have_attributes(class: Edition, base_path: "/a.ar", locale: "ar"),
+        have_attributes(class: Edition, base_path: "/a.es", locale: "es"),
       ])
     end
   end
@@ -83,6 +95,11 @@ RSpec.describe Presenters::Queries::AvailableTranslations do
         expect(translations_by_edition).to match_array([
           a_hash_including(base_path: "/a", locale: "en", title: "VAT rates"),
           a_hash_including(base_path: "/a.fr", locale: "fr"),
+        ])
+
+        expect(translation_editions_by_edition).to match_array([
+          have_attributes(base_path: "/a", locale: "en", title: "VAT rates"),
+          have_attributes(base_path: "/a.fr", locale: "fr"),
         ])
       end
     end


### PR DESCRIPTION
* Always select `api_url` and `web_url` fields for links (in GraphqlQueryBuilder)
* Support `api_url` and `web_url` in `EditionType.links.available_translations`