### PR TITLE
[PP-7913] Do not send substitute message for blocking editions

### DIFF
--- a/app/substitution_helper.rb
+++ b/app/substitution_helper.rb
@@ -30,7 +30,6 @@ module SubstitutionHelper
         discard_draft(blocking_edition, downstream, nested, callbacks)
       else
         blocking_edition.substitute
-        substitute_message(blocking_edition)
       end
     end
   end

--- a/spec/commands/v2/publish_spec.rb
+++ b/spec/commands/v2/publish_spec.rb
@@ -438,10 +438,6 @@ RSpec.describe Commands::V2::Publish do
 
       it "unpublishes the edition which is in the way" do
         expect(PublishingAPI.service(:queue_publisher)).to receive(:send_message).with(
-          hash_including(content_id: other_edition.content_id, document_type: "substitute"),
-          hash_including(event_type: "unpublish"),
-        )
-        expect(PublishingAPI.service(:queue_publisher)).to receive(:send_message).with(
           hash_including(content_id: draft_item.content_id),
           hash_including(event_type: "major"),
         )


### PR DESCRIPTION
In b99667da09fa83642bc20625730eac8a05fa692f, some changes were made to broadcast a message to the message queue for substitute editions.

Within the `SubstitutionHelper`, we added a broadcast message after the `substitute` method is called on the "blocking editions".

However the `subsitute` method does not actually result in any changes being pushed downstream (i.e. to Content Store) but this broadcast message results in the document being removed from Search API (which indexes by base path, not Content ID).

It then means the document is present in Content Store, but has completely been removed from Search API v1 and cannot be found.

Removing this call, as it is not needed at this location.

There is [already code present](https://github.com/alphagov/publishing-api/blob/0674799792665b1ff12fd6d3cc8279a631beb2f5/app/downstream_payload.rb#L85) that broadcasts the substitute message at the correct time.

This resolves an issue where sometimes organisations are removed from Search API v1, despite having a live edition present in Content Store.