### PR TITLE
Correct docs of discard_draft rake task

### DIFF
--- a/docs/admin-tasks.md
+++ b/docs/admin-tasks.md
@@ -7,7 +7,13 @@ This is a place to list all of the admin tasks available in Publishing API.
 If you need to discard a draft of a document, run the `discard_draft` rake task:
 
 ```
-bundle exec rake discard_draft['some-content-id']
+bundle exec rake discard_draft[some-content-id]
+```
+
+For example:
+
+```
+bundle exec rake discard_draft[4f0fa224-2cfb-4c5f-a4bf-68146bc20ba9]
 ```
 
 ## Representing data downstream


### PR DESCRIPTION
The Content ID should not be quoted.

This application is owned by the Content APIs team. Please let us know in [#govuk-content-apis](https://gds.slack.com/archives/C03D792LYJG) when you raise any PRs.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
