### PR TITLE
Exempt `role_appointment` from base path validation [WHIT-3965]

### DIFF
--- a/app/commands/v2/put_content_validator.rb
+++ b/app/commands/v2/put_content_validator.rb
@@ -8,6 +8,7 @@ module Commands
         government
         redirect
         role
+        role_appointment
         world_location
       ].freeze
 


### PR DESCRIPTION
## What

Add `role_appointment` to list of formats exempt from base path validation

## Why

Role appointment does not result in a navigable page so does not have a base path assigned. This validation has prevented updates roles within Whitehall propagating to the content store.

This application is owned by the Content APIs team. Please let us know in [#govuk-content-apis](https://gds.slack.com/archives/C03D792LYJG) when you raise any PRs.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
