### PR TITLE
[PP-7327] Bulk validate live content

### DIFF
--- a/script/live_content/bulk_check
+++ b/script/live_content/bulk_check
@@ -1,0 +1,31 @@
+#!/usr/bin/env ruby
+
+require "English"
+
+def usage
+  abort("Usage:\n\t#{$PROGRAM_NAME} a_checker_script")
+end
+
+check = ARGV.fetch(0) { usage }
+
+base_paths_file_path = "tmp/base_paths/filtered_base_paths"
+base_paths = File.read(base_paths_file_path).split("\n")
+total_base_paths = base_paths.count
+
+base_paths.each_with_index do |base_path, index|
+  info = "#{index + 1}/#{total_base_paths}: #{base_path}"
+  puts "Processing #{info}"
+  puts `#{check} #{base_path}`
+  puts "Processed #{info}\n\n"
+
+  next if $CHILD_STATUS.success?
+
+  print "Continue? (Y/n) "
+
+  continue = nil
+  continue = $stdin.gets.chomp.downcase until ["", "y", "n"].include?(continue)
+
+  abort if continue == "n"
+
+  puts
+end

--- a/script/live_content/bulk_diff
+++ b/script/live_content/bulk_diff
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
 
+# Start Content Store and Publishing API before running this script
 
 script/live_content/bulk_check "script/live_content/diff"

--- a/script/live_content/bulk_diff
+++ b/script/live_content/bulk_diff
@@ -1,26 +1,4 @@
-#!/usr/bin/env ruby
+#!/usr/bin/env bash
 
-require "English"
 
-base_paths_file_path = "tmp/base_paths/filtered_base_paths"
-base_paths = File.read(base_paths_file_path).split("\n")
-total_base_paths = base_paths.count
-
-base_paths.each_with_index do |base_path, index|
-  info = "#{index + 1}/#{total_base_paths}: #{base_path}"
-  puts "Processing #{info}"
-  diff = `script/live_content/diff #{base_path}`
-  puts diff unless $CHILD_STATUS.success?
-  puts "Processed #{info}\n\n"
-
-  next if $CHILD_STATUS.success?
-
-  print "Continue? (Y/n) "
-
-  continue = nil
-  continue = gets.chomp.downcase until ["", "y", "n"].include?(continue)
-
-  abort if continue == "n"
-
-  puts
-end
+script/live_content/bulk_check "script/live_content/diff"

--- a/script/live_content/bulk_validate
+++ b/script/live_content/bulk_validate
@@ -1,0 +1,25 @@
+#!/usr/bin/env ruby
+
+require "English"
+
+base_paths_file_path = "tmp/base_paths/filtered_base_paths"
+base_paths = File.read(base_paths_file_path).split("\n")
+total_base_paths = base_paths.count
+
+base_paths.each_with_index do |base_path, index|
+  info = "#{index + 1}/#{total_base_paths}: #{base_path}"
+  puts "Processing #{info}"
+  puts `script/live_content/validate #{base_path}`
+  puts "Processed #{info}\n\n"
+
+  next if $CHILD_STATUS.success?
+
+  print "Continue? (Y/n) "
+
+  continue = nil
+  continue = gets.chomp.downcase until ["", "y", "n"].include?(continue)
+
+  abort if continue == "n"
+
+  puts
+end

--- a/script/live_content/bulk_validate
+++ b/script/live_content/bulk_validate
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
 
+# Start Publishing API before running this script
 
 script/live_content/bulk_check "script/live_content/validate"

--- a/script/live_content/bulk_validate
+++ b/script/live_content/bulk_validate
@@ -1,25 +1,4 @@
-#!/usr/bin/env ruby
+#!/usr/bin/env bash
 
-require "English"
 
-base_paths_file_path = "tmp/base_paths/filtered_base_paths"
-base_paths = File.read(base_paths_file_path).split("\n")
-total_base_paths = base_paths.count
-
-base_paths.each_with_index do |base_path, index|
-  info = "#{index + 1}/#{total_base_paths}: #{base_path}"
-  puts "Processing #{info}"
-  puts `script/live_content/validate #{base_path}`
-  puts "Processed #{info}\n\n"
-
-  next if $CHILD_STATUS.success?
-
-  print "Continue? (Y/n) "
-
-  continue = nil
-  continue = gets.chomp.downcase until ["", "y", "n"].include?(continue)
-
-  abort if continue == "n"
-
-  puts
-end
+script/live_content/bulk_check "script/live_content/validate"

--- a/script/live_content/diff
+++ b/script/live_content/diff
@@ -1,5 +1,7 @@
 #!/usr/bin/env ruby
 
+# Start Content Store and Publishing API before running this script
+
 require "English"
 require "fileutils"
 require "json"

--- a/script/live_content/validate
+++ b/script/live_content/validate
@@ -1,5 +1,7 @@
 #!/usr/bin/env ruby
 
+# Start Publishing API before running this script
+
 require "json"
 require "net/http"
 require "uri"

--- a/script/live_content/validate
+++ b/script/live_content/validate
@@ -25,4 +25,5 @@ if errors.empty?
 else
   puts("Errors:")
   errors.each(&method(:puts))
+  exit 1
 end


### PR DESCRIPTION
It's useful to be able to go through a list of base paths quickly. This works the same as the existing bulk diff script, so there's a bit of abstraction here