### PR TITLE
Add additional formats to exempt from base path validation [WHIT-3965]

### DIFF
--- a/app/commands/v2/put_content_validator.rb
+++ b/app/commands/v2/put_content_validator.rb
@@ -7,6 +7,8 @@ module Commands
         external_content
         government
         redirect
+        role
+        world_location
       ].freeze
 
       def initialize(payload, put_content)


### PR DESCRIPTION
## What

Follows on from https://github.com/alphagov/publishing-api/pull/4183

Add `role` and `worldwide_location` to list of formats exempt from base path validation

## Why

Both of these formats have a `base_path` of `nil` as they don't result in navigable pages on GOV.UK. The new changes to validator have meant that Whitehall has not been able to push updates to roles or worldwide locations.

This application is owned by the Content APIs team. Please let us know in [#govuk-content-apis](https://gds.slack.com/archives/C03D792LYJG) when you raise any PRs.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
