### PR TITLE
[PP-7732] Allow skipping schema validation in patch links

### DIFF
--- a/app/commands/v2/patch_link_set.rb
+++ b/app/commands/v2/patch_link_set.rb
@@ -4,7 +4,7 @@ module Commands
       def call
         raise_unless_links_hash_is_provided
         check_bulk_publishing_present
-        validate_schema
+        validate_schema if validate_schema?
         link_set = LinkSet.find_or_create_locked(content_id:)
         check_version_and_raise_if_conflicting(link_set, previous_version_number)
 
@@ -138,6 +138,12 @@ module Commands
           "update_dependencies" => update_dependencies,
           "source_command" => "patch_link_set",
         )
+      end
+
+      def validate_schema?
+        return true unless payload.key?(:validate_schema)
+
+        payload[:validate_schema]
       end
 
       def validate_schema

--- a/docs/api.md
+++ b/docs/api.md
@@ -155,7 +155,7 @@ presented edition and [warnings](#warnings).
 - `update_type` *(optional)*
   - Accepts: "major", "minor", "republish"
   - It is acceptable to send a "minor" update for the first ever draft
-- `bulk_publishing` *(optional, default: false)*
+- `bulk_publishing` *(required)*
   - Set this to true when making multiple requests. Publishing API will use a
     lower priority queue to avoid delays to standard publishing activity.
 
@@ -525,10 +525,10 @@ in the request is preserved.
     }
   }
 ```
+- `bulk_publishing` *(required)*
+  - Set this to true when making multiple requests. Publishing API will use a lower priority queue to avoid delays to standard publishing activity.
 - `previous_version` *(optional, recommended)*
   - Used to ensure that we are updating the current version of the link set.
-- `bulk_publishing` *(optional, default: false)*
-  - Set this to true when making multiple requests. Publishing API will use a lower priority queue to avoid delays to standard publishing activity.
 - `validate_schema` *(optional, default: true)*
   - Set to false to skip validation of links against the content schema for
     the current payload. After changing a document's document type, allows

--- a/docs/api.md
+++ b/docs/api.md
@@ -529,6 +529,10 @@ in the request is preserved.
   - Used to ensure that we are updating the current version of the link set.
 - `bulk_publishing` *(optional, default: false)*
   - Set this to true when making multiple requests. Publishing API will use a lower priority queue to avoid delays to standard publishing activity.
+- `validate_schema` *(optional, default: true)*
+  - Set to false to skip validation of links against the content schema for
+    the current payload. After changing a document's document type, allows
+    for removal of links of types unsupported.
 
 ### State changes
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -464,7 +464,7 @@ it wants to defer to a reusable piece of content, such as an email address.
 
 - [`content_id`](model.md#content_id)
   - Identifies the target document for the reusable piece of content
-  
+
 ### Query parameters
 
 - `order` *(optional, default: "unique_pageviews")*
@@ -476,7 +476,7 @@ it wants to defer to a reusable piece of content, such as an email address.
 
 ## `GET /v2/content/:content_id/host-content/:host_content_id`
 
-Returns metadata for a single item of content with ID `:host_content_id` that has an embedded reference to 
+Returns metadata for a single item of content with ID `:host_content_id` that has an embedded reference to
 the target `:content_id`.
 
 ### Path parameters

--- a/spec/commands/v2/patch_link_set_spec.rb
+++ b/spec/commands/v2/patch_link_set_spec.rb
@@ -501,5 +501,34 @@ RSpec.describe Commands::V2::PatchLinkSet do
     end
   end
 
+  context "when an edition exists for the content_id" do
+    before do
+      create(
+        :edition,
+        document: create(:document, content_id:),
+        base_path: "/some-path",
+        title: "Some Title",
+      )
+    end
+
+    context "when called with validate: false in the payload" do
+      before { payload[:validate_schema] = false }
+
+      it "skips validation" do
+        expect_any_instance_of(described_class).not_to receive(:validate_schema)
+
+        described_class.call(payload)
+      end
+    end
+
+    context "when called without :validate in the payload" do
+      it "validates the payload against the schema" do
+        expect_any_instance_of(described_class).to receive(:validate_schema)
+
+        described_class.call(payload)
+      end
+    end
+  end
+
   it_behaves_like TransactionalCommand
 end


### PR DESCRIPTION
There are some instances where we want to allow patch links requests without validating against the schema. One example is when an edition's schema name/document type has changed and a publishing app needs to remove links of types not accepted by the new schema. The canonical way of removing all links of a given type is to include in the request's links hash a key of the link type pointing to an empty array. But including keys of unsupported link types is considered invalid by the schema validator. Though the `validate_schema` method only appears to warn when validation fails, we've had reports that the request is actually rejected in such cases. We therefore want to add the ability to skip validation on request

Initially I just used the `payload[:validate_schema]` value directly and gave it a default in the `V2::LinkSetsController` (5e82971fe17eddbe2d288311d7f6d6533952bfdf; like we do with the `payload[:bulk_publishing]` value, but `Commands::V2::PatchLinkSet` is called in other places and we want the default to be `true` regardless of where it's called (unlike `payload[:bulk_publishing]`, which we want to be set intentionally everywhere: https://github.com/alphagov/publishing-api/pull/3861). This therefore
fully manages the defaulting to `true` behaviour within the command itself

Dropped commits:
- e61ffc1af655c0d4146039491b953140685537fb
- 5e82971fe17eddbe2d288311d7f6d6533952bfdf