### PR TITLE
[PP-7913] Add extra logging for message queue broadcasts

### DIFF
--- a/app/substitution_helper.rb
+++ b/app/substitution_helper.rb
@@ -37,7 +37,13 @@ module SubstitutionHelper
 
   def substitute_message(edition)
     payload = DownstreamPayload.new(edition, Event.maximum_id)
-    DownstreamService.broadcast_to_message_queue(payload, "unpublish")
+    event_type = "unpublish"
+
+    Rails.logger.info(
+      "SubstitutionHelper#substitute_message" \
+      "Broadcasting #{edition.content_id}@#{payload.payload_version} to message queue as type #{event_type}",
+    )
+    DownstreamService.broadcast_to_message_queue(payload, event_type)
   end
 
 private


### PR DESCRIPTION
In 6d0766c2f06028203073ce6b3cbc5b3bea02af29, extra logging was added to the `DownstreamLiveWorker` for broadcasts to the message queue.

This has proven useful in debugging an issue where an organisation had gone missing from Search API v1. However there were no logs for the `unpublish` event when triggered through the `SubstitutionHelper`.

Adding the same logic there, so it can be used in the future.