### PR TITLE
[PNP-5241] Add parent/ordered_related_items to webchat special route

### DIFF
--- a/lib/data/special_routes.yaml
+++ b/lib/data/special_routes.yaml
@@ -220,6 +220,12 @@
   :title: "HM Passport Office webchat"
   :description: "Handles the webchat view for HM Passport Office"
   :rendering_app: "government-frontend"
+  :links:
+    :ordered_related_items:
+      - "89426190-c98e-4997-8149-7e0f03aecc8d"
+      - "99d076d9-a9f7-4b25-9031-85e311c01da5"
+    :parent:
+      - "3a96a1e0-21e3-4aae-8e84-f90860ed3dbf"
 
 - :base_path: "/government/uploads"
   :content_id: "5a0ca87e-0e91-4d4c-bd26-29feb24f98ab"


### PR DESCRIPTION
- At the moment, various details of the webchat are hardcoded in government-frontend. We should try to move as much as we can to the actual content item.

Audit trail:
https://github.com/alphagov/government-frontend/blob/2a1927a3a8100374593aa708525d928a7e3c51a6/lib/webchat.yaml#L10-L17

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
