### PR TITLE
[PP-7768] Add collector to export Sidekiq lock metrics

### DIFF
--- a/config/initializers/prometheus.rb
+++ b/config/initializers/prometheus.rb
@@ -1,2 +1,4 @@
 require "govuk_app_config/govuk_prometheus_exporter"
-GovukPrometheusExporter.configure
+require "collectors/sidekiq_old_locks_collector"
+
+GovukPrometheusExporter.configure(collectors: [Collectors::SidekiqOldLocksCollector])

--- a/lib/collectors/sidekiq_old_locks_collector.rb
+++ b/lib/collectors/sidekiq_old_locks_collector.rb
@@ -1,0 +1,21 @@
+require "sidekiq_old_locks/web/helpers"
+
+module Collectors
+  class SidekiqOldLocksCollector < PrometheusExporter::Server::CollectorBase
+    include SidekiqOldLocks::Web::Helpers
+
+    def type
+      "publishing_api"
+    end
+
+    def metrics
+      old_lock_count_gauge = PrometheusExporter::Metric::Gauge.new(
+        "publishing_api_old_lock_count",
+        "Count of sidekiq-unique-jobs locks that are older than #{SidekiqUniqueJobs.config.lock_ttl.seconds} seconds in Publishing API",
+      )
+      old_lock_count_gauge.observe(old_digests.count)
+
+      [old_lock_count_gauge]
+    end
+  end
+end

--- a/spec/lib/collectors/sidekiq_old_locks_collector_spec.rb
+++ b/spec/lib/collectors/sidekiq_old_locks_collector_spec.rb
@@ -1,0 +1,39 @@
+RSpec.describe(Collectors::SidekiqOldLocksCollector) do
+  describe "#metrics" do
+    let(:gauge) { instance_double(PrometheusExporter::Metric::Gauge) }
+
+    before do
+      allow(PrometheusExporter::Metric::Gauge)
+        .to receive(:new)
+        .and_return(gauge)
+
+      allow(gauge).to receive(:observe)
+    end
+
+    context "when there are no locks older than one hour" do
+      before do
+        allow_any_instance_of(SidekiqOldLocks::Web::Helpers).to receive(:old_digests).and_return([])
+      end
+      it "set a zero value" do
+        described_class.new.metrics
+
+        expect(gauge).to have_received(:observe).with(0)
+      end
+    end
+
+    context "when there are locks older than one hour" do
+      before do
+        allow_any_instance_of(SidekiqOldLocks::Web::Helpers).to receive(:old_digests).and_return(
+          [
+            { digest: "uniquejobs:f2f8d140b3191770c992ad238c95dbb9", created_at: 1_778_154_689.8511593, state: :active },
+          ],
+        )
+      end
+      it "sets the value" do
+        described_class.new.metrics
+
+        expect(gauge).to have_received(:observe).with(1)
+      end
+    end
+  end
+end


### PR DESCRIPTION
We recently added a dashboard that allows us to see old `sidekiq-unique-jobs` locks that have not been removed after the default expiry time (currently one hour). See https://github.com/alphagov/publishing-api/pull/4045.

This adds a collector that pushes the count of the same into Prometheus.

This metric is used to add a Slack alert in https://github.com/alphagov/govuk-helm-charts/pull/4291.