### PR TITLE
[PP-7356] Compact empty links

### DIFF
--- a/lib/graphql/content_item_compactor.rb
+++ b/lib/graphql/content_item_compactor.rb
@@ -25,13 +25,18 @@ private
 
   def compact_links(hash)
     links = hash["links"]
-    return hash if links.blank?
-
-    hash.merge(
-      "links" =>
-        links
-          .reject { |_link_type, content_items| content_items.empty? }
-          .transform_values { |content_items| content_items.map(&method(:compact_links)) },
-    )
+    if links.nil?
+      # In content-store all content-items have a links field, if they're empty then they're empty hashes:
+      hash.merge("links" => {})
+    else
+      # If there are no links for a particular link type, content-store doesn't include it in the response
+      # so we should remove any empty arrays:
+      hash.merge(
+        "links" =>
+          links
+            .reject { |_link_type, content_items| content_items.empty? }
+            .transform_values { |content_items| content_items.map(&method(:compact_links)) },
+      )
+    end
   end
 end

--- a/spec/lib/graphql/content_item_compactor_spec.rb
+++ b/spec/lib/graphql/content_item_compactor_spec.rb
@@ -14,45 +14,64 @@ RSpec.describe Graphql::ContentItemCompactor do
 
     context "top level fields" do
       it "should not remove fields with values" do
-        expect(compactor.compact({ "some_field" => "some value" })).to eq({ "some_field" => "some value" })
+        result = compactor.compact({ "some_field" => "some value", "links" => {} })
+        expect(result).to eq({ "some_field" => "some value", "links" => {} })
       end
 
       it "should remove optional fields with nil values" do
-        expect(compactor.compact({ "some_optional_field" => nil })).to eq({})
+        result = compactor.compact({ "some_optional_field" => nil, "links" => {} })
+        expect(result).to eq({ "links" => {} })
       end
 
       it "should not remove required fields with nil values" do
-        expect(compactor.compact({ "some_required_field" => nil })).to eq({ "some_required_field" => nil })
+        result = compactor.compact({ "some_required_field" => nil, "links" => {} })
+        expect(result).to eq({ "some_required_field" => nil, "links" => {} })
       end
     end
 
     context "details fields" do
       it "should not remove fields with values" do
-        result = compactor.compact({ "details" => { "some_field" => "some value" } })
-        expect(result).to eq({ "details" => { "some_field" => "some value" } })
+        result = compactor.compact({ "details" => { "some_field" => "some value" }, "links" => {} })
+        expect(result).to eq({ "details" => { "some_field" => "some value" }, "links" => {} })
       end
 
       it "should remove optional fields with nil values" do
-        result = compactor.compact({ "details" => { "some_optional_field" => nil } })
-        expect(result).to eq({ "details" => {} })
+        result = compactor.compact({ "details" => { "some_optional_field" => nil }, "links" => {} })
+        expect(result).to eq({ "details" => {}, "links" => {} })
       end
 
       it "should not remove required fields with nil values" do
-        result = compactor.compact("details" => { "some_required_details_field" => nil })
-        expect(result).to eq("details" => { "some_required_details_field" => nil })
+        result = compactor.compact("details" => { "some_required_details_field" => nil }, "links" => {})
+        expect(result).to eq("details" => { "some_required_details_field" => nil }, "links" => {})
       end
     end
 
     context "links" do
+      it "should add an empty links hash for a content-item with no links" do
+        result = compactor.compact({})
+        expect(result).to eq("links" => {})
+      end
+
+      it "should add empty links hashes for nested content-items with no links" do
+        result = compactor.compact("links" => {
+          "some_link_type" => [{}, {}],
+          "some_other_link_type" => [{}, {}],
+        })
+        expect(result).to eq("links" => {
+          "some_link_type" => [{ "links" => {} }, { "links" => {} }],
+          "some_other_link_type" => [{ "links" => {} }, { "links" => {} }],
+        })
+      end
+
       it "should not remove link arrays with items" do
         result = compactor.compact(
           "links" => {
-            "some_link_type" => [{ "some_content_item" => "which exists" }],
+            "some_link_type" => [{ "some_content_item" => "which exists", "links" => {} }],
           },
         )
         expect(result).to eq(
           "links" => {
-            "some_link_type" => [{ "some_content_item" => "which exists" }],
+            "some_link_type" => [{ "some_content_item" => "which exists", "links" => {} }],
           },
         )
       end


### PR DESCRIPTION
Two features to make live_content responses more similar to content store.

Firstly, we remove any empty arrays from the links hash, so if you have:

```graphql
# GraphQL
{
  links {
    some_link_type_with_no_results
  }
}
```

Instead of this:
```json
{
  "links": {
    "some_link_type_with_no_results": []
  }
}
```

You get:

```json
{
  "links": {
  }
}
```

Secondly, we handle the special case where there are no links in the query. In GraphQL you can't write this:

```graphql
{
  links
}
```

... because links requires fields. That means for queries that don't need links, we don't get a links field. But content store does include links fields, with empty hashes as the values. Like:

```json
{
  "links": {}
}
```

So we add those empty link fields to any content_items (at the top level or nested) that don't already have a links field.