### PR TITLE
[PP-7366] Order reverse links by position in GraphQL

### DIFF
--- a/app/graphql/sources/reverse_linked_to_editions_source.rb
+++ b/app/graphql/sources/reverse_linked_to_editions_source.rb
@@ -10,7 +10,7 @@ module Sources
 
     def fetch(editions_and_link_types)
       all_selections = {
-        links: %i[target_content_id link_type edition_id],
+        links: %i[target_content_id link_type edition_id position],
         documents: %i[content_id],
       }
       row_number_selection = Arel.sql(
@@ -88,7 +88,7 @@ module Sources
         SQL
       )
         .where(editions: { row_number: 1 })
-        .order("editions.id")
+        .order(link_type: :asc, position: :asc, id: :asc)
 
       all_editions.each_with_object(link_types_map) { |edition, hash|
         unless hash[[edition.target_content_id, edition.link_type]].include?(edition)


### PR DESCRIPTION
b1ddb6eda4f62d58da1e3cc282c9292cf68bf7fe introduced a deterministic order for reverse links retrieved by GraphQL to address flakiness in tests that assert on the order of links (amongst other reasons?)

However, ordering by edition ID is a divergence from the behaviour of the queries powering link expansion, so we end up with inconsistencies between Content Store and Publishing API responses, and noise when diffing the two (including via frontend applications). The ordering of reverse links is arbitrary (more on this below the fold for the fellow nerd), but for migration purposes it's beneficial to minimise noise in diffs

We've decided to make things as consistent with Content Store as we can without changing anything more than the `ORDER BY` clause. For a few reasons (again, explained below the fold) this isn't enough to guarantee complete consistency with Content Store, but it should bring us closer

For their document_collections links, this:
- makes the following base path consistent with Content Store because the links have distinct positions: `/government/publications/international-qualified-teacher-status-criteria-for-providers`
- does not fix inconsistency for the following base path for which all links have a position of 0: `/government/statistics/modern-slavery-nrm-and-dtn-statistics-april-to-june-2025`

We're retaining the `editions.id` ordering (as the lowest priority sort field) to ensure that link type/position collisions continue to be handled in a deterministic way (avoiding the reintroduction of
flakiness)

There doesn't appear to be a significant effect on performance (in either direction) based on two examples of news articles with reverse links. Below are the average times in milliseconds reported by `EXPLAIN ANALYZE` for the old code and new code across five runs each

`/government/news/local-communities-urged-to-help-shape-the-natural-world-around-them`
| | old code | new code |
|---|---|---|
| **planning** | 1.9 | 1.381 |
| **execution** | 0.468 | 0.327 |

`/government/news/uk-to-observe-minutes-silence-for-victims-of-grenfell-tower-fire`
| | old code | new code |
|---|---|---|
| **planning** | 1.403 | 1.533 |
| **execution** | 0.727 | 0.759 |

---

For link expansion (and dependency resolution), the order is determined by `Queries::Links,EditionLinks}#links_results` which is used by `Queries::{Links,EditionLinks}#to` which in turn is used by `LinkReference#{linked_to,edition_links}` (and one more method for direct link set links: `#own_links`). The latter methods are used by `LinkReference#root_links_by_link_type`. Ultimately the methods in `LinkReference` merge together any collisions between the combinations of link set/edition and direct/reverse links with the following order of precedence (highest first): direct edition, reverse edition, direct link set, reverse link set. This means the way Postgres plans the query for reverse edition links would have more impact on the order of the results than the way it plans the reverse link set links query: where there are collisions, the order will be determined by the plan for the former. Our GraphQL queries are shaped differently, and we merge link set and edition links via a `UNION`, so we can't guarantee complete consistency with the link expansion code that determines the order of links for Content Store