### PR TITLE
[PP-7327] Ignore hashed value diff in data-controls

### DIFF
--- a/script/live_content/diff_frontend_functions.sh
+++ b/script/live_content/diff_frontend_functions.sh
@@ -31,7 +31,7 @@ function curl_and_strip_hashes() {
   echo "$response" | sed -r \
     -e 's/\?graphql=(true|false)//g' \
     -e 's/nonce="[^"]{22}=="/nonce="HASH=="/g' \
-    -e 's/ (aria-labelledby|for|id)="([^"]+)-[a-z0-9]{8}"/ \1="\2-HASH"/g' \
+    -e 's/ (aria-labelledby|data-controls|for|id)="([^"]+)-[a-z0-9]{8}"/ \1="\2-HASH"/g' \
     -e 's/<(meta name="govuk:updated-at" content=)"[^"]+">/<\1"TIMESTAMP">/' \
     -e '/<meta name="govuk:content-has-history" content=".*">/d' \
     -e 's/(This news article was withdrawn on &lt;time datetime=)"[^"]+"/\1"TIMESTAMP"/' \


### PR DESCRIPTION
This is another HTML element attribute where we include an eight-digit hashed value at the end which changes on every request. This is a per-request difference not a backend-based difference