### PR TITLE
Add special route for route added in frontend#5783 [WHIT-3983]

### DIFF
--- a/lib/data/special_routes.yaml
+++ b/lib/data/special_routes.yaml
@@ -118,6 +118,11 @@
   :type: "prefix"
   :rendering_app: "frontend"
 
+- :base_path: "/draft-asset-preflight"
+  :content_id: "d49af813-e4a0-4680-8904-9658f3acdc44"
+  :title: "Signing in to Asset Manager"
+  :rendering_app: "frontend"
+
 - :base_path: "/email/authenticate"
   :content_id: "889e5a6f-d63b-4e10-8ffb-8d3959453285"
   :title: "Email - authenticate"


### PR DESCRIPTION
A new route has been added in https://github.com/alphagov/frontend/pull/5783. But accessing that route 404s and doesn't get as far as Frontend, since there's no route for it in Router.

Adding it as a special route.

Jira: https://gov-uk.atlassian.net/browse/WHIT-3983

This application is owned by the Content APIs team. Please let us know in [#govuk-content-apis](https://gds.slack.com/archives/C03D792LYJG) when you raise any PRs.

⚠️ This repo is Continuously Deployed: make sure you [follow the guidance](https://docs.publishing.service.gov.uk/manual/development-pipeline.html#merge-your-own-pull-request) ⚠️

Follow [these steps](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html) if you are doing a Rails upgrade.
