### PR TITLE
[PP-7972] Do not retry Delete Publish Intent Job on not found error

### DIFF
--- a/app/sidekiq/delete_publish_intent_job.rb
+++ b/app/sidekiq/delete_publish_intent_job.rb
@@ -21,5 +21,7 @@ class DeletePublishIntentJob
     PublishingAPI.service(:live_content_store).delete_publish_intent(args["base_path"])
   rescue AbortWorkerError => e
     notify_govuk_error(e, args)
+  rescue GdsApi::HTTPNotFound => e
+    logger.warn(e.message)
   end
 end

--- a/spec/sidekiq/delete_publish_intent_job_spec.rb
+++ b/spec/sidekiq/delete_publish_intent_job_spec.rb
@@ -1,0 +1,19 @@
+RSpec.describe DeletePublishIntentJob do
+  describe "when Content Store returns a 404 response" do
+    let(:base_path) { "/foo" }
+    let(:argument) do
+      {
+        "base_path" => base_path,
+      }
+    end
+
+    before do
+      stub_request(:delete, %r{.*content-store.*/publish-intent#{base_path}})
+    end
+    it "logs the error" do
+      expect {
+        subject.perform(argument)
+      }.not_to raise_error
+    end
+  end
+end


### PR DESCRIPTION
We currently raise a `GdsApi::NotFound` exception when attempting to delete a publish intent which already does not exist in Content Store.

This results in the job retrying, even though it will always fail as the publish intent does not exist.

If the publish intent does get created again, but then we try to delete it, we attempt to schedule another job but that fails because of the lock that has been readded.

The retries occur over a period of 20 days, meaning deletion of a publish intent could potentially be blocked for that period.

Changing the logic here to rescue from this exception and log the error instead of failing. This will mean the job doesn't get added to the retry queue and won't remain locked.