### PR TITLE
Add special route for /api/places

### DIFF
--- a/lib/data/special_routes.yaml
+++ b/lib/data/special_routes.yaml
@@ -47,6 +47,13 @@
   :description: "Personalisation API exposing email subscription data for progressive enhancement of GOV.UK pages"
   :rendering_app: "account-api"
 
+- :base_path: "/api/places"
+  :content_id: "dd924c50-7b11-4ca9-bcd6-0909c9e65d42"
+  :title: "Places API"
+  :description: "GeoJSON API places list for interactive maps"
+  :type: "prefix"
+  :rendering_app: "frontend"
+
 - :base_path: "/api/search.json"
   :content_id: "0818867d-8026-482c-b797-306fb74f5a2d"
   :title: "GOV.UK search results API"


### PR DESCRIPTION
This route supplies geojson suitable for the experimental map component. If that isn't taken forward, this can be removed. 

https://gov-uk.atlassian.net/browse/PNP-9892

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
