### PR TITLE
Add VALOUR organisations to specialist document schema [WHIT-3883]

### DIFF
--- a/content_schemas/dist/formats/specialist_document/frontend/schema.json
+++ b/content_schemas/dist/formats/specialist_document/frontend/schema.json
@@ -2431,6 +2431,12 @@
           "items": {
             "type": "string"
           }
+        },
+        "veterans_support_organisation_valour_organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         }
       }
     },

--- a/content_schemas/dist/formats/specialist_document/notification/schema.json
+++ b/content_schemas/dist/formats/specialist_document/notification/schema.json
@@ -2577,6 +2577,12 @@
           "items": {
             "type": "string"
           }
+        },
+        "veterans_support_organisation_valour_organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         }
       }
     },

--- a/content_schemas/dist/formats/specialist_document/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/specialist_document/publisher_v2/schema.json
@@ -2285,6 +2285,12 @@
           "items": {
             "type": "string"
           }
+        },
+        "veterans_support_organisation_valour_organisations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         }
       }
     },

--- a/content_schemas/formats/shared/definitions/_specialist_document.jsonnet
+++ b/content_schemas/formats/shared/definitions/_specialist_document.jsonnet
@@ -1507,6 +1507,12 @@
           type: "string",
         },
       },
+      veterans_support_organisation_valour_organisations: {
+        type: "array",
+        items: {
+          type: "string"
+        },
+      },
     },
   },
 }


### PR DESCRIPTION
Adds the `VALOUR organisations` field to the `veterans-support-organisation` specialist publisher doucment schema, to service a support request (https://govuk.zendesk.com/agent/tickets/6784682)

This application is owned by the Content APIs team. Please let us know in [#govuk-content-apis](https://gds.slack.com/archives/C03D792LYJG) when you raise any PRs.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
