### PR TITLE
[PNP-10123] RFC-192 compliance

### DIFF
--- a/app/commands/v2/put_content_validator.rb
+++ b/app/commands/v2/put_content_validator.rb
@@ -1,6 +1,13 @@
 module Commands
   module V2
     class PutContentValidator
+      FORMATS_WITHOUT_BASE_PATH_VALIDATION = %w[
+        contact
+        content_block
+        government
+        redirect
+      ].freeze
+
       def initialize(payload, put_content)
         @payload = payload
         @put_content = put_content
@@ -9,6 +16,7 @@ module Commands
       def validate
         validate_schema
         validate_publishing_app
+        validate_base_path
       end
 
     private
@@ -41,6 +49,28 @@ module Commands
               code:,
               message:,
               fields: { publishing_app: ["is required"] },
+            },
+          },
+        )
+      end
+
+      def validate_base_path
+        return if FORMATS_WITHOUT_BASE_PATH_VALIDATION.include?(payload[:schema_name])
+
+        base_path_validator = GdsApi::Validators::BasePathValidator.new(payload[:base_path])
+        return if base_path_validator.valid?
+
+        code = 422
+        message = "base_path did not conform to standard"
+        raise CommandError.new(
+          code:,
+          error_code: :base_path_invalid,
+          message:,
+          error_details: {
+            error: {
+              code:,
+              message:,
+              fields: base_path_validator.errors,
             },
           },
         )

--- a/app/models/path_reservation.rb
+++ b/app/models/path_reservation.rb
@@ -2,7 +2,8 @@ class PathReservation < ApplicationRecord
   validates :base_path, absolute_path: true
   validates :publishing_app, presence: true
 
-  validate :base_path_not_too_long
+  validate :base_path_not_too_long, if: :from_short_url_manager?
+  validate :base_path_valid, unless: :from_short_url_manager?
 
   def self.reserve_base_path!(base_path, publishing_app, override_existing: false)
     existing = find_by(base_path:)
@@ -48,6 +49,19 @@ class PathReservation < ApplicationRecord
 
   def base_path_not_too_long
     errors.add(:base_path, "over 512 bytes", code: :base_path_too_long) if base_path.bytesize > 512
+  end
+
+  def from_short_url_manager?
+    publishing_app == "short-url-manager"
+  end
+
+  def base_path_valid
+    base_path_validator = GdsApi::Validators::BasePathValidator.new(base_path)
+    return if base_path_validator.valid?
+
+    base_path_validator.errors.each do |code, messages|
+      errors.add(:base_path, messages.join(", "), code:)
+    end
   end
 
   ERROR_CODE_MAP = {

--- a/spec/commands/v2/put_content_validator_spec.rb
+++ b/spec/commands/v2/put_content_validator_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe Commands::V2::PutContentValidator do
-  let(:payload) { { publishing_app: "foo" } }
+  let(:payload) { { publishing_app: "foo", base_path: "/hello" } }
   let(:command) { instance_double(Commands::V2::PutContent) }
   subject { described_class.new(payload, command) }
 
@@ -41,6 +41,24 @@ RSpec.describe Commands::V2::PutContentValidator do
           expect {
             subject.validate
           }.to raise_error(CommandError, /publishing_app is required/)
+        end
+      end
+
+      context "with an invalid base_path" do
+        let(:payload) { { publishing_app: "foo", base_path: "/Hello", schema_name: "guide" } }
+
+        it "raises an error" do
+          expect {
+            subject.validate
+          }.to raise_error(CommandError, /base_path did not conform to standard/)
+        end
+
+        context "when the content item is a redirect" do
+          let(:payload) { { publishing_app: "foo", base_path: "/Hello", schema_name: "redirect" } }
+
+          it "doesn't raise anything" do
+            expect { subject.validate }.not_to raise_error
+          end
         end
       end
     end

--- a/spec/lib/database_record_validator_spec.rb
+++ b/spec/lib/database_record_validator_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe DatabaseRecordValidator do
 
       output = File.read("/tmp/validation_results")
       expect(output).to eq(
-        "PathReservation id=#{invalid_record.id}: [\"Base path is not a valid absolute URL path\"]\n",
+        "PathReservation id=#{invalid_record.id}: [\"Base path is not a valid absolute URL path\", \"Base path must start with a /\"]\n",
       )
     end
   end

--- a/spec/models/path_reservation_spec.rb
+++ b/spec/models/path_reservation_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe PathReservation, type: :model do
       it "is a valid absolute URL base_path" do
         reservation.base_path = "not a URL"
         expect(reservation).to be_invalid
-        expect(reservation.errors[:base_path].size).to eq(1)
+        expect(reservation.errors[:base_path].size).to eq(2)
       end
 
       it "has a db level uniqueness constraint" do
@@ -22,6 +22,29 @@ RSpec.describe PathReservation, type: :model do
         expect(reservation.base_path.bytesize).to eq(514)
         expect(reservation).to be_invalid
         expect(reservation.errors[:base_path].size).to eq(1)
+      end
+
+      it "is valid according to GdsApi::Validators::BasePathValidator" do
+        reservation.base_path = "/Hello"
+        expect(reservation).to be_invalid
+        expect(reservation.errors[:base_path].size).to eq(1)
+      end
+
+      context "when publishing_app is short-url-manager" do
+        let(:reservation) { build(:path_reservation, publishing_app: "short-url-manager") }
+
+        it "is 512 bytes or fewer" do
+          reservation.base_path = "/#{'bbc' * 171}"
+          expect(reservation.base_path.bytesize).to eq(514)
+          expect(reservation).to be_invalid
+          expect(reservation.errors[:base_path].size).to eq(1)
+        end
+
+        it "does not validate against GdsApi::Validators::BasePathValidator" do
+          reservation.base_path = "/Hello"
+          expect(reservation).to be_valid
+          expect(reservation.errors[:base_path].size).to eq(0)
+        end
       end
     end
 
@@ -154,7 +177,17 @@ RSpec.describe PathReservation, type: :model do
         described_class.reserve_base_path!("/#{'bbc' * 171}", "publisher")
       }.to raise_error(ActiveRecord::RecordInvalid) { |exception|
              expect(exception.record.errors.details[:base_path]).to include(
-               error: "over 512 bytes", code: :base_path_too_long,
+               error: "must not be longer than 512 bytes", code: :base_path_too_long,
+             )
+           }
+    end
+
+    it "raises an error with :base_path_invalid error code when base_path is invalid according to GdsApi::Validators::BasePathValidator " do
+      expect {
+        described_class.reserve_base_path!("/Hello", "publisher")
+      }.to raise_error(ActiveRecord::RecordInvalid) { |exception|
+             expect(exception.record.errors.details[:base_path]).to include(
+               error: "must not include characters that are not lowercase letters, numbers, -, ., or /", code: :base_path_invalid,
              )
            }
     end


### PR DESCRIPTION
Adds RFC-192 compliance to publishing api.

This update checks against RFC-192 compliance in two places:
- In the put content command (where it is applied to all base paths except those on excluded content items - redirects, contacts, governments or content_blocks)
- In the path reservation class (where it is applied to all base paths except if the publishing app is short-url-manager).

This allows redirects to be created with non-RFC-192 characters in them (desirable), but blocks with a 422 any attempt to publish documents with a base_path present if it does not confirm to the RFC.

After merging this, publishing apps may (if they allow non-RFC-192 characters in their own slug/base_path creation) receive an error when pushing to publishing-api. Publishing apps should ensure they can either handle that error as gracefully as possible or use the same validation code internally (GdsApi::Validators::BasePathValidator).

https://gov-uk.atlassian.net/browse/PNP-10123

Previous PRs:
- https://github.com/alphagov/publishing-api/pull/4128
- https://github.com/alphagov/publishing-api/pull/4138 (reverting 4128 - revert occured because it blocked publishing content blocks, which at the time still had a path).

This application is owned by the Content APIs team. Please let us know in [#govuk-content-apis](https://gds.slack.com/archives/C03D792LYJG) when you raise any PRs.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
