### PR TITLE
[PP-7750] Do not retry downstream jobs on specific failures

### DIFF
--- a/app/sidekiq/downstream_discard_draft_job.rb
+++ b/app/sidekiq/downstream_discard_draft_job.rb
@@ -22,7 +22,7 @@ class DownstreamDiscardDraftJob
     update_expanded_links
 
     enqueue_dependencies if update_dependencies
-  rescue DiscardDraftBasePathConflictError => e
+  rescue DiscardDraftBasePathConflictError, DownstreamDraftExistsError, DownstreamInvalidStateError => e
     logger.warn(e.message)
   end
 

--- a/app/sidekiq/downstream_draft_job.rb
+++ b/app/sidekiq/downstream_draft_job.rb
@@ -40,6 +40,8 @@ class DownstreamDraftJob
     end
 
     enqueue_dependencies if update_dependencies
+  rescue DownstreamDraftExistsError, DownstreamInvalidStateError => e
+    logger.warn(e.message)
   end
 
 private

--- a/app/sidekiq/downstream_live_job.rb
+++ b/app/sidekiq/downstream_live_job.rb
@@ -52,6 +52,8 @@ class DownstreamLiveJob
     end
 
     enqueue_dependencies if update_dependencies
+  rescue DownstreamInvalidStateError => e
+    logger.warn(e.message)
   end
 
 private

--- a/spec/sidekiq/downstream_discard_draft_job_spec.rb
+++ b/spec/sidekiq/downstream_discard_draft_job_spec.rb
@@ -236,4 +236,37 @@ RSpec.describe DownstreamDiscardDraftJob do
       subject.perform(arguments)
     end
   end
+
+  describe "when DownstreamService's update_draft_content_store raises a DownstreamInvalidStateError exception" do
+    before do
+      allow(DownstreamService).to receive(:update_draft_content_store).and_raise(DownstreamInvalidStateError)
+    end
+    it "rescues from the error" do
+      expect {
+        subject.perform(arguments)
+      }.not_to raise_error
+    end
+  end
+
+  describe "when DownstreamService's update_draft_content_store raises a DownstreamDraftExistsError exception" do
+    before do
+      allow(DownstreamService).to receive(:update_draft_content_store).and_raise(DownstreamDraftExistsError)
+    end
+    it "rescues from the error" do
+      expect {
+        subject.perform(arguments)
+      }.not_to raise_error
+    end
+  end
+
+  describe "when DownstreamService's discard_from_draft_content_store raises a DiscardDraftBasePathConflictError exception" do
+    before do
+      allow(DownstreamService).to receive(:discard_from_draft_content_store).and_raise(DiscardDraftBasePathConflictError)
+    end
+    it "rescues from the error" do
+      expect {
+        subject.perform(arguments)
+      }.not_to raise_error
+    end
+  end
 end

--- a/spec/sidekiq/downstream_draft_job_spec.rb
+++ b/spec/sidekiq/downstream_draft_job_spec.rb
@@ -139,4 +139,36 @@ RSpec.describe DownstreamDraftJob do
       end
     end
   end
+  describe "when DownstreamService's broadcast_to_message_queue raises a DownstreamInvalidStateError exception" do
+    before do
+      allow(DownstreamService).to receive(:broadcast_to_message_queue).and_raise(DownstreamInvalidStateError)
+    end
+    it "rescues from the error" do
+      expect {
+        subject.perform(arguments)
+      }.not_to raise_error
+    end
+  end
+
+  describe "when DownstreamService's update_draft_content_store raises a DownstreamInvalidStateError exception" do
+    before do
+      allow(DownstreamService).to receive(:update_draft_content_store).and_raise(DownstreamInvalidStateError)
+    end
+    it "rescues from the error" do
+      expect {
+        subject.perform(arguments)
+      }.not_to raise_error
+    end
+  end
+
+  describe "when DownstreamService's update_draft_content_store raises a DownstreamDraftExistsError exception" do
+    before do
+      allow(DownstreamService).to receive(:update_draft_content_store).and_raise(DownstreamDraftExistsError)
+    end
+    it "rescues from the error" do
+      expect {
+        subject.perform(arguments)
+      }.not_to raise_error
+    end
+  end
 end

--- a/spec/sidekiq/downstream_live_job_spec.rb
+++ b/spec/sidekiq/downstream_live_job_spec.rb
@@ -218,4 +218,26 @@ RSpec.describe DownstreamLiveJob do
       subject.perform(arguments)
     end
   end
+
+  describe "when DownstreamService's broadcast_to_message_queue raises a DownstreamInvalidStateError exception" do
+    before do
+      allow(DownstreamService).to receive(:broadcast_to_message_queue).and_raise(DownstreamInvalidStateError)
+    end
+    it "rescues from the error" do
+      expect {
+        subject.perform(arguments)
+      }.not_to raise_error
+    end
+  end
+
+  describe "when DownstreamService's update_live_content_store raises a DownstreamInvalidStateError exception" do
+    before do
+      allow(DownstreamService).to receive(:update_live_content_store).and_raise(DownstreamInvalidStateError)
+    end
+    it "rescues from the error" do
+      expect {
+        subject.perform(arguments)
+      }.not_to raise_error
+    end
+  end
 end


### PR DESCRIPTION
We currently raise an exception for certain failures in the `DownstreamService`. This leads to the job being added to the retry queue and the lock (from sidekiq-unique-jobs) being reapplied.

However the job will never succeed because the conditional will always raise that same error, unless the document gets updated between retries to take it out of the current state. If the document gets updated, we attempt to schedule another job but that fails because of the lock that has been readded.

The retries occur over a period of 20 days. This means that following an update to the document that changes its state so it can be sent downstream, we won't actually exectute the job for some time, possibly days. Resulting in the document not being updated in Content Store immediately.

Changing the logic here to rescue from those exceptions and log the error instead of failing. This will mean the job doesn't get added to the retry queue and won't remain locked. This means if the document is updated so it can be sent downstream, a new job can be scheduled and the document sent to Content Store immediately.