### PR TITLE
[PP-7623] Expose SidekiqUniqueJobs lock info

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,6 +1,7 @@
 SidekiqUniqueJobs.configure do |config|
   config.enabled = !Rails.env.test? # SidekiqUniqueJobs recommends not testing this behaviour https://github.com/mhenrixon/sidekiq-unique-jobs#uniqueness
   config.lock_ttl = 1.hour.to_i
+  config.lock_info = true
 end
 
 Sidekiq.configure_client do |config|


### PR DESCRIPTION
We occasionally have issues with publishing where we're unable to acquire a lock for a job via SidekiqUniqueJobs. We'd like to make it easier to understand what locks are currently in place

This adds extra information to the locks created by SidekiqUniqueJobs and available via a Rails console or in the Sidekiq web UI. This includes the lock args: values that determine a job's uniqueness, which vary by job (see the individual job classes for their definitions) but generally include a base path or a content ID

Example lock info (in the console):

```rb
{
  "worker" => "DownstreamDraftJob",
  "queue" => "downstream_low",
  "limit" => nil,
  "timeout" => 0,
  "ttl" => 3600,
  "type" => "until_executing",
  "lock_args" =>
    [
      "c6c6c598-31e6-472c-9266-fd6e559e6377",
      "en",
      false,
      [],
      "DownstreamDraftJob"
    ],
  "time" => 1772740352.249766,
  "at" => nil
}
```
