### PR TITLE
[PP-7357] Deep sort GraphQL content item

### DIFF
--- a/spec/services/graphql_content_item_service_spec.rb
+++ b/spec/services/graphql_content_item_service_spec.rb
@@ -22,6 +22,44 @@ RSpec.describe GraphqlContentItemService do
     })
   end
 
+  it "deep sorts the hash, stringifying keys in the process" do
+    result = {
+      "data" => {
+        "edition" => {
+          "links" => {
+            "organisations" => [
+              { title: "The Big Dogs", base_path: "/government/big-dogs" },
+            ],
+          },
+          "title" => "The best edition yet!",
+          "details" => {
+            "zeta" => {
+              b: false,
+              a: false,
+            },
+            "beta" => 123,
+          },
+        },
+      },
+    }
+
+    expect(graphql_content_item_service.process(result)).to eq({
+      "details" => {
+        "beta" => 123,
+        "zeta" => {
+          "a" => false,
+          "b" => false,
+        },
+      },
+      "links" => {
+        "organisations" => [
+          { "base_path" => "/government/big-dogs", "title" => "The Big Dogs" },
+        ],
+      },
+      "title" => "The best edition yet!",
+    })
+  end
+
   context "when the edition has been unpublished" do
     it "returns unpublishing data from the error extensions" do
       result = {

--- a/spec/services/graphql_content_item_service_spec.rb
+++ b/spec/services/graphql_content_item_service_spec.rb
@@ -28,14 +28,14 @@ RSpec.describe GraphqlContentItemService do
         "errors" => [
           {
             "message" => "Edition has been unpublished",
-            "extensions" => "presented unpublishing data",
+            "extensions" => { "a" => "hash" },
           },
         ],
         "data" => { "edition" => nil },
       }
 
       expect(graphql_content_item_service.process(result))
-        .to eq("presented unpublishing data")
+        .to eq({ "a" => "hash" })
     end
   end
 


### PR DESCRIPTION
This is done in Content Store: https://github.com/alphagov/content-store/pull/1100

Without this, we can get diffs like "Applies to England and Wales" in Content Store and "Applies to Wales and England" due to the properties of details["national_applicability"] being in a different order to how
Content Store returns them