### PR TITLE
Fix reverse_links_field for secondary step navs

### DIFF
--- a/app/graphql/types/edition_type.rb
+++ b/app/graphql/types/edition_type.rb
@@ -95,7 +95,7 @@ module Types
       reverse_links_field :part_of_step_navs, :pages_part_of_step_nav, [EditionType]
       reverse_links_field :policies, :working_groups, [EditionType]
       reverse_links_field :related_to_step_navs, :pages_related_to_step_nav, [EditionType]
-      reverse_links_field :secondary_to_step_navs, :secondary_to_step_navs, [EditionType]
+      reverse_links_field :secondary_to_step_navs, :pages_secondary_to_step_nav, [EditionType]
 
       field :available_translations, [EditionType]
       field :role_appointments, [EditionType]


### PR DESCRIPTION

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance]
(https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
