### PR TITLE
[PP-7606] Add error codes to 422 responses

### DIFF
--- a/app/commands/base_command.rb
+++ b/app/commands/base_command.rb
@@ -6,16 +6,14 @@ module Commands
       logger.debug "#{self} called with payload:\n#{payload}"
 
       response = EventLogger.log_command(self, payload) do |event|
-        PublishingAPI.service(:statsd).time(name.gsub(/:+/, ".")) do
-          new(
-            payload,
-            event:,
-            downstream:,
-            callbacks:,
-            nested:,
-            **options,
-          ).call
-        end
+        new(
+          payload,
+          event: event,
+          downstream: downstream,
+          callbacks: callbacks,
+          nested: nested,
+          **options,
+        ).call
       end
 
       execute_callbacks(callbacks) unless nested

--- a/app/commands/base_command.rb
+++ b/app/commands/base_command.rb
@@ -82,7 +82,7 @@ module Commands
           },
         }
 
-        raise_command_error(409, "Conflict", fields, friendly_message:)
+        raise_command_error(409, "Conflict", fields, error_code: :conflict, friendly_message:)
       end
 
       current_version

--- a/app/commands/base_command.rb
+++ b/app/commands/base_command.rb
@@ -47,15 +47,18 @@ module Commands
     def self.raise_validation_command_error(error)
       errors = error.record.errors
       full_message = errors.full_messages.join(", ")
+      error_code = errors.count == 1 ? errors.first.details[:code] : :multiple_validation_errors
 
       raise CommandError.new(
         code: 422,
+        error_code: error_code,
         message: full_message,
         error_details: {
           error: {
             code: 422,
             message: full_message,
-            fields: errors.to_hash,
+            error_code: error_code,
+            fields: errors.details,
           },
         },
       )
@@ -85,9 +88,10 @@ module Commands
       current_version
     end
 
-    def raise_command_error(code, message, fields, friendly_message: nil)
+    def raise_command_error(code, message, fields, error_code: nil, friendly_message: nil)
       raise CommandError.new(
         code:,
+        **(code == 422 ? { error_code: error_code } : {}),
         message:,
         error_details: {
           error: {

--- a/app/commands/delete_publish_intent.rb
+++ b/app/commands/delete_publish_intent.rb
@@ -31,6 +31,7 @@ module Commands
       {
         error: {
           code: upstream_error.code,
+          **(upstream_error.code == 422 ? { error_code: :content_store_validation_failed } : {}),
           message: upstream_error.message,
           fields: (upstream_error.error_details || {}).fetch("errors", {}),
         },

--- a/app/commands/unreserve_path.rb
+++ b/app/commands/unreserve_path.rb
@@ -24,7 +24,7 @@ module Commands
       return if reservation.publishing_app == publishing_app
 
       msg = "#{base_path} is reserved by #{reservation.publishing_app}"
-      raise CommandError.new(code: 422, message: msg)
+      raise CommandError.new(code: 422, message: msg, error_code: :base_path_already_in_use)
     end
   end
 end

--- a/app/commands/v2/discard_draft.rb
+++ b/app/commands/v2/discard_draft.rb
@@ -27,7 +27,7 @@ module Commands
         code = document.published_or_unpublished.present? ? 422 : 404
         message = "There is not a draft edition of this document to discard"
 
-        raise CommandError.new(code:, message:)
+        raise CommandError.new(code:, message:, error_code: :no_draft_to_discard)
       end
 
       def delete_draft_from_database

--- a/app/commands/v2/patch_link_set.rb
+++ b/app/commands/v2/patch_link_set.rb
@@ -51,6 +51,7 @@ module Commands
 
         raise CommandError.new(
           code: 422,
+          error_code: :bulk_publishing_flag_missing,
           message: "A value for bulk_publishing is required",
           error_details: {
             error: {
@@ -82,6 +83,7 @@ module Commands
           raise CommandError.new(
             code: 422,
             message: "Links are required",
+            error_code: :links_missing,
             error_details: {
               error: {
                 code: 422,

--- a/app/commands/v2/publish.rb
+++ b/app/commands/v2/publish.rb
@@ -101,6 +101,7 @@ module Commands
                 update_type: ["is invalid"],
               },
             },
+            error_code: :update_type_missing,
           )
         elsif !valid_update_types.include?(update_type)
           raise_command_error(
@@ -111,6 +112,7 @@ module Commands
                 update_type: ["must be one of #{valid_update_types.inspect}"],
               },
             },
+            error_code: :update_type_invalid,
           )
         end
       end

--- a/app/commands/v2/put_content.rb
+++ b/app/commands/v2/put_content.rb
@@ -92,6 +92,7 @@ module Commands
 
         raise CommandError.new(
           code: 422,
+          error_code: :bulk_publishing_flag_missing,
           message: "A value for bulk_publishing is required",
           error_details: {
             error: {
@@ -133,7 +134,11 @@ module Commands
         if (content_id_alias = ContentIdAlias.find_by(name: content_id_alias_name))
           return if content_id_alias.content_id == payload[:content_id]
 
-          raise CommandError.new(code: 422, message: "ContentIdAlias with name \"#{content_id_alias_name}\" exists for a different content ID.")
+          raise CommandError.new(
+            code: 422,
+            error_code: :content_id_alias_already_in_use,
+            message: "ContentIdAlias with name \"#{content_id_alias_name}\" exists for a different content ID.",
+          )
         end
 
         ContentIdAlias.create!(name: content_id_alias_name, content_id: payload[:content_id])

--- a/app/commands/v2/put_content_validator.rb
+++ b/app/commands/v2/put_content_validator.rb
@@ -21,6 +21,7 @@ module Commands
         message = "The payload did not conform to the schema"
         raise CommandError.new(
           code: 422,
+          error_code: :schema_validation_failed,
           message:,
           error_details: schema_validator.errors,
         )
@@ -33,6 +34,7 @@ module Commands
         message = "publishing_app is required"
         raise CommandError.new(
           code:,
+          error_code: :publishing_app_missing,
           message:,
           error_details: {
             error: {

--- a/app/commands/v2/unpublish.rb
+++ b/app/commands/v2/unpublish.rb
@@ -44,7 +44,7 @@ module Commands
 
       def raise_invalid_unpublishing_type
         message = "#{unpublishing_type} is not a valid unpublishing type"
-        raise_command_error(422, message, { fields: {} })
+        raise_command_error(422, message, { fields: {} }, error_code: :type_invalid)
       end
 
       def edition
@@ -54,7 +54,7 @@ module Commands
       def validate_allow_discard_draft
         if payload[:allow_draft] && payload[:discard_drafts]
           message = "allow_draft and discard_drafts cannot be used together"
-          raise_command_error(422, message, { fields: {} })
+          raise_command_error(422, message, { fields: {} }, error_code: :conflicting_unpublishing_flags)
         end
       end
 
@@ -79,7 +79,7 @@ module Commands
             )
           else
             message = "Cannot unpublish with a draft present"
-            raise_command_error(422, message, { fields: {} })
+            raise_command_error(422, message, { fields: {} }, error_code: :cannot_unpublish_with_draft)
           end
         end
       end
@@ -102,7 +102,9 @@ module Commands
             .merge(redirects:),
         )
       rescue ActiveRecord::RecordInvalid => e
-        raise_command_error(422, e.message, { fields: {} })
+        errors = e.record.errors
+        error_code = errors.count == 1 ? errors.first.details[:code] : :multiple_validation_errors
+        raise_command_error(422, e.message, { fields: errors.details }, error_code: error_code)
       end
 
       def redirects

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -16,9 +16,11 @@ private
   def parameter_missing_error(error)
     error = CommandError.new(
       code: 422,
+      error_code: :parameter_missing_or_invalid,
       error_details: {
         error: {
           code: 422,
+          error_code: :parameter_missing_or_invalid,
           message: error.message,
         },
       },

--- a/app/errors/command_error.rb
+++ b/app/errors/command_error.rb
@@ -10,11 +10,7 @@ class CommandError < StandardError
     return if e.code == 404 && ignore_404s
 
     # ignore payload_version conflicts
-    if e.code == 409 && e.message =~ /transmitted_at|payload_version/
-      Rails.logger.debug e.message
-      PublishingAPI.service(:statsd).increment("payload_version_conflicts")
-      return
-    end
+    return if e.code == 409 && e.message =~ /transmitted_at|payload_version/
 
     fields = if e.error_details.present?
                e.error_details.fetch("errors", {})

--- a/app/errors/command_error.rb
+++ b/app/errors/command_error.rb
@@ -1,5 +1,5 @@
 class CommandError < StandardError
-  attr_reader :code, :error_details
+  attr_reader :code, :error_code, :error_details
 
   def self.with_error_handling(ignore_404s: false, &block)
     block.call
@@ -22,6 +22,7 @@ class CommandError < StandardError
       error_details: {
         error: {
           code: e.code,
+          **(e.code == 422 ? { error_code: :content_store_validation_failed } : {}),
           message: e.message,
           fields:,
         },
@@ -32,16 +33,18 @@ class CommandError < StandardError
   end
 
   # error_details: Hash(field_name: String => [error_messages]: Array(String))
-  def initialize(code:, message: nil, error_details: nil)
+  def initialize(code:, message: nil, error_code: nil, error_details: nil)
     raise "Invalid code #{code}" unless valid_code?(code)
 
     @code = code
+    @error_code = error_code
     @error_details = if error_details
                        error_details
                      elsif message
                        {
                          "error" => {
                            "code" => code,
+                           **(error_code ? { "error_code" => error_code } : {}),
                            "message" => message,
                          },
                        }

--- a/app/errors/command_error.rb
+++ b/app/errors/command_error.rb
@@ -19,6 +19,7 @@ class CommandError < StandardError
              end
     raise CommandError.new(
       code: e.code,
+      **(e.code == 422 ? { error_code: :content_store_validation_failed } : {}),
       error_details: {
         error: {
           code: e.code,

--- a/app/errors/command_error.rb
+++ b/app/errors/command_error.rb
@@ -1,6 +1,65 @@
 class CommandError < StandardError
   attr_reader :code, :error_code, :error_details
 
+  ERROR_CODES = %i[
+    absolute_path_invalid
+    action_invalid
+    base_path_already_in_use
+    base_path_invalid
+    base_path_too_long
+    bulk_publishing_flag_missing
+    cannot_unpublish_with_draft
+    conflict
+    conflicting_unpublishing_flags
+    content_id_alias_already_in_use
+    content_store_validation_failed
+    dns_hostname_invalid
+    edition_missing
+    edition_not_unique
+    embedded_content_alias_not_found
+    embedded_content_alias_not_found
+    embedded_content_not_found
+    explanation_missing_for_withdrawal
+    fields_parameter_missing
+    links_missing
+    multiple_validation_errors
+    no_draft_to_discard
+    order_field_invalid
+    parameter_missing_or_invalid
+    publishing_app_missing
+    redirect_destination_invalid
+    redirect_destination_missing
+    redirect_external_disallowed_domain
+    redirect_external_govuk_should_be_internal
+    redirect_external_missing_host
+    redirect_external_not_https
+    redirect_fragment_not_allowed_with_preserve
+    redirect_path_equals_destination
+    redirect_path_missing
+    redirect_paths_not_unique
+    redirect_query_not_allowed_with_preserve
+    redirect_subdomain_invalid_chars
+    redirect_subdomain_starts_with_hyphen
+    redirect_subdomain_too_long
+    redirects_missing_for_redirect
+    redirects_must_include_base_path
+    route_not_below_base_path
+    route_path_missing
+    route_paths_not_unique
+    route_type_invalid
+    route_type_missing
+    route_unsupported_keys
+    routes_must_include_base_path
+    schema_validation_failed
+    type_invalid
+    type_missing
+    unsupported_version_parameter
+    update_type_invalid
+    update_type_missing
+    uuid_invalid
+    validation_failed
+  ].freeze
+
   def self.with_error_handling(ignore_404s: false, &block)
     block.call
   rescue GdsApi::HTTPServerError => e
@@ -36,6 +95,9 @@ class CommandError < StandardError
   # error_details: Hash(field_name: String => [error_messages]: Array(String))
   def initialize(code:, message: nil, error_code: nil, error_details: nil)
     raise "Invalid code #{code}" unless valid_code?(code)
+
+    notify_or_raise("Descriptive error code missing for 422 error") if code == 422 && error_code.nil?
+    notify_or_raise("Unknown error_code: #{error_code}. Code must be included in ERROR_CODES") if error_code && !ERROR_CODES.include?(error_code)
 
     @code = code
     @error_code = error_code
@@ -86,5 +148,11 @@ class CommandError < StandardError
   # request. The request has not been processed and the client should retry.
   def server_error?
     (500..599).cover?(code)
+  end
+
+  def notify_or_raise(message)
+    return GovukError.notify(message, level: "warning") if Rails.env.production?
+
+    raise ArgumentError, message
   end
 end

--- a/app/models/action.rb
+++ b/app/models/action.rb
@@ -49,4 +49,14 @@ class Action < ApplicationRecord
     after_links = link_set.links.to_a
     LinkChangeService.new(action, before_links, after_links).record
   end
+
+  def save!(*args)
+    super
+  rescue ActiveRecord::RecordInvalid => e
+    e.record.errors.each do |error|
+      error.options[:code] ||= :action_invalid
+    end
+
+    raise e
+  end
 end

--- a/app/models/path_reservation.rb
+++ b/app/models/path_reservation.rb
@@ -13,6 +13,10 @@ class PathReservation < ApplicationRecord
     else
       existing.ensure_unique(publishing_app)
     end
+  rescue ActiveRecord::RecordInvalid => e
+    add_error_codes!(e.record)
+
+    raise e
   end
 
   def self.create_path_reservation(base_path, publishing_app)
@@ -38,11 +42,22 @@ class PathReservation < ApplicationRecord
 
   def already_reserved_error
     msg = "#{base_path} is already reserved by #{publishing_app}"
-    errors.add(:base_path, msg)
+    errors.add(:base_path, msg, code: :base_path_already_in_use)
     ActiveRecord::RecordInvalid.new(self)
   end
 
   def base_path_not_too_long
-    errors.add(:base_path, "over 512 bytes") if base_path.bytesize > 512
+    errors.add(:base_path, "over 512 bytes", code: :base_path_too_long) if base_path.bytesize > 512
+  end
+
+  ERROR_CODE_MAP = {
+    %i[publishing_app blank] => :publishing_app_missing,
+    %i[base_path invalid] => :base_path_invalid,
+  }.freeze
+
+  def self.add_error_codes!(record)
+    record.errors.each do |error|
+      error.options[:code] ||= ERROR_CODE_MAP[[error.attribute, error.type]] || :validation_failed
+    end
   end
 end

--- a/app/models/unpublishing.rb
+++ b/app/models/unpublishing.rb
@@ -42,4 +42,29 @@ class Unpublishing < ApplicationRecord
   def self.is_substitute?(edition)
     where(edition:).pick(:type) == "substitute"
   end
+
+  def save!(*args)
+    super
+  rescue ActiveRecord::RecordInvalid => e
+    add_error_codes!(e.record)
+
+    raise e
+  end
+
+private
+
+  ERROR_CODE_MAP = {
+    %i[edition blank] => :edition_missing,
+    %i[edition taken] => :edition_not_unique,
+    %i[type blank] => :type_missing,
+    %i[type inclusion] => :type_invalid,
+    %i[explanation blank] => :explanation_missing_for_withdrawal,
+    %i[redirects blank] => :redirects_missing_for_redirect,
+  }.freeze
+
+  def add_error_codes!(record)
+    record.errors.each do |error|
+      error.options[:code] ||= ERROR_CODE_MAP[[error.attribute, error.type]] || :validation_failed
+    end
+  end
 end

--- a/app/pagination.rb
+++ b/app/pagination.rb
@@ -49,12 +49,16 @@ private
   def raise_unless_valid_order_field(field)
     return if valid_order_fields.include?(field)
 
-    message = "Invalid order field: #{field}."
-    message += " Valid order fields: [#{valid_order_fields.join(', ')}]"
+    message = <<~MESSAGE.squish
+      The order parameter contains an unsupported field "#{field}".
+      Supported fields are: #{valid_order_fields.join(', ')}.
+      Prefix a field with "-" to sort in descending order.
+    MESSAGE
 
     raise CommandError.new(
       code: 422,
       message: "Invalid order field: #{field}",
+      error_code: :order_field_invalid,
       error_details: {
         error: {
           code: 422,

--- a/app/presenters/content_embed_presenter.rb
+++ b/app/presenters/content_embed_presenter.rb
@@ -54,6 +54,7 @@ module Presenters
         else
           GovukError.notify(CommandError.new(
                               code: 422,
+                              error_code: :embedded_content_not_found,
                               message: "Could not find a live edition for embedded content ID: #{content_reference.identifier}",
                             ))
         end

--- a/app/queries/get_content.rb
+++ b/app/queries/get_content.rb
@@ -1,7 +1,7 @@
 module Queries
   module GetContent
     def self.call(content_id, locale = nil, version: nil, include_warnings: false, content_store: nil)
-      raise CommandError.new(code: 422, message: "version parameter no longer supported in get_content") if version
+      raise CommandError.new(code: 422, error_code: :unsupported_version_parameter, message: "version parameter no longer supported in get_content") if version
 
       locale_to_use = locale || Edition::DEFAULT_LOCALE
 

--- a/app/queries/get_linked.rb
+++ b/app/queries/get_linked.rb
@@ -49,6 +49,7 @@ module Queries
 
       if fields.empty?
         code = 422
+        error_code = :fields_parameter_missing
         message = "Fields must be provided"
       else
         code = 400
@@ -57,6 +58,7 @@ module Queries
 
       raise CommandError.new(
         code:,
+        **(code == 422 ? { error_code: error_code } : {}),
         error_details: {
           error: {
             code:,

--- a/app/services/embedded_content_finder_service.rb
+++ b/app/services/embedded_content_finder_service.rb
@@ -33,7 +33,10 @@ private
     not_found_content_ids = identifiers - found_content_ids
 
     if not_found_content_ids.any?
-      log_error "Could not find any live editions for embedded content IDs: #{not_found_content_ids.join(', ')}"
+      log_error(
+        "Could not find any live editions for embedded content IDs: #{not_found_content_ids.join(', ')}",
+        :embedded_content_not_found,
+      )
       identifiers - not_found_content_ids
     else
       identifiers
@@ -53,10 +56,11 @@ private
     )
   end
 
-  def log_error(message)
+  def log_error(message, error_code)
     GovukError.notify(
       CommandError.new(
         code: 422,
+        error_code:,
         message:,
       ),
     )
@@ -92,7 +96,8 @@ private
     def replace_alias_content_id_with_content_id(reference)
       identifier = content_id_aliases[reference.identifier]
       if identifier.nil?
-        log_error "Could not find a Content ID for alias #{reference.identifier}"
+        log_error("Could not find a Content ID for alias #{reference.identifier}",
+                  :embedded_content_alias_not_found)
         return
       end
 
@@ -101,10 +106,11 @@ private
       )
     end
 
-    def log_error(message)
+    def log_error(message, error_code)
       GovukError.notify(
         CommandError.new(
           code: 422,
+          error_code:,
           message:,
         ),
       )

--- a/app/services/get_host_content_service.rb
+++ b/app/services/get_host_content_service.rb
@@ -41,6 +41,7 @@ private
     message = "Invalid order field: #{order}"
     raise CommandError.new(
       code: 422,
+      error_code: :order_field_invalid,
       message:,
       error_details: {
         error: {

--- a/app/validators/absolute_path_validator.rb
+++ b/app/validators/absolute_path_validator.rb
@@ -1,7 +1,7 @@
 class AbsolutePathValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
     unless valid_absolute_url_path?(value)
-      record.errors.add(attribute, "is not a valid absolute URL path")
+      record.errors.add(attribute, "is not a valid absolute URL path", code: :absolute_path_invalid)
     end
   end
 

--- a/app/validators/base_path_for_state_validator.rb
+++ b/app/validators/base_path_for_state_validator.rb
@@ -10,7 +10,7 @@ private
   def check_conflict(record)
     conflict = Queries::BasePathForState.conflict(record.id, record.state, record.base_path)
     if conflict
-      record.errors.add(:base, error_message(record.base_path, conflict))
+      record.errors.add(:base, error_message(record.base_path, conflict), code: :conflict)
     end
   end
 

--- a/app/validators/dns_hostname_validator.rb
+++ b/app/validators/dns_hostname_validator.rb
@@ -3,7 +3,7 @@ class DnsHostnameValidator < ActiveModel::EachValidator
 
   def validate_each(record, attribute, value)
     unless value && value.match(DNS_HOSTNAME_PATTERN)
-      record.errors.add(attribute, "is not a valid dns hostname")
+      record.errors.add(attribute, "is not a valid dns hostname", code: :dns_hostname_invalid)
     end
   end
 end

--- a/app/validators/routes_and_redirects_validator.rb
+++ b/app/validators/routes_and_redirects_validator.rb
@@ -50,24 +50,24 @@ private
   def must_have_unique_paths(record, routes, redirects)
     paths = routes.map { |r| r[:path] }
     unless paths == paths.uniq
-      record.errors.add(:routes, "must have unique paths")
+      record.errors.add(:routes, "must have unique paths", code: :route_paths_not_unique)
     end
 
     paths += redirects.map { |r| r[:path] }
     unless paths == paths.uniq
-      record.errors.add(:redirects, "must have unique paths")
+      record.errors.add(:redirects, "must have unique paths", code: :redirect_paths_not_unique)
     end
   end
 
   def redirects_must_include_base_path(record, base_path, redirects)
     if redirects.none? { |r| r[:path] == base_path }
-      record.errors.add(:redirects, "must include the base path")
+      record.errors.add(:redirects, "must include the base path", code: :redirects_must_include_base_path)
     end
   end
 
   def routes_must_include_base_path(record, base_path, routes)
     if routes.none? { |r| r[:path] == base_path }
-      record.errors.add(:routes, "must include the base path")
+      record.errors.add(:routes, "must include the base path", code: :routes_must_include_base_path)
     end
   end
 
@@ -77,27 +77,27 @@ private
       path = route[:path]
 
       if type.blank?
-        record.errors.add(attribute, "type must be present")
+        record.errors.add(attribute, "type must be present", code: :route_type_missing)
       end
 
       if path.blank?
-        record.errors.add(attribute, "path must be present")
+        record.errors.add(attribute, "path must be present", code: :route_path_missing)
       end
 
       unless type.present? && %(exact prefix).include?(type)
-        record.errors.add(attribute, "type must be either 'exact' or 'prefix'")
+        record.errors.add(attribute, "type must be either 'exact' or 'prefix'", code: :route_type_invalid)
       end
 
       unsupported_keys = additional_keys(route, attribute)
       if unsupported_keys.any?
-        record.errors.add(attribute, "unsupported keys: #{unsupported_keys.join(', ')}")
+        record.errors.add(attribute, "unsupported keys: #{unsupported_keys.join(', ')}", code: :route_unsupported_keys)
       end
 
       validator = AbsolutePathValidator.new(attributes: attribute)
       validator.validate_each(record, attribute, path)
 
       unless path.present? && below_base_path?(path, base_path)
-        record.errors.add(attribute, "path must be below the base path")
+        record.errors.add(attribute, "path must be below the base path", code: :route_not_below_base_path)
       end
     end
 
@@ -105,10 +105,6 @@ private
 
     def below_base_path?(path, base_path)
       path.start_with?(base_path)
-    end
-
-    def segments(path)
-      path.split("/").reject(&:blank?)
     end
 
     def additional_keys(route, attribute)
@@ -133,12 +129,15 @@ private
       path = redirect[:path]
       destination = redirect[:destination]
 
-      errors.add(:redirects, "path must be present") if path.blank?
-      errors.add(:redirects, "destination must be present") if destination.blank?
-      errors.add(:redirects, "path cannot equal the destination") if path == destination
+      errors.add(:redirects, "path must be present", code: :redirect_path_missing) if path.blank?
+      errors.add(:redirects, "destination must be present", code: :redirect_destination_missing) if destination.blank?
+      errors.add(:redirects, "path cannot equal the destination", code: :redirect_path_equals_destination) if path == destination
       return unless errors.empty?
 
-      errors.add(:redirects, "destination invalid (#{destination})") if invalid_destination?(destination)
+      if invalid_destination?(destination)
+        errors.add(:redirects, "destination invalid (#{destination})",
+                   code: :redirect_destination_invalid)
+      end
       return unless errors.empty?
 
       if internal?(destination)
@@ -170,8 +169,7 @@ private
     def government_domain?(host)
       return true if EXTERNAL_HOST_ALLOW_LIST.include?(host)
 
-      host_allow_list_for_subdomains = EXTERNAL_HOST_ALLOW_LIST.map { |allowed_host| ".#{allowed_host}" }
-      host.end_with?(*host_allow_list_for_subdomains)
+      EXTERNAL_HOST_ALLOW_LIST.any? { |allowed| host.end_with?(".#{allowed}") }
     end
 
     def invalid_destination?(destination)
@@ -182,36 +180,35 @@ private
     end
 
     def validate_internal_redirect(destination)
-      errors.add(:redirects, "destination invalid (#{destination}), internal redirects cannot end with /") if
-        destination != "/" && (destination.end_with? "/")
+      if destination != "/" && destination.end_with?("/")
+        errors.add(:redirects, "destination invalid (#{destination}), internal redirects cannot end with /", code: :redirect_destination_invalid)
+      end
     end
 
     def validate_external_redirect(destination)
       uri = URI.parse(destination)
 
       if uri.host.nil?
-        errors.add(:redirects, "missing host for external redirect (#{destination})")
+        errors.add(:redirects, "missing host for external redirect (#{destination})", code: :redirect_external_missing_host)
         return
       end
 
-      errors.add(:redirects, "external redirects only accepted for the domains #{EXTERNAL_HOST_ALLOW_LIST.to_sentence} (#{destination})") unless
-        government_domain?(uri.host)
+      errors.add(:redirects, "external redirects only accepted for the domains #{EXTERNAL_HOST_ALLOW_LIST.to_sentence} (#{destination})", code: :redirect_external_disallowed_domain) unless government_domain?(uri.host)
 
-      errors.add(:redirects, "internal redirect should not be specified with full url (#{destination})") if
-        %w[gov.uk www.gov.uk].include? uri.host
+      errors.add(:redirects, "internal redirect should not be specified with full url (#{destination})", code: :redirect_external_govuk_should_be_internal) if %w[gov.uk www.gov.uk].include?(uri.host)
 
-      errors.add(:redirects, "external redirects must use https (#{destination})") unless uri.scheme == "https"
+      errors.add(:redirects, "external redirects must use https (#{destination})", code: :redirect_external_not_https) unless uri.scheme == "https"
 
       uri.host.split(".").each { |subdomain| validate_subdomain(subdomain) }
     end
 
     def validate_subdomain(subdomain)
       prefix = "subdomain #{subdomain}"
-      errors.add(:redirects, "#{prefix} is longer than 63 characters") if
+      errors.add(:redirects, "#{prefix} is longer than 63 characters", code: :redirect_subdomain_too_long) if
         subdomain.length > 63
-      errors.add(:redirects, "#{prefix} should not start with a hyphen") if
+      errors.add(:redirects, "#{prefix} should not start with a hyphen", code: :redirect_subdomain_starts_with_hyphen) if
         subdomain.starts_with?("-")
-      errors.add(:redirects, "#{prefix} contains prohibited characters") unless
+      errors.add(:redirects, "#{prefix} contains prohibited characters", code: :redirect_subdomain_invalid_chars) unless
         subdomain =~ /\A[a-z0-9-]*\z/i
     end
 
@@ -219,10 +216,11 @@ private
       uri = URI.parse(destination)
 
       if uri.fragment.present?
-        errors.add(:redirects, "destination #{destination} cannot contain a fragment if the segments_mode is 'preserve'")
+        errors.add(:redirects, "destination #{destination} cannot contain a fragment if the segments_mode is 'preserve'", code: :redirect_fragment_not_allowed_with_preserve)
       end
+
       if uri.query.present?
-        errors.add(:redirects, "destination #{destination} cannot contain query parameters if the segments_mode is 'preserve'")
+        errors.add(:redirects, "destination #{destination} cannot contain query parameters if the segments_mode is 'preserve'", code: :redirect_query_not_allowed_with_preserve)
       end
     end
 

--- a/app/validators/state_for_document_validator.rb
+++ b/app/validators/state_for_document_validator.rb
@@ -12,7 +12,7 @@ class StateForDocumentValidator < ActiveModel::Validator
     if conflict_id
       error = "state=#{record.state} and document=#{record.document_id} "\
         "conflicts with edition id=#{conflict_id}"
-      record.errors.add(:base, error)
+      record.errors.add(:base, error, code: :conflict)
     end
   end
 end

--- a/app/validators/uuid_validator.rb
+++ b/app/validators/uuid_validator.rb
@@ -25,7 +25,7 @@ class UuidValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
     unless self.class.valid?(value)
       message = options[:message] || "is not a canonical UUID"
-      record.errors.add(attribute, message)
+      record.errors.add(attribute, message, code: :uuid_invalid)
     end
   end
 

--- a/app/validators/version_for_document_validator.rb
+++ b/app/validators/version_for_document_validator.rb
@@ -13,7 +13,7 @@ class VersionForDocumentValidator < ActiveModel::Validator
       error = "user_facing_version=#{record.user_facing_version} and "\
         "document=#{record.document_id} conflicts with edition "\
         "id=#{conflict_id}"
-      record.errors.add(:base, error)
+      record.errors.add(:base, error, code: :conflict)
     end
   end
 end

--- a/app/validators/well_formed_content_types_validator.rb
+++ b/app/validators/well_formed_content_types_validator.rb
@@ -6,7 +6,7 @@ class WellFormedContentTypesValidator < ActiveModel::EachValidator
 
     if @error_messages.present?
       @error_messages.each do |message|
-        record.errors.add(attribute, message)
+        record.errors.add(attribute, message, code: :content_type_invalid)
       end
     end
   end

--- a/docs/publishing-application-examples.md
+++ b/docs/publishing-application-examples.md
@@ -187,6 +187,39 @@ returned along with error messages in the `response.body.error` object. eg.
   }
 ```
 
+Additionally, `422 Unprocessable Entity` responses include an `error_code`, eg.
+
+```js
+  {
+    "status": 422,
+    "headers": {
+      "Content-Type": "application/json; charset=utf-8"
+    },
+    "body": {
+      "error": {
+        "code": 422,
+        "message": "Base path /foo is already reserved by publisher",
+        "error_code": "base_path_already_in_use",
+        "fields": {
+          "base_path": [
+            {
+              "error": "/foo is already reserved by publisher",
+              "code": "base_path_already_in_use"
+            }
+          ]
+        }
+      }
+    }
+  }
+```
+
+If multiple validation errors occur, the response uses the
+`multiple_validation_errors` error code, and details for each validation issue
+are provided in the `fields` object. 
+
+A complete list of possible error codes is available in the `ERROR_CODES`
+constant defined in the [`CommandError` class](app/errors/command_error.rb).
+
 ## LockVersioning
 
 The response body contains the current lock version of the document for GET

--- a/spec/commands/base_command_spec.rb
+++ b/spec/commands/base_command_spec.rb
@@ -67,16 +67,4 @@ RSpec.describe Commands::BaseCommand do
       top_level_command.call(payload)
     end
   end
-
-  describe "timing" do
-    it "sends a command's duration to statsd" do
-      expect(PublishingAPI.service(:statsd)).to receive(:timing) do |name, time, sample_rate|
-        expect(name).to eq "Commands.SlowCommand"
-        expect(time).to within(100).of(1000)
-        expect(sample_rate).to eq 1
-      end
-
-      expect(slow_command.call({ foo: "bar" })).to eq :foo
-    end
-  end
 end

--- a/spec/commands/base_command_spec.rb
+++ b/spec/commands/base_command_spec.rb
@@ -45,6 +45,18 @@ RSpec.describe Commands::BaseCommand do
     end
   end
 
+  let(:validating_command) do
+    Class.new(Commands::BaseCommand) do
+      def self.name
+        "Commands::ValidatingCommand"
+      end
+
+      def call
+        payload[:record].save!
+      end
+    end
+  end
+
   before { stub_const("Commands::NestedCommand", nested_command) }
 
   describe "callbacks for nested commands" do
@@ -65,6 +77,56 @@ RSpec.describe Commands::BaseCommand do
       }
 
       top_level_command.call(payload)
+    end
+  end
+
+  it "raises CommandError with error_code from validation error" do
+    allow(EventLogger).to receive(:log_command) do |_klass, _payload, &block|
+      block.call(double(:event))
+    end
+
+    payload = {
+      record: build(:unpublishing, type: "not_a_valid_type"),
+    }
+
+    expect {
+      validating_command.call(payload)
+    }.to raise_error(CommandError) do |error|
+      expect(error.code).to eq(422)
+      expect(error.error_code).to eq(:type_invalid)
+      expect(error.message).to eq("Type is not included in the list")
+      expect(error.error_details[:error][:fields]).to eq(
+        { type: [{ code: :type_invalid, error: :inclusion, value: "not_a_valid_type" }] },
+      )
+    end
+  end
+
+  it "raises CommandError with :multiple_validation_errors code and error details" do
+    allow(EventLogger).to receive(:log_command) do |_klass, _payload, &block|
+      block.call(double(:event))
+    end
+
+    Class.new(Commands::BaseCommand) do
+    end
+
+    payload = {
+      record: build(:unpublishing, type: nil),
+    }
+
+    expect {
+      validating_command.call(payload)
+    }.to raise_error(CommandError) do |error|
+      expect(error.code).to eq(422)
+      expect(error.error_code).to eq(:multiple_validation_errors)
+      expect(error.message).to eq("Type can't be blank, Type is not included in the list")
+      expect(error.error_details[:error][:fields]).to eq(
+        {
+          type: [
+            { code: :type_missing, error: :blank },
+            { code: :type_invalid, error: :inclusion, value: nil },
+          ],
+        },
+      )
     end
   end
 end

--- a/spec/commands/unreserve_path_spec.rb
+++ b/spec/commands/unreserve_path_spec.rb
@@ -20,9 +20,11 @@ RSpec.describe Commands::UnreservePath do
         )
 
         expect { described_class.call(payload) }
-          .to raise_error(
-            CommandError, /is reserved/
-          )
+          .to raise_error(CommandError) do |error|
+          expect(error.code).to eq(422)
+          expect(error.message).to eq("/bar is reserved by bar")
+          expect(error.error_code).to eq(:base_path_already_in_use)
+        end
       end
     end
 

--- a/spec/commands/v2/discard_draft_spec.rb
+++ b/spec/commands/v2/discard_draft_spec.rb
@@ -280,6 +280,7 @@ RSpec.describe Commands::V2::DiscardDraft do
         it "raises a command error with code 422" do
           expect { described_class.call(payload) }.to raise_error(CommandError) do |error|
             expect(error.code).to eq(422)
+            expect(error.error_code).to eq(:no_draft_to_discard)
           end
         end
       end

--- a/spec/commands/v2/patch_link_set_spec.rb
+++ b/spec/commands/v2/patch_link_set_spec.rb
@@ -242,6 +242,7 @@ RSpec.describe Commands::V2::PatchLinkSet do
           described_class.call(payload)
         }.to raise_error(CommandError) { |error|
                expect(error.code).to eq(422)
+               expect(error.error_code).to eq(:bulk_publishing_flag_missing)
                expect(error.message).to eq("A value for bulk_publishing is required")
              }
       end
@@ -478,7 +479,10 @@ RSpec.describe Commands::V2::PatchLinkSet do
     it "raises a command error" do
       expect {
         described_class.call(payload)
-      }.to raise_error(CommandError, "Links are required")
+      }.to raise_error(CommandError) { |error|
+             expect(error.error_code).to eq(:links_missing)
+             expect(error.message).to eq("Links are required")
+           }
     end
   end
 
@@ -490,7 +494,10 @@ RSpec.describe Commands::V2::PatchLinkSet do
     it "raises a command error" do
       expect {
         described_class.call(payload)
-      }.to raise_error(CommandError, "Links are required")
+      }.to raise_error(CommandError) { |error|
+             expect(error.error_code).to eq(:links_missing)
+             expect(error.message).to eq("Links are required")
+           }
     end
   end
 

--- a/spec/commands/v2/post_action_spec.rb
+++ b/spec/commands/v2/post_action_spec.rb
@@ -46,7 +46,10 @@ RSpec.describe Commands::V2::PostAction do
         it "raises a 422 command error" do
           expect {
             described_class.call(payload)
-          }.to raise_error(CommandError) { |e| expect(e.code).to eq(422) }
+          }.to raise_error(CommandError) { |e|
+                 expect(e.code).to eq(422)
+                 expect(e.error_code).to eq(:action_invalid)
+               }
         end
       end
 

--- a/spec/commands/v2/publish_spec.rb
+++ b/spec/commands/v2/publish_spec.rb
@@ -97,7 +97,9 @@ RSpec.describe Commands::V2::Publish do
         it "raises an error" do
           expect {
             described_class.call(payload)
-          }.to raise_error(CommandError, /update_type is required/)
+          }.to raise_error(CommandError, /update_type is required/) do |error|
+            expect(error.error_code).to eq(:update_type_missing)
+          end
         end
       end
     end
@@ -727,7 +729,9 @@ RSpec.describe Commands::V2::Publish do
       it "raises an error" do
         expect {
           described_class.call(payload)
-        }.to raise_error(CommandError, "An update_type of 'invalid' is invalid")
+        }.to raise_error(CommandError, "An update_type of 'invalid' is invalid") do |error|
+          expect(error.error_code).to eq(:update_type_invalid)
+        end
       end
     end
 

--- a/spec/commands/v2/put_content_spec.rb
+++ b/spec/commands/v2/put_content_spec.rb
@@ -162,6 +162,7 @@ RSpec.describe Commands::V2::PutContent do
               described_class.call(content_block_payload)
             }.to raise_error(CommandError) { |error|
               expect(error.code).to eq(422)
+              expect(error.error_code).to eq(:content_id_alias_already_in_use)
               expect(error.message).to eq("ContentIdAlias with name \"#{content_block_payload[:content_id_alias]}\" exists for a different content ID.")
             }
           end
@@ -196,6 +197,7 @@ RSpec.describe Commands::V2::PutContent do
           described_class.call(payload)
         }.to raise_error(CommandError) { |error|
                expect(error.code).to eq(422)
+               expect(error.error_code).to eq(:bulk_publishing_flag_missing)
                expect(error.message).to eq("A value for bulk_publishing is required")
              }
       end

--- a/spec/commands/v2/put_content_validator_spec.rb
+++ b/spec/commands/v2/put_content_validator_spec.rb
@@ -17,9 +17,9 @@ RSpec.describe Commands::V2::PutContentValidator do
 
       it "raises command error and exits" do
         expect(PathReservation).not_to receive(:reserve_base_path!)
-        expect { subject.validate }.to raise_error do |error|
-          expect(error).to be_a(CommandError)
+        expect { subject.validate }.to raise_error(CommandError) do |error|
           expect(error.code).to eq 422
+          expect(error.error_code).to eq :schema_validation_failed
           expect(error.error_details).to eq errors
         end
       end

--- a/spec/commands/v2/unpublish_spec.rb
+++ b/spec/commands/v2/unpublish_spec.rb
@@ -57,6 +57,7 @@ RSpec.describe Commands::V2::Unpublish do
         expect { described_class.call(payload) }
           .to raise_error(CommandError, msg) do |error|
             expect(error.code).to eq(422)
+            expect(error.error_code).to eq(:explanation_missing_for_withdrawal)
           end
       end
 
@@ -65,6 +66,26 @@ RSpec.describe Commands::V2::Unpublish do
         expect { described_class.call(payload.merge(type: "redirect", alternative_path: "")) }
           .to raise_error(CommandError, msg) do |error|
             expect(error.code).to eq(422)
+            expect(error.error_code).to eq(:redirect_destination_missing)
+          end
+      end
+
+      it "raises multiple_validation_errors when multiple validations fail" do
+        invalid_payload =
+          {   content_id:,
+              type: "redirect",
+              redirects: [
+                {
+                  path: "",
+                  destination: "",
+                  type: "exact",
+                },
+              ] }
+
+        expect { described_class.call(invalid_payload) }
+          .to raise_error(CommandError) do |error|
+            expect(error.code).to eq(422)
+            expect(error.error_code).to eq(:multiple_validation_errors)
           end
       end
     end
@@ -322,6 +343,7 @@ RSpec.describe Commands::V2::Unpublish do
               described_class.call(payload_with_allow_draft_and_discard_drafts)
             }.to raise_error(CommandError, expected_message) { |error|
               expect(error.code).to eq(422)
+              expect(error.error_code).to eq(:conflicting_unpublishing_flags)
             }
           end
         end
@@ -443,6 +465,7 @@ RSpec.describe Commands::V2::Unpublish do
           described_class.call(payload)
         }.to raise_error(CommandError, "Cannot unpublish with a draft present") { |error|
           expect(error.code).to eq(422)
+          expect(error.error_code).to eq(:cannot_unpublish_with_draft)
         }
       end
 

--- a/spec/errors/command_error_spec.rb
+++ b/spec/errors/command_error_spec.rb
@@ -1,0 +1,62 @@
+RSpec.describe CommandError do
+  describe ".with_error_handling" do
+    it "raises a CommandError with content_store_validation_failed for 422 errors" do
+      error = GdsApi::HTTPUnprocessableEntity.new(
+        422,
+        { "error" => { "message" => "Validation failed" } },
+      )
+
+      expect {
+        described_class.with_error_handling do
+          raise error
+        end
+      }.to raise_error(CommandError) { |command_error|
+        expect(command_error.code).to eq(422)
+
+        expect(command_error.error_details).to include(
+          error: hash_including(
+            code: 422,
+            error_code: :content_store_validation_failed,
+            message: error.message,
+          ),
+        )
+      }
+    end
+  end
+
+  describe "#initialize" do
+    it "includes error_code in error_details when provided" do
+      error = described_class.new(
+        code: 422,
+        message: "Validation failed",
+        error_code: :validation_failed,
+      )
+
+      expect(error.error_details).to eq(
+        {
+          "error" => {
+            "code" => 422,
+            "error_code" => :validation_failed,
+            "message" => "Validation failed",
+          },
+        },
+      )
+    end
+
+    it "does not include error_code in error_details when not provided" do
+      error = described_class.new(
+        code: 500,
+        message: "Internal server error",
+      )
+
+      expect(error.error_details).to eq(
+        {
+          "error" => {
+            "code" => 500,
+            "message" => "Internal server error",
+          },
+        },
+      )
+    end
+  end
+end

--- a/spec/errors/command_error_spec.rb
+++ b/spec/errors/command_error_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe CommandError do
   describe ".with_error_handling" do
     it "raises a CommandError with content_store_validation_failed for 422 errors" do
-      error = GdsApi::HTTPUnprocessableEntity.new(
+      error = GdsApi::HTTPClientError.new(
         422,
         { "error" => { "message" => "Validation failed" } },
       )
@@ -12,7 +12,7 @@ RSpec.describe CommandError do
         end
       }.to raise_error(CommandError) { |command_error|
         expect(command_error.code).to eq(422)
-
+        expect(command_error.error_code).to eq(:content_store_validation_failed)
         expect(command_error.error_details).to include(
           error: hash_including(
             code: 422,
@@ -25,6 +25,66 @@ RSpec.describe CommandError do
   end
 
   describe "#initialize" do
+    context "when not in production" do
+      around do |example|
+        ClimateControl.modify RAILS_ENV: "test" do
+          example.run
+        end
+      end
+
+      it "raises ArgumentError when error_code is missing for 422" do
+        expect {
+          described_class.new(
+            code: 422,
+            message: "Invalid",
+          )
+        }.to raise_error(ArgumentError, /Descriptive error code missing/)
+      end
+
+      it "raises ArgumentError for unknown error_code on 422" do
+        expect {
+          described_class.new(
+            code: 422,
+            error_code: :unknown_code,
+            message: "Invalid",
+          )
+        }.to raise_error(ArgumentError, /Unknown error_code/)
+      end
+    end
+
+    context "when in production environment" do
+      before do
+        allow(Rails).to receive(:env).and_return(
+          ActiveSupport::StringInquirer.new("production"),
+        )
+      end
+
+      it "notifies Sentry instead of raising when error_code is missing for 422" do
+        expect(GovukError).to receive(:notify).with(
+          "Descriptive error code missing for 422 error",
+          level: "warning",
+        )
+
+        described_class.new(
+          code: 422,
+          message: "Invalid",
+        )
+      end
+
+      it "notifies Sentry instead of raising for unknown error_code" do
+        expect(GovukError).to receive(:notify).with(
+          "Unknown error_code: unknown_code. Code must be included in ERROR_CODES",
+          level: "warning",
+        )
+
+        described_class.new(
+          code: 422,
+          error_code: :unknown_code,
+          message: "Invalid",
+        )
+      end
+    end
+
     it "includes error_code in error_details when provided" do
       error = described_class.new(
         code: 422,

--- a/spec/models/edition_spec.rb
+++ b/spec/models/edition_spec.rb
@@ -135,7 +135,7 @@ RSpec.describe Edition do
 
         it "should be invalid" do
           expect(subject).to be_invalid
-          expect(subject.errors[:base_path].size).to eq(1)
+          expect(subject.errors.added?(:base_path, "is not a valid absolute URL path", code: :absolute_path_invalid)).to be true
         end
       end
 

--- a/spec/models/path_reservation_spec.rb
+++ b/spec/models/path_reservation_spec.rb
@@ -3,12 +3,6 @@ RSpec.describe PathReservation, type: :model do
     let(:reservation) { build(:path_reservation) }
 
     describe "on base_path" do
-      it "is required" do
-        reservation.base_path = ""
-        expect(reservation).to be_invalid
-        expect(reservation.errors[:base_path].size).to eq(1)
-      end
-
       it "is a valid absolute URL base_path" do
         reservation.base_path = "not a URL"
         expect(reservation).to be_invalid

--- a/spec/models/path_reservation_spec.rb
+++ b/spec/models/path_reservation_spec.rb
@@ -55,9 +55,11 @@ RSpec.describe PathReservation, type: :model do
       it "raises an error" do
         expect {
           described_class.reserve_base_path!("/vat-rates", "publisher")
-        }.to raise_error(
-          ActiveRecord::RecordInvalid, /already reserved/
-        )
+        }.to raise_error(ActiveRecord::RecordInvalid) { |exception|
+               expect(exception.record.errors.details[:base_path]).to include(
+                 error: "/vat-rates is already reserved by something-else", code: :base_path_already_in_use,
+               )
+             }
       end
 
       context "when override_existing is true" do
@@ -119,8 +121,42 @@ RSpec.describe PathReservation, type: :model do
 
         expect {
           described_class.reserve_base_path!("/vat-rates", "publisher")
-        }.to raise_error(ActiveRecord::RecordInvalid)
+        }.to raise_error(ActiveRecord::RecordInvalid) { |exception|
+               expect(exception.record.errors.details[:base_path]).to include(
+                 error: "/vat-rates is already reserved by different", code: :base_path_already_in_use,
+               )
+             }
       end
+    end
+
+    it "raises an error with publishing_app_missing error code when publishing_app is blank" do
+      expect {
+        described_class.reserve_base_path!("/vat-rates", nil)
+      }.to raise_error(ActiveRecord::RecordInvalid) { |exception|
+             expect(exception.record.errors.details[:publishing_app]).to include(
+               error: :blank, code: :publishing_app_missing,
+             )
+           }
+    end
+
+    it "raises an error with :absolute_path_invalid error code when base_path is not absolute" do
+      expect {
+        described_class.reserve_base_path!("not-a-valid-path", "publisher")
+      }.to raise_error(ActiveRecord::RecordInvalid) { |exception|
+             expect(exception.record.errors.details[:base_path]).to include(
+               error: "is not a valid absolute URL path", code: :absolute_path_invalid,
+             )
+           }
+    end
+
+    it "raises an error with :base_path_too_long error code when base_path is too long" do
+      expect {
+        described_class.reserve_base_path!("/#{'bbc' * 171}", "publisher")
+      }.to raise_error(ActiveRecord::RecordInvalid) { |exception|
+             expect(exception.record.errors.details[:base_path]).to include(
+               error: "over 512 bytes", code: :base_path_too_long,
+             )
+           }
     end
   end
 end

--- a/spec/models/unpublishing_spec.rb
+++ b/spec/models/unpublishing_spec.rb
@@ -27,6 +27,7 @@ RSpec.describe Unpublishing do
       subject.type = "redirect"
       expect(subject).to be_invalid
       expect(subject.errors[:redirects].size).to eq(2)
+      expect(subject.errors.added?(:redirects, "must include the base path", code: :redirects_must_include_base_path)).to be true
 
       subject.type = nil
       expect(subject).to be_invalid
@@ -106,6 +107,98 @@ RSpec.describe Unpublishing do
     context "when there isn't an edition" do
       let(:edition) { nil }
       it { is_expected.to be false }
+    end
+  end
+
+  describe "#save!" do
+    let(:edition) { create(:edition, base_path: "/test") }
+
+    it "adds edition_missing error code when edition is missing" do
+      record = described_class.new(type: "gone")
+
+      expect_error_code(
+        record: record,
+        attribute: :edition,
+        error: :blank,
+        code: :edition_missing,
+      )
+    end
+
+    it "returns edition_not_unique error code when edition is not unique" do
+      create(:unpublishing, edition: edition)
+
+      duplicate = build(:unpublishing, edition: edition)
+
+      expect_error_code(
+        record: duplicate,
+        attribute: :edition,
+        error: :taken,
+        code: :edition_not_unique,
+      )
+    end
+
+    it "adds type_missing error code when type is invalid" do
+      record = described_class.new(edition: edition)
+
+      expect_error_code(
+        record: record,
+        attribute: :type,
+        error: :blank,
+        code: :type_missing,
+      )
+    end
+
+    it "adds type_invalid error code when type is invalid" do
+      record = described_class.new(
+        edition: edition,
+        type: "not_a_valid_type",
+      )
+
+      expect_error_code(
+        record: record,
+        attribute: :type,
+        error: :inclusion,
+        code: :type_invalid,
+      )
+    end
+
+    it "adds explanation_missing_for_withdrawal error code when explanation is missing" do
+      record = described_class.new(
+        edition: edition,
+        type: "withdrawal",
+        explanation: nil,
+      )
+
+      expect_error_code(
+        record: record,
+        attribute: :explanation,
+        error: :blank,
+        code: :explanation_missing_for_withdrawal,
+      )
+    end
+
+    it "adds redirects_missing_for_redirect error code when redirects are missing" do
+      record = described_class.new(
+        edition: edition,
+        type: "redirect",
+        redirects: nil,
+      )
+
+      expect_error_code(
+        record: record,
+        attribute: :redirects,
+        error: :blank,
+        code: :redirects_missing_for_redirect,
+      )
+    end
+
+    def expect_error_code(record:, attribute:, error:, code:)
+      expect { record.save! }
+        .to raise_error(ActiveRecord::RecordInvalid) { |exception|
+          expect(exception.record.errors.details[attribute]).to include(
+            a_hash_including(error: error, code: code),
+          )
+        }
     end
   end
 end

--- a/spec/pagination_spec.rb
+++ b/spec/pagination_spec.rb
@@ -47,6 +47,15 @@ RSpec.describe Pagination do
       it "do not append the id field  if it already exists" do
         expect(Pagination.new(order: "-id, public_updated_at").order).to eq([%i[id desc], %i[public_updated_at asc]])
       end
+
+      it "raises CommandError for invalid order value" do
+        expect {
+          described_class.new(order: "not_valid, asc")
+        }.to raise_error(CommandError) do |error|
+          expect(error.code).to eq(422)
+          expect(error.error_code).to eq(:order_field_invalid)
+        end
+      end
     end
 
     context "with page option" do
@@ -61,7 +70,7 @@ RSpec.describe Pagination do
       let(:total) { 19 }
       subject(:pagination) { described_class.new(page: 2, per_page: 20) }
 
-      it "calculats the total number of pages" do
+      it "calculates the total number of pages" do
         expect(pagination.pages(total)).to eq(1)
       end
     end

--- a/spec/presenters/content_embed_presenter_spec.rb
+++ b/spec/presenters/content_embed_presenter_spec.rb
@@ -42,6 +42,7 @@ RSpec.describe Presenters::ContentEmbedPresenter do
         it "alerts Sentry and returns the content as is" do
           expect(GovukError).to receive(:notify).with(CommandError.new(
                                                         code: 422,
+                                                        error_code: :embedded_content_not_found,
                                                         message: "Could not find a live edition for embedded content ID: #{fake_content_id}",
                                                       ))
           expect(described_class.new(edition).render_embedded_content(details)).to eq({

--- a/spec/queries/get_content_spec.rb
+++ b/spec/queries/get_content_spec.rb
@@ -163,7 +163,10 @@ RSpec.describe Queries::GetContent do
     it "raises an error if version is provided" do
       expect {
         subject.call(content_id, version: 1)
-      }.to raise_error(CommandError, /version parameter no longer supported in get_content/)
+      }.to raise_error(CommandError, /version parameter no longer supported in get_content/) do |error|
+        expect(error.code).to eq(422)
+        expect(error.error_code).to eq(:unsupported_version_parameter)
+      end
     end
 
     it "returns the most recent if version isn't given" do

--- a/spec/queries/get_linked_spec.rb
+++ b/spec/queries/get_linked_spec.rb
@@ -70,6 +70,18 @@ RSpec.describe Queries::GetLinked do
           ).call).to match_array([hash_including("title" => "VAT rules 2020")])
         end
       end
+
+      it "raises an error when fields are not provided" do
+        expect {
+          Queries::GetLinked.new(
+            content_id: target_content_id,
+            link_type: "organisations",
+            fields: [],
+          ).call
+        }.to raise_error(CommandError) do |error|
+          expect(error.error_code).to eq(:fields_parameter_missing)
+        end
+      end
     end
 
     context "when a document with draft exists " do

--- a/spec/requests/linkables_spec.rb
+++ b/spec/requests/linkables_spec.rb
@@ -54,6 +54,11 @@ RSpec.describe "GET /v2/linkables", type: :request do
       get "/v2/linkables"
 
       expect(response.status).to eq(422)
+      expect(parsed_response).to eql("error" => {
+        "code" => 422,
+        "error_code" => "parameter_missing_or_invalid",
+        "message" => "param is missing or the value is empty or invalid: document_type",
+      })
     end
   end
 end

--- a/spec/requests/lookups_spec.rb
+++ b/spec/requests/lookups_spec.rb
@@ -1,7 +1,11 @@
 RSpec.describe "POST /lookup-by-base-path", type: :request do
   context "validating" do
     it "requires a base_paths param" do
-      expected_error_response = { "error" => { "code" => 422, "message" => "param is missing or the value is empty or invalid: base_paths" } }
+      expected_error_response = { "error" => {
+        "code" => 422,
+        "error_code" => "parameter_missing_or_invalid",
+        "message" => "param is missing or the value is empty or invalid: base_paths",
+      } }
 
       post "/lookup-by-base-path"
 

--- a/spec/services/embedded_content_finder_service_spec.rb
+++ b/spec/services/embedded_content_finder_service_spec.rb
@@ -246,6 +246,7 @@ RSpec.describe EmbeddedContentFinderService do
       details = { body: "{{embed:contact:00000000-0000-0000-0000-000000000000}}" }
       expect(GovukError).to receive(:notify).with(CommandError.new(
                                                     code: 422,
+                                                    error_code: :embedded_content_alias_not_found,
                                                     message: "Could not find any live editions for embedded content IDs: 00000000-0000-0000-0000-000000000000",
                                                   ))
 
@@ -258,6 +259,7 @@ RSpec.describe EmbeddedContentFinderService do
       details = { body: "{{embed:contact:some-content-id-alias}}" }
       expect(GovukError).to receive(:notify).with(CommandError.new(
                                                     code: 422,
+                                                    error_code: :embedded_content_alias_not_found,
                                                     message: "Could not find a Content ID for alias some-content-id-alias",
                                                   ))
 
@@ -468,6 +470,7 @@ RSpec.describe EmbeddedContentFinderService do
 
           expect(CommandError).to have_received(:new).with(
             code: 422,
+            error_code: :embedded_content_alias_not_found,
             message: "Could not find a Content ID for alias alias-1",
           )
           expect(GovukError).to have_received(:notify).with(command_error)

--- a/spec/services/get_host_content_service_spec.rb
+++ b/spec/services/get_host_content_service_spec.rb
@@ -119,6 +119,7 @@ RSpec.describe GetHostContentService do
           it "returns a 422 error" do
             expect { described_class.new(target_content_id, "something", nil, nil).call }.to raise_error(CommandError) do |error|
               expect(error.code).to eq(422)
+              expect(error.error_code).to eq(:order_field_invalid)
               expect(error.message).to eq("Invalid order field: something")
             end
           end

--- a/spec/support/shared_examples/renders_embedded_content.rb
+++ b/spec/support/shared_examples/renders_embedded_content.rb
@@ -26,6 +26,7 @@ RSpec.shared_examples "renders embedded content" do
         it "alerts Sentry and returns the expected content" do
           expect(GovukError).to receive(:notify).with(CommandError.new(
                                                         code: 422,
+                                                        error_code: :embedded_content_not_found,
                                                         message: "Could not find a live edition for embedded content ID: #{fake_content_id}",
                                                       ))
           expect(described_class.new(edition).render_embedded_content(details)).to eq({

--- a/spec/validators/base_path_for_state_validator_spec.rb
+++ b/spec/validators/base_path_for_state_validator_spec.rb
@@ -61,6 +61,7 @@ RSpec.describe BasePathForStateValidator do
 
           it "adds the error to edition attribute" do
             expect(edition.errors[:base]).to eq([expected_error])
+            expect(edition.errors.first.details[:code]).to eq(:conflict)
           end
         end
       end
@@ -84,6 +85,7 @@ RSpec.describe BasePathForStateValidator do
 
             it "adds the error to edition attribute" do
               expect(edition.errors[:base]).to eq([expected_error])
+              expect(edition.errors.first.details[:code]).to eq(:conflict)
             end
           end
         end

--- a/spec/validators/state_for_document_validator_spec.rb
+++ b/spec/validators/state_for_document_validator_spec.rb
@@ -48,6 +48,7 @@ RSpec.describe StateForDocumentValidator do
           end
 
           it "adds the error to the base attribute" do
+            expect(edition.errors.first.details[:code]).to eq(:conflict)
             expect(edition.errors[:base]).to eq([expected_error])
           end
         end

--- a/spec/validators/version_for_document_validator_spec.rb
+++ b/spec/validators/version_for_document_validator_spec.rb
@@ -46,6 +46,7 @@ RSpec.describe VersionForDocumentValidator do
 
       it "adds the error to the base attribute" do
         expect(edition.errors[:base]).to eq([expected_error])
+        expect(edition.errors.first.details[:code]).to eq(:conflict)
       end
     end
   end

--- a/spec/validators/well_formed_content_types_validator_spec.rb
+++ b/spec/validators/well_formed_content_types_validator_spec.rb
@@ -152,6 +152,7 @@ RSpec.describe WellFormedContentTypesValidator do
     it "communicates all of those reasons back to the programmer in one go" do
       subject.validate_each(record, attribute, value)
       expect(record.errors).to be_present
+      expect(record.errors.first.details[:code]).to eq(:content_type_invalid)
 
       error_messages = record.errors.messages_for(attribute)
       expect(error_messages).to include("the 'text/plain' content type does not contain content")


### PR DESCRIPTION
### Changes proposed
- 422 error responses from the API now include `error_code` by adding support for it in `BaseCommand` and `CommandError`
- relevant validation errors (`ActiveRecord::RecordInvalid`) include codes in `errors.details`
- Fallback behaviour:
  - explicit codes are preserved
  - missing mappings default to generic `:validation_failed` in relevant models
- `CommandError` validates that 422 errors always include a valid `error_code` and only predefined error codes are allowed (which acts as lightweight documentation of possible codes)
- To avoid breaking existing behaviour while gradually enforcing consistency unknown or missing codes:
    - notify the app team via Sentry in production
    - raise `ArgumentError` in test/development This avoids 

### Why

Publishing applications (e.g. Manuals Publisher) currently rely on regex parsing of the human-readable message field returned by Publishing API to determine the underlying validation failure to then display it nicely to the users in the UI.
Providing stable validation error codes will:
- Enable publishing apps to implement reliable validation error handling
- Remove the need for regex-based parsing of error messages
- Improve developer experience for publishing app teams
- Reduce accidental breaking changes caused by message copy updates
- Establish a clearer API contract for validation errors.

#### Notes
- Includes some cleanup:
  - Removed redundant `GovukStatsd` usage from CommandError and BaseCommand
  - Removed redundant path reservation test
- Not all validation errors are exposed via the API, so requiring explicit codes everywhere would create unnecessary maintenance overhead.
- Error code format was picked by a popular vote but it was 50/50 between snake case and upper snake case.
- Review note/question: `ActiveRecordError` store the values under `code` key, while higher level classes and response use `error_code`. We may want to keep it consistent. 
- Publishing app teams should add/update Pact tests once they start relying on the error codes

### Depends on
- https://github.com/alphagov/gds-api-adapters/pull/1395