### PR TITLE
Add further schemas to list of schemas without a base path

### DIFF
--- a/app/commands/v2/put_content_validator.rb
+++ b/app/commands/v2/put_content_validator.rb
@@ -1,7 +1,7 @@
 module Commands
   module V2
     class PutContentValidator
-      FORMATS_WITHOUT_BASE_PATH_VALIDATION = %w[
+      SCHEMAS_WITHOUT_BASE_PATH_VALIDATION = %w[
         contact
         content_block
         external_content
@@ -61,7 +61,7 @@ module Commands
       end
 
       def validate_base_path
-        return if FORMATS_WITHOUT_BASE_PATH_VALIDATION.include?(payload[:schema_name])
+        return if SCHEMAS_WITHOUT_BASE_PATH_VALIDATION.include?(payload[:schema_name])
 
         base_path_validator = GdsApi::Validators::BasePathValidator.new(payload[:base_path])
         return if base_path_validator.valid?

--- a/app/commands/v2/put_content_validator.rb
+++ b/app/commands/v2/put_content_validator.rb
@@ -6,8 +6,11 @@ module Commands
         content_block
         external_content
         government
+        facet
+        link_collection
         redirect
         role
+        role_appointment
         world_location
       ].freeze
 


### PR DESCRIPTION
The list of schemas without a base path is incomplete, so updating it to include all schemas that currently do not have a base path.

This was obtained using the following query in Publishing API:

```rb
Edition.live.where(base_path: nil).pluck(:schema_name).uniq.sort
=> ["contact", "content_block", "external_content", "facet", "facet_group", "facet_value", "link_collection", "role", "role_appointment", "world_location"]
```

`facet_group` and `facet_value` have been excluded, as they do not have a schema, so will not be publishable anyway.  These are most likely orphaned documents.

These were missed in 819bb79d3997ee3c64d1080f85ebe17120ccd275, but inspired by https://github.com/alphagov/publishing-api/pull/4180 and https://github.com/alphagov/publishing-api/pull/4181.