### PR TITLE
Remove /media special route

### DIFF
--- a/lib/data/special_routes.yaml
+++ b/lib/data/special_routes.yaml
@@ -268,13 +268,6 @@
   :description: "You can choose which cookies you're happy for GOV.UK to use."
   :rendering_app: "frontend"
 
-- :base_path: "/media"
-  :content_id: "cdcad470-21c6-4e19-b644-9e499de1ad12"
-  :title: "Government Uploads"
-  :description: "Handles redirects for /media/:id/:filename path for asset manager"
-  :type: "prefix"
-  :rendering_app: "government-frontend"
-
 - :base_path: "/random"
   :content_id: "3c991cea-cdee-4e58-b8d1-d38e7c0e6327"
   :title: "GOV.UK random page"


### PR DESCRIPTION
I accidentally removed this route before running the task for unpublishing it. Now that is done, so we can remove this path from special routes.

Reverts alphagov/publishing-api#3608