### PR TITLE
[PP-7705] Add information about old locks to Sidekiq UI

### DIFF
--- a/app/views/sidekiq/old_lock.html.erb
+++ b/app/views/sidekiq/old_lock.html.erb
@@ -1,0 +1,33 @@
+<header>
+  <h3>
+    Old lock information for digest <%= @digest %> <a class="btn btn-default btn-xs" href="<%= root_path %>old_locks">Back</a>
+  </h3>
+</header>
+
+<h4>Retry set data </h4>
+
+<% @retry_set_data.each_with_index do |entry, index| %>
+  <h5>Entry <%= index + 1 %> of <%= @retry_set_data.size %></h5>
+  <div class="table_container">
+    <table class="table table-striped table-bordered table-hover">
+      <tbody>
+        <% entry.entries.each do |key, value| %>
+          <tr class="lock-row">
+            <th><%= key %></th>
+            <td>
+              <% if key == :queue %>
+                <a href="<%= root_path %>queues/<%= value %>"><%= value %></a>
+              <% elsif key.in?(%i[class error_class]) %>
+                <code><%= value %></code>
+              <% elsif key.in?(%i[args lock_args]) %>
+                <pre><%= value %></pre>
+              <% else %>
+                <%= value %>
+              <% end %>
+            </td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
+<% end %>

--- a/app/views/sidekiq/old_lock.html.erb
+++ b/app/views/sidekiq/old_lock.html.erb
@@ -8,6 +8,11 @@
 
 <% @retry_set_data.each_with_index do |entry, index| %>
   <h5>Entry <%= index + 1 %> of <%= @retry_set_data.size %></h5>
+  <p>
+    <a href="<%= root_path %>retries/<%= entry.delete(:retries_param) %>" %>
+      View in retries tab
+    </a>
+  </p>
   <div class="table_container">
     <table class="table table-striped table-bordered table-hover">
       <tbody>

--- a/app/views/sidekiq/old_locks.html.erb
+++ b/app/views/sidekiq/old_locks.html.erb
@@ -1,0 +1,35 @@
+<header>
+  <h3>Old locks</h3>
+</header>
+
+<p>
+  By 'old locks', we mean those that were created at least the default TTL ago
+  (<%= @default_ttl %>).
+</p>
+
+<% if @locks.any? %>
+    <div class="table_container">
+    <table class="table table-striped table-bordered table-hover">
+      <thead>
+        <tr>
+          <th>Digest</th>
+          <th>State</th>
+          <th>Since</th>
+        </tr>
+      </thead>
+      <tbody>
+        <% @locks.each do |lock| %>
+          <tr class="lock-row">
+            <td><%= lock[:digest] %></td>
+            <td><%= lock[:state] %></td>
+            <td><%= _safe_relative_time(lock[:created_at]) %></td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
+<% else %>
+  <div class="alert alert-success">
+    No old locks were found
+  </div>
+<% end %>

--- a/app/views/sidekiq/old_locks.html.erb
+++ b/app/views/sidekiq/old_locks.html.erb
@@ -20,7 +20,7 @@
       <tbody>
         <% @locks.each do |lock| %>
           <tr class="lock-row">
-            <td><%= lock[:digest] %></td>
+            <td><a href="<%= root_path %>old_locks/<%= lock[:digest] %>"><%= lock[:digest] %></a></td>
             <td><%= lock[:state] %></td>
             <td><%= _safe_relative_time(lock[:created_at]) %></td>
           </tr>

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,3 +1,5 @@
+require "sidekiq_old_locks/web"
+
 SidekiqUniqueJobs.configure do |config|
   config.enabled = !Rails.env.test? # SidekiqUniqueJobs recommends not testing this behaviour https://github.com/mhenrixon/sidekiq-unique-jobs#uniqueness
   config.lock_ttl = 1.hour.to_i

--- a/docs/sidekiq_investigation_recipes.md
+++ b/docs/sidekiq_investigation_recipes.md
@@ -1,0 +1,94 @@
+# Useful recipes for investigating issues with Sidekiq
+
+This document provides various code snippets for looking into locks/digests in
+Sidekiq/SidekiqUniqueJobs. They might prove useful when investigating suspected
+issues with the publishing queue (e.g. when updates to a document are failing).
+
+These recipes were initially developed when working on adding the [old locks][]
+'tab' to the Sidekiq web UI, which might also prove useful (as well as the
+[helper code][] that powers it). To see the Sidekiq web UI in Publishing API,
+you'll first need to set up [port forwarding][].
+
+[helper code]: https://github.com/alphagov/publishing-api/blob/main/lib/sidekiq_old_locks/web/helpers.rb
+[old locks]: http://localhost:8080/sidekiq/old_locks
+[port forwarding]: https://docs.publishing.service.gov.uk/repos/publishing-api/admin-tasks.html#viewing-the-sidekiq-ui
+
+## Digests and their creation time
+
+```rb
+# using SidekiqUniqueJobs
+SidekiqUniqueJobs::Digests.new.entries
+
+# using Sidekiq
+Sidekiq.redis { it.zscan("uniquejobs:digests", match: "*", count: 1000).to_a }.to_h
+```
+
+## Digests ready to be reaped
+
+This uses the SidekiqUniqueJobs v8 API. The API changes in v9.
+
+```rb
+Sidekiq.redis { SidekiqUniqueJobs::Orphans::RubyReaper.new(it).orphans }
+```
+
+## Digest and lock information
+
+```rb
+digest = "uniquejobs:7fd6118dc979f0376b72cb5b9291dc68"
+
+SidekiqUniqueJobs::Digests.new(digest)
+SidekiqUniqueJobs::Lock.new(digest)
+```
+
+### Locked job IDs
+
+```rb
+digest = "uniquejobs:7fd6118dc979f0376b72cb5b9291dc68"
+
+# using SidekiqUniqueJobs
+SidekiqUniqueJobs::Lock.new(digest).locked_jids
+SidekiqUniqueJobs::Redis::Hash.new(digest)
+
+# using Sidekiq
+Sidekiq.redis { it.hkeys("#{digest}:LOCKED") }
+Sidekiq.redis { it.call("HKEYS", "#{digest}:LOCKED") }
+```
+
+### Creation time by job
+
+This is the time listed in Redis for the job but it's likely equivalent to the
+digest creation time.
+
+```rb
+digest = "uniquejobs:7fd6118dc979f0376b72cb5b9291dc68"
+
+# using SidekiqUniqueJobs
+SidekiqUniqueJobs::Redis::Hash.new("#{digest}:LOCKED").entries(with_values: true)
+
+# using Sidekiq
+Sidekiq.redis { it.hgetall("#{digest}:LOCKED") }
+```
+
+### Lock TTL
+
+`-2` seems to mean the lock is past TTL; positive values are the time until TTL.
+
+```rb
+digest = "uniquejobs:7fd6118dc979f0376b72cb5b9291dc68"
+
+Sidekiq.redis { it.ttl("#{digest}:LOCKED") }
+```
+
+## Retry set
+
+```rb
+Sidekiq::RetrySet.new.entries
+```
+
+### Check if a digest is in the retry set
+
+```rb
+digest = "uniquejobs:7fd6118dc979f0376b72cb5b9291dc68"
+
+Sidekiq.redis { it.zscan("uniquejobs:digests", match: "*#{digest}*", count: 1).to_a.any? }
+```

--- a/lib/sidekiq_old_locks/web.rb
+++ b/lib/sidekiq_old_locks/web.rb
@@ -11,6 +11,13 @@ module SidekiqOldLocks
 
         erb(File.read(Rails.root.join("app/views/sidekiq/old_locks.html.erb")))
       end
+
+      app.get "/old_locks/:digest" do
+        @digest = safe_route_params(:digest)
+        @retry_set_data = old_digest_retry_set_data(@digest)
+
+        erb(File.read(Rails.root.join("app/views/sidekiq/old_lock.html.erb")))
+      end
     end
   end
 end

--- a/lib/sidekiq_old_locks/web.rb
+++ b/lib/sidekiq_old_locks/web.rb
@@ -1,0 +1,37 @@
+require "sidekiq_old_locks/web/helpers"
+
+module SidekiqOldLocks
+  module Web
+    def self.registered(app)
+      app.helpers SidekiqOldLocks::Web::Helpers
+
+      app.get "/old_locks" do
+        @locks = old_digests
+        @default_ttl = "#{SidekiqUniqueJobs.config.lock_ttl / 60} minutes"
+
+        erb(File.read(Rails.root.join("app/views/sidekiq/old_locks.html.erb")))
+      end
+    end
+  end
+end
+
+begin
+  require "delegate" unless defined?(DelegateClass)
+  require "sidekiq/web" unless defined?(Sidekiq::Web)
+
+  if Sidekiq::MAJOR >= 8
+    Sidekiq::Web.configure do |config|
+      config.register_extension(
+        SidekiqOldLocks::Web,
+        name: "unique_jobs_custom",
+        tab: ["Old Locks"],
+        index: %w[old_locks/],
+      )
+    end
+  else
+    Sidekiq::Web.register(SidekiqOldLocks::Web)
+    Sidekiq::Web.tabs["Old Locks"] = "old_locks"
+  end
+rescue NameError, LoadError => e
+  SidekiqUniqueJobs.logger.error(e)
+end

--- a/lib/sidekiq_old_locks/web/helpers.rb
+++ b/lib/sidekiq_old_locks/web/helpers.rb
@@ -19,6 +19,7 @@ module SidekiqOldLocks
           next unless entry.item["lock_digest"] == digest
 
           {
+            retries_param: "#{entry.score}-#{entry.item['jid']}",
             jid: entry.item["jid"],
             created_at: pretty_time(entry.item["created_at"]),
             failed_at: pretty_time(entry.item["failed_at"]),

--- a/lib/sidekiq_old_locks/web/helpers.rb
+++ b/lib/sidekiq_old_locks/web/helpers.rb
@@ -1,0 +1,40 @@
+module SidekiqOldLocks
+  module Web
+    module Helpers
+      def old_digests
+        SidekiqUniqueJobs::Digests.new.entries.map { |digest, created_at|
+          created_at_float = created_at.to_f
+          created_at_time = Time.zone.at(created_at_float)
+
+          next if created_at_time > expiry_window_end
+
+          { digest:, created_at: created_at_float, state: state(digest) }
+        }
+          .compact
+          .sort_by { -it[:created_at] }
+      end
+
+    private
+
+      def expiry_window_end
+        @expiry_window_end ||= Time.zone.now - SidekiqUniqueJobs.config.lock_ttl.seconds
+      end
+
+      def state(digest)
+        @reaper ||= Sidekiq.redis { SidekiqUniqueJobs::Orphans::RubyReaper.new(it) }
+
+        if @reaper.active?(digest)
+          :active
+        elsif @reaper.enqueued?(digest)
+          :enqueued
+        elsif @reaper.retried?(digest)
+          :retried
+        elsif @reaper.scheduled?(digest)
+          :scheduled
+        else
+          :unknown
+        end
+      end
+    end
+  end
+end

--- a/lib/sidekiq_old_locks/web/helpers.rb
+++ b/lib/sidekiq_old_locks/web/helpers.rb
@@ -14,6 +14,28 @@ module SidekiqOldLocks
           .sort_by { -it[:created_at] }
       end
 
+      def old_digest_retry_set_data(digest)
+        Sidekiq::RetrySet.new.entries.map { |entry|
+          next unless entry.item["lock_digest"] == digest
+
+          {
+            jid: entry.item["jid"],
+            created_at: pretty_time(entry.item["created_at"]),
+            failed_at: pretty_time(entry.item["failed_at"]),
+            enqueued_at: pretty_time(entry.item["enqueued_at"]),
+            retried_at: pretty_time(entry.item["retried_at"]),
+            retry_count: entry.item["retry_count"],
+            queue: entry.item["queue"],
+            class: entry.item["class"],
+            lock_args: JSON.pretty_generate(entry.item["lock_args"]),
+            args: JSON.pretty_generate(entry.item["args"]),
+            lock_ttl: entry.item["lock_ttl"],
+            error_class: entry.item["error_class"],
+            error_message: entry.item["error_message"],
+          }
+        }.compact
+      end
+
     private
 
       def expiry_window_end
@@ -34,6 +56,10 @@ module SidekiqOldLocks
         else
           :unknown
         end
+      end
+
+      def pretty_time(epoch_time)
+        Time.zone.at(epoch_time.to_f).to_s
       end
     end
   end

--- a/spec/lib/sidekiq_old_locks/web/helpers_spec.rb
+++ b/spec/lib/sidekiq_old_locks/web/helpers_spec.rb
@@ -179,11 +179,13 @@ RSpec.describe SidekiqOldLocks::Web::Helpers do
         "retried_at" => 1_778_116_697.778639,
       }
     end
+    let(:example_retry_set_entry_score) { 1_778_116_697.101102 }
     let(:retry_set_entries) do
       [
         instance_double(
           Sidekiq::SortedEntry,
           item: example_retry_set_entry_item,
+          score: example_retry_set_entry_score,
         ),
       ]
     end
@@ -201,6 +203,7 @@ RSpec.describe SidekiqOldLocks::Web::Helpers do
       expect(subject).to match_array(
         [
           {
+            retries_param: "1778116697.101102-d483be7120625851f37531d6",
             jid: "d483be7120625851f37531d6",
             created_at: "2026-04-30 10:07:42 UTC",
             failed_at: "2026-04-30 10:32:47 UTC",
@@ -270,8 +273,17 @@ RSpec.describe SidekiqOldLocks::Web::Helpers do
       ])
     end
 
+    it "includes a field for linking to the related entry in the retries tab" do
+      retries_param = subject.first[:retries_param]
+
+      expect(retries_param).to match(/#{example_retry_set_entry_score}/)
+      expect(retries_param).to match(/#{example_retry_set_entry_item['jid']}/)
+      expect(retries_param).to eq("1778116697.101102-d483be7120625851f37531d6")
+    end
+
     it "orders the fields in a sensible way" do
       expect(subject.first.keys).to eq(%i[
+        retries_param
         jid
         created_at
         failed_at
@@ -307,13 +319,12 @@ RSpec.describe SidekiqOldLocks::Web::Helpers do
           instance_double(
             Sidekiq::SortedEntry,
             item: example_retry_set_entry_item,
+            score: example_retry_set_entry_score,
           ),
           instance_double(
             Sidekiq::SortedEntry,
-            item: {
-              **example_retry_set_entry_item,
-              "jid" => "8732647d72711fbbd89fa1c5",
-            },
+            item: example_retry_set_entry_item,
+            score: example_retry_set_entry_score + 10,
           ),
           instance_double(
             Sidekiq::SortedEntry,
@@ -322,6 +333,7 @@ RSpec.describe SidekiqOldLocks::Web::Helpers do
               "jid" => "7078792606ac550943217ct3",
               "class" => "DownstreamLiveJob",
             },
+            score: example_retry_set_entry_score,
           ),
         ]
       end
@@ -349,6 +361,7 @@ RSpec.describe SidekiqOldLocks::Web::Helpers do
               "class" => "ClassForUnexpectedEntry",
               "lock_digest" => "uniquejobs:3a605fc8bbfeba49ab3cc7a94d37b8ca",
             },
+            score: example_retry_set_entry_score,
           ),
         ]
       end

--- a/spec/lib/sidekiq_old_locks/web/helpers_spec.rb
+++ b/spec/lib/sidekiq_old_locks/web/helpers_spec.rb
@@ -130,4 +130,233 @@ RSpec.describe SidekiqOldLocks::Web::Helpers do
       end
     end
   end
+
+  describe "#old_digest_retry_set_data" do
+    subject { test_class_instance.old_digest_retry_set_data(digest) }
+
+    let(:example_retry_set_entry_item) do
+      {
+        "retry" => true,
+        "queue" => "downstream_low",
+        "lock" => "until_executing",
+        "lock_args_method" => "uniq_args",
+        "on_conflict" => "log",
+        "class" => "DownstreamDraftJob",
+        "args" => [
+          {
+            "content_id" => "5f4cdd5a-7631-11e4-a3cb-005056011aef",
+            "locale" => "en",
+            "update_dependencies" => false,
+            "dependency_resolution_source_content_id" => "16628142-57b2-4611-bc03-5912785acee3",
+            "source_command" => "put_content",
+            "source_fields" => %w[details],
+          },
+        ],
+        "jid" => "d483be7120625851f37531d6",
+        "created_at" => 1_777_543_662.566768,
+        "traceparent" => "blah",
+        "baggage" => "sentry data",
+        "trace_propagation_headers" => {
+          "sentry-trace" => "an ID",
+          "baggage" => "sentry data",
+        },
+        "lock_timeout" => 0,
+        "lock_ttl" => 3600,
+        "lock_prefix" => "uniquejobs",
+        "lock_args" => [
+          "5f4cdd5a-7631-11e4-a3cb-005056011aef",
+          "en",
+          false,
+          [],
+          "DownstreamDraftJob",
+        ],
+        "lock_digest" => digest,
+        "enqueued_at" => 1_778_116_697.653957,
+        "error_message" => "Can't send unpublished item to draft content store, as there is a draft occupying the same base path",
+        "error_class" => "DownstreamDraftExistsError",
+        "failed_at" => 1_777_545_167.352332,
+        "retry_count" => 20,
+        "retried_at" => 1_778_116_697.778639,
+      }
+    end
+    let(:retry_set_entries) do
+      [
+        instance_double(
+          Sidekiq::SortedEntry,
+          item: example_retry_set_entry_item,
+        ),
+      ]
+    end
+
+    before do
+      allow(Sidekiq::RetrySet)
+        .to receive(:new)
+        .and_return(instance_double(
+                      Sidekiq::RetrySet,
+                      entries: retry_set_entries,
+                    ))
+    end
+
+    it "returns an array of hashes with retry set data for the given digest" do
+      expect(subject).to match_array(
+        [
+          {
+            jid: "d483be7120625851f37531d6",
+            created_at: "2026-04-30 10:07:42 UTC",
+            failed_at: "2026-04-30 10:32:47 UTC",
+            enqueued_at: "2026-05-07 01:18:17 UTC",
+            retried_at: "2026-05-07 01:18:17 UTC",
+            retry_count: 20,
+            queue: "downstream_low",
+            class: "DownstreamDraftJob",
+            lock_args: <<~LOCK_ARGS.chomp,
+              [
+                "5f4cdd5a-7631-11e4-a3cb-005056011aef",
+                "en",
+                false,
+                [],
+                "DownstreamDraftJob"
+              ]
+            LOCK_ARGS
+            args: <<~ARGS.chomp,
+              [
+                {
+                  "content_id": "5f4cdd5a-7631-11e4-a3cb-005056011aef",
+                  "locale": "en",
+                  "update_dependencies": false,
+                  "dependency_resolution_source_content_id": "16628142-57b2-4611-bc03-5912785acee3",
+                  "source_command": "put_content",
+                  "source_fields": [
+                    "details"
+                  ]
+                }
+              ]
+            ARGS
+            lock_ttl: 3600,
+            error_class: "DownstreamDraftExistsError",
+            error_message: "Can't send unpublished item to draft content store, as there is a draft occupying the same base path",
+          },
+        ],
+      )
+    end
+
+    it "includes only a subset of fields from retry set entries" do
+      expect(subject.first.keys).to include(*%i[
+        args
+        class
+        created_at
+        enqueued_at
+        error_class
+        error_message
+        failed_at
+        jid
+        lock_args
+        lock_ttl
+        queue
+        retried_at
+        retry_count
+      ])
+
+      expect(subject.first.keys).not_to include(*%i[
+        lock
+        lock_args_method
+        lock_digest
+        lock_prefix
+        lock_timeout
+        on_conflict
+        retry
+        trace_propagation_headers
+        traceparent
+      ])
+    end
+
+    it "orders the fields in a sensible way" do
+      expect(subject.first.keys).to eq(%i[
+        jid
+        created_at
+        failed_at
+        enqueued_at
+        retried_at
+        retry_count
+        queue
+        class
+        lock_args
+        args
+        lock_ttl
+        error_class
+        error_message
+      ])
+    end
+
+    it "uses a human-readable date format" do
+      expect(
+        subject.first.slice(*%i[created_at failed_at enqueued_at retried_at]),
+      ).to eq(
+        {
+          created_at: "2026-04-30 10:07:42 UTC",
+          failed_at: "2026-04-30 10:32:47 UTC",
+          enqueued_at: "2026-05-07 01:18:17 UTC",
+          retried_at: "2026-05-07 01:18:17 UTC",
+        },
+      )
+    end
+
+    context "when there are multiple retry set entries for the given digest" do
+      let(:retry_set_entries) do
+        [
+          instance_double(
+            Sidekiq::SortedEntry,
+            item: example_retry_set_entry_item,
+          ),
+          instance_double(
+            Sidekiq::SortedEntry,
+            item: {
+              **example_retry_set_entry_item,
+              "jid" => "8732647d72711fbbd89fa1c5",
+            },
+          ),
+          instance_double(
+            Sidekiq::SortedEntry,
+            item: {
+              **example_retry_set_entry_item,
+              "jid" => "7078792606ac550943217ct3",
+              "class" => "DownstreamLiveJob",
+            },
+          ),
+        ]
+      end
+
+      it "includes all of them" do
+        expect(subject.size).to eq(3)
+      end
+    end
+
+    context "when there are retry set entries for other digests" do
+      let(:retry_set_entries) do
+        [
+          instance_double(
+            Sidekiq::SortedEntry,
+            item: {
+              **example_retry_set_entry_item,
+              "class" => "ClassForExpectedEntry",
+            },
+            score: example_retry_set_entry_score,
+          ),
+          instance_double(
+            Sidekiq::SortedEntry,
+            item: {
+              **example_retry_set_entry_item,
+              "class" => "ClassForUnexpectedEntry",
+              "lock_digest" => "uniquejobs:3a605fc8bbfeba49ab3cc7a94d37b8ca",
+            },
+          ),
+        ]
+      end
+
+      it "excludes them" do
+        expect(subject.size).to eq(1)
+        expect(subject.first[:class]).to eq("ClassForExpectedEntry")
+      end
+    end
+  end
 end

--- a/spec/lib/sidekiq_old_locks/web/helpers_spec.rb
+++ b/spec/lib/sidekiq_old_locks/web/helpers_spec.rb
@@ -1,0 +1,133 @@
+class TestClass
+  include SidekiqOldLocks::Web::Helpers
+end
+
+RSpec.describe SidekiqOldLocks::Web::Helpers do
+  let(:test_class_instance) { TestClass.new }
+  let(:digest) { "uniquejobs:f2f8d140b3191770c992ad238c95dbb9" }
+
+  describe "#old_digests" do
+    let(:digest_entries) { { digest => "1778154689.8511593" } }
+    let(:mock_reaper) { instance_double(SidekiqUniqueJobs::Orphans::RubyReaper) }
+
+    before do
+      allow(SidekiqUniqueJobs::Digests)
+        .to receive(:new)
+        .and_return(instance_double(
+                      SidekiqUniqueJobs::Digests,
+                      entries: digest_entries,
+                    ))
+      allow(SidekiqUniqueJobs::Orphans::RubyReaper)
+        .to receive(:new)
+        .and_return(mock_reaper)
+    end
+
+    subject { test_class_instance.old_digests }
+
+    it "returns an array of hashes with basic lock digest information" do
+      allow(mock_reaper).to receive(:active?).and_return(true)
+
+      expect(subject).to match_array(
+        [{ digest:, created_at: 1_778_154_689.8511593, state: :active }],
+      )
+    end
+
+    context "when the digest has existed for at least the default TTL" do
+      let(:digest_entries) { { digest => (Time.zone.now - 3600.seconds).to_f.to_s } }
+
+      before do
+        allow(SidekiqUniqueJobs)
+          .to receive_message_chain(:config, :lock_ttl)
+          .and_return(3600)
+        allow(mock_reaper).to receive(:active?).and_return(true)
+      end
+
+      it "includes the digest" do
+        expect(subject).not_to be_empty
+      end
+    end
+
+    context "when the digest has existed for less than the default TTL" do
+      let(:digest_entries) { { digest => Time.zone.now.to_f.to_s } }
+
+      before do
+        allow(SidekiqUniqueJobs)
+          .to receive_message_chain(:config, :lock_ttl)
+          .and_return(3600)
+      end
+
+      it "ignores the digest" do
+        expect(subject).to be_empty
+      end
+    end
+
+    context "with an active digest" do
+      before { allow(mock_reaper).to receive(:active?).and_return(true) }
+
+      it "includes accurate state information" do
+        expect(subject).to match_array([hash_including(state: :active)])
+      end
+    end
+
+    context "with an enqueued digest" do
+      before do
+        allow(mock_reaper).to receive_messages(active?: false, enqueued?: true)
+      end
+
+      it "includes accurate state information" do
+        expect(subject).to match_array([hash_including(state: :enqueued)])
+      end
+    end
+
+    context "with a retried digest" do
+      before do
+        allow(mock_reaper).to receive_messages(
+          active?: false,
+          enqueued?: false,
+          retried?: true,
+        )
+      end
+
+      it "includes accurate state information" do
+        expect(subject).to match_array([hash_including(state: :retried)])
+      end
+    end
+
+    context "with a scheduled digest" do
+      before do
+        allow(mock_reaper).to receive_messages(
+          active?: false,
+          enqueued?: false,
+          retried?: false,
+          scheduled?: true,
+        )
+      end
+
+      it "includes accurate state information" do
+        expect(subject).to match_array([hash_including(state: :scheduled)])
+      end
+    end
+
+    context "with multiple old digests" do
+      let(:digest_entries) do
+        {
+          digest => "1778154689.8511593",
+          "uniquejobs:3a605fc8bbfeba49ab3cc7a94d37b8ca" => "1778136727.1882838",
+          "uniquejobs:89d09fafa861031d4882a7499e12b171" => "1778116239.961951",
+          "uniquejobs:e8a6a3befa0ee0edf2096d3d94adb5f9" => "1778168687.9721427",
+        }
+      end
+
+      before { allow(mock_reaper).to receive(:active?).and_return(true) }
+
+      it "sorts the digest hashes by created time, newest first" do
+        expect(subject).to match_array([
+          hash_including(created_at: 1_778_168_687.9721427),
+          hash_including(created_at: 1_778_154_689.8511593),
+          hash_including(created_at: 1_778_136_727.1882838),
+          hash_including(created_at: 1_778_116_239.961951),
+        ])
+      end
+    end
+  end
+end

--- a/spec/requests/sidekiq_old_jobs_spec.rb
+++ b/spec/requests/sidekiq_old_jobs_spec.rb
@@ -10,4 +10,18 @@ RSpec.describe "Sidekiq old jobs", type: :request do
       expect(response.body).to include("Old locks")
     end
   end
+
+  describe "GET /sidekiq/old_locks/:digest" do
+    before { get "/sidekiq/old_locks/uniquejobs:f2f8d140b3191770c992ad238c95dbb9" }
+
+    it "responds with a 200" do
+      expect(response.status).to eq(200)
+    end
+
+    it "presents information about a specific old lock" do
+      expect(response.body).to include(
+        "Old lock information for digest uniquejobs:f2f8d140b3191770c992ad238c95dbb9",
+      )
+    end
+  end
 end

--- a/spec/requests/sidekiq_old_jobs_spec.rb
+++ b/spec/requests/sidekiq_old_jobs_spec.rb
@@ -1,0 +1,13 @@
+RSpec.describe "Sidekiq old jobs", type: :request do
+  describe "GET /sidekiq/old_locks" do
+    before { get "/sidekiq/old_locks" }
+
+    it "responds with a 200" do
+      expect(response.status).to eq(200)
+    end
+
+    it "presents information about old locks" do
+      expect(response.body).to include("Old locks")
+    end
+  end
+end


### PR DESCRIPTION
This adds a 'tab' to the Sidekiq web UI which provides:
- a table listing locks whose digests were created at least the default lock TTL ago (one hour at the time of writing)
- links from that table to retry set information on each digest (the locks usually if not always hang around because of working their way through retries)

It also records various recipes I noted down while working on this and which might prove useful to future Sidekiq investigators

## Screenshots

### Old locks

<img width="2368" height="6146" alt="image" src="https://github.com/user-attachments/assets/d2e57e5b-97d1-4373-99ea-9bbf0d8743c3" />

### With no data

<img width="2368" height="1714" alt="image" src="https://github.com/user-attachments/assets/3b09b9cf-2ed2-444c-afd3-45f66f3f01a7" />

### Old lock information for a specific digest

<img width="2368" height="4157" alt="image" src="https://github.com/user-attachments/assets/cc918c08-09be-4114-ae2f-7f71a99290e6" />
