### PR TITLE
Make "Read more" link text optional, and start sending "parent" link, for Topical Event About pages [WHIT-3341]

### DIFF
--- a/content_schemas/dist/formats/topical_event_about_page/frontend/schema.json
+++ b/content_schemas/dist/formats/topical_event_about_page/frontend/schema.json
@@ -273,7 +273,6 @@
     "details": {
       "type": "object",
       "required": [
-        "read_more",
         "body"
       ],
       "additionalProperties": false,

--- a/content_schemas/dist/formats/topical_event_about_page/frontend/schema.json
+++ b/content_schemas/dist/formats/topical_event_about_page/frontend/schema.json
@@ -72,12 +72,16 @@
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "emphasised_organisations": {
-          "description": "Lead organisations linked to this content item.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"
+        },
+        "government": {
+          "description": "The government associated with this document",
+          "$ref": "#/definitions/frontend_links_with_base_path",
+          "maxItems": 1
         },
         "lead_organisations": {
           "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
@@ -104,13 +108,10 @@
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "organisations": {
-          "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "parent": {
-          "description": "The parent content item.",
-          "$ref": "#/definitions/frontend_links_with_base_path",
-          "maxItems": 1
+          "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "part_of_step_navs": {
           "description": "Link type automatically added by Publishing API",
@@ -129,6 +130,9 @@
           "$ref": "#/definitions/frontend_links_with_base_path",
           "maxItems": 1
         },
+        "related_policies": {
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "related_to_step_navs": {
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -143,6 +147,9 @@
         },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
+        "topical_events": {
           "$ref": "#/definitions/frontend_links_with_base_path"
         }
       }

--- a/content_schemas/dist/formats/topical_event_about_page/notification/schema.json
+++ b/content_schemas/dist/formats/topical_event_about_page/notification/schema.json
@@ -90,12 +90,16 @@
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "emphasised_organisations": {
-          "description": "Lead organisations linked to this content item.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/frontend_links_with_base_path"
+        },
+        "government": {
+          "description": "The government associated with this document",
+          "$ref": "#/definitions/frontend_links_with_base_path",
+          "maxItems": 1
         },
         "lead_organisations": {
           "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
@@ -122,13 +126,10 @@
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "organisations": {
-          "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "parent": {
-          "description": "The parent content item.",
-          "$ref": "#/definitions/frontend_links_with_base_path",
-          "maxItems": 1
+          "$ref": "#/definitions/frontend_links_with_base_path"
         },
         "part_of_step_navs": {
           "description": "Link type automatically added by Publishing API",
@@ -147,6 +148,9 @@
           "$ref": "#/definitions/frontend_links_with_base_path",
           "maxItems": 1
         },
+        "related_policies": {
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
         "related_to_step_navs": {
           "description": "Link type automatically added by Publishing API",
           "$ref": "#/definitions/frontend_links_with_base_path"
@@ -161,6 +165,9 @@
         },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
+          "$ref": "#/definitions/frontend_links_with_base_path"
+        },
+        "topical_events": {
           "$ref": "#/definitions/frontend_links_with_base_path"
         }
       }
@@ -184,12 +191,16 @@
           "$ref": "#/definitions/guid_list"
         },
         "emphasised_organisations": {
-          "description": "Lead organisations linked to this content item.",
           "$ref": "#/definitions/guid_list"
         },
         "finder": {
           "description": "Powers links from content back to finders the content is surfaced on",
           "$ref": "#/definitions/guid_list"
+        },
+        "government": {
+          "description": "The government associated with this document",
+          "$ref": "#/definitions/guid_list",
+          "maxItems": 1
         },
         "lead_organisations": {
           "description": "DEPRECATED: A subset of organisations that should be emphasised in relation to this content item. All organisations specified here should also be part of the organisations array.",
@@ -208,13 +219,10 @@
           "$ref": "#/definitions/guid_list"
         },
         "organisations": {
-          "description": "All organisations linked to this content item. This should include lead organisations.",
           "$ref": "#/definitions/guid_list"
         },
         "parent": {
-          "description": "The parent content item.",
-          "$ref": "#/definitions/guid_list",
-          "maxItems": 1
+          "$ref": "#/definitions/guid_list"
         },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
@@ -225,8 +233,14 @@
           "$ref": "#/definitions/guid_list",
           "maxItems": 1
         },
+        "related_policies": {
+          "$ref": "#/definitions/guid_list"
+        },
         "taxons": {
           "description": "Prototype-stage taxonomy label for this content item",
+          "$ref": "#/definitions/guid_list"
+        },
+        "topical_events": {
           "$ref": "#/definitions/guid_list"
         }
       }

--- a/content_schemas/dist/formats/topical_event_about_page/notification/schema.json
+++ b/content_schemas/dist/formats/topical_event_about_page/notification/schema.json
@@ -356,7 +356,6 @@
     "details": {
       "type": "object",
       "required": [
-        "read_more",
         "body"
       ],
       "additionalProperties": false,

--- a/content_schemas/dist/formats/topical_event_about_page/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/topical_event_about_page/publisher_v2/schema.json
@@ -181,7 +181,6 @@
     "details": {
       "type": "object",
       "required": [
-        "read_more",
         "body"
       ],
       "additionalProperties": false,

--- a/content_schemas/dist/formats/topical_event_about_page/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/topical_event_about_page/publisher_v2/schema.json
@@ -73,8 +73,33 @@
           "description": "Content that will be embedded within the document, using embed tags.",
           "$ref": "#/definitions/guid_list"
         },
+        "emphasised_organisations": {
+          "$ref": "#/definitions/guid_list"
+        },
+        "government": {
+          "description": "The government associated with this document",
+          "$ref": "#/definitions/guid_list",
+          "maxItems": 1
+        },
+        "organisations": {
+          "$ref": "#/definitions/guid_list"
+        },
+        "parent": {
+          "$ref": "#/definitions/guid_list"
+        },
         "policy_areas": {
           "description": "A largely deprecated tag currently only used to power email alerts.",
+          "$ref": "#/definitions/guid_list"
+        },
+        "primary_publishing_organisation": {
+          "description": "The organisation that published the page. Corresponds to the first of the 'Lead organisations' in Whitehall, and is empty for all other publishing applications.",
+          "$ref": "#/definitions/guid_list",
+          "maxItems": 1
+        },
+        "related_policies": {
+          "$ref": "#/definitions/guid_list"
+        },
+        "topical_events": {
           "$ref": "#/definitions/guid_list"
         }
       }

--- a/content_schemas/formats/topical_event_about_page.jsonnet
+++ b/content_schemas/formats/topical_event_about_page.jsonnet
@@ -20,4 +20,5 @@
       },
     },
   },
+  edition_links: (import "shared/whitehall_edition_links.jsonnet")
 }

--- a/content_schemas/formats/topical_event_about_page.jsonnet
+++ b/content_schemas/formats/topical_event_about_page.jsonnet
@@ -5,7 +5,6 @@
       type: "object",
       additionalProperties: false,
       required: [
-        "read_more",
         "body",
       ],
       properties: {


### PR DESCRIPTION
We're likely to drop this altogether in the move to config-driven topical events.

Needed in conjunction with https://github.com/alphagov/whitehall/pull/11431

Jira: https://gov-uk.atlassian.net/browse/WHIT-3341

---

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
