### PR TITLE
Add world location news links to world location schema

### DIFF
--- a/app/graphql/queries/news_article.graphql
+++ b/app/graphql/queries/news_article.graphql
@@ -106,6 +106,16 @@ query news_article($base_path: String!) {
           content_id
           locale
           title
+          links {
+            world_location_news {
+              analytics_identifier
+              base_path
+              content_id
+              locale
+              title
+              description
+            }
+          }
         }
         worldwide_organisations {
           analytics_identifier

--- a/app/graphql/types/edition_type.rb
+++ b/app/graphql/types/edition_type.rb
@@ -83,6 +83,7 @@ module Types
       links_field :taxons, [EditionType]
       links_field :top_level_browse_pages, [EditionType]
       links_field :topical_events, [EditionType]
+      links_field :world_location_news, [EditionType]
       links_field :world_locations, [EditionType]
       links_field :worldwide_organisation, [EditionType]
       links_field :worldwide_organisations, [EditionType]

--- a/content_schemas/dist/formats/world_location/frontend/schema.json
+++ b/content_schemas/dist/formats/world_location/frontend/schema.json
@@ -152,6 +152,10 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
+        },
+        "world_location_news": {
+          "description": "Updates, news and events from the UK government in this world location",
+          "$ref": "#/definitions/frontend_links_with_base_path"
         }
       }
     },

--- a/content_schemas/dist/formats/world_location/notification/schema.json
+++ b/content_schemas/dist/formats/world_location/notification/schema.json
@@ -170,6 +170,10 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/frontend_links_with_base_path"
+        },
+        "world_location_news": {
+          "description": "Updates, news and events from the UK government in this world location",
+          "$ref": "#/definitions/frontend_links_with_base_path"
         }
       }
     },
@@ -243,6 +247,10 @@
         },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
+          "$ref": "#/definitions/guid_list"
+        },
+        "world_location_news": {
+          "description": "Updates, news and events from the UK government in this world location",
           "$ref": "#/definitions/guid_list"
         }
       }

--- a/content_schemas/dist/formats/world_location/publisher_v2/links.json
+++ b/content_schemas/dist/formats/world_location/publisher_v2/links.json
@@ -59,6 +59,10 @@
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
           "$ref": "#/definitions/guid_list"
+        },
+        "world_location_news": {
+          "description": "Updates, news and events from the UK government in this world location",
+          "$ref": "#/definitions/guid_list"
         }
       }
     },

--- a/content_schemas/formats/world_location.jsonnet
+++ b/content_schemas/formats/world_location.jsonnet
@@ -25,5 +25,8 @@
   edition_links: (import "shared/base_edition_links.jsonnet") + {
     featured_policies: "Featured policies primarily for use with Whitehall organisations",
   },
+  links: (import "shared/base_links.jsonnet") + {
+    world_location_news: "Updates, news and events from the UK government in this world location"
+  },
   rendering_app: "optional",
 }

--- a/lib/expansion_rules.rb
+++ b/lib/expansion_rules.rb
@@ -54,6 +54,7 @@ module_function
     %i[home_page_offices contact],
     %i[worldwide_organisation sponsoring_organisations],
     %i[worldwide_organisation world_locations],
+    %i[world_locations world_location_news],
   ].freeze
 
   REVERSE_LINKS = {
@@ -110,6 +111,7 @@ module_function
   TAKE_PART_PAGE_FIELDS = (DEFAULT_FIELDS + %i[description details]).freeze
   TRAVEL_ADVICE_FIELDS = (DEFAULT_FIELDS + details_fields(:country, :change_description)).freeze
   WORLD_LOCATION_FIELDS = %i[content_id title schema_name locale analytics_identifier].freeze
+  WORLD_LOCATION_NEWS_FIELDS = DEFAULT_FIELDS_AND_DESCRIPTION
   WORLDWIDE_OFFICE_FIELDS = (DEFAULT_FIELDS + details_fields(:access_and_opening_times)).freeze
   WORLDWIDE_ORGANISATION_FIELDS = (DEFAULT_FIELDS_AND_DESCRIPTION + details_fields(:logo, :world_location_names, :default_news_image)).freeze
   LINK_COLLECTION_FIELDS = (DEFAULT_FIELDS + details_fields(:link_items)).freeze
@@ -197,6 +199,8 @@ module_function
         fields: TRAVEL_ADVICE_FIELDS },
       { document_type: :world_location,
         fields: WORLD_LOCATION_FIELDS },
+      { document_type: :world_location_news,
+        fields: WORLD_LOCATION_NEWS_FIELDS },
       { document_type: :worldwide_office,
         fields: WORLDWIDE_OFFICE_FIELDS },
       { document_type: :worldwide_organisation,

--- a/spec/lib/expansion_rules_spec.rb
+++ b/spec/lib/expansion_rules_spec.rb
@@ -58,6 +58,7 @@ RSpec.describe ExpansionRules do
     let(:step_by_step_auth_bypass_fields) { step_by_step_fields + %i[auth_bypass_ids] }
     let(:travel_advice_fields) { default_fields + [%i[details country], %i[details change_description]] }
     let(:world_location_fields) { %i[content_id title schema_name locale analytics_identifier] }
+    let(:world_location_news_fields) { default_fields_and_description }
     let(:worldwide_office_fields) { default_fields + [%i[details access_and_opening_times]] }
     let(:worldwide_organisation_fields) { default_fields_and_description + [%i[details logo]] + [%i[details world_location_names]] + [%i[details default_news_image]] }
     let(:link_collection_fields) { default_fields + [%i[details link_items]] }
@@ -120,6 +121,7 @@ RSpec.describe ExpansionRules do
     specify { expect(rules.expansion_fields(:taxon)).to eq(taxon_fields) }
     specify { expect(rules.expansion_fields(:travel_advice)).to eq(travel_advice_fields) }
     specify { expect(rules.expansion_fields(:world_location)).to eq(world_location_fields) }
+    specify { expect(rules.expansion_fields(:world_location_news)).to eq(world_location_news_fields) }
     specify { expect(rules.expansion_fields(:worldwide_organisation)).to eq(worldwide_organisation_fields) }
     specify { expect(rules.expansion_fields(:worldwide_office)).to eq(worldwide_office_fields) }
 


### PR DESCRIPTION
This will enable the frontend team to fix a bug on a number of non-English locale pages which have broken links to world location news pages. For example https://www.gov.uk/government/news/541732.cs (broken link in footer) and https://www.gov.uk/world/organisations/british-embassy-ankara.tr (broken link near top of page)

Zendesk ticket: https://govuk.zendesk.com/agent/tickets/6214134
