### PR TITLE
[PP-7685] Update Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,8 @@ updates:
       interval: weekly
       day: tuesday
       time: "07:00"
+    allow:
+      - dependency-type: direct
     cooldown:
       default-days: 3
     open-pull-requests-limit: 25

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,9 @@ updates:
   - package-ecosystem: bundler
     directory: /
     schedule:
-      interval: daily
+      interval: weekly
+      day: tuesday
+      time: "07:00"
     cooldown:
       default-days: 3
     groups:
@@ -33,12 +35,16 @@ updates:
     directory: /
     schedule:
       interval: weekly
+      day: tuesday
+      time: "07:00"
     cooldown:
       default-days: 7
 
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: daily
+      interval: weekly
+      day: tuesday
+      time: "07:00"
     cooldown:
       default-days: 3

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,21 @@ updates:
       interval: daily
     cooldown:
       default-days: 3
+    groups:
+      test:
+        patterns:
+          - "*rspec"
+          - "climate_control"
+          - "database_cleaner"
+          - "factory_bot*"
+          - "govuk_test"
+          - "pact*"
+          - "*rspec"
+          - "rspec-*"
+          - "simplecov"
+          - "stackprof"
+          - "timecop"
+          - "webmock"
 
   # Ruby needs to be upgraded manually in multiple places, so cannot
   # be upgraded by Dependabot. That effectively makes the below

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,7 @@ updates:
       time: "07:00"
     cooldown:
       default-days: 3
+    open-pull-requests-limit: 25
     groups:
       test:
         patterns:
@@ -39,6 +40,7 @@ updates:
       time: "07:00"
     cooldown:
       default-days: 7
+    open-pull-requests-limit: 25
 
   - package-ecosystem: github-actions
     directory: /
@@ -48,3 +50,4 @@ updates:
       time: "07:00"
     cooldown:
       default-days: 3
+    open-pull-requests-limit: 25

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@ updates:
     directory: /
     schedule:
       interval: daily
+    cooldown:
+      default-days: 3
 
   # Ruby needs to be upgraded manually in multiple places, so cannot
   # be upgraded by Dependabot. That effectively makes the below
@@ -16,7 +18,12 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    cooldown:
+      default-days: 7
+
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: daily
+    cooldown:
+      default-days: 3

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,23 +27,6 @@ updates:
           - "timecop"
           - "webmock"
 
-  # Ruby needs to be upgraded manually in multiple places, so cannot
-  # be upgraded by Dependabot. That effectively makes the below
-  # config redundant, as ruby is the only updatable thing in the
-  # Dockerfile, although this may change in the future. We hope this
-  # config will save a dev from trying to upgrade ruby via Dependabot.
-  - package-ecosystem: docker
-    ignore:
-      - dependency-name: ruby
-    directory: /
-    schedule:
-      interval: weekly
-      day: tuesday
-      time: "07:00"
-    cooldown:
-      default-days: 7
-    open-pull-requests-limit: 25
-
   - package-ecosystem: github-actions
     directory: /
     schedule:
@@ -52,4 +35,21 @@ updates:
       time: "07:00"
     cooldown:
       default-days: 3
+    open-pull-requests-limit: 25
+
+  # Ruby needs to be upgraded manually in multiple places, so cannot
+  # be upgraded by Dependabot. That effectively makes the below
+  # config redundant, as ruby is the only updatable thing in the
+  # Dockerfile, although this may change in the future. We hope this
+  # config will save a dev from trying to upgrade ruby via Dependabot.
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: weekly
+      day: tuesday
+      time: "07:00"
+    ignore:
+      - dependency-name: ruby
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 25


### PR DESCRIPTION
This PR refines Dependabot configuration to reduce noise and improve update safety. It introduces cooldown periods to avoid unstable releases, groups related Bundler updates and switches to a weekly Tuesday 7:00 UTC schedule.

It also increases the open PR limit to 25 to support batching, and restricts updates to direct dependencies for more relevant, manageable changes. 

Security updates remain unaffected and continue to be raised immediately.