### PR TITLE
Add graphql query for transaction document type

### DIFF
--- a/app/graphql/queries/transaction.graphql
+++ b/app/graphql/queries/transaction.graphql
@@ -152,7 +152,6 @@ query transaction($base_path: String!) {
           api_url
           base_path
           content_id
-          description
           details {
             country
             change_description
@@ -268,7 +267,6 @@ query transaction($base_path: String!) {
           api_url
           base_path
           content_id
-          description
           details: details_json
           document_type
           links {
@@ -302,7 +300,6 @@ query transaction($base_path: String!) {
           api_url
           base_path
           content_id
-          description
           details {
             logo
             world_location_names
@@ -628,7 +625,6 @@ query transaction($base_path: String!) {
           api_url
           base_path
           content_id
-          description
           details {
             country
             change_description


### PR DESCRIPTION
Mostly generated from the build_query script, only notable edit is the removal of a few errant `description` fields.

Nested links inside `document_collections` are still returning a few false positives, but these are being addressed in seperate work.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
