### PR TITLE
Excuse external content from base path check

### DIFF
--- a/app/commands/v2/put_content_validator.rb
+++ b/app/commands/v2/put_content_validator.rb
@@ -4,6 +4,7 @@ module Commands
       FORMATS_WITHOUT_BASE_PATH_VALIDATION = %w[
         contact
         content_block
+        external_content
         government
         redirect
       ].freeze


### PR DESCRIPTION
Search Admin publishes links to external content [1] (also known as "recommended links"), that we need to appear in search results. Currently, these are getting caught by the base path validation in publishing-api because recommended links don't have a base path. This means we're currently unable to publish recommended links from Search Admin. This change adds external_content to the list of formats that the base path validation doesn't apply to.

[1] https://github.com/alphagov/search-admin/blob/main/app/models/recommended_link.rb#L20
