### PR TITLE
Configure Dependabot for pip ecosystem and upgrade dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -37,6 +37,18 @@ updates:
       default-days: 3
     open-pull-requests-limit: 25
 
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: weekly
+      day: tuesday
+      time: "07:00"
+    allow:
+      - dependency-type: direct
+    cooldown:
+      default-days: 3
+    open-pull-requests-limit: 25
+
   # Ruby needs to be upgraded manually in multiple places, so cannot
   # be upgraded by Dependabot. That effectively makes the below
   # config redundant, as ruby is the only updatable thing in the

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-sqlfluff==3.5.*
+sqlfluff==4.1.*


### PR DESCRIPTION
To resolved:
- https://github.com/alphagov/publishing-api/security/dependabot/121
- https://github.com/alphagov/publishing-api/security/dependabot/122