### PR TITLE
CM-480: Remove custom 'x-govspeak-enabled' property

### DIFF
--- a/content_schemas/dist/formats/content_block_contact/notification/schema.json
+++ b/content_schemas/dist/formats/content_block_contact/notification/schema.json
@@ -494,10 +494,7 @@
                       "type": "string",
                       "default": "British Sign Language (BSL) [video relay service](https://connect.interpreterslive.co.uk/vrs) if you’re on a computer - find out how to [use the service on mobile or tablet](https://www.youtube.com/watch?v=oELNMfAvDxw)"
                     }
-                  },
-                  "x-govspeak_enabled": [
-                    "value"
-                  ]
+                  }
                 },
                 "call_charges": {
                   "type": "object",
@@ -607,10 +604,7 @@
                       "prefix",
                       "telephone_number"
                     ]
-                  },
-                  "x-govspeak_enabled": [
-                    "prefix"
-                  ]
+                  }
                 }
               }
             }

--- a/content_schemas/dist/formats/content_block_contact/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/content_block_contact/publisher_v2/schema.json
@@ -319,10 +319,7 @@
                       "type": "string",
                       "default": "British Sign Language (BSL) [video relay service](https://connect.interpreterslive.co.uk/vrs) if you’re on a computer - find out how to [use the service on mobile or tablet](https://www.youtube.com/watch?v=oELNMfAvDxw)"
                     }
-                  },
-                  "x-govspeak_enabled": [
-                    "value"
-                  ]
+                  }
                 },
                 "call_charges": {
                   "type": "object",
@@ -432,10 +429,7 @@
                       "prefix",
                       "telephone_number"
                     ]
-                  },
-                  "x-govspeak_enabled": [
-                    "prefix"
-                  ]
+                  }
                 }
               }
             }

--- a/content_schemas/formats/content_block_contact.jsonnet
+++ b/content_schemas/formats/content_block_contact.jsonnet
@@ -90,7 +90,6 @@ local utils = import "shared/utils/content_block_utils.jsonnet";
               "else": {
                 required: []
               },
-              'x-govspeak_enabled': ["prefix"],
             },
             call_charges: {
               type: "object",
@@ -147,7 +146,6 @@ local utils = import "shared/utils/content_block_utils.jsonnet";
                         default: "British Sign Language (BSL) [video relay service](https://connect.interpreterslive.co.uk/vrs) if you’re on a computer - find out how to [use the service on mobile or tablet](https://www.youtube.com/watch?v=oELNMfAvDxw)",
                     },
                 },
-                'x-govspeak_enabled': ["value"],
             },
          },
             ["title", "telephone_numbers"],


### PR DESCRIPTION
Jira [CM-480](https://gov-uk.atlassian.net/browse/CM-480)

## Remove the custom 'x-govspeak-enabled' property

Content Block Manager is now making the 'govspeak-enabled'
declarations within its own "config":

[/config/content_block_manager.yml][]

See [Content Block Manager PR 57][]

[/config/content_block_manager.yml]:
https://github.com/alphagov/content-block-manager/blob/main/config/content_block_manager.yml

[Content Block Manager PR 57]:
https://github.com/alphagov/content-block-manager/pull/57


[CM-480]: https://gov-uk.atlassian.net/browse/CM-480?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ