### PR TITLE
Eagerload `locale` for linked-to Editions

### DIFF
--- a/app/graphql/sources/linked_to_editions_source.rb
+++ b/app/graphql/sources/linked_to_editions_source.rb
@@ -11,7 +11,7 @@ module Sources
     def fetch(editions_and_link_types)
       all_selections = {
         links: %i[link_type position],
-        documents: %i[content_id],
+        documents: %i[content_id locale],
       }
       edition_id_tuples = []
       content_id_tuples = []

--- a/app/graphql/sources/reverse_linked_to_editions_source.rb
+++ b/app/graphql/sources/reverse_linked_to_editions_source.rb
@@ -11,7 +11,7 @@ module Sources
     def fetch(editions_and_link_types)
       all_selections = {
         links: %i[target_content_id link_type edition_id position],
-        documents: %i[content_id],
+        documents: %i[content_id locale],
       }
       row_number_selection = Arel.sql(
         <<~SQL,


### PR DESCRIPTION
We recently introduced a use of Edition.locale to the GraphQL EditionType's `#details` resolver 7e6a8265995573c2dda2ad9c609668f91fa8826f.

But since editions get `locale` via their document, that means that the document will be loaded from the database if it isn't already in memory for every "details" field in the GraphQL query.

We have a little hack called `attribute_or_delegate` in the Edition model that allows us to `SELECT` just the locale (also the content_id) of its document, so we don't need to eagerload the whole association.

I've been looking into the performance of a GraphQL query for a travel_advice edition and this change reduces the number of database queries needed to serve that edition from 30 to 10.