### PR TITLE
Add validators to ensure base_path conforms to RFC-192

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -181,7 +181,7 @@ GEM
       et-orbi (~> 1.4)
       raabro (~> 1.4)
     fuzzy_match (2.1.0)
-    gds-api-adapters (103.3.1)
+    gds-api-adapters (103.4.0)
       addressable
       link_header
       null_logger
@@ -358,7 +358,7 @@ GEM
     mime-types (3.7.0)
       logger
       mime-types-data (~> 3.2025, >= 3.2025.0507)
-    mime-types-data (3.2026.0414)
+    mime-types-data (3.2026.0701)
     mini_mime (1.1.5)
     mini_portile2 (2.8.9)
     minitest (6.0.6)

--- a/app/commands/v2/put_content_validator.rb
+++ b/app/commands/v2/put_content_validator.rb
@@ -1,6 +1,13 @@
 module Commands
   module V2
     class PutContentValidator
+      FORMATS_WITHOUT_BASE_PATH_VALIDATION = %w[
+        contact
+        content_block
+        government
+        redirect
+      ].freeze
+
       def initialize(payload, put_content)
         @payload = payload
         @put_content = put_content
@@ -9,6 +16,7 @@ module Commands
       def validate
         validate_schema
         validate_publishing_app
+        validate_base_path
       end
 
     private
@@ -41,6 +49,28 @@ module Commands
               code:,
               message:,
               fields: { publishing_app: ["is required"] },
+            },
+          },
+        )
+      end
+
+      def validate_base_path
+        return if FORMATS_WITHOUT_BASE_PATH_VALIDATION.include?(payload[:schema_name])
+
+        base_path_validator = GdsApi::Validators::BasePathValidator.new(payload[:base_path])
+        return if base_path_validator.valid?
+
+        code = 422
+        message = "base_path did not conform to standard"
+        raise CommandError.new(
+          code:,
+          error_code: :base_path_invalid,
+          message:,
+          error_details: {
+            error: {
+              code:,
+              message:,
+              fields: base_path_validator.errors,
             },
           },
         )

--- a/app/models/path_reservation.rb
+++ b/app/models/path_reservation.rb
@@ -2,7 +2,7 @@ class PathReservation < ApplicationRecord
   validates :base_path, absolute_path: true
   validates :publishing_app, presence: true
 
-  validate :base_path_not_too_long
+  validate :base_path_valid
 
   def self.reserve_base_path!(base_path, publishing_app, override_existing: false)
     existing = find_by(base_path:)
@@ -46,8 +46,13 @@ class PathReservation < ApplicationRecord
     ActiveRecord::RecordInvalid.new(self)
   end
 
-  def base_path_not_too_long
-    errors.add(:base_path, "over 512 bytes", code: :base_path_too_long) if base_path.bytesize > 512
+  def base_path_valid
+    base_path_validator = GdsApi::Validators::BasePathValidator.new(base_path)
+    return if base_path_validator.valid?
+
+    base_path_validator.errors.each do |code, messages|
+      errors.add(:base_path, messages.join(", "), code:)
+    end
   end
 
   ERROR_CODE_MAP = {

--- a/spec/commands/v2/put_content_validator_spec.rb
+++ b/spec/commands/v2/put_content_validator_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe Commands::V2::PutContentValidator do
-  let(:payload) { { publishing_app: "foo" } }
+  let(:payload) { { publishing_app: "foo", base_path: "/hello" } }
   let(:command) { instance_double(Commands::V2::PutContent) }
   subject { described_class.new(payload, command) }
 
@@ -41,6 +41,24 @@ RSpec.describe Commands::V2::PutContentValidator do
           expect {
             subject.validate
           }.to raise_error(CommandError, /publishing_app is required/)
+        end
+      end
+
+      context "with an invalid base_path" do
+        let(:payload) { { publishing_app: "foo", base_path: "/Hello", schema_name: "guide" } }
+
+        it "raises an error" do
+          expect {
+            subject.validate
+          }.to raise_error(CommandError, /base_path did not conform to standard/)
+        end
+
+        context "when the content item is a redirect" do
+          let(:payload) { { publishing_app: "foo", base_path: "/Hello", schema_name: "redirect" } }
+
+          it "doesn't raise anything" do
+            expect { subject.validate }.not_to raise_error
+          end
         end
       end
     end

--- a/spec/lib/database_record_validator_spec.rb
+++ b/spec/lib/database_record_validator_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe DatabaseRecordValidator do
 
       output = File.read("/tmp/validation_results")
       expect(output).to eq(
-        "PathReservation id=#{invalid_record.id}: [\"Base path is not a valid absolute URL path\"]\n",
+        "PathReservation id=#{invalid_record.id}: [\"Base path is not a valid absolute URL path\", \"Base path must start with a /\"]\n",
       )
     end
   end

--- a/spec/models/path_reservation_spec.rb
+++ b/spec/models/path_reservation_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe PathReservation, type: :model do
       it "is a valid absolute URL base_path" do
         reservation.base_path = "not a URL"
         expect(reservation).to be_invalid
-        expect(reservation.errors[:base_path].size).to eq(1)
+        expect(reservation.errors[:base_path].size).to eq(2)
       end
 
       it "has a db level uniqueness constraint" do
@@ -20,6 +20,12 @@ RSpec.describe PathReservation, type: :model do
       it "is 512 bytes or fewer" do
         reservation.base_path = "/#{'bbc' * 171}"
         expect(reservation.base_path.bytesize).to eq(514)
+        expect(reservation).to be_invalid
+        expect(reservation.errors[:base_path].size).to eq(1)
+      end
+
+      it "is valid according to GdsApi::Validators::BasePathValidator" do
+        reservation.base_path = "/Hello"
         expect(reservation).to be_invalid
         expect(reservation.errors[:base_path].size).to eq(1)
       end
@@ -154,7 +160,17 @@ RSpec.describe PathReservation, type: :model do
         described_class.reserve_base_path!("/#{'bbc' * 171}", "publisher")
       }.to raise_error(ActiveRecord::RecordInvalid) { |exception|
              expect(exception.record.errors.details[:base_path]).to include(
-               error: "over 512 bytes", code: :base_path_too_long,
+               error: "must not be longer than 512 bytes", code: :base_path_too_long,
+             )
+           }
+    end
+
+    it "raises an error with :base_path_invalid error code when base_path is invalid according to GdsApi::Validators::BasePathValidator " do
+      expect {
+        described_class.reserve_base_path!("/Hello", "publisher")
+      }.to raise_error(ActiveRecord::RecordInvalid) { |exception|
+             expect(exception.record.errors.details[:base_path]).to include(
+               error: "must not include characters that are not lowercase letters, numbers, -, ., or /", code: :base_path_invalid,
              )
            }
     end


### PR DESCRIPTION
Uses the new GdsApi::Validators::BasePathValidator to check base_path validity on:
- Content put
- Path reservation
- Publishing intent put

...against [RFC-192 base path rules](https://github.com/alphagov/govuk-rfcs/blob/d4b4087ca64b522dc23afaee386265b211f542af/rfc-192-restrict-base-paths-to-a-smaller-character-set.md)

IMPORTANT - Do not merge before:
- [x] https://github.com/alphagov/gds-api-adapters/pull/1411 has been merged
- [x] a gem release including that code has happened 

This application is owned by the Content APIs team. Please let us know in [#govuk-content-apis](https://gds.slack.com/archives/C03D792LYJG) when you raise any PRs.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
