### PR TITLE
Fix legacy path reservations for /guidance/* [WHIT-3973]

### DIFF
--- a/lib/tasks/data_hygiene.rake
+++ b/lib/tasks/data_hygiene.rake
@@ -67,4 +67,23 @@ namespace :data_hygiene do
       )
     end
   end
+
+  desc "Update legacy specialist-publisher guidance path reservations to manuals-publisher"
+  task :update_guidance_path_reservations, [] => :environment do
+    path_reservations = PathReservation.where(
+      publishing_app: "specialist-publisher",
+    ).where(
+      "base_path LIKE ?",
+      "/guidance/%",
+    )
+
+    puts "Found #{path_reservations.count} path reservations"
+
+    path_reservations.update_all(
+      publishing_app: "manuals-publisher",
+      updated_at: Time.current,
+    )
+
+    puts "Updated the path reservations"
+  end
 end


### PR DESCRIPTION
Specialist Publisher and Manuals Publisher were historically the same application (see https://docs.publishing.service.gov.uk/repos/manuals-publisher/2017-migration-project-archive/history.html), and 288 legacy `/guidance/*` path reservations still identify Specialist Publisher as their publishing app.

Specialist Publisher now owns finders rather than manuals, so these reservations should belong to Manuals Publisher. This commit updates the publishing app for all matching reservations to ensure legacy paths are correctly associated with Manuals Publisher.

This is needed in order to unblock a publisher who is trying to edit a section of a manual whose base path is currently reserved by Specialist Publisher. The publisher is seeing a 500 server error when attempting to update the content.

Jira: https://gov-uk.atlassian.net/browse/WHIT-3973

---

This application is owned by the Content APIs team. Please let us know in [#govuk-content-apis](https://gds.slack.com/archives/C03D792LYJG) when you raise any PRs.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
