### PR TITLE
Bump content_block_tools to v1.14

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -126,7 +126,7 @@ GEM
     climate_control (1.2.0)
     concurrent-ruby (1.3.6)
     connection_pool (2.5.5)
-    content_block_tools (1.14.0)
+    content_block_tools (1.14.1)
       actionview (>= 6, < 8.1.4)
       gds-api-adapters (>= 101.0)
       govspeak (>= 10.6.3)
@@ -257,15 +257,15 @@ GEM
       nokogiri (~> 1.12)
       rinku (~> 2.0)
       sanitize (>= 6, < 8)
-    govuk_app_config (9.24.0)
-      connection_pool (< 3)
+    govuk_app_config (9.25.0)
+      connection_pool (< 4)
       logstasher (~> 2.1)
       opentelemetry-exporter-otlp (>= 0.25, < 0.34)
       opentelemetry-instrumentation-all (>= 0.39.1, < 0.92.0)
       opentelemetry-sdk (~> 1.2)
       plek (>= 4, < 6)
       prometheus_exporter (~> 2.3)
-      puma (>= 5.6, < 8.0)
+      puma (>= 5.6, < 9.0)
       rack-proxy (~> 0.7)
       sentry-rails (>= 5.3, < 7.0)
       sentry-ruby (>= 5.3, < 7.0)
@@ -650,7 +650,7 @@ GEM
       date
       stringio
     public_suffix (7.0.5)
-    puma (7.2.1)
+    puma (8.0.2)
       nio4r (~> 2.0)
     raabro (1.4.0)
     racc (1.8.1)
@@ -977,4 +977,4 @@ DEPENDENCIES
   with_advisory_lock
 
 BUNDLED WITH
-  4.0.10
+  4.0.6


### PR DESCRIPTION
The Content Modelling team is in the process of migrating pension “amount” values so that they do not contain the currency symbol ‘£’ at the start of the value string, but rather as a separate prefix. We have updated content block tools with v1.14 to temporarily accommodate both the new and legacy format in presenting pension amounts whilst we migrate the data.

This application is owned by the Content APIs team. Please let us know in [#govuk-content-apis](https://gds.slack.com/archives/C03D792LYJG) when you raise any PRs.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
