### PR TITLE
Update Bundler

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -968,4 +968,4 @@ DEPENDENCIES
   with_advisory_lock
 
 BUNDLED WITH
-   2.5.22
+  4.0.9


### PR DESCRIPTION
The deploy action is currently failing with the following error in the `build-push-action` step (from the build-and-push-multiarch-image.yml workflow in govuk-infrastructure)

```
#16 [builder 6/6] RUN bootsnap precompile --gemfile .
#16 0.072 INFO: with_tmpdir_for_ruby: execing ruby with TMPDIR=/tmp/ruby-app-kUL2Z2k9
#16 0.125 Activating bundler (~> 2.5) failed:
#16 0.125 Could not find 'bundler' (~> 2.5) - did find: [bundler-4.0.9]
#16 0.125 Checked in 'GEM_PATH=/usr/local/lib/ruby/gems/3.4:/usr/local/bundle' , execute `gem env` for more information
#16 0.125 
#16 0.125 To install the version of bundler this project requires, run `gem install bundler -v '~> 2.5'`
#16 ERROR: process "/bin/bash -euo pipefail -c bootsnap precompile --gemfile ." did not complete successfully: exit code: 42
```

The action worked earlier today, but maybe support for this version of Bundler is no longer supported. We did just drop Ruby 3.1 support in many of our gems, and Bundler has certain requirements about Ruby versions. This webpage only mentions minimum versions for each Bundler version, but perhaps there's also a maximum:
https://bundler.io/compatibility.html. It does say that "The latest Bundler release should always support, at the very least, all rubies that have not yet reached their End of Life date" and 3.1 just reached end of life today (though we weren't on the latest Bundler release)