### PR TITLE
[PP-7327] Add publication GraphQL query

### DIFF
--- a/app/graphql/queries/publication.graphql
+++ b/app/graphql/queries/publication.graphql
@@ -1,0 +1,904 @@
+query publication($base_path: String!) {
+  edition(base_path: $base_path) {
+    ... on Edition {
+      analytics_identifier
+      base_path
+      content_id
+      description
+      details {
+        attachments
+        body
+        brexit_no_deal_notice
+        change_history
+        document_type_label
+        documents
+        emphasised_organisations
+        featured_attachments
+        first_public_at
+        government
+        national_applicability
+        political
+        tags
+      }
+      document_type
+      first_published_at
+      links {
+        available_translations {
+          analytics_identifier
+          api_path
+          api_url
+          base_path
+          content_id
+          document_type
+          locale
+          public_updated_at
+          schema_name
+          title
+          web_url
+        }
+        children {
+          analytics_identifier
+          api_path
+          api_url
+          base_path
+          content_id
+          description
+          details {
+            access_and_opening_times
+            country
+            change_description
+            step_by_step_nav
+            political_party
+            dates_in_office
+            description
+            title
+            contact_form_links
+            post_addresses
+            email_addresses
+            phone_numbers
+          }
+          document_type
+          locale
+          public_updated_at
+          schema_name
+          title
+          web_url
+        }
+        document_collections {
+          analytics_identifier
+          api_path
+          api_url
+          base_path
+          content_id
+          document_type
+          locale
+          public_updated_at
+          schema_name
+          title
+          web_url
+        }
+        embed {
+          analytics_identifier
+          api_path
+          api_url
+          base_path
+          content_id
+          details {
+            description
+            rates
+          }
+          document_type
+          locale
+          public_updated_at
+          schema_name
+          title
+          web_url
+        }
+        finder {
+          analytics_identifier
+          api_path
+          api_url
+          base_path
+          content_id
+          details {
+            facets
+            show_metadata_block
+            show_table_of_contents
+          }
+          document_type
+          locale
+          public_updated_at
+          schema_name
+          title
+          web_url
+        }
+        government {
+          analytics_identifier
+          api_path
+          api_url
+          base_path
+          content_id
+          details {
+            started_on
+            ended_on
+            current
+          }
+          document_type
+          locale
+          public_updated_at
+          schema_name
+          title
+          web_url
+        }
+        lead_organisations {
+          analytics_identifier
+          api_path
+          api_url
+          base_path
+          content_id
+          details {
+            acronym
+            logo
+            brand
+            default_news_image
+            organisation_govuk_status
+          }
+          document_type
+          locale
+          public_updated_at
+          schema_name
+          title
+          web_url
+        }
+        mainstream_browse_pages {
+          analytics_identifier
+          api_path
+          api_url
+          base_path
+          content_id
+          description
+          document_type
+          locale
+          public_updated_at
+          schema_name
+          title
+          web_url
+        }
+        ordered_related_items {
+          analytics_identifier
+          api_path
+          api_url
+          base_path
+          content_id
+          description
+          details {
+            country
+            change_description
+            step_by_step_nav
+            political_party
+            dates_in_office
+            description
+            title
+            contact_form_links
+            post_addresses
+            email_addresses
+            phone_numbers
+          }
+          document_type
+          links {
+            mainstream_browse_pages {
+              analytics_identifier
+              api_path
+              api_url
+              base_path
+              content_id
+              description
+              document_type
+              links {
+                parent {
+                  analytics_identifier
+                  api_path
+                  api_url
+                  base_path
+                  content_id
+                  description
+                  details {
+                    logo
+                    world_location_names
+                    default_news_image
+                    acronym
+                    brand
+                    organisation_govuk_status
+                  }
+                  document_type
+                  links {
+                    parent {
+                      analytics_identifier
+                      api_path
+                      api_url
+                      base_path
+                      content_id
+                      description
+                      details {
+                        logo
+                        world_location_names
+                        default_news_image
+                        acronym
+                        brand
+                        organisation_govuk_status
+                      }
+                      document_type
+                      links {
+                        parent {
+                          analytics_identifier
+                          api_path
+                          api_url
+                          base_path
+                          content_id
+                          description
+                          details {
+                            logo
+                            world_location_names
+                            default_news_image
+                            acronym
+                            brand
+                            organisation_govuk_status
+                          }
+                          document_type
+                          locale
+                          public_updated_at
+                          schema_name
+                          title
+                          web_url
+                        }
+                      }
+                      locale
+                      public_updated_at
+                      schema_name
+                      title
+                      web_url
+                    }
+                  }
+                  locale
+                  public_updated_at
+                  schema_name
+                  title
+                  web_url
+                }
+              }
+              locale
+              public_updated_at
+              schema_name
+              title
+              web_url
+            }
+          }
+          locale
+          phase
+          public_updated_at
+          schema_name
+          title
+          web_url
+        }
+        ordered_related_items_overrides {
+          analytics_identifier
+          api_path
+          api_url
+          base_path
+          content_id
+          description
+          details: details_json
+          document_type
+          links {
+            taxons {
+              analytics_identifier
+              api_path
+              api_url
+              base_path
+              content_id
+              description
+              details: details_json
+              document_type
+              locale
+              phase
+              public_updated_at
+              schema_name
+              title
+              web_url
+            }
+          }
+          locale
+          phase
+          public_updated_at
+          schema_name
+          title
+          web_url
+        }
+        organisations {
+          analytics_identifier
+          api_path
+          api_url
+          base_path
+          content_id
+          description
+          details {
+            logo
+            world_location_names
+            default_news_image
+            access_and_opening_times
+            acronym
+            brand
+            organisation_govuk_status
+            description
+            title
+            contact_form_links
+            post_addresses
+            email_addresses
+            phone_numbers
+          }
+          document_type
+          locale
+          public_updated_at
+          schema_name
+          title
+          web_url
+        }
+        original_primary_publishing_organisation {
+          analytics_identifier
+          api_path
+          api_url
+          base_path
+          content_id
+          details {
+            acronym
+            logo
+            brand
+            default_news_image
+            organisation_govuk_status
+          }
+          document_type
+          locale
+          public_updated_at
+          schema_name
+          title
+          web_url
+        }
+        parent {
+          analytics_identifier
+          api_path
+          api_url
+          base_path
+          content_id
+          description
+          details {
+            logo
+            world_location_names
+            default_news_image
+            acronym
+            brand
+            organisation_govuk_status
+          }
+          document_type
+          links {
+            parent {
+              analytics_identifier
+              api_path
+              api_url
+              base_path
+              content_id
+              description
+              details {
+                logo
+                world_location_names
+                default_news_image
+                acronym
+                brand
+                organisation_govuk_status
+              }
+              document_type
+              links {
+                parent {
+                  analytics_identifier
+                  api_path
+                  api_url
+                  base_path
+                  content_id
+                  description
+                  details {
+                    logo
+                    world_location_names
+                    default_news_image
+                    acronym
+                    brand
+                    organisation_govuk_status
+                  }
+                  document_type
+                  links {
+                    parent {
+                      analytics_identifier
+                      api_path
+                      api_url
+                      base_path
+                      content_id
+                      description
+                      details {
+                        logo
+                        world_location_names
+                        default_news_image
+                        acronym
+                        brand
+                        organisation_govuk_status
+                      }
+                      document_type
+                      links {
+                        parent {
+                          analytics_identifier
+                          api_path
+                          api_url
+                          base_path
+                          content_id
+                          description
+                          details {
+                            logo
+                            world_location_names
+                            default_news_image
+                            acronym
+                            brand
+                            organisation_govuk_status
+                          }
+                          document_type
+                          locale
+                          public_updated_at
+                          schema_name
+                          title
+                          web_url
+                        }
+                      }
+                      locale
+                      public_updated_at
+                      schema_name
+                      title
+                      web_url
+                    }
+                  }
+                  locale
+                  public_updated_at
+                  schema_name
+                  title
+                  web_url
+                }
+              }
+              locale
+              public_updated_at
+              schema_name
+              title
+              web_url
+            }
+          }
+          locale
+          public_updated_at
+          schema_name
+          title
+          web_url
+        }
+        part_of_step_navs {
+          analytics_identifier
+          api_path
+          api_url
+          base_path
+          content_id
+          details {
+            step_by_step_nav
+          }
+          document_type
+          locale
+          public_updated_at
+          schema_name
+          title
+          web_url
+        }
+        people {
+          analytics_identifier
+          api_path
+          api_url
+          base_path
+          content_id
+          document_type
+          locale
+          public_updated_at
+          schema_name
+          title
+          web_url
+        }
+        policy_areas {
+          analytics_identifier
+          api_path
+          api_url
+          base_path
+          content_id
+          document_type
+          locale
+          public_updated_at
+          schema_name
+          title
+          web_url
+        }
+        primary_publishing_organisation {
+          analytics_identifier
+          api_path
+          api_url
+          base_path
+          content_id
+          details {
+            acronym
+            logo
+            brand
+            default_news_image
+            organisation_govuk_status
+          }
+          document_type
+          locale
+          public_updated_at
+          schema_name
+          title
+          web_url
+        }
+        related_policies {
+          analytics_identifier
+          api_path
+          api_url
+          base_path
+          content_id
+          document_type
+          locale
+          public_updated_at
+          schema_name
+          title
+          web_url
+        }
+        related_statistical_data_sets {
+          analytics_identifier
+          api_path
+          api_url
+          base_path
+          content_id
+          document_type
+          locale
+          public_updated_at
+          schema_name
+          title
+          web_url
+        }
+        related_to_step_navs {
+          analytics_identifier
+          api_path
+          api_url
+          base_path
+          content_id
+          details {
+            step_by_step_nav
+          }
+          document_type
+          locale
+          public_updated_at
+          schema_name
+          title
+          web_url
+        }
+        role_appointments {
+          analytics_identifier
+          api_path
+          api_url
+          base_path
+          content_id
+          details {
+            started_on
+            ended_on
+            current
+            person_appointment_order
+          }
+          document_type
+          links {
+            person {
+              analytics_identifier
+              api_path
+              api_url
+              base_path
+              content_id
+              details {
+                body
+                image
+              }
+              document_type
+              locale
+              public_updated_at
+              schema_name
+              title
+              web_url
+            }
+            role {
+              analytics_identifier
+              api_path
+              api_url
+              base_path
+              content_id
+              details {
+                body
+                role_payment_type
+                seniority
+                whip_organisation
+              }
+              document_type
+              links {
+                ordered_parent_organisations {
+                  analytics_identifier
+                  api_path
+                  api_url
+                  base_path
+                  content_id
+                  details {
+                    acronym
+                    logo
+                    brand
+                    default_news_image
+                    organisation_govuk_status
+                  }
+                  document_type
+                  locale
+                  schema_name
+                  title
+                  web_url
+                }
+              }
+              locale
+              public_updated_at
+              schema_name
+              title
+              web_url
+            }
+          }
+          locale
+          public_updated_at
+          schema_name
+          title
+          web_url
+        }
+        roles {
+          analytics_identifier
+          api_path
+          api_url
+          base_path
+          content_id
+          details {
+            body
+            role_payment_type
+            seniority
+            whip_organisation
+          }
+          document_type
+          locale
+          public_updated_at
+          schema_name
+          title
+          web_url
+        }
+        secondary_to_step_navs {
+          analytics_identifier
+          api_path
+          api_url
+          base_path
+          content_id
+          details {
+            step_by_step_nav
+          }
+          document_type
+          locale
+          public_updated_at
+          schema_name
+          title
+          web_url
+        }
+        suggested_ordered_related_items {
+          analytics_identifier
+          api_path
+          api_url
+          base_path
+          content_id
+          description
+          details {
+            country
+            change_description
+            step_by_step_nav
+          }
+          document_type
+          locale
+          public_updated_at
+          schema_name
+          title
+          web_url
+        }
+        taxons {
+          analytics_identifier
+          api_path
+          api_url
+          base_path
+          content_id
+          description
+          details: details_json
+          document_type
+          links {
+            root_taxon {
+              analytics_identifier
+              api_path
+              api_url
+              base_path
+              content_id
+              document_type
+              locale
+              public_updated_at
+              schema_name
+              title
+              web_url
+            }
+            parent_taxons {
+              analytics_identifier
+              api_path
+              api_url
+              base_path
+              content_id
+              description
+              details: details_json
+              document_type
+              links {
+                parent_taxons {
+                  analytics_identifier
+                  api_path
+                  api_url
+                  base_path
+                  content_id
+                  description
+                  details: details_json
+                  document_type
+                  links {
+                    parent_taxons {
+                      analytics_identifier
+                      api_path
+                      api_url
+                      base_path
+                      content_id
+                      description
+                      details: details_json
+                      document_type
+                      links {
+                        parent_taxons {
+                          analytics_identifier
+                          api_path
+                          api_url
+                          base_path
+                          content_id
+                          description
+                          details: details_json
+                          document_type
+                          locale
+                          phase
+                          public_updated_at
+                          schema_name
+                          title
+                          web_url
+                        }
+                        root_taxon {
+                          analytics_identifier
+                          api_path
+                          api_url
+                          base_path
+                          content_id
+                          document_type
+                          locale
+                          public_updated_at
+                          schema_name
+                          title
+                          web_url
+                        }
+                      }
+                      locale
+                      phase
+                      public_updated_at
+                      schema_name
+                      title
+                      web_url
+                    }
+                    root_taxon {
+                      analytics_identifier
+                      api_path
+                      api_url
+                      base_path
+                      content_id
+                      document_type
+                      locale
+                      public_updated_at
+                      schema_name
+                      title
+                      web_url
+                    }
+                  }
+                  locale
+                  phase
+                  public_updated_at
+                  schema_name
+                  title
+                  web_url
+                }
+                root_taxon {
+                  analytics_identifier
+                  api_path
+                  api_url
+                  base_path
+                  content_id
+                  document_type
+                  locale
+                  public_updated_at
+                  schema_name
+                  title
+                  web_url
+                }
+              }
+              locale
+              phase
+              public_updated_at
+              schema_name
+              title
+              web_url
+            }
+          }
+          locale
+          phase
+          public_updated_at
+          schema_name
+          title
+          web_url
+        }
+        topical_events {
+          analytics_identifier
+          api_path
+          api_url
+          base_path
+          content_id
+          document_type
+          locale
+          public_updated_at
+          schema_name
+          title
+          web_url
+        }
+        world_locations {
+          analytics_identifier
+          api_path
+          api_url
+          base_path
+          content_id
+          document_type
+          locale
+          public_updated_at
+          schema_name
+          title
+          web_url
+        }
+      }
+      locale
+      phase
+      public_updated_at
+      publishing_app
+      publishing_request_id
+      publishing_scheduled_at
+      rendering_app
+      scheduled_publishing_delay_seconds
+      schema_name
+      title
+      updated_at
+      withdrawn_notice {
+        explanation
+        withdrawn_at
+      }
+    }
+  }
+}

--- a/spec/integration/graphql/live_content_spec.rb
+++ b/spec/integration/graphql/live_content_spec.rb
@@ -1,6 +1,7 @@
 RSpec.describe "Requesting live content by base path" do
   schema_specific_fields = {
     news_article: { details: { body: "" } },
+    publication: { details: { body: "", documents: [], political: false } },
     world_index: {
       details: { world_locations: [], international_delegations: [] },
     },


### PR DESCRIPTION
Two things to note:
* there are a few inconsistencies compared with Content Store responses at the moment. These are documented in Jira
* the query doesn't always provide schema-valid output for real data. There's a Jira card to look into intelligently compacting the content item, which should fix some (maybe even all?) or the validation issues

But if there's no meaningful diff comparing the frontend-rendered HTML when backed by Content Store and Publishing API, the query is probably ready enough

NOTE: ^ this is not the case... I hadn't updated `GRAPHQL_ALLOWED_SCHEMAS` in frontend so everything was being rendered by Content Store...