### PR TITLE
Allow embedded about page details on topical event pages [WHIT-3520]

### DIFF
--- a/content_schemas/dist/formats/topical_event/frontend/schema.json
+++ b/content_schemas/dist/formats/topical_event/frontend/schema.json
@@ -286,6 +286,33 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "about": {
+          "type": "object",
+          "required": [
+            "title",
+            "slug",
+            "summary",
+            "body"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "body": {
+              "type": "string"
+            },
+            "headers": {
+              "$ref": "#/definitions/nested_headers"
+            },
+            "slug": {
+              "type": "string"
+            },
+            "summary": {
+              "type": "string"
+            },
+            "title": {
+              "type": "string"
+            }
+          }
+        },
         "about_page_link_text": {
           "type": "string"
         },
@@ -685,6 +712,33 @@
         "zh-hk",
         "zh-tw"
       ]
+    },
+    "nested_headers": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "text",
+          "level",
+          "id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "headers": {
+            "$ref": "#/definitions/nested_headers"
+          },
+          "id": {
+            "type": "string"
+          },
+          "level": {
+            "type": "integer"
+          },
+          "text": {
+            "type": "string"
+          }
+        }
+      },
+      "minItems": 1
     },
     "ordered_featured_documents": {
       "description": "A set of featured documents to display.",

--- a/content_schemas/dist/formats/topical_event/notification/schema.json
+++ b/content_schemas/dist/formats/topical_event/notification/schema.json
@@ -376,6 +376,33 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "about": {
+          "type": "object",
+          "required": [
+            "title",
+            "slug",
+            "summary",
+            "body"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "body": {
+              "type": "string"
+            },
+            "headers": {
+              "$ref": "#/definitions/nested_headers"
+            },
+            "slug": {
+              "type": "string"
+            },
+            "summary": {
+              "type": "string"
+            },
+            "title": {
+              "type": "string"
+            }
+          }
+        },
         "about_page_link_text": {
           "type": "string"
         },
@@ -788,6 +815,33 @@
         "zh-hk",
         "zh-tw"
       ]
+    },
+    "nested_headers": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "text",
+          "level",
+          "id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "headers": {
+            "$ref": "#/definitions/nested_headers"
+          },
+          "id": {
+            "type": "string"
+          },
+          "level": {
+            "type": "integer"
+          },
+          "text": {
+            "type": "string"
+          }
+        }
+      },
+      "minItems": 1
     },
     "ordered_featured_documents": {
       "description": "A set of featured documents to display.",

--- a/content_schemas/dist/formats/topical_event/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/topical_event/publisher_v2/schema.json
@@ -233,6 +233,33 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "about": {
+          "type": "object",
+          "required": [
+            "title",
+            "slug",
+            "summary",
+            "body"
+          ],
+          "additionalProperties": false,
+          "properties": {
+            "body": {
+              "type": "string"
+            },
+            "headers": {
+              "$ref": "#/definitions/nested_headers"
+            },
+            "slug": {
+              "type": "string"
+            },
+            "summary": {
+              "type": "string"
+            },
+            "title": {
+              "type": "string"
+            }
+          }
+        },
         "about_page_link_text": {
           "type": "string"
         },
@@ -506,6 +533,33 @@
         "zh-hk",
         "zh-tw"
       ]
+    },
+    "nested_headers": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "text",
+          "level",
+          "id"
+        ],
+        "additionalProperties": false,
+        "properties": {
+          "headers": {
+            "$ref": "#/definitions/nested_headers"
+          },
+          "id": {
+            "type": "string"
+          },
+          "level": {
+            "type": "integer"
+          },
+          "text": {
+            "type": "string"
+          }
+        }
+      },
+      "minItems": 1
     },
     "ordered_featured_documents": {
       "description": "A set of featured documents to display.",

--- a/content_schemas/examples/topical_event/frontend/topical-event-with-about-page.json
+++ b/content_schemas/examples/topical_event/frontend/topical-event-with-about-page.json
@@ -1,0 +1,190 @@
+{
+  "base_path": "/government/topical-events/western-balkans-summit-london-2018",
+  "content_id": "03271421-4cfe-4b50-a4e0-5b953541be54",
+  "description": "On 10 July 2018 the UK hosted the Western Balkans Summit in London. The summit brought together the leaders of the Western Balkans countries and like-minded European partners to strengthen security co-operation, increase economic stability and encourage political co-operation.",
+  "details": {
+    "body": "This is the body of the topical event. <a href=\"/government/topical-events/western-balkans-summit-london-2018/about\">Read more about the summit</a>",
+    "emphasised_organisations": [],
+    "image": {
+      "alt_text": "Western Balkans Summit London 2018",
+      "high_resolution_url": "https://assets.publishing.service.gov.uk/media/5abbc256e5274a1aa2d41ad0/s960_WB_Summit_Logo_Main.png",
+      "medium_resolution_url": "https://assets.publishing.service.gov.uk/media/5abbc25740f0b67d67479d09/s630_WB_Summit_Logo_Main.png",
+      "url": "https://assets.publishing.service.gov.uk/media/5abbc29b40f0b67d67479d0b/s300_WB_Summit_Logo_Main.png"
+    },
+    "ordered_featured_documents": [
+      {
+        "href": "/government/news/uk-hosts-western-balkans-summit",
+        "image": {
+          "alt_text": "Family Photo",
+          "url": "https://assets.publishing.service.gov.uk/media/5b45a61be5274a3755402bfa/s465_IMG_11Jul2018at072855.jpg"
+        },
+        "summary": "The fifth Western Balkans Summit concluded on 10 July with the signing of joint declarations on Good Neighbourly Relations, War Crimes and Missing Persons.",
+        "title": "UK hosts Western Balkans Summit",
+        "public_updated_at": "2018-07-11T14:24:09Z",
+        "document_type": "News story"
+      },
+      {
+        "href": "/government/publications/western-balkans-summit-leaders-meeting-10-july-2018-chairs-conclusions",
+        "image": {
+          "alt_text": "PM and Chancellor",
+          "url": "https://assets.publishing.service.gov.uk/media/5b45af18e5274a3779f80a5f/s465_IMG_11Jul2018at081529.jpg"
+        },
+        "summary": "Prime Minister Theresa May's conclusions from the leaders meeting of the London 2018 Western Balkans Summit.",
+        "title": "Western Balkans Summit Leaders Meeting, 10 July 2018: chair's conclusions",
+        "public_updated_at": "2018-07-11T14:24:09Z", 
+        "document_type": "Publication"
+      },
+      {
+        "href": "/government/publications/joint-declarations-signed-at-the-leaders-meeting-of-the-western-balkans-summit-by-berlin-process-participants",
+        "image": {
+          "alt_text": "plenary",
+          "url": "https://assets.publishing.service.gov.uk/media/5b45ae80e5274a377077466a/s465_IMG_11Jul2018at073300.jpg"
+        },
+        "summary": "These joint declarations cover regional cooperation and good neighbourly relations, war crimes and missing persons, as part of the Berlin Process framework.",
+        "title": "Leaders Meeting of the London 2018 Western Balkans Summit: joint declarations",
+        "public_updated_at": "2018-07-11T14:24:09Z", 
+        "document_type": "Publication"
+      },
+      {
+        "href": "/government/news/pm-reveals-package-of-measures-to-promote-a-more-peaceful-prosperous-and-democratic-western-balkans",
+        "image": {
+          "alt_text": "PM reveals package of measures to promote a more peaceful, prosperous and democratic Western Balkans’ within ‘Western Balkans Summit: London 2018’",
+          "url": "https://assets.publishing.service.gov.uk/media/5b44b224e5274a37779450a2/s465_43251111092_7aeb21688c_k.jpg"
+        },
+        "summary": "UK to remain fully committed to Western Balkans prosperity and security after Brexit, PM confirms as host of Summit.",
+        "title": "PM reveals package of measures to promote a more peaceful, prosperous and democratic Western Balkans",
+        "public_updated_at": "2018-07-11T14:24:09Z", 
+        "document_type": "News story"
+      },
+      {
+        "href": "/government/news/global-entrepreneur-scheme-set-to-boost-trade-with-western-balkans",
+        "image": {
+          "alt_text": "Start Up Games",
+          "url": "https://assets.publishing.service.gov.uk/media/5b44558340f0b678c68bcf37/s465_IMG_10Jul2018at074156.jpg"
+        },
+        "summary": "The Department for International Trade's programme will be expanded into 6 new countries, strengthening relationships and promoting investment.",
+        "title": "Global entrepreneur scheme set to boost trade with Western Balkans",
+        "public_updated_at": "2018-07-11T14:24:09Z", 
+        "document_type": "News story"
+      }
+    ],
+    "about": {
+      "title": "About the Western Balkans Summit",
+      "slug": "about",
+      "summary": "On 10 July 2018 the UK hosted the Western Balkans Summit in London, the fifth summit convened under the Berlin Process.",
+      "body": "<div class=\"govspeak\"><p>Prime Minister Theresa May hosted the Western Balkans Summit in London on 10 July, demonstrating our longstanding commitment to the region and to European security. Heads of Government of the Western Balkans 6, Albania, Bosnia and Herzegovina, Kosovo, Macedonia, Montenegro and Serbia, attended the Summit, and also representatives of Austria, Croatia, France, Germany, Italy, Poland and Slovenia, as well as Bulgaria and Greece and the EU institutions.</p>\n\n<p>The Summit was the fifth to take place under the Berlin Process after Berlin (2014), Vienna (2015), Paris (2016) and Trieste (2017). The Berlin Process is a diplomatic initiative that Chancellor Merkel launched in 2014. Each year it brings together the 6 Western Balkans countries, like-minded EU partners and representatives of the EU institutions to work together to support security, stability and prosperity in the region.</p>\n\n<h2 id=\"summit-aims\">Summit aims</h2>\n\n<p>The summit focused on 3 areas:</p>\n\n<ul>\n  <li>increasing economic stability with a view to improving the business environment, encouraging entrepreneurship, addressing youth unemployment, and promoting regional inter-connectivity</li>\n  <li>strengthening regional security co-operation to help tackle common threats, including corruption, serious and organised crime, trafficking of people, drugs and firearms, terrorism and violent extremism</li>\n  <li>facilitating political co-operation – to help the region resolve bilateral disputes and overcome legacy issues stemming from the conflicts of the 1990s and strengthen democracy</li>\n</ul>\n\n<p>The UK wants a strong, stable and prosperous Western Balkans region. By hosting the summit in London, we demonstrate our continued interest and involvement in the stability of the region beyond our exit from the EU.</p>\n</div>",
+      "headers": [
+        {
+          "text": "Summit aims",
+          "level": 2,
+          "id": "summit-aims"
+        }
+      ]
+    },
+    "social_media_links": [
+      {
+        "href": "https://twitter.com/foreignoffice",
+        "service_type": "twitter",
+        "title": "Twitter"
+      }
+    ]
+  },
+  "document_type": "topical_event",
+  "first_published_at": "2018-03-28T17:27:00+01:00",
+  "links": {
+    "available_translations": [
+      {
+        "api_path": "/api/content/government/topical-events/western-balkans-summit-london-2018",
+        "api_url": "https://www.gov.uk/api/content/government/topical-events/western-balkans-summit-london-2018",
+        "base_path": "/government/topical-events/western-balkans-summit-london-2018",
+        "content_id": "03271421-4cfe-4b50-a4e0-5b953541be54",
+        "document_type": "topical_event",
+        "links": {},
+        "locale": "en",
+        "public_updated_at": "2018-07-12T14:24:09Z",
+        "schema_name": "topical_event",
+        "title": "Western Balkans Summit: London 2018",
+        "web_url": "https://www.gov.uk/government/topical-events/western-balkans-summit-london-2018",
+        "withdrawn": false
+      }
+    ],
+    "children": [
+      {
+        "api_path": "/api/content/government/topical-events/western-balkans-summit-london-2018/about",
+        "api_url": "https://www.gov.uk/api/content/government/topical-events/western-balkans-summit-london-2018/about",
+        "base_path": "/government/topical-events/western-balkans-summit-london-2018/about",
+        "content_id": "5095cc32-51b3-4f60-8e6e-b29945644cb1",
+        "document_type": "topical_event_about_page",
+        "links": {
+          "parent": [
+            {
+              "api_path": "/api/content/government/topical-events/western-balkans-summit-london-2018",
+              "api_url": "https://www.gov.uk/api/content/government/topical-events/western-balkans-summit-london-2018",
+              "base_path": "/government/topical-events/western-balkans-summit-london-2018",
+              "content_id": "03271421-4cfe-4b50-a4e0-5b953541be54",
+              "document_type": "topical_event",
+              "links": {},
+              "locale": "en",
+              "public_updated_at": "2018-07-12T14:24:09Z",
+              "schema_name": "topical_event",
+              "title": "Western Balkans Summit: London 2018",
+              "web_url": "https://www.gov.uk/government/topical-events/western-balkans-summit-london-2018",
+              "withdrawn": false
+            }
+          ]
+        },
+        "locale": "en",
+        "public_updated_at": "2018-07-12T14:27:55Z",
+        "schema_name": "topical_event_about_page",
+        "title": "About the Western Balkans Summit",
+        "web_url": "https://www.gov.uk/government/topical-events/western-balkans-summit-london-2018/about",
+        "withdrawn": false
+      }
+    ],
+    "organisations": [
+      {
+        "analytics_identifier": "D13",
+        "api_path": "/api/content/government/organisations/foreign-commonwealth-office",
+        "api_url": "https://www.gov.uk/api/content/government/organisations/foreign-commonwealth-office",
+        "base_path": "/government/organisations/foreign-commonwealth-office",
+        "content_id": "9adfc4ed-9f6c-4976-a6d8-18d34356367c",
+        "details": {
+          "acronym": "FCO",
+          "brand": "foreign-commonwealth-office",
+          "default_news_image": {
+            "high_resolution_url": "https://assets.publishing.service.gov.uk/media/5a37dae3ed915d5a5f966021/s960_Main-building-gov.uk.jpg",
+            "url": "https://assets.publishing.service.gov.uk/media/5a37dae240f0b649cceb1839/s300_Main-building-gov.uk.jpg"
+          },
+          "logo": {
+            "crest": "single-identity",
+            "formatted_title": "Foreign \u0026amp;\u003cbr/\u003eCommonwealth \u003cbr/\u003eOffice"
+          },
+          "organisation_govuk_status": {
+            "status": "replaced",
+            "updated_at": "2020-09-02T00:00:00.000+01:00",
+            "url": "http://www.gov.uk/fco"
+          }
+        },
+        "document_type": "organisation",
+        "links": {},
+        "locale": "en",
+        "schema_name": "organisation",
+        "title": "Foreign \u0026 Commonwealth Office",
+        "web_url": "https://www.gov.uk/government/organisations/foreign-commonwealth-office",
+        "withdrawn": false
+      }
+    ]
+  },
+  "locale": "en",
+  "phase": "live",
+  "public_updated_at": "2018-07-12T15:24:09+01:00",
+  "publishing_app": "whitehall",
+  "publishing_request_id": "21-1706871735.096-10.13.27.63-698",
+  "publishing_scheduled_at": null,
+  "rendering_app": "frontend",
+  "scheduled_publishing_delay_seconds": null,
+  "schema_name": "topical_event",
+  "title": "Western Balkans Summit: London 2018",
+  "updated_at": "2026-01-07T17:40:12+00:00",
+  "withdrawn_notice": {}
+}

--- a/content_schemas/formats/topical_event.jsonnet
+++ b/content_schemas/formats/topical_event.jsonnet
@@ -37,8 +37,30 @@
           type: "array",
           items: {
             "$ref": "#/definitions/image_asset",
-          }
-        }
+          },
+        },
+        about: {
+          "type": "object",
+          additionalProperties: false,
+          required: ["title", "slug", "summary", "body"],
+          properties: {
+            title: {
+              type: "string",
+            },
+            slug: {
+              type: "string",
+            },
+            summary: {
+              type: "string",
+            },
+            body: {
+              type: "string",
+            },
+            headers: {
+              "$ref": "#/definitions/nested_headers"
+            },
+          },
+        },
       },
     },
   },


### PR DESCRIPTION
## What & Why

We need to support topical event about pages. Since the about page is tied very closely to the topical event page and could (reasonably) be rendered in the same page, it's been decided to keep it in the same content item as the topical event itself (this allows us after migration to retire the `topical_event_about_page` schema).

https://gov-uk.atlassian.net/browse/WHIT-3520

---

This application is owned by the Content APIs team. Please let us know in [#govuk-content-apis](https://gds.slack.com/archives/C03D792LYJG) when you raise any PRs.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
