### PR TITLE
[PP-7327] Present bulk diffs using less

### DIFF
--- a/script/live_content/bulk_check
+++ b/script/live_content/bulk_check
@@ -7,6 +7,15 @@ def usage
 end
 
 check = ARGV.fetch(0) { usage }
+use_less = ARGV.include?("--less")
+
+def pipe_to_less(info, result)
+  less_input = "#{info}\n\n#{result}"
+    .gsub(/\n\+([^+])/, "\n\e[32m+\\1")
+    .gsub(/\n-([^-])/, "\n\e[31m-\\1")
+
+  IO.popen("less -R", "w") { |pipe| pipe.puts less_input }
+end
 
 base_paths_file_path = "tmp/base_paths/filtered_base_paths"
 base_paths = File.read(base_paths_file_path).split("\n")
@@ -15,10 +24,17 @@ total_base_paths = base_paths.count
 base_paths.each_with_index do |base_path, index|
   info = "#{index + 1}/#{total_base_paths}: #{base_path}"
   puts "Processing #{info}"
-  puts `#{check} #{base_path}`
+  result = `#{check} #{base_path}`
+  success = $CHILD_STATUS.success?
+
+  unless success
+    pipe_to_less(info, result) if use_less
+    puts result
+  end
+
   puts "Processed #{info}\n\n"
 
-  next if $CHILD_STATUS.success?
+  next if success
 
   print "Continue? (Y/n) "
 

--- a/script/live_content/bulk_diff
+++ b/script/live_content/bulk_diff
@@ -2,4 +2,4 @@
 
 # Start Content Store and Publishing API before running this script
 
-script/live_content/bulk_check "script/live_content/diff"
+script/live_content/bulk_check "script/live_content/diff" --less


### PR DESCRIPTION
Previously when using the bulk diff script the result would be printed and you'd need to scroll back if you wanted to read it top to bottom

With this change we initially pipe the output to less, which starts us at the top of the diff and is nicer to scroll through. We need to do a little bit of processing to get the diff colours showing properly

On exiting less, the result is printed like before, so you still have a record in your console if you want to scroll back through or compare against another edition