### PR TITLE
Navigation spike - expanded reverse links [WHIT-3342]

### DIFF
--- a/lib/expansion_rules.rb
+++ b/lib/expansion_rules.rb
@@ -71,6 +71,12 @@ module_function
     ministerial: :ministers,
   }.freeze
 
+  # These expand every member of the reciprocal direct link type from
+  # the source link set, instead of only mirroring the edition being expanded.
+  REVERSE_LINKS_WITH_MEMBER_EXPANSION = {
+    document_collections: :documents,
+  }.freeze
+
   # These fields are required by the frontend_links definition
   MANDATORY_FIELDS = %i[
     content_id
@@ -227,6 +233,10 @@ module_function
 
   def reverse_link_type(link_type)
     REVERSE_LINKS[link_type.to_sym]
+  end
+
+  def member_expansion_direct_link_type(reverse_link_type)
+    REVERSE_LINKS_WITH_MEMBER_EXPANSION[reverse_link_type.to_sym]
   end
 
   def reverse_to_direct_link_type(link_type)

--- a/lib/expansion_rules.rb
+++ b/lib/expansion_rules.rb
@@ -112,6 +112,7 @@ module_function
   PERSON_FIELDS_WITH_IMAGE = (DEFAULT_FIELDS + details_fields(:image, :privy_counsellor)).freeze
   ROLE_FIELDS = (DEFAULT_FIELDS + details_fields(:body, :role_payment_type)).freeze
   ROLE_APPOINTMENT_FIELDS = (DEFAULT_FIELDS + details_fields(:started_on, :ended_on, :current, :person_appointment_order)).freeze
+  SHARED_NAVIGATION_FIELDS = (DEFAULT_FIELDS + details_fields(:menu_items)).freeze
   STEP_BY_STEP_FIELDS = (DEFAULT_FIELDS + [%i[details step_by_step_nav title], %i[details step_by_step_nav steps]]).freeze
   STEP_BY_STEP_AUTH_BYPASS_FIELDS = (STEP_BY_STEP_FIELDS + %i[auth_bypass_ids]).freeze
   TAKE_PART_PAGE_FIELDS = (DEFAULT_FIELDS + %i[description details]).freeze
@@ -167,6 +168,8 @@ module_function
         fields: CONTACT_FIELDS },
       { document_type: :content_block_pension,
         fields: CONTENT_BLOCK_PENSION_FIELDS },
+      { document_type: :document_collections, # TODO: this would be shared_navigation
+        fields: SHARED_NAVIGATION_FIELDS },
       { document_type: :topical_event,
         fields: DEFAULT_FIELDS },
       { document_type: :organisation,

--- a/lib/link_expansion.rb
+++ b/lib/link_expansion.rb
@@ -83,9 +83,10 @@ private
     end
 
     reverse_link_type = node.link_types_path.first
+    direct_link_type = rules.member_expansion_direct_link_type(reverse_link_type)
 
-    if reverse_link_type == :document_collections
-      return document_collection_member_links(node.content_id)
+    if direct_link_type
+      return reverse_link_member_links(node.content_id, direct_link_type)
     end
 
     edition_hash = content_cache.find(content_id)
@@ -103,26 +104,26 @@ private
       end
   end
 
-  def document_collection_member_links(collection_content_id)
-    document_links = Queries::Links.from(
-      collection_content_id,
-      allowed_link_types: [:documents],
-    )[:documents] || []
+  def reverse_link_member_links(source_content_id, direct_link_type)
+    member_links = Queries::Links.from(
+      source_content_id,
+      allowed_link_types: [direct_link_type],
+    )[direct_link_type] || []
 
-    documents = document_links.filter_map do |link|
+    members = member_links.filter_map do |link|
       edition_hash = content_cache.find(link[:content_id])
-      next unless edition_hash && should_link?(:documents, edition_hash)
+      next unless edition_hash && should_link?(direct_link_type, edition_hash)
 
       rules.expand_fields(
         edition_hash,
-        link_type: :documents,
+        link_type: direct_link_type,
         draft: with_drafts,
       ).merge(links: {})
     end
 
-    return {} if documents.empty?
+    return {} if members.empty?
 
-    { documents: documents }
+    { direct_link_type => members }
   end
 
   def should_link?(link_type, edition_hash)

--- a/lib/link_expansion.rb
+++ b/lib/link_expansion.rb
@@ -82,11 +82,17 @@ private
       return {}
     end
 
+    reverse_link_type = node.link_types_path.first
+
+    if reverse_link_type == :document_collections
+      return document_collection_member_links(node.content_id)
+    end
+
     edition_hash = content_cache.find(content_id)
     return {} if !edition_hash || !should_link?(node.link_type, edition_hash)
 
     rules
-      .reverse_to_direct_link_type(node.link_types_path.first)
+      .reverse_to_direct_link_type(reverse_link_type)
       .each_with_object({}) do |reverse_to_direct_link_type, memo|
         expanded = rules.expand_fields(
           edition_hash,
@@ -95,6 +101,28 @@ private
         )
         memo[reverse_to_direct_link_type] = [expanded.merge(links: {})]
       end
+  end
+
+  def document_collection_member_links(collection_content_id)
+    document_links = Queries::Links.from(
+      collection_content_id,
+      allowed_link_types: [:documents],
+    )[:documents] || []
+
+    documents = document_links.filter_map do |link|
+      edition_hash = content_cache.find(link[:content_id])
+      next unless edition_hash && should_link?(:documents, edition_hash)
+
+      rules.expand_fields(
+        edition_hash,
+        link_type: :documents,
+        draft: with_drafts,
+      ).merge(links: {})
+    end
+
+    return {} if documents.empty?
+
+    { documents: documents }
   end
 
   def should_link?(link_type, edition_hash)

--- a/spec/lib/expansion_rules_spec.rb
+++ b/spec/lib/expansion_rules_spec.rb
@@ -387,6 +387,30 @@ RSpec.describe ExpansionRules do
     end
   end
 
+  describe "REVERSE_LINKS_WITH_MEMBER_EXPANSION" do
+    it "only lists reverse link types that exist in REVERSE_LINKS" do
+      described_class::REVERSE_LINKS_WITH_MEMBER_EXPANSION.each_key do |reverse_link_type|
+        expect(described_class::REVERSE_LINKS.values).to include(reverse_link_type)
+      end
+    end
+
+    it "maps each reverse link type to its reciprocal direct link type" do
+      described_class::REVERSE_LINKS_WITH_MEMBER_EXPANSION.each do |reverse_link_type, direct_link_type|
+        expect(described_class.reverse_link_type(direct_link_type)).to eq(reverse_link_type)
+      end
+    end
+
+    describe ".member_expansion_direct_link_type" do
+      it "returns the direct link type for configured reverse links" do
+        expect(described_class.member_expansion_direct_link_type(:document_collections)).to eq(:documents)
+      end
+
+      it "returns nil for reverse links with reciprocal-only expansion" do
+        expect(described_class.member_expansion_direct_link_type(:parent)).to be_nil
+      end
+    end
+  end
+
   describe "REVERSE_LINKS" do
     let(:reverse_links) { described_class.reverse_links.map(&:to_s) }
 

--- a/spec/lib/link_expansion_spec.rb
+++ b/spec/lib/link_expansion_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe LinkExpansion do
       end
     end
 
-    context "with a reverse link" do
+    context "with a reverse link with member expansion configured" do
       let(:collection_content_id) { SecureRandom.uuid }
       let(:first_document_content_id) { SecureRandom.uuid }
       let(:second_document_content_id) { SecureRandom.uuid }

--- a/spec/lib/link_expansion_spec.rb
+++ b/spec/lib/link_expansion_spec.rb
@@ -59,6 +59,76 @@ RSpec.describe LinkExpansion do
       end
     end
 
+    context "with a reverse link" do
+      let(:collection_content_id) { SecureRandom.uuid }
+      let(:first_document_content_id) { SecureRandom.uuid }
+      let(:second_document_content_id) { SecureRandom.uuid }
+
+      let!(:collection) do
+        create_edition(
+          collection_content_id,
+          "/government/collections/example-collection",
+          document_type: "document_collection",
+          schema_name: "document_collection",
+          title: "Example Collection",
+        )
+      end
+
+      let!(:first_document) do
+        create_edition(
+          first_document_content_id,
+          "/government/publications/first-publication",
+          document_type: "policy_paper",
+          schema_name: "publication",
+          title: "First Publication",
+        )
+      end
+
+      let!(:second_document) do
+        create_edition(
+          second_document_content_id,
+          "/government/publications/second-publication",
+          document_type: "policy_paper",
+          schema_name: "publication",
+          title: "Second Publication",
+        )
+      end
+
+      let(:content_id) { first_document_content_id }
+
+      before do
+        create(
+          :link_set,
+          content_id: collection_content_id,
+          links_hash: {
+            documents: [
+              first_document_content_id,
+              second_document_content_id,
+            ],
+          },
+        )
+      end
+
+      it "expands all member documents under the collection" do
+        document_collections = subject.fetch(:document_collections)
+        expect(document_collections.size).to eq(1)
+
+        member_documents = document_collections.first.fetch(:links).fetch(:documents)
+        expect(member_documents).to contain_exactly(
+          a_hash_including(
+            content_id: first_document_content_id,
+            title: first_document.title,
+            base_path: first_document.base_path,
+          ),
+          a_hash_including(
+            content_id: second_document_content_id,
+            title: second_document.title,
+            base_path: second_document.base_path,
+          ),
+        )
+      end
+    end
+
     context "with recursive links" do
       let(:child_content_id) { SecureRandom.uuid }
       let(:grand_child_content_id) { SecureRandom.uuid }


### PR DESCRIPTION
Jira: https://gov-uk.atlassian.net/browse/WHIT-3342

---

This application is owned by the Content APIs team. Please let us know in [#govuk-content-apis](https://gds.slack.com/archives/C03D792LYJG) when you raise any PRs.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
