### PR TITLE
Update patent decisions finder [WHIT-3885]

### DIFF
--- a/content_schemas/dist/formats/specialist_document/frontend/schema.json
+++ b/content_schemas/dist/formats/specialist_document/frontend/schema.json
@@ -1746,10 +1746,26 @@
         "bulk_published": {
           "type": "boolean"
         },
+        "patent_decision_application_patent_number": {
+          "type": "string"
+        },
         "patent_decision_british_library_number": {
           "type": "string"
         },
+        "patent_decision_date_of_issue": {
+          "type": "string",
+          "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
+        },
         "patent_decision_hearing_officer": {
+          "type": "string"
+        },
+        "patent_decision_keyword_or_phrase": {
+          "type": "string"
+        },
+        "patent_decision_persons_or_companies_involved": {
+          "type": "string"
+        },
+        "patent_decision_provisions_discussed": {
           "type": "string"
         },
         "patent_decision_type_of_hearing": {

--- a/content_schemas/dist/formats/specialist_document/notification/schema.json
+++ b/content_schemas/dist/formats/specialist_document/notification/schema.json
@@ -1864,10 +1864,26 @@
         "bulk_published": {
           "type": "boolean"
         },
+        "patent_decision_application_patent_number": {
+          "type": "string"
+        },
         "patent_decision_british_library_number": {
           "type": "string"
         },
+        "patent_decision_date_of_issue": {
+          "type": "string",
+          "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
+        },
         "patent_decision_hearing_officer": {
+          "type": "string"
+        },
+        "patent_decision_keyword_or_phrase": {
+          "type": "string"
+        },
+        "patent_decision_persons_or_companies_involved": {
+          "type": "string"
+        },
+        "patent_decision_provisions_discussed": {
           "type": "string"
         },
         "patent_decision_type_of_hearing": {

--- a/content_schemas/dist/formats/specialist_document/publisher_v2/schema.json
+++ b/content_schemas/dist/formats/specialist_document/publisher_v2/schema.json
@@ -1587,10 +1587,26 @@
         "bulk_published": {
           "type": "boolean"
         },
+        "patent_decision_application_patent_number": {
+          "type": "string"
+        },
         "patent_decision_british_library_number": {
           "type": "string"
         },
+        "patent_decision_date_of_issue": {
+          "type": "string",
+          "pattern": "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$"
+        },
         "patent_decision_hearing_officer": {
+          "type": "string"
+        },
+        "patent_decision_keyword_or_phrase": {
+          "type": "string"
+        },
+        "patent_decision_persons_or_companies_involved": {
+          "type": "string"
+        },
+        "patent_decision_provisions_discussed": {
           "type": "string"
         },
         "patent_decision_type_of_hearing": {

--- a/content_schemas/formats/shared/definitions/_specialist_document.jsonnet
+++ b/content_schemas/formats/shared/definitions/_specialist_document.jsonnet
@@ -998,6 +998,22 @@
       patent_decision_hearing_officer: {
         type: "string",
       },
+      patent_decision_application_patent_number: {
+        type: "string",
+      },
+      patent_decision_date_of_issue: {
+        type: "string",
+        pattern: "^[1-9][0-9]{3}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[0-1])$",
+      },
+      patent_decision_persons_or_companies_involved: {
+        type: "string",
+      },
+      patent_decision_provisions_discussed: {
+        type: "string",
+      },
+      patent_decision_keyword_or_phrase: {
+        type: "string",
+      }
     },
   },
   product_safety_alert_report_recall_metadata: {


### PR DESCRIPTION
See https://github.com/alphagov/specialist-publisher/pull/3823

---

This application is owned by the Content APIs team. Please let us know in [#govuk-content-apis](https://gds.slack.com/archives/C03D792LYJG) when you raise any PRs.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
