### PR TITLE
[PP-7357] Deep stringify and sort

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,3 +52,5 @@ group :development, :test do
   gem "timecop"
   gem "webmock", require: false
 end
+
+gem "deepsort", "~> 0.5.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -140,6 +140,7 @@ GEM
     database_cleaner-core (2.0.1)
     date (3.4.1)
     declarative (0.0.20)
+    deepsort (0.5.0)
     diff-lcs (1.6.2)
     dig_rb (1.0.1)
     docile (1.4.1)
@@ -954,6 +955,7 @@ DEPENDENCIES
   csv
   dalli
   database_cleaner
+  deepsort (~> 0.5.0)
   factory_bot_rails
   fuzzy_match
   gds-api-adapters

--- a/app/services/graphql_content_item_service.rb
+++ b/app/services/graphql_content_item_service.rb
@@ -1,3 +1,5 @@
+require "deepsort"
+
 class GraphqlContentItemService
   class QueryResultError < StandardError; end
 
@@ -12,7 +14,9 @@ class GraphqlContentItemService
       raise QueryResultError, error_messages.join("\n")
     end
 
-    unpublishing || edition
+    (unpublishing || edition)
+      .deep_stringify_keys
+      .deep_sort(array: false)
   end
 
 private

--- a/spec/services/graphql_content_item_service_spec.rb
+++ b/spec/services/graphql_content_item_service_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe GraphqlContentItemService do
           "array" => [1, 2, 3],
           "boolean" => true,
           "details" => {},
-          "hash" => { "a": 1 },
+          "hash" => { "a" => 1 },
           "null" => nil,
           "number" => 1,
           "string" => "howdy",
@@ -34,7 +34,7 @@ RSpec.describe GraphqlContentItemService do
       "array" => [1, 2, 3],
       "boolean" => true,
       "details" => {},
-      "hash" => { "a": 1 },
+      "hash" => { "a" => 1 },
       "number" => 1,
       "string" => "howdy",
     })
@@ -47,7 +47,7 @@ RSpec.describe GraphqlContentItemService do
           "details" => {
             "array" => [1, 2, 3],
             "boolean" => true,
-            "hash" => { "a": 1 },
+            "hash" => { "a" => 1 },
             "null" => nil,
             "number" => 1,
             "string" => "howdy",
@@ -59,7 +59,7 @@ RSpec.describe GraphqlContentItemService do
     expect(GraphqlContentItemService.new(result).process).to eq({ "details" => {
       "array" => [1, 2, 3],
       "boolean" => true,
-      "hash" => { "a": 1 },
+      "hash" => { "a" => 1 },
       "number" => 1,
       "string" => "howdy",
     } })

--- a/spec/services/graphql_content_item_service_spec.rb
+++ b/spec/services/graphql_content_item_service_spec.rb
@@ -65,6 +65,34 @@ RSpec.describe GraphqlContentItemService do
     } })
   end
 
+  it "deep sorts and stringifies the keys" do
+    result = {
+      "data" => {
+        "edition" => {
+          "details" => {
+            "def" => 123,
+            "abc" => {
+              initially_a_sybol_key: "value",
+            },
+            "xyz" => false,
+          },
+          "base_path" => "/world",
+        },
+      },
+    }
+
+    expect(GraphqlContentItemService.new(result).process).to eq({
+      "base_path" => "/world",
+      "details" => {
+        "abc" => {
+          "initially_a_sybol_key" => "value",
+        },
+        "def" => 123,
+        "xyz" => false,
+      },
+    })
+  end
+
   context "when the edition has been unpublished" do
     it "returns unpublishing data from the error extensions" do
       result = {

--- a/spec/services/graphql_content_item_service_spec.rb
+++ b/spec/services/graphql_content_item_service_spec.rb
@@ -71,14 +71,14 @@ RSpec.describe GraphqlContentItemService do
         "errors" => [
           {
             "message" => "Edition has been unpublished",
-            "extensions" => "presented unpublishing data",
+            "extensions" => { "a" => "hash" },
           },
         ],
         "data" => { "edition" => nil },
       }
 
       expect(GraphqlContentItemService.new(result).process)
-        .to eq("presented unpublishing data")
+        .to eq({ "a" => "hash" })
     end
   end
 


### PR DESCRIPTION
This is done in Content Store: https://github.com/alphagov/content-store/pull/1100

Without this, we can get diffs like "Applies to England and Wales" in Content Store and "Applies to Wales and England" due to the properties of details["national_applicability"] being in a different order to how Content Store returns them. This likely only affects fields with a JSON type where we can't specify the order of fields (via selections)

We need to stringify the keys before sorting - otherwise symbols and strings would be sorted separately. We wanted to stringify the keys anyway for consistency...

TODO: stringify in one commit, sort in the next
TODO: check if Richard's intelligent compact traversal mechanism could be used for sorting and stringifying without the external library