### PR TITLE
Log extra context on Timeout::Error in QueuePublisher 

### DIFF
--- a/lib/queue_publisher.rb
+++ b/lib/queue_publisher.rb
@@ -74,9 +74,7 @@ private
       success = exchange.wait_for_confirms
       event_type = routing_key.split(".").last
 
-      if success
-        PublishingAPI.service(:statsd).increment("message-sent.#{event_type}")
-      else
+      unless success
         GovukError.notify(
           PublishFailedError.new("Publishing message failed"),
           level: "error",
@@ -86,7 +84,6 @@ private
             options:,
           },
         )
-        PublishingAPI.service(:statsd).increment("message-send-failure.#{event_type}")
       end
     ensure
       channel.close if channel.open?

--- a/lib/queue_publisher.rb
+++ b/lib/queue_publisher.rb
@@ -11,6 +11,7 @@ class QueuePublisher
   def connection
     @connection_mutex.synchronize do
       @connection ||= Bunny.new(ENV["RABBITMQ_URL"], @options)
+      @connection_created_at = Time.zone.now
       @connection.start
     end
   end
@@ -85,8 +86,39 @@ private
           },
         )
       end
-    ensure
+    rescue Timeout::Error => e
+      Rails.logger.error(
+        e,
+        extra: {
+          routing_key:,
+          event_type:,
+          connection_open: connection.open?,
+          channel_open: channel.open?,
+          connection_status: connection.status,
+          connection_age_seconds: Time.zone.now.to_i - @connection_created_at.to_i,
+          broker_host: connection.transport.host,
+        },
+      )
+
+      raise
+    end
+  ensure
+    begin
       channel.close if channel.open?
+    rescue Timeout::Error => e
+      Rails.logger.error(
+        e,
+        extra: {
+          routing_key:,
+          event_type:,
+          connection_open: connection.open?,
+          connection_status: connection.status,
+          connection_age_seconds: Time.zone.now.to_i - @connection_created_at.to_i,
+          broker_host: connection.transport.host,
+        },
+      )
+
+      raise
     end
   end
 end

--- a/spec/lib/queue_publisher_spec.rb
+++ b/spec/lib/queue_publisher_spec.rb
@@ -116,6 +116,19 @@ RSpec.describe QueuePublisher do
 
             queue_publisher.send_message(content_item)
           end
+
+          it "logs and re-raises timeout errors" do
+            allow(mock_channel).to receive(:open?).and_return(true)
+            allow(mock_channel).to receive(:close).and_raise(Timeout::Error)
+            allow(mock_session).to receive_messages(
+              open?: true,
+              status: :connected,
+              transport: instance_double("Bunny::Transport", host: "rabbitmq.example.com"),
+            )
+
+            expect(Rails.logger).to receive(:error)
+            expect { queue_publisher.send_message(content_item) }.to raise_error(Timeout::Error)
+          end
         end
       end
     end


### PR DESCRIPTION
We’ve seen some intermittent `Timeout::Error errors` raised by exchange.wait_for_confirms which are hard to reproduce.

We want to collect more data when it happen next time, without suppressing the error.  This will lets us see, in the logs, exactly what the state of the connection, channel and broker was at the moment of failure, which can help
pinpoint whether the issue is:
- AMQP connection dropped
- Broker failover
- Network issues
- Something wrong in the code’s connection management

Relevant incident report: https://docs.google.com/document/d/1gUOMQ3kEEYh9IhHEyWohfR67SVFbp8f6rBjqt6pKeDk/edit