### PR TITLE
Fix linting error

### DIFF
--- a/app/views/sidekiq/old_lock.html.erb
+++ b/app/views/sidekiq/old_lock.html.erb
@@ -9,7 +9,7 @@
 <% @retry_set_data.each_with_index do |entry, index| %>
   <h5>Entry <%= index + 1 %> of <%= @retry_set_data.size %></h5>
   <p>
-    <a href="<%= root_path %>retries/<%= entry.delete(:retries_param) %>" %>
+    <a href="<%= root_path %>retries/<%= entry.delete(:retries_param) %>">
       View in retries tab
     </a>
   </p>


### PR DESCRIPTION
⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

This application is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.

## What
Fix a syntax error in an erb file.

## Why
Multiple PRs are currently failing in `govuk_publishing_components` because the pre merge checks include linting of the gem itself plus any dependencies, including `publishing-api`. There are multiple linting errors in that file but I think they stem from this initial typo.

Causing problems like this: https://github.com/alphagov/govuk_publishing_components/actions/runs/25788234714/job/75746836541?pr=5456